### PR TITLE
fix(auth): surface password policy errors on reset instead of hiding the form

### DIFF
--- a/__tests__/api/custom-auth.test.ts
+++ b/__tests__/api/custom-auth.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
+import sinon from 'sinon';
+import { BadRequestException, NotFoundException } from '@workos-inc/node';
 import dotenv from 'dotenv';
 import path from 'path';
 
@@ -9,6 +11,7 @@ process.env.NODE_ENV = 'test';
 
 import { TestSetup } from '../setup/testSetup';
 import { generateUniqueUsername } from '../../app/api/auth-controller';
+import { WorkOSService } from '../../app/api/services/workos-service';
 
 describe('Custom Auth API', function () {
   let testData: any;
@@ -20,6 +23,7 @@ describe('Custom Auth API', function () {
 
   afterEach(async function () {
     this.timeout(5000);
+    sinon.restore();
     await TestSetup.afterEach();
   });
 
@@ -167,6 +171,59 @@ describe('Custom Auth API', function () {
       const response = await TestSetup.request()
         .post('/api/auth/reset-password')
         .send({ token: 'some-token' });
+      expect(response.status).to.equal(400);
+    });
+
+    it('should return 400 with a descriptive message when the token is not found', async function () {
+      sinon.stub(console, 'error');
+      sinon.stub(WorkOSService, 'resetPassword').rejects(
+        new NotFoundException({ code: 'password_reset_token_not_found', message: 'Could not locate user with provided token', path: '/user_management/password_reset/confirm', requestID: 'req_test' }),
+      );
+
+      const response = await TestSetup.request()
+        .post('/api/auth/reset-password')
+        .send({ token: 'expired-token', newPassword: 'NewPass123!' });
+
+      expect(response.status).to.equal(400);
+      expect(response.body.errors[0].title).to.include('invalid or has expired');
+    });
+
+    it('should return 422 and keep the form usable when WorkOS rejects the password', async function () {
+      sinon.stub(console, 'error');
+      sinon.stub(WorkOSService, 'resetPassword').rejects(
+        new BadRequestException({ code: 'password_reset_error', message: 'Could not reset password.', errors: [{ message: 'Password is too weak' }], requestID: 'req_test' }),
+      );
+
+      const response = await TestSetup.request()
+        .post('/api/auth/reset-password')
+        .send({ token: 'valid-token', newPassword: 'weak' });
+
+      expect(response.status).to.equal(422);
+      expect(response.body.errors[0].title).to.equal('Password is too weak');
+    });
+
+    it('should return 422 with a generic policy message when WorkOS errors array has no message', async function () {
+      sinon.stub(console, 'error');
+      sinon.stub(WorkOSService, 'resetPassword').rejects(
+        new BadRequestException({ code: 'password_reset_error', message: 'Could not reset password.', requestID: 'req_test' }),
+      );
+
+      const response = await TestSetup.request()
+        .post('/api/auth/reset-password')
+        .send({ token: 'valid-token', newPassword: 'weak' });
+
+      expect(response.status).to.equal(422);
+      expect(response.body.errors[0].title).to.include('does not meet the requirements');
+    });
+
+    it('should return 400 for an unexpected WorkOS error', async function () {
+      sinon.stub(console, 'error');
+      sinon.stub(WorkOSService, 'resetPassword').rejects(new Error('Unexpected network failure'));
+
+      const response = await TestSetup.request()
+        .post('/api/auth/reset-password')
+        .send({ token: 'some-token', newPassword: 'NewPass123!' });
+
       expect(response.status).to.equal(400);
     });
   });

--- a/app/api/auth-controller.ts
+++ b/app/api/auth-controller.ts
@@ -358,9 +358,25 @@ export class AuthController {
     try {
       await WorkOSService.resetPassword(token, newPassword);
       res.json({ message: 'Password reset successfully' });
-    } catch (err) {
+    } catch (err: any) {
       console.error('resetPassword error:', err);
-      res.status(400).json(apiError(400, 'Invalid or expired reset token'));
+
+      if (err?.code === 'password_reset_token_not_found') {
+        res.status(400).json(apiError(400, 'Reset link is invalid or has expired. Please request a new one.'));
+        return;
+      }
+
+      if (err?.code === 'password_reset_error') {
+        // Password policy violation — surface WorkOS detail if available
+        const detail: string =
+          err?.errors?.[0]?.message ||
+          err?.errors?.[0]?.code ||
+          'Password does not meet the requirements. Please try a different password.';
+        res.status(422).json(apiError(422, detail));
+        return;
+      }
+
+      res.status(400).json(apiError(400, 'Could not reset password. Please request a new reset link.'));
     }
   }
 

--- a/frontend/src/app/module-blueprint/components/user-auth/reset-password/reset-password.component.ts
+++ b/frontend/src/app/module-blueprint/components/user-auth/reset-password/reset-password.component.ts
@@ -50,10 +50,19 @@ export class ResetPasswordComponent implements OnInit {
         },
         error: (err) => {
           this.loading = false;
-          this.tokenError = true;
           const title = err?.error?.errors?.[0]?.title;
-          this.errorMessage =
-            title || "Failed to reset password. The link may have expired.";
+          if (err?.status === 422) {
+            // Password policy violation — keep form visible so user can retry
+            this.tokenError = false;
+            this.errorMessage =
+              title ||
+              "Password does not meet the requirements. Please try a different password.";
+          } else {
+            // Invalid or expired token — hide form, prompt for new link
+            this.tokenError = true;
+            this.errorMessage =
+              title || "Failed to reset password. The link may have expired.";
+          }
         },
       });
   }


### PR DESCRIPTION
All WorkOS reset failures showed "Invalid or expired reset token" and hid the form, even when the token was valid but the password was too weak. Users had no way to retry with a better password.

- 400 password_reset_token_not_found → clear expiry message + new-link prompt
- 400 password_reset_error → 422 with WorkOS policy detail, form stays visible
- Frontend branches on HTTP 422 to keep form open vs hiding it on token errors

<img width="447" height="313" alt="Screenshot 2026-04-14 at 7 57 41 PM" src="https://github.com/user-attachments/assets/01191896-30e6-47a8-a286-03b99ad5d077" />