### PR TITLE
Fix Docker build: prevent frontend build from overwriting backend build

### DIFF
--- a/deploy.Dockerfile
+++ b/deploy.Dockerfile
@@ -37,7 +37,7 @@ WORKDIR /bpni
 COPY package*.json ./
 RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
 COPY --from=build-backend /bpni/build /bpni/build
-COPY --from=build-frontend /bpni/build /bpni/build
+COPY --from=build-frontend /bpni/build/app/public /bpni/build/app/public
 
 EXPOSE 3000
 WORKDIR /bpni/build


### PR DESCRIPTION
- Changed COPY command to only copy frontend public assets to specific path
- This ensures /bpni/build/app/server.js is preserved in final image
- Fixes production deployment error: Cannot find module '/bpni/build/app/server.js'