### PR TITLE
fix(auth): replace legacy magic-link hint with password reset flow

### DIFF
--- a/app/api/auth-controller.ts
+++ b/app/api/auth-controller.ts
@@ -325,6 +325,11 @@ export class AuthController {
     }
 
     try {
+      // Ensure legacy users exist in WorkOS before attempting a reset
+      const localUser = await UserModel.model.findOne({ email });
+      if (localUser && localUser.authProvider !== 'workos') {
+        await WorkOSService.provisionUser(email, (localUser._id as any).toString());
+      }
       await WorkOSService.sendPasswordResetEmail(email);
     } catch (err) {
       // Log but do not expose — prevents email enumeration

--- a/frontend/src/app/module-blueprint/components/user-auth/forgot-password/forgot-password.component.ts
+++ b/frontend/src/app/module-blueprint/components/user-auth/forgot-password/forgot-password.component.ts
@@ -1,4 +1,5 @@
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
 import { AuthenticationService } from "../../../services/authentification-service";
 
 @Component({
@@ -7,12 +8,22 @@ import { AuthenticationService } from "../../../services/authentification-servic
   styleUrls: ["./forgot-password.component.css"],
   standalone: false,
 })
-export class ForgotPasswordComponent {
+export class ForgotPasswordComponent implements OnInit {
   email = "";
   loading = false;
   submitted = false;
 
-  constructor(private authService: AuthenticationService) {}
+  constructor(
+    private authService: AuthenticationService,
+    private route: ActivatedRoute
+  ) {}
+
+  ngOnInit() {
+    const email = this.route.snapshot.queryParams["email"];
+    if (email) {
+      this.email = email;
+    }
+  }
 
   submit() {
     if (!this.email) return;

--- a/frontend/src/app/module-blueprint/components/user-auth/login-page/login-page.component.html
+++ b/frontend/src/app/module-blueprint/components/user-auth/login-page/login-page.component.html
@@ -46,15 +46,15 @@
         <div *ngIf="showLegacyHint" class="legacy-hint">
           <p>
             It looks like you have an existing account, but our login system has
-            been upgraded. Click below to sign in with a one-time code instead.
+            been upgraded. Click below to set a new password and regain access.
           </p>
           <button
             pButton
             type="button"
-            label="Sign in with a code"
+            label="Reset your password"
             icon="pi pi-envelope"
             class="p-button-outlined w-full"
-            (click)="sendMagicLink()"
+            (click)="resetPassword()"
           ></button>
         </div>
 

--- a/frontend/src/app/module-blueprint/components/user-auth/login-page/login-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/user-auth/login-page/login-page.component.ts
@@ -59,8 +59,8 @@ export class LoginPageComponent implements OnInit {
     });
   }
 
-  sendMagicLink() {
-    this.router.navigate(["/login/magic"], {
+  resetPassword() {
+    this.router.navigate(["/login/forgot"], {
       queryParams: { email: this.email },
     });
   }


### PR DESCRIPTION
Legacy accounts seeing the login hint were directed to sign in with a one-time code, which got them in once but left the root problem unsolved — they still had no WorkOS password and would hit the same wall next session.

Now the hint directs them to reset their password instead:
- Backend forgotPassword provisions the user in WorkOS (if not already there) before sending the reset email, so the email actually arrives
- Forgot-password page accepts an ?email= query param so it arrives pre-filled from the login hint
- After they set a password and log in successfully, resolveLocalUser migrates their authProvider to 'workos' automatically