### PR TITLE
feat(auth): bulk-provision WorkOS accounts for all legacy users

### DIFF
--- a/__tests__/api/workos-provision.test.ts
+++ b/__tests__/api/workos-provision.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import dotenv from 'dotenv';
+import path from 'path';
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup } from '../setup/testSetup';
+import { UserModel } from '../../app/api/models/user';
+import { WorkOSService } from '../../app/api/services/workos-service';
+import { provisionWorkOSUsers } from '../../scripts/provision-workos-users';
+
+describe('provisionWorkOSUsers', function () {
+  let provisionStub: sinon.SinonStub;
+  let ensureOrgStub: sinon.SinonStub;
+
+  beforeEach(async function () {
+    this.timeout(5000);
+    await TestSetup.beforeEach();
+    delete process.env.WORKOS_PLATFORM_ORG_ID;
+    provisionStub = sinon.stub(WorkOSService, 'provisionUser');
+    ensureOrgStub = sinon.stub(WorkOSService, 'ensureOrgMembership');
+    // Default: succeed for any email (handles the 3 seeded legacy users)
+    provisionStub.callsFake(async (email: string) => ({
+      user: { id: `wos_${email}`, email },
+      created: true,
+    }));
+    ensureOrgStub.resolves({ membershipId: 'mem_default', created: true });
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    sinon.restore();
+    await TestSetup.afterEach();
+  });
+
+  async function createLegacyUser(email: string, username: string) {
+    const user = new UserModel.model({ email, username, authProvider: 'legacy' });
+    user.setPassword('password123');
+    await user.save();
+    return user;
+  }
+
+  it('provisions legacy users without a workosUserId', async function () {
+    const user = await createLegacyUser('alice@example.com', 'alice');
+
+    const result = await provisionWorkOSUsers();
+
+    expect(result.errorCount).to.equal(0);
+    // The specific user we created must be provisioned
+    const updated = await UserModel.model.findById(user._id).lean();
+    expect(updated?.workosUserId).to.equal(`wos_alice@example.com`);
+  });
+
+  it('calls provisionUser with the correct email and mongoId', async function () {
+    const user = await createLegacyUser('bob@example.com', 'bob');
+
+    await provisionWorkOSUsers();
+
+    const callForBob = provisionStub.getCalls().find((c) => c.args[0] === 'bob@example.com');
+    expect(callForBob, 'expected a provisionUser call for bob@example.com').to.exist;
+    expect(callForBob!.args[1]).to.equal(String(user._id));
+  });
+
+  it('counts alreadyExisted when WorkOS returns created: false', async function () {
+    const user = await createLegacyUser('carol@example.com', 'carol');
+    provisionStub.withArgs('carol@example.com', sinon.match.string).resolves({
+      user: { id: 'wos_carol', email: 'carol@example.com' },
+      created: false,
+    });
+
+    const result = await provisionWorkOSUsers();
+
+    expect(result.alreadyExisted).to.equal(1);
+    // workosUserId should still be written back
+    const updated = await UserModel.model.findById(user._id).lean();
+    expect(updated?.workosUserId).to.equal('wos_carol');
+  });
+
+  it('re-confirms users that already have a workosUserId (idempotent)', async function () {
+    const alreadyProvisioned = new UserModel.model({
+      email: 'dave@example.com',
+      username: 'dave',
+      authProvider: 'legacy',
+      workosUserId: 'wos_existing',
+    });
+    await alreadyProvisioned.save();
+    provisionStub
+      .withArgs('dave@example.com', sinon.match.string)
+      .resolves({ user: { id: 'wos_existing', email: 'dave@example.com' }, created: false });
+
+    const result = await provisionWorkOSUsers();
+
+    const callForDave = provisionStub.getCalls().find((c) => c.args[0] === 'dave@example.com');
+    expect(callForDave, 'should call provisionUser to confirm the WorkOS account').to.exist;
+    expect(result.alreadyExisted).to.be.at.least(1);
+
+    // workosUserId must remain unchanged
+    const unchanged = await UserModel.model.findById(alreadyProvisioned._id).lean();
+    expect(unchanged?.workosUserId).to.equal('wos_existing');
+  });
+
+  it('re-links a user whose WorkOS account was deleted and recreated', async function () {
+    const user = new UserModel.model({
+      email: 'relinked@example.com',
+      username: 'relinked',
+      authProvider: 'legacy',
+      workosUserId: 'wos_old_id',
+    });
+    await user.save();
+    // WorkOS recreated the account with a new ID (old was deleted)
+    provisionStub
+      .withArgs('relinked@example.com', sinon.match.string)
+      .resolves({ user: { id: 'wos_new_id', email: 'relinked@example.com' }, created: true });
+
+    await provisionWorkOSUsers();
+
+    const updated = await UserModel.model.findById(user._id).lean();
+    expect(updated?.workosUserId).to.equal('wos_new_id');
+  });
+
+  it('records errors without aborting other users', async function () {
+    await createLegacyUser('good@example.com', 'good');
+    await createLegacyUser('bad@example.com', 'bad');
+
+    provisionStub.withArgs('bad@example.com', sinon.match.string).rejects(new Error('API timeout'));
+
+    const result = await provisionWorkOSUsers();
+
+    expect(result.errorCount).to.equal(1);
+    expect(result.errors[0].email).to.equal('bad@example.com');
+    expect(result.errors[0].error).to.equal('API timeout');
+
+    // good@example.com should still have been provisioned
+    const good = await UserModel.model.findOne({ email: 'good@example.com' }).lean();
+    expect(good?.workosUserId).to.exist;
+  });
+
+  it('does not call WorkOS or update the DB in dry-run mode', async function () {
+    const user = await createLegacyUser('eve@example.com', 'eve');
+
+    await provisionWorkOSUsers({ dryRun: true });
+
+    expect(provisionStub.called).to.be.false;
+    const unchanged = await UserModel.model.findById(user._id).lean();
+    expect(unchanged?.workosUserId).to.be.undefined;
+  });
+
+  it('is idempotent — re-running counts already-provisioned users as alreadyExisted', async function () {
+    const user = new UserModel.model({
+      email: 'frank@example.com',
+      username: 'frank',
+      authProvider: 'legacy',
+      workosUserId: 'wos_frank',
+    });
+    await user.save();
+    provisionStub
+      .withArgs('frank@example.com', sinon.match.string)
+      .resolves({ user: { id: 'wos_frank', email: 'frank@example.com' }, created: false });
+
+    const result = await provisionWorkOSUsers();
+
+    const callForFrank = provisionStub.getCalls().find((c) => c.args[0] === 'frank@example.com');
+    expect(callForFrank, 'should confirm the WorkOS account on re-run').to.exist;
+    expect(result.alreadyExisted).to.be.at.least(1);
+
+    const unchanged = await UserModel.model.findById(user._id).lean();
+    expect(unchanged?.workosUserId).to.equal('wos_frank');
+  });
+
+  describe('org membership (WORKOS_PLATFORM_ORG_ID set)', function () {
+    beforeEach(function () {
+      process.env.WORKOS_PLATFORM_ORG_ID = 'org_test123';
+    });
+
+    it('calls ensureOrgMembership with the WorkOS user id and org id', async function () {
+      await createLegacyUser('org-test@example.com', 'orgtest');
+
+      await provisionWorkOSUsers();
+
+      const call = ensureOrgStub
+        .getCalls()
+        .find((c) => c.args[0] === `wos_org-test@example.com`);
+      expect(call, 'expected ensureOrgMembership call for org-test user').to.exist;
+      expect(call!.args[1]).to.equal('org_test123');
+    });
+
+    it('counts orgMembershipsCreated and orgMembershipsExisted separately', async function () {
+      await createLegacyUser('new-member@example.com', 'newmember');
+      await createLegacyUser('old-member@example.com', 'oldmember');
+
+      // Seeded users return existed; only the two test users differ
+      ensureOrgStub.resolves({ membershipId: 'mem_default', created: false });
+      ensureOrgStub
+        .withArgs(`wos_new-member@example.com`, sinon.match.string)
+        .resolves({ membershipId: 'mem_new', created: true });
+      ensureOrgStub
+        .withArgs(`wos_old-member@example.com`, sinon.match.string)
+        .resolves({ membershipId: 'mem_old', created: false });
+
+      const result = await provisionWorkOSUsers();
+
+      expect(result.orgMembershipsCreated).to.equal(1);
+      expect(result.orgMembershipsExisted).to.be.at.least(1);
+    });
+
+    it('does not call ensureOrgMembership in dry-run mode', async function () {
+      await createLegacyUser('dry@example.com', 'dry');
+
+      await provisionWorkOSUsers({ dryRun: true });
+
+      expect(ensureOrgStub.called).to.be.false;
+    });
+  });
+
+  it('skips users with no email address', async function () {
+    await UserModel.model.collection.insertOne({
+      username: 'noemail',
+      authProvider: 'legacy',
+      hash: 'x',
+      salt: 'x',
+    });
+    const callsBefore = provisionStub.callCount;
+
+    const result = await provisionWorkOSUsers();
+
+    expect(result.skipped).to.equal(1);
+    // no additional WorkOS call for the no-email user
+    const callsForNoEmail = provisionStub.getCalls().find((c) => !c.args[0]);
+    expect(callsForNoEmail).to.not.exist;
+    expect(provisionStub.callCount).to.equal(callsBefore + result.totalFound - result.skipped);
+  });
+});

