### PR TITLE
fix(blueprint): fix crash on BP save

### DIFF
--- a/__tests__/api/blueprints.test.ts
+++ b/__tests__/api/blueprints.test.ts
@@ -348,6 +348,37 @@ describe('Blueprint API (Mocha)', function () {
       expect(response.body.errors).to.be.an('array');
       expect(response.body.errors[0].status).to.equal('400');
     });
+
+    it('should correct out-of-bounds building positions after upload', async function () {
+      const token = testData.users.user1.generateJwt();
+
+      const blueprintWithOffsets = {
+        blueprintItems: [
+          { id: 'Generator', position: { x: 10000, y: 0 } },   // x > 8000 → 10000 - 9999 = 1
+          { id: 'Battery',   position: { x: 0,     y: -9000 } }, // y < -8000 → -9000 + 9999 = 999
+          { id: 'Wire',      position: { x: 100,   y: -100 } },  // in bounds, unchanged
+        ],
+      };
+
+      const upload = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'Position Correction Test', blueprint: blueprintWithOffsets, thumbnail: TINY_PNG });
+
+      expect(upload.status).to.equal(200);
+      const id = upload.body.id;
+
+      // Allow the async UpdatePositionCorrection save to complete
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      const saved = await BlueprintModel.model.findById(id);
+      const items = (saved!.data as any).blueprintItems;
+
+      expect(items[0].position.x).to.equal(1);
+      expect(items[1].position.y).to.equal(999);
+      expect(items[2].position.x).to.equal(100);
+      expect(items[2].position.y).to.equal(-100);
+    });
   });
 
   describe('POST /api/likeblueprint', function () {

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -447,14 +447,14 @@ export class BlueprintController {
         let id = newBlueprint.id;
         res.json({ id: id });
 
-        // Then we identify if the uploaded bleuprint is a duplicate
-        BlueprintModel.model
-          .find({})
-          .sort({ createdAt: 1 })
-          .then(blueprints => {
-            BatchUtils.UpdateBasedOn(newBlueprint, blueprints, blueprints.length - 1);
-            BatchUtils.UpdatePositionCorrection(newBlueprint);
-          });
+        BatchUtils.UpdatePositionCorrection(newBlueprint);
+
+        // TODO: duplicate detection
+        // The old approach (UpdateBasedOn) loaded every blueprint into memory on each upload — removed due to OOM crashes.
+        // Proper approach: at upload time, compute a stable hash of the canonical blueprint content
+        // (sorted blueprintItems by id+position, excluding metadata like name/thumbnail) and store it
+        // on the document. Duplicate detection then becomes a single indexed query: find({ owner, contentHash }).
+        // The batch script update-based-on.ts can be repurposed to backfill hashes on existing documents.
       })
       .catch(error => {
         console.log('Blueprint save error');


### PR DESCRIPTION
After each blueprint upload, the server was fetching every blueprint from the database to run duplicate detection (UpdateBasedOn). As the collection grew this exhausted the Node.js heap and crashed the process.

Removed the inline UpdateBasedOn call. The batch script (update-based-on.ts) covers this retroactively. A TODO documents the correct long-term approach: hash blueprint content at upload time and use an indexed query instead of a full scan.

UpdatePositionCorrection is retained — it only operates on the newly saved document. Added a test to cover this post-save correction behavior.