### PR TITLE
fix(browse): prevent blueprint connection corruption when loading from browse menu

### DIFF
--- a/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.spec.ts
@@ -11,6 +11,7 @@ import { DatePipe } from "@angular/common";
 import { AuthenticationService } from "src/app/module-blueprint/services/authentification-service";
 import { BuildTool } from "src/app/module-blueprint/common/tools/build-tool";
 import { ComponentBlueprintParentComponent } from "./component-blueprint-parent.component";
+import { BlueprintService } from "src/app/module-blueprint/services/blueprint-service";
 import { ElementReport } from "src/app/module-blueprint/common/tools/element-report";
 import { SelectTool } from "src/app/module-blueprint/common/tools/select-tool";
 
@@ -47,5 +48,14 @@ describe("ComponentBlueprintParentComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should unsubscribe from blueprintService on destroy", () => {
+    const blueprintService = TestBed.inject(BlueprintService);
+    const observersBefore = blueprintService.observersBlueprintChanged.length;
+    fixture.destroy();
+    expect(blueprintService.observersBlueprintChanged.length).toBe(
+      observersBefore - 1
+    );
   });
 });

--- a/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.ts
@@ -2,6 +2,7 @@ import { HttpClient } from "@angular/common/http";
 import {
   Component,
   ElementRef,
+  OnDestroy,
   OnInit,
   Renderer2,
   ViewChild,
@@ -77,7 +78,7 @@ TODO Feature List before release :
   standalone: false,
 })
 export class ComponentBlueprintParentComponent
-  implements OnInit, IObsBlueprintChanged
+  implements OnInit, OnDestroy, IObsBlueprintChanged
 {
   @ViewChild("canvas", { static: true })
   canvas!: ComponentCanvasComponent;
@@ -201,6 +202,10 @@ export class ComponentBlueprintParentComponent
         this.sidePanelLeft.nativeElement.getBoundingClientRect().y;
       this.selectionTool.setMaxHeight(sidePanelPosition);
     }
+  }
+
+  ngOnDestroy() {
+    this.blueprintService.unsubscribeBlueprintChanged(this);
   }
 
   blueprintChanged(blueprint: Blueprint) {

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -69,6 +69,10 @@ export class BlueprintService implements IObsBlueprintChange {
   subscribeBlueprintChanged(observer: IObsBlueprintChanged) {
     this.observersBlueprintChanged.push(observer);
   }
+  unsubscribeBlueprintChanged(observer: IObsBlueprintChanged) {
+    const index = this.observersBlueprintChanged.indexOf(observer);
+    if (index !== -1) this.observersBlueprintChanged.splice(index, 1);
+  }
 
   openBlueprintFromUpload(fileType: BlueprintFileType, fileList: FileList) {
     if (fileList.length > 0) {


### PR DESCRIPTION
When navigating between routes (e.g. `/` → `/browse` → `/b/:id`), Angular destroys and recreates `ComponentBlueprintParentComponent` for each route change. Each new instance subscribed to `BlueprintService.observersBlueprintChanged` on init, but the destroyed instances were never removed, no `ngOnDestroy` was implemented.

After N navigations, N ghost subscribers accumulated. When `handleGetBlueprint fired`, every ghost subscriber called `blueprintChanged()` → `destroyAndCopyItems()` on the same source blueprint. The first call populated `blueprintService.blueprint` with the source items (added by reference). The second call then ran `destroy()` on `blueprintService.blueprint` which iterated those same items and cleared opposite connection bits on neighbours that were already in `templateTiles`. Since items are processed left-to-right/bottom-to-top, this propagated across the entire grid, zeroing bit 0 (Left) and bit 3 (Down) from every wire, reducing all connection flags to `originalFlags & 6`.

## Before
<img width="510" height="551" alt="Screenshot 2026-04-11 at 8 11 59 AM" src="https://github.com/user-attachments/assets/5c0d053b-8c6e-4f12-a232-d1288a815a4b" />

# Fix

Add `unsubscribeBlueprintChanged()` to `BlueprintService` and implement `ngOnDestroy` in `ComponentBlueprintParentComponent` to call it, ensuring each destroyed instance is removed from the observer list immediately.

Regression test: verifies that `fixture.destroy()` reduces the observer count by exactly 1, catching any future removal of `ngOnDestroy`.

## After
<img width="499" height="506" alt="Screenshot 2026-04-11 at 8 12 09 AM" src="https://github.com/user-attachments/assets/b1ee3b62-f0e5-444c-b9d6-86697db71ab0" />