--- a/agent/WORKOS_PLAN.md
+++ b/agent/WORKOS_PLAN.md
@@ -7,9 +7,14 @@ The `auth-workos` branch introduces WorkOS AuthKit as the primary authentication
 - **Login / OAuth flow** — `GET /api/auth/workos` → WorkOS → `GET /api/auth/callback`
 - **User migration** — on callback, existing legacy users are linked to their WorkOS ID; new users are created
 - **Self-service migration** — `POST /api/migration/migrate` lets a logged-in legacy user trigger a magic-link email
-- **Admin status check** — `GET /api/migration/status` gated behind `adminAuth`, which today reads `ADMIN_USERNAMES` from an env var (a stopgap)
-
-The `accessToken` returned by `authenticateWithCode` is currently discarded. This is the key gap — that token is a signed JWT that WorkOS populates with the user's organization memberships and roles, and it is the natural carrier for admin status.
+- **Admin status check** — `GET /api/migration/status` is gated behind `adminAuth` in `app/routes.ts`, which checks `req.user.role === 'admin'` on the JWT; no env var needed
+- **Role plumbing** — after `authenticateWithCode`, the callback calls `WorkOSService.getPlatformRole(workosUser.id)` to check the user's membership in the platform org; the role slug is embedded in the JWT via `localUser.generateJwt(role)` in `app/api/models/user.ts`; role-bearing JWTs expire in 24 h (vs 7 days for regular users)
+- **externalId write-back** — on each login the callback writes `localUser._id` to WorkOS as `externalId`, linking the two systems bidirectionally; for legacy-user migration the write-back happens *before* clearing the local password hash so a failed WorkOS write leaves credentials intact
+- **One-time code exchange** — the OAuth callback no longer puts the JWT in the redirect URL; instead it issues a short-lived (60 s) single-use code and redirects to `/auth/callback?code=…`; the frontend calls `GET /api/auth/exchange?code=…` to obtain the JWT
+- **Email verification gate** — legacy accounts are only linked/migrated when `workosUser.emailVerified` is true; unverified callbacks are rejected before touching local credentials
+- **env vars** — `HOST` is the public-facing site URL; `BACKEND_HOST` is the server origin used for WorkOS redirect URI and switch-account login URL; `WORKOS_CLIENT_ID` and `BACKEND_HOST` are validated at call time in `WorkOSService` with descriptive errors
+- **Atomic migration script** — `scripts/migrate-to-workos.ts` uses `updateOne` with a conditional filter instead of `document.save()`, preventing race-condition double-processing
+- **Bulk WorkOS provisioning** — `scripts/provision-workos-users.ts` creates WorkOS accounts for all legacy MongoDB users (no password; users sign in via "forgot password" or magic link). Idempotent: re-running re-confirms existing accounts and repairs stale `workosUserId` links. If `WORKOS_PLATFORM_ORG_ID` is set, each user is also added to the platform org (existing memberships, including admin role, are left untouched).
 
 ---
 
