### PR TITLE
fix(dialogs): missing buttons in modals

### DIFF
--- a/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.html
@@ -38,7 +38,7 @@
       You must be logged in to save a blueprint
     </div>
 
-    <p-footer>
+    <ng-template pTemplate="footer">
       <p-button
         *ngIf="!overwrite"
         type="submit"
@@ -66,6 +66,6 @@
         label="Yes"
         [disabled]="disabledSaveButton"
       ></button>
-    </p-footer>
+    </ng-template>
   </p-dialog>
 </form>

--- a/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.spec.ts
@@ -1,13 +1,27 @@
-import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
+import {
+  waitForAsync,
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+  discardPeriodicTasks,
+} from "@angular/core/testing";
 import {
   provideHttpClient,
   withInterceptorsFromDi,
 } from "@angular/common/http";
 import { RouterTestingModule } from "@angular/router/testing";
+import { CommonModule } from "@angular/common";
+import { ReactiveFormsModule } from "@angular/forms";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { MessageService } from "primeng/api";
+import { DialogModule } from "primeng/dialog";
+import { ButtonModule } from "primeng/button";
+import { InputTextModule } from "primeng/inputtext";
 
 import { ComponentSaveDialogComponent } from "./component-save-dialog.component";
 import { AuthenticationService } from "src/app/module-blueprint/services/authentification-service";
+import { BlueprintService } from "src/app/module-blueprint/services/blueprint-service";
 
 describe("ComponentSaveDialogComponent", () => {
   let component: ComponentSaveDialogComponent;
@@ -16,9 +30,18 @@ describe("ComponentSaveDialogComponent", () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ComponentSaveDialogComponent],
-      imports: [RouterTestingModule.withRoutes([])],
+      imports: [
+        CommonModule,
+        ReactiveFormsModule,
+        NoopAnimationsModule,
+        RouterTestingModule.withRoutes([]),
+        DialogModule,
+        ButtonModule,
+        InputTextModule,
+      ],
       providers: [
         AuthenticationService,
+        BlueprintService,
         MessageService,
         provideHttpClient(withInterceptorsFromDi()),
       ],
@@ -34,4 +57,16 @@ describe("ComponentSaveDialogComponent", () => {
   it("should create", () => {
     expect(component).toBeTruthy();
   });
+
+  it("should render save button in dialog footer when opened", fakeAsync(() => {
+    component.showDialog();
+    fixture.detectChanges();
+    tick(500);
+    fixture.detectChanges();
+    discardPeriodicTasks();
+
+    // PrimeNG dialog appends to document.body as an overlay
+    const saveButton = document.body.querySelector("button[type='submit']");
+    expect(saveButton).not.toBeNull();
+  }));
 });

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-export-images/dialog-export-images.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-export-images/dialog-export-images.component.html
@@ -60,12 +60,12 @@
     </div>
   </div>
 
-  <p-footer>
+  <ng-template pTemplate="footer">
     <p-button
       i18n-label
       label="Download images"
       [disabled]="disabled"
       (click)="downloadImages()"
     ></p-button>
-  </p-footer>
+  </ng-template>
 </p-dialog>


### PR DESCRIPTION
<p-footer> was removed in PrimeNG 17+ in favour of ng-template pTemplate="footer". The save dialog and export-images dialog both used the old API, silently dropping their footer content (Save, Yes/No overwrite, Download images buttons) after the PrimeNG 20 upgrade.

Also upgrades the save-dialog spec to import real PrimeNG modules so the template actually renders, and adds a fakeAsync regression test that asserts the save button is present in the DOM when the dialog opens.