### PR TITLE
fix(admin): build and deploy admin app, navigate in same tab

### DIFF
--- a/deploy.Dockerfile
+++ b/deploy.Dockerfile
@@ -32,6 +32,7 @@ RUN npm ci --ignore-scripts && npm cache clean --force
 COPY ./lib ../lib
 COPY ./frontend ./
 RUN npm run build -- --output-path=../build/app/public/
+RUN npm run build:admin -- --output-path=../build/app/public/admin/
 
 FROM --platform=amd64 node:20-alpine as serve-prod
 WORKDIR /bpni

--- a/frontend/src/app/module-blueprint/components/component-menu/component-menu.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-menu/component-menu.component.ts
@@ -406,7 +406,6 @@ export class ComponentMenuComponent
         label: $localize`Admin Panel`,
         icon: "pi pi-shield",
         url: "/admin",
-        target: "_blank",
         visible: isAdmin,
       },
       { separator: true },


### PR DESCRIPTION
The admin app was never included in the Docker build — deploy.Dockerfile only ran the main frontend build, so public/admin/ never existed and /admin fell through to the main Angular catch-all.

Also removes target="_blank" from the Admin Panel menu item so it navigates in the current tab instead of opening a new one.