### PR TITLE
fix: restore selection visuals on canvas (closes #27)

### DIFF
--- a/frontend/src/app/module-blueprint/common/tools/select-tool.spec.ts
+++ b/frontend/src/app/module-blueprint/common/tools/select-tool.spec.ts
@@ -1,0 +1,107 @@
+import { SelectTool } from "./select-tool";
+import { Vector2 } from "../../../../../../lib/index";
+
+describe("SelectTool", () => {
+  let tool: SelectTool;
+  let mockBlueprintService: any;
+  let mockDrawPixi: any;
+  let mockCamera: any;
+
+  beforeEach(() => {
+    mockBlueprintService = {
+      blueprint: {
+        getBlueprintItemsAt: () => [],
+      },
+    };
+    mockDrawPixi = {
+      drawTileRectangle: jasmine.createSpy("drawTileRectangle"),
+    };
+    mockCamera = {
+      cameraOffset: { x: 0, y: 0 },
+      currentZoom: 32,
+    };
+    tool = new SelectTool(mockBlueprintService as any);
+  });
+
+  describe("draw()", () => {
+    it("should not draw when no drag is active", () => {
+      tool.draw(mockDrawPixi, mockCamera);
+      expect(mockDrawPixi.drawTileRectangle).not.toHaveBeenCalled();
+    });
+
+    it("should draw selection rectangle while dragging", () => {
+      tool.drag(new Vector2(1, 5), new Vector2(4, 2));
+      tool.draw(mockDrawPixi, mockCamera);
+      expect(mockDrawPixi.drawTileRectangle).toHaveBeenCalledTimes(1);
+      const args = mockDrawPixi.drawTileRectangle.calls.mostRecent().args;
+      const [
+        camera,
+        topLeft,
+        bottomRight,
+        frontGraphics,
+        borderWidth,
+        fillColor,
+        borderColor,
+        fillAlpha,
+        borderAlpha,
+      ] = args;
+      expect(camera).toBe(mockCamera);
+      expect(topLeft.x).toBe(1);
+      expect(topLeft.y).toBe(5);
+      expect(bottomRight.x).toBe(4);
+      expect(bottomRight.y).toBe(2);
+      expect(frontGraphics).toBe(true); // must be true so it renders above blueprint tiles
+      expect(borderWidth).toBe(2);
+      expect(fillColor).toBe(0x4cff00); // lime green fill
+      expect(borderColor).toBe(0x2d9600); // dark green border
+      expect(fillAlpha).toBe(0.25);
+      expect(borderAlpha).toBe(0.8);
+    });
+
+    it("should normalise coordinates when drag goes top-right to bottom-left", () => {
+      // User drags from (5,1) to (1,5): beginSelection gets the larger coords
+      tool.drag(new Vector2(5, 1), new Vector2(1, 5));
+      tool.draw(mockDrawPixi, mockCamera);
+      const [, topLeft, bottomRight] =
+        mockDrawPixi.drawTileRectangle.calls.mostRecent().args;
+      expect(topLeft.x).toBeLessThanOrEqual(bottomRight.x);
+      expect(topLeft.y).toBeGreaterThanOrEqual(bottomRight.y);
+    });
+
+    it("should not draw after dragStop clears the selection", () => {
+      tool.drag(new Vector2(0, 5), new Vector2(3, 2));
+      tool.dragStop();
+      tool.draw(mockDrawPixi, mockCamera);
+      expect(mockDrawPixi.drawTileRectangle).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("drag()", () => {
+    it("should set beginSelection from the first valid tileStart", () => {
+      const start = new Vector2(2, 3);
+      tool.drag(start, new Vector2(4, 1));
+      expect(tool.beginSelection).toEqual(start);
+    });
+
+    it("should update endSelection on every drag event", () => {
+      tool.drag(new Vector2(0, 0), new Vector2(1, 1));
+      tool.drag(new Vector2(1, 1), new Vector2(5, 5));
+      expect(tool.endSelection).toEqual(new Vector2(5, 5));
+    });
+
+    it("should keep the original beginSelection across multiple drag events", () => {
+      const start = new Vector2(1, 4);
+      tool.drag(start, new Vector2(2, 3));
+      tool.drag(new Vector2(2, 3), new Vector2(3, 2));
+      expect(tool.beginSelection).toEqual(start);
+    });
+  });
+
+  describe("dragStop()", () => {
+    it("should clear beginSelection", () => {
+      tool.drag(new Vector2(0, 0), new Vector2(2, 2));
+      tool.dragStop();
+      expect(tool.beginSelection).toBeNull();
+    });
+  });
+});

--- a/frontend/src/app/module-blueprint/drawing/draw-pixi.ts
+++ b/frontend/src/app/module-blueprint/drawing/draw-pixi.ts
@@ -88,8 +88,8 @@ export class DrawPixi implements PixiUtil {
     this.blueprintContainer.addChild(this.utilityGraphicsBack);
     this.blueprintContainer.addChild(this.utilityGraphicsFront);
     this.pixiApp.stage.addChild(this.backGraphics);
-    this.pixiApp.stage.addChild(this.frontGraphics);
     this.pixiApp.stage.addChild(this.blueprintContainer);
+    this.pixiApp.stage.addChild(this.frontGraphics);
 
     //this.pixiApp.stage.sortableChildren = true;
     this.pixiApp.ticker.add(() => {

--- a/lib/src/blueprint/blueprint-item.ts
+++ b/lib/src/blueprint/blueprint-item.ts
@@ -579,12 +579,17 @@ export class BlueprintItem {
             drawPart.tint = 0x4cff00;
             drawPart.alpha = camera.sinWave * 0.8;
           }
+        } else if (drawPart.hasTag(SpriteTag.solid) && this.visualizationTint == -1) {
+          // Most buildings, tiles, and pipes have no white overlay sprite.
+          // Pulse the solid sprite itself — cameraChanged sets its tint to 0xffffff so
+          // the base is stable and the blend does not accumulate across frames.
+          drawPart.tint = DrawHelpers.blendColor(0xffffff, 0x4cff00, camera.sinWave);
         }
       } else if (camera.display == Display.blueprint) {
         if (drawPart.hasTag(SpriteTag.place)) {
-          drawPart.tint = DrawHelpers.blendColor(drawPart.tint, 0x4cff00, camera.sinWave);
-        } else if (drawPart.hasTag(SpriteTag.white)) {
-          drawPart.tint = DrawHelpers.blendColor(drawPart.tint, 0x4cff00, camera.sinWave);
+          drawPart.tint = DrawHelpers.blendColor(0xffffff, 0x4cff00, camera.sinWave);
+        } else if (drawPart.hasTag(SpriteTag.white) && this.visualizationTint !== -1) {
+          drawPart.tint = DrawHelpers.blendColor(this.visualizationTint, 0x4cff00, camera.sinWave);
         }
       }
 


### PR DESCRIPTION
Fixes https://github.com/blueprintnotincluded/blueprintnotincluded/issues/27

![selection](https://github.com/user-attachments/assets/96cc19fa-4203-41ea-bf63-e38d38eb1c11)

## What was broken

Two independent bugs caused selection feedback to be invisible:

1. **Drag-select rectangle not visible during drag** — the green marquee box drawn while click-dragging on the canvas was always hidden under all blueprint tiles.
2. **Selected items not highlighted** — selecting a building, tile, or pipe showed no visual change. Only water and other element tiles pulsed green correctly.

## Root causes

### 1. PIXI stage child order (`draw-pixi.ts`)

`frontGraphics` (where the drag-select rectangle is drawn) was added to the PIXI stage *before* `blueprintContainer` (where all tile sprites live). With `sortableChildren` disabled, PIXI renders children in insertion order, so every blueprint sprite was painted on top of the selection rectangle, completely hiding it.

### 2. Missing sprite tag on buildings and pipes (`blueprint-item.ts`)

`modulateSelectedTint` in solid-display mode only checked for `SpriteTag.white` (tag 27) drawParts. Inspection of the asset database confirmed that **no building, tile, or pipe has a white-overlay sprite** — only element tiles (water, gas) have those. So the selection loop found nothing to tint and silently did nothing.

Water worked because `BlueprintItemElement` has its own `modulateSelectedTint` override that targets `SpriteTag.element_back` sprites instead.

### 3. Tint accumulation in blueprint display mode (`blueprint-item.ts`)

The blueprint-mode branch of `modulateSelectedTint` blended from `drawPart.tint` — the already-mutated value from the previous frame — rather than from a stable baseline. Each frame compounded the blend, saturating the sprite to solid green almost immediately instead of producing a sinWave pulse.

## Fixes

| Commit | File | Change |
|--------|------|--------|
| `aae0a44` | `frontend/src/app/module-blueprint/drawing/draw-pixi.ts` | Move `frontGraphics` to be added to the PIXI stage after `blueprintContainer`, so the drag rectangle renders above all tiles |
| `cc1bb74` | `lib/src/blueprint/blueprint-item.ts` | Add `SpriteTag.solid` fallback in solid-mode selection: pulses the solid sprite directly from the stable `0xffffff` baseline. Fix blueprint-mode branch to blend from `0xffffff` (place sprites) or `visualizationTint` (white sprites) rather than the accumulated `drawPart.tint` |

## Tests

Added `select-tool.spec.ts` (8 tests) covering:

- No draw call when no drag is active
- Draw call present with correct arguments while dragging
- `frontGraphics: true` flag — ensures the overlay targets the layer above blueprint tiles
- Coordinate normalisation for drags in any direction
- `beginSelection` cleared after `dragStop`