@@ -243,26 +248,45 @@ This only needs to run once per user. If you want to avoid the extra write on ev
 | 0.5 | Add Staging keys + Staging org ID to local `.env` |
 | 0.6 | Add Production keys + Production org ID to staging/production server config |
 
-### Phase 1 — Code changes (single PR)
+### Phase 1 — Code changes (complete)
 
-| Step | Action | Blocks what |
-|------|--------|-------------|
-| 1.1 | Add `updateUser` to `workos-service.ts` | 1.2 |
-| 1.2 | Write `externalId` back to WorkOS in the auth callback | — |
-| 1.3 | Implement `getPlatformRole` in `workos-service.ts` | 1.4 |
-| 1.4 | Add `role` field to `UserJwt` | 1.5 |
-| 1.5 | Pass role into `generateJwt` in the callback controller | 1.6 |
-| 1.6 | Replace env-var `adminAuth` in `routes.ts` with role check | — |
-| 1.7 | Remove `ADMIN_USERNAMES` from `.env.sample` and docs | — |
+| Step | Action | Status |
+|------|--------|--------|
+| 1.1 | Add `updateUser` to `workos-service.ts` | ✅ done |
+| 1.2 | Write `externalId` back to WorkOS in the auth callback | ✅ done |
+| 1.3 | Implement `getPlatformRole` in `workos-service.ts` | ✅ done |
+| 1.4 | Add `role` field to `UserJwt` | ✅ done |
+| 1.5 | Pass role into `generateJwt` in the callback controller | ✅ done |
+| 1.6 | Replace env-var `adminAuth` in `routes.ts` with role check | ✅ done |
+| 1.7 | `ADMIN_USERNAMES` env var is not used — no `.env.sample` entry exists | ✅ done |
 
 ### Phase 2 — Validate locally
 
 Test against WorkOS Staging + local DB. Confirm login, org membership check, admin role on `GET /api/migration/status`, and `externalId` being written back.
 
