### PR TITLE
fix(styles): replace hard-coded colors with PrimeNG theme vars for dark mode

### DIFF
--- a/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.css
+++ b/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.css
@@ -1,5 +1,5 @@
 .error-red {
-  color: darkred;
+  color: var(--p-red-500);
   margin-left: 0.5em;
 }
 

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.css
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.css
@@ -1,5 +1,5 @@
 .error-red {
-  color: darkred;
+  color: var(--p-red-500);
   margin-left: 0.5em;
 }
 
@@ -16,7 +16,7 @@
   padding: 10px;
 
   border-radius: 3px;
-  border: 1px solid #c8c8c8;
+  border: 1px solid var(--p-content-border-color);
 }
 
 .title-line {

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-export-images/dialog-export-images.component.css
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-export-images/dialog-export-images.component.css
@@ -15,6 +15,6 @@
 }
 
 .error-red {
-  color: darkred;
+  color: var(--p-red-500);
   margin-left: 0.5em;
 }

--- a/frontend/src/app/module-blueprint/components/side-bar/build-tool/build-tool.component.css
+++ b/frontend/src/app/module-blueprint/components/side-bar/build-tool/build-tool.component.css
@@ -34,7 +34,7 @@
 }
 
 .error-red {
-  color: darkred;
+  color: var(--p-red-500);
   text-align: justify;
 }
 

--- a/frontend/src/app/module-blueprint/components/side-bar/buildable-element-picker/buildable-element-picker.component.css
+++ b/frontend/src/app/module-blueprint/components/side-bar/buildable-element-picker/buildable-element-picker.component.css
@@ -19,7 +19,7 @@
 }
 
 .error-red {
-  color: darkred;
+  color: var(--p-red-500);
   font-size: smaller;
   text-align: justify;
 }

--- a/frontend/src/app/module-blueprint/components/side-bar/pipe-content/pipe-content.component.css
+++ b/frontend/src/app/module-blueprint/components/side-bar/pipe-content/pipe-content.component.css
@@ -19,7 +19,7 @@
 }
 
 .error-red {
-  color: darkred;
+  color: var(--p-red-500);
   font-size: smaller;
   text-align: justify;
 }

--- a/frontend/src/app/module-blueprint/components/side-bar/temperature-picker/temperature-picker.component.css
+++ b/frontend/src/app/module-blueprint/components/side-bar/temperature-picker/temperature-picker.component.css
@@ -20,7 +20,7 @@
 }
 
 .error-red {
-  color: darkred;
+  color: var(--p-red-500);
   font-size: smaller;
   text-align: justify;
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -18,9 +18,9 @@ body {
 }
 
 .ui-clickable-icon {
-  color: #333333;
-  background-color: #f4f4f4;
-  border: 1px solid #f4f4f4;
+  color: var(--p-text-color);
+  background-color: var(--p-content-hover-background);
+  border: 1px solid var(--p-content-hover-background);
   box-sizing: border-box;
   display: inline-block;
   transition: background-color 0.2s, box-shadow 0.2s;
@@ -29,9 +29,9 @@ body {
 }
 
 .ui-clickable-icon:hover {
-  background-color: #c8c8c8;
-  color: #333333;
-  border-color: #c8c8c8;
+  background-color: var(--p-content-border-color);
+  color: var(--p-text-color);
+  border-color: var(--p-content-border-color);
 }
 
 .ui-clickable-icon:focus {
@@ -41,27 +41,28 @@ body {
 }
 
 .ui-clickable-icon:active {
-  background-color: #a0a0a0;
-  color: #333333;
-  border-color: #a0a0a0;
+  background-color: var(--p-content-border-color);
+  color: var(--p-text-color);
+  border-color: var(--p-content-border-color);
+  filter: brightness(0.9);
 }
 
 .ui-close-button {
-  color: #848484;
+  color: var(--p-text-muted-color);
   float: right;
   cursor: pointer;
   transition: color 0.2s;
 }
 
 .ui-close-button:hover {
-  color: #333333;
+  color: var(--p-text-color);
 }
 
 .ui-fieldset {
-  border: 1px solid #c8c8c8;
-  background-color: #fff;
+  border: 1px solid var(--p-content-border-color);
+  background-color: var(--p-content-background);
   border-radius: 3px;
-  color: #333;
+  color: var(--p-text-color);
 }
 
 .ui-widget {
@@ -80,8 +81,8 @@ body {
 }
 
 .box-card {
-  background-color: #ffffff;
-  color: #333333;
+  background-color: var(--p-content-background);
+  color: var(--p-text-color);
   border-radius: 3px;
   padding: 10px;
   width: 100%;


### PR DESCRIPTION
PrimeNG 20 + Aura uses darkModeSelector: "system" by default, meaning its own components adapt to prefers-color-scheme: dark automatically. Our custom utility classes used hard-coded light-mode hex values, causing jarring mismatches: white card backgrounds, light-gray element buttons, and near-invisible darkred error text on dark surfaces.

<img width="301" height="591" alt="before" src="https://github.com/user-attachments/assets/6ccadb59-3d77-4b23-b191-b046ef1b28b7" />
<img width="298" height="486" alt="after" src="https://github.com/user-attachments/assets/12e5cbda-2329-431b-8ea4-45f3f2d8a967" />

Semantic token substitutions in styles.css:
- .box-card bg/color → --p-content-background / --p-text-color
- .ui-fieldset bg/border/color → --p-content-background / --p-content-border-color / --p-text-color
- .ui-clickable-icon states → --p-content-hover-background (default), --p-content-border-color (hover/active) + brightness(0.9) filter
- .ui-close-button → --p-text-muted-color / --p-text-color

In 7 component CSS files:
- .error-red: darkred → --p-red-500 (visible on both light/dark)

Also fixes .blueprint-line border in dialog-browse from #c8c8c8 to --p-content-border-color.