### PR TITLE
fix(auth): fix dark mode and copy for legacy account hint

### DIFF
--- a/frontend/src/app/module-blueprint/components/user-auth/login-page/login-page.component.css
+++ b/frontend/src/app/module-blueprint/components/user-auth/login-page/login-page.component.css
@@ -53,8 +53,9 @@
 }
 
 .legacy-hint {
-  background: var(--surface-100, #f3f4f6);
-  border-left: 3px solid var(--primary-500, #007ad9);
+  background: var(--surface-section);
+  color: var(--text-color);
+  border-left: 3px solid var(--primary-color);
   padding: 0.75rem 1rem;
   border-radius: 4px;
   margin-bottom: 1rem;

--- a/frontend/src/app/module-blueprint/components/user-auth/login-page/login-page.component.html
+++ b/frontend/src/app/module-blueprint/components/user-auth/login-page/login-page.component.html
@@ -46,13 +46,12 @@
         <div *ngIf="showLegacyHint" class="legacy-hint">
           <p>
             It looks like you have an existing account, but our login system has
-            been upgraded. Check your email for a sign-in link, or click below
-            to send one now.
+            been upgraded. Click below to sign in with a one-time code instead.
           </p>
           <button
             pButton
             type="button"
-            label="Send me a sign-in link"
+            label="Sign in with a code"
             icon="pi pi-envelope"
             class="p-button-outlined w-full"
             (click)="sendMagicLink()"


### PR DESCRIPTION
Use PrimeNG theme tokens (--surface-section, --text-color, --primary-color) so the legacy hint renders correctly in dark mode. Update the hint text and button label to accurately describe the code-based sign-in flow.