+Run the provisioning script against your local DB to create WorkOS Staging accounts for all local legacy users:
+
+```bash
+npx ts-node scripts/provision-workos-users.ts --dry-run --verbose
+npx ts-node scripts/provision-workos-users.ts --verbose
+```
+
 ### Phase 3 — Migrate on staging site
 
-Deploy the branch to the staging site (WorkOS Production + shared DB). Log in as yourself — this populates your real WorkOS Production user, links your `workosUserId` in the shared DB, and your pre-created org membership means `adminAuth` will pass. Verify migration status counts, run a test migration for a legacy user if possible.
+Deploy to the staging site (WorkOS Production + shared DB). Run the provisioning script on the server to create WorkOS Production accounts for all existing users and add them to the platform org:
+
+```bash
+# Dry run first
+WORKOS_API_KEY=sk_… WORKOS_CLIENT_ID=client_… WORKOS_PLATFORM_ORG_ID=org_… \
+  npx ts-node scripts/provision-workos-users.ts --dry-run --verbose
+
+# Apply
+WORKOS_API_KEY=sk_… WORKOS_CLIENT_ID=client_… WORKOS_PLATFORM_ORG_ID=org_… \
+  npx ts-node scripts/provision-workos-users.ts --verbose
+```
+
+After running: log in via the staging site, confirm `adminAuth` passes on `GET /api/migration/status`, and verify migration status counts.
 
 ### Phase 4 — Deploy to production
 
-Merge and deploy. WorkOS Production is already populated; the shared DB already has `workosUserId` links from Phase 3. Production traffic flows through the new auth path with no further migration work needed.
+Merge and deploy. WorkOS Production already has all user accounts (from Phase 3). The shared DB already has `workosUserId` links. Production traffic flows through the new auth path with no further migration work needed.

--- a/app/api/services/workos-service.ts
+++ b/app/api/services/workos-service.ts
@@ -113,6 +113,71 @@ export class WorkOSService {
   }
 
   /**
+   * Create a WorkOS account for a legacy user (no password — they must use
+   * magic link or "forgot password" to sign in for the first time).
+   * If a WorkOS user already exists for this email, returns it rather than
+   * throwing, so the script is safe to re-run.
+   */
+  static async provisionUser(
+    email: string,
+    externalId: string
+  ): Promise<{ user: { id: string; email: string }; created: boolean }> {
+    const workos = getWorkOSClient();
+    try {
+      const user = await workos.userManagement.createUser({
+        email,
+        emailVerified: true,
+        externalId,
+      });
+      return { user, created: true };
+    } catch {
+      // createUser failed — the user may already exist in WorkOS under a
+      // different ID or error code. Attempt a lookup before giving up.
+      const list = await workos.userManagement.listUsers({ email });
+      const user = list.data[0];
+      if (!user) {
+        throw new Error(`Could not create or find WorkOS user for ${email}`);
+      }
+      return { user, created: false };
+    }
+  }
+
+  /**
+   * Ensure a WorkOS user is a member of the given org. Creates the membership
+   * if it doesn't exist; returns the existing one if it does. Safe to call on
+   * every provision run (idempotent).
+   */
+  static async ensureOrgMembership(
+    workosUserId: string,
+    organizationId: string
+  ): Promise<{ membershipId: string; created: boolean }> {
+    const workos = getWorkOSClient();
+    try {
+      const membership = await workos.userManagement.createOrganizationMembership({
+        userId: workosUserId,
+        organizationId,
+      });
+      return { membershipId: membership.id, created: true };
+    } catch (error: any) {
+      // Membership already exists — fetch it rather than erroring
+      if (error?.status === 409 || error?.status === 422) {
+        const list = await workos.userManagement.listOrganizationMemberships({
+          userId: workosUserId,
+          organizationId,
+        });
+        const existing = list.data[0];
+        if (!existing) {
+          throw new Error(
+            `Membership conflict for user ${workosUserId} in org ${organizationId} but could not be retrieved`
+          );
+        }
+        return { membershipId: existing.id, created: false };
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Update a WorkOS user record (e.g. to set externalId)
    */
   static async updateUser(userId: string, attrs: { externalId?: string }) {

--- a/scripts/provision-workos-users.ts
+++ b/scripts/provision-workos-users.ts
@@ -1,0 +1,191 @@
+#!/usr/bin/env ts-node
+
+/**
+ * WorkOS User Provisioning Script
+ *
+ * Creates WorkOS accounts for all legacy MongoDB users that don't have one yet.
+ * Users are created without a password (emailVerified: true) so they can sign in
+ * via "forgot password" or magic link without knowing about the migration.
+ *
+ * If WORKOS_PLATFORM_ORG_ID is set, each provisioned user is also added to that
+ * organization (as a member). This is idempotent — existing memberships are left
+ * as-is (so admin role assignments made in the WorkOS dashboard are preserved).
+ *
+ * Safe to re-run: already-provisioned users are skipped, and existing WorkOS
+ * accounts for the same email are reused rather than causing an error.
+ *
+ * Usage:
+ *   npx ts-node scripts/provision-workos-users.ts           # Run
+ *   npx ts-node scripts/provision-workos-users.ts --dry-run # Preview only
+ *   npx ts-node scripts/provision-workos-users.ts --verbose # Show per-user detail
+ */
+
+import dotenv from 'dotenv';
+dotenv.config();
+
+import mongoose from 'mongoose';
+import { UserModel } from '../app/api/models/user';
+import { WorkOSService } from '../app/api/services/workos-service';
+
+export interface ProvisionResult {
+  totalFound: number;
+  created: number;
+  alreadyExisted: number;
+  skipped: number;
+  orgMembershipsCreated: number;
+  orgMembershipsExisted: number;
+  errorCount: number;
+  errors: Array<{ email: string; error: string }>;
+}
+
+export async function provisionWorkOSUsers(
+  options: { dryRun?: boolean; verbose?: boolean } = {}
+): Promise<ProvisionResult> {
+  const { dryRun = false, verbose = false } = options;
+  const platformOrgId = process.env.WORKOS_PLATFORM_ORG_ID;
+
+  let openedConnection = false;
+  try {
+    if (mongoose.connection.readyState === 0) {
+      await mongoose.connect(process.env.DB_URI as string);
+      openedConnection = true;
+    }
+    UserModel.init();
+
+    // Process all legacy users — provisionUser is idempotent (find-or-create),
+    // so users already in WorkOS are handled correctly. This also repairs users
+    // whose WorkOS account was deleted after workosUserId was written to MongoDB.
+    const users = await UserModel.model
+      .find({ authProvider: 'legacy' })
+      .select('_id email username workosUserId')
+      .lean();
+
+    const result: ProvisionResult = {
+      totalFound: users.length,
+      created: 0,
+      alreadyExisted: 0,
+      skipped: 0,
+      orgMembershipsCreated: 0,
+      orgMembershipsExisted: 0,
+      errorCount: 0,
+      errors: [],
+    };
+
+    if (users.length === 0) {
+      return result;
+    }
+
+    for (const user of users) {
+      const email = user.email;
+      const mongoId = String(user._id);
+
+      if (!email) {
+        result.skipped++;
+        if (verbose) console.log(`Skipping ${user.username}: no email address`);
+        continue;
+      }
+
+      if (dryRun) {
+        result.created++;
+        if (verbose) {
+          const orgNote = platformOrgId ? ' + org membership' : '';
+          console.log(`[DRY RUN] Would provision: ${email}${orgNote}`);
+        }
+        continue;
+      }
+
+      try {
+        const { user: workosUser, created } = await WorkOSService.provisionUser(email, mongoId);
+
+        await UserModel.model.updateOne(
+          { _id: user._id },
+          { $set: { workosUserId: workosUser.id } }
+        );
+
+        if (created) {
+          result.created++;
+          if (verbose) console.log(`Created WorkOS user for: ${email}`);
+        } else {
+          result.alreadyExisted++;
+          const relinked = user.workosUserId && user.workosUserId !== workosUser.id;
+          if (verbose) {
+            console.log(
+              relinked
+                ? `Re-linked WorkOS user for: ${email} (id changed)`
+                : `Already in WorkOS: ${email}`
+            );
+          }
+        }
+
+        if (platformOrgId) {
+          const { created: membershipCreated } = await WorkOSService.ensureOrgMembership(
+            workosUser.id,
+            platformOrgId
+          );
+          if (membershipCreated) {
+            result.orgMembershipsCreated++;
+            if (verbose) console.log(`  Added to platform org: ${email}`);
+          } else {
+            result.orgMembershipsExisted++;
+            if (verbose) console.log(`  Already in platform org: ${email}`);
+          }
+        }
+      } catch (error: any) {
+        result.errorCount++;
+        const msg = error.message || String(error);
+        result.errors.push({ email, error: msg });
+        if (verbose) console.error(`Failed to provision ${email}:`, msg);
+      }
+    }
+
+    return result;
+  } finally {
+    if (openedConnection) {
+      await mongoose.disconnect();
+    }
+  }
+}
+
+// CLI execution
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const verbose = args.includes('--verbose') || args.includes('-v');
+
+  provisionWorkOSUsers({ dryRun, verbose })
+    .then((result) => {
+      const prefix = dryRun ? '[DRY RUN] ' : '';
+      if (result.totalFound === 0) {
+        console.log('✅ No users to provision — all legacy users already have WorkOS accounts');
+        process.exit(0);
+      }
+
+      console.log(`\n${prefix}Provisioning Summary:`);
+      console.log(`  Found:                   ${result.totalFound}`);
+      console.log(`  Created:                 ${result.created}`);
+      console.log(`  Already existed:         ${result.alreadyExisted}`);
+      console.log(`  Skipped:                 ${result.skipped}`);
+      if (process.env.WORKOS_PLATFORM_ORG_ID) {
+        console.log(`  Org memberships created: ${result.orgMembershipsCreated}`);
+        console.log(`  Org memberships existed: ${result.orgMembershipsExisted}`);
+      }
+      console.log(`  Errors:                  ${result.errorCount}`);
+
+      if (result.errors.length > 0) {
+        console.log(`\nErrors:`);
+        result.errors.forEach(({ email, error }) => {
+          console.log(`  - ${email}: ${error}`);
+        });
+      }
+
+      if (dryRun) {
+        console.log(`\n💡 Run without --dry-run to apply changes`);
+      }
+
+      process.exit(result.errorCount > 0 ? 1 : 0);
+    })
+    .catch((error) => {
+      console.error('Provisioning failed:', error.message);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
Adds scripts/provision-workos-users.ts — a safe, idempotent script that creates WorkOS accounts (no password) for every legacy MongoDB user so they can sign in via "forgot password" or magic link without knowing a migration is happening.

Key behaviours:
- Processes all legacy users on every run; re-confirms existing accounts and repairs stale workosUserId links (e.g. after a WorkOS account is deleted and recreated).
- If WORKOS_PLATFORM_ORG_ID is set, each user is added to the platform org (ensureOrgMembership is idempotent — existing admin roles are never clobbered).
- createUser failure falls back to listUsers lookup before erroring, so "user already exists" edge cases from any WorkOS error code are handled.
- Dry-run and verbose flags mirror migrate-to-workos.ts conventions.

Adds WorkOSService.provisionUser and WorkOSService.ensureOrgMembership. Adds 12 Mocha tests (sinon stubs for WorkOS API calls). Updates WORKOS_PLAN.md with provisioning step in Phases 2 and 3.