### PR TITLE
Unskip frontend tests

### DIFF
--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -2,7 +2,7 @@ import { TestBed, waitForAsync } from "@angular/core/testing";
 import { RouterOutlet } from "@angular/router";
 import { AppComponent } from "./app.component";
 
-xdescribe("AppComponent", () => {
+describe("AppComponent", () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [AppComponent],
@@ -20,14 +20,5 @@ xdescribe("AppComponent", () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app.title).toEqual("blueprintnotincluded");
-  });
-
-  it("should render title", () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector(".content span").textContent).toContain(
-      "blueprintnotincluded app is running!"
-    );
   });
 });

--- a/frontend/src/app/module-blueprint/components/component-menu/component-menu.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/component-menu/component-menu.component.spec.ts
@@ -1,32 +1,43 @@
 import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from "@angular/common/http";
-import { RouterTestingModule } from "@angular/router/testing";
+import { LOCALE_ID, NO_ERRORS_SCHEMA } from "@angular/core";
+import { Router } from "@angular/router";
 import { MessageService } from "primeng/api";
 
+import { CameraService } from "../../../../../../lib/index";
 import { AuthenticationService } from "src/app/module-blueprint/services/authentification-service";
-import { BuildTool } from "src/app/module-blueprint/common/tools/build-tool";
-import { ElementReport } from "src/app/module-blueprint/common/tools/element-report";
+import { BlueprintService } from "src/app/module-blueprint/services/blueprint-service";
+import { ToolService } from "src/app/module-blueprint/services/tool-service";
 import { ComponentMenuComponent } from "./component-menu.component";
-import { SelectTool } from "src/app/module-blueprint/common/tools/select-tool";
 
-xdescribe("ComponentMenuComponent", () => {
+describe("ComponentMenuComponent", () => {
   let component: ComponentMenuComponent;
   let fixture: ComponentFixture<ComponentMenuComponent>;
 
   beforeEach(waitForAsync(() => {
+    // The component subscribes to the CameraService singleton in its
+    // constructor; instantiate one so the static accessor is populated.
+    new CameraService(null);
+
     TestBed.configureTestingModule({
       declarations: [ComponentMenuComponent],
-      imports: [RouterTestingModule.withRoutes([])],
+      schemas: [NO_ERRORS_SCHEMA],
       providers: [
-        AuthenticationService,
-        BuildTool,
-        ElementReport,
-        MessageService,
-        SelectTool,
-        provideHttpClient(withInterceptorsFromDi()),
+        {
+          provide: AuthenticationService,
+          useValue: { isLoggedIn: () => false, getUserDetails: () => null },
+        },
+        { provide: MessageService, useValue: {} },
+        {
+          provide: ToolService,
+          useValue: {
+            subscribeToolChanged: () => {},
+            changeTool: () => {},
+            getTool: () => ({ visible: false }),
+          },
+        },
+        { provide: BlueprintService, useValue: {} },
+        { provide: Router, useValue: { navigate: () => {} } },
+        { provide: LOCALE_ID, useValue: "en-US" },
       ],
     }).compileComponents();
   }));

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.spec.ts
@@ -1,26 +1,31 @@
 import { DatePipe } from "@angular/common";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from "@angular/common/http";
 import { RouterTestingModule } from "@angular/router/testing";
+import { DialogModule } from "primeng/dialog";
 
 import { DialogBrowseComponent } from "./dialog-browse.component";
 import { AuthenticationService } from "src/app/module-blueprint/services/authentification-service";
+import { BlueprintService } from "src/app/module-blueprint/services/blueprint-service";
 
-xdescribe("DialogBrowseComponent", () => {
+describe("DialogBrowseComponent", () => {
   let component: DialogBrowseComponent;
   let fixture: ComponentFixture<DialogBrowseComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [DialogBrowseComponent],
-      imports: [RouterTestingModule.withRoutes([])],
+      // DialogModule is real so the #browseDialog ViewChild (whose onShow
+      // ngOnInit subscribes to) resolves; everything else is shallow.
+      imports: [RouterTestingModule.withRoutes([]), DialogModule],
+      schemas: [NO_ERRORS_SCHEMA],
       providers: [
-        AuthenticationService,
         DatePipe,
-        provideHttpClient(withInterceptorsFromDi()),
+        {
+          provide: AuthenticationService,
+          useValue: { isLoggedIn: () => false },
+        },
+        { provide: BlueprintService, useValue: {} },
       ],
     }).compileComponents();
   }));

--- a/frontend/src/app/module-blueprint/components/side-bar/cell-element-picker/cell-element-picker.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/cell-element-picker/cell-element-picker.component.spec.ts
@@ -1,18 +1,26 @@
 import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormsModule } from "@angular/forms";
+import { CheckboxModule } from "primeng/checkbox";
+import { InputTextModule } from "primeng/inputtext";
 
+import { BuildableElement } from "../../../../../../../lib/index";
+import { ElementIconComponent } from "../element-icon/element-icon.component";
 import { CellElementPickerComponent } from "./cell-element-picker.component";
 
-xdescribe("CellElementPickerComponent", () => {
+describe("CellElementPickerComponent", () => {
   let component: CellElementPickerComponent;
   let fixture: ComponentFixture<CellElementPickerComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [CellElementPickerComponent],
+      declarations: [CellElementPickerComponent, ElementIconComponent],
+      imports: [FormsModule, CheckboxModule, InputTextModule],
     }).compileComponents();
   }));
 
   beforeEach(() => {
+    BuildableElement.init();
+    BuildableElement.load([]);
     fixture = TestBed.createComponent(CellElementPickerComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/frontend/src/app/module-blueprint/components/side-bar/element-icon/element-icon.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/element-icon/element-icon.component.spec.ts
@@ -1,8 +1,9 @@
 import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
 
+import { BuildableElement } from "../../../../../../../lib/index";
 import { ElementIconComponent } from "./element-icon.component";
 
-xdescribe("ElementIconComponent", () => {
+describe("ElementIconComponent", () => {
   let component: ElementIconComponent;
   let fixture: ComponentFixture<ElementIconComponent>;
 
@@ -15,6 +16,12 @@ xdescribe("ElementIconComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ElementIconComponent);
     component = fixture.componentInstance;
+    const element = new BuildableElement();
+    element.id = "None";
+    element.name = "None";
+    component.element = element;
+    component.width = "16px";
+    component.height = "16px";
     fixture.detectChanges();
   });
 

--- a/frontend/src/app/module-blueprint/components/side-bar/element-report-tool/element-report-tool.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/element-report-tool/element-report-tool.component.spec.ts
@@ -1,30 +1,35 @@
+import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from "@angular/common/http";
-import { RouterTestingModule } from "@angular/router/testing";
 
-import { AuthenticationService } from "src/app/module-blueprint/services/authentification-service";
-import { BuildTool } from "src/app/module-blueprint/common/tools/build-tool";
-import { ElementReport } from "src/app/module-blueprint/common/tools/element-report";
+import { CameraService } from "../../../../../../../lib/index";
+import { ToolService } from "src/app/module-blueprint/services/tool-service";
+import { AddMassUnitPipe } from "src/app/module-blueprint/pipes/add-mass-unit.pipe";
+import { FilterElementGasPipe } from "src/app/module-blueprint/pipes/filter-element-gas.pipe";
+import { FilterElementLiquidPipe } from "src/app/module-blueprint/pipes/filter-element-liquid.pipe";
+import { FilterElementSolidPipe } from "src/app/module-blueprint/pipes/filter-element-solid.pipe";
 import { ElementReportToolComponent } from "./element-report-tool.component";
-import { SelectTool } from "src/app/module-blueprint/common/tools/select-tool";
 
-xdescribe("ElementReportToolComponent", () => {
+describe("ElementReportToolComponent", () => {
   let component: ElementReportToolComponent;
   let fixture: ComponentFixture<ElementReportToolComponent>;
 
   beforeEach(waitForAsync(() => {
+    // The constructor reads the CameraService singleton.
+    new CameraService(null);
+
     TestBed.configureTestingModule({
-      declarations: [ElementReportToolComponent],
-      imports: [RouterTestingModule.withRoutes([])],
+      // The pipes the template uses must be declared even under
+      // NO_ERRORS_SCHEMA (schemas don't cover pipes).
+      declarations: [
+        ElementReportToolComponent,
+        AddMassUnitPipe,
+        FilterElementGasPipe,
+        FilterElementLiquidPipe,
+        FilterElementSolidPipe,
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
       providers: [
-        AuthenticationService,
-        BuildTool,
-        ElementReport,
-        SelectTool,
-        provideHttpClient(withInterceptorsFromDi()),
+        { provide: ToolService, useValue: { elementReport: { data: [] } } },
       ],
     }).compileComponents();
   }));

--- a/frontend/src/app/module-blueprint/components/side-bar/info-input/info-input.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/info-input/info-input.component.spec.ts
@@ -1,20 +1,34 @@
 import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormsModule } from "@angular/forms";
+import { ColorPickerModule } from "primeng/colorpicker";
+import { InputTextModule } from "primeng/inputtext";
+import { PopoverModule } from "primeng/popover";
 
+import { BlueprintItemInfo } from "../../../../../../../lib/src/blueprint/blueprint-item-info";
+import { InfoInputIconComponent } from "../info-input-icon/info-input-icon.component";
 import { InfoInputComponent } from "./info-input.component";
 
-xdescribe("InfoInputComponent", () => {
+describe("InfoInputComponent", () => {
   let component: InfoInputComponent;
   let fixture: ComponentFixture<InfoInputComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [InfoInputComponent],
+      declarations: [InfoInputComponent, InfoInputIconComponent],
+      imports: [FormsModule, ColorPickerModule, InputTextModule, PopoverModule],
     }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(InfoInputComponent);
     component = fixture.componentInstance;
+    component.blueprintIteminfo = {
+      infoString: "",
+      title: "",
+      htmlFrontColor: "#ffffff",
+      htmlBackColor: "#007ad9",
+      htmlSvgPath: "",
+    } as unknown as BlueprintItemInfo;
     fixture.detectChanges();
   });
 

--- a/frontend/src/app/module-blueprint/components/side-bar/item-collection-info/item-collection-info.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/item-collection-info/item-collection-info.component.spec.ts
@@ -1,30 +1,22 @@
+import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from "@angular/common/http";
-import { RouterTestingModule } from "@angular/router/testing";
 
-import { BuildTool } from "src/app/module-blueprint/common/tools/build-tool";
-import { ElementReport } from "src/app/module-blueprint/common/tools/element-report";
+import { SameItemCollection } from "src/app/module-blueprint/common/tools/same-item-collection";
+import { BlueprintService } from "src/app/module-blueprint/services/blueprint-service";
+import { ToolService } from "src/app/module-blueprint/services/tool-service";
 import { ItemCollectionInfoComponent } from "./item-collection-info.component";
-import { AuthenticationService } from "src/app/module-blueprint/services/authentification-service";
-import { SelectTool } from "src/app/module-blueprint/common/tools/select-tool";
 
-xdescribe("ItemCollectionInfoComponent", () => {
+describe("ItemCollectionInfoComponent", () => {
   let component: ItemCollectionInfoComponent;
   let fixture: ComponentFixture<ItemCollectionInfoComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ItemCollectionInfoComponent],
-      imports: [RouterTestingModule.withRoutes([])],
+      schemas: [NO_ERRORS_SCHEMA],
       providers: [
-        AuthenticationService,
-        BuildTool,
-        ElementReport,
-        SelectTool,
-        provideHttpClient(withInterceptorsFromDi()),
+        { provide: BlueprintService, useValue: {} },
+        { provide: ToolService, useValue: {} },
       ],
     }).compileComponents();
   }));
@@ -32,6 +24,21 @@ xdescribe("ItemCollectionInfoComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ItemCollectionInfoComponent);
     component = fixture.componentInstance;
+    // The template reads a wide slice of the collection; zIndex is kept
+    // off the conduit values so showPipeContent stays false.
+    component.itemCollection = {
+      items: [{ buildableElements: [{ hasTag: () => false }] }],
+      oniItem: {
+        isInfo: false,
+        iconUrl: null,
+        buildableElementsArray: [],
+        name: "Test",
+        zIndex: -1,
+      },
+      nbElements: 0,
+      temperatureWarning: false,
+      subscribeSelected: () => {},
+    } as unknown as SameItemCollection;
     fixture.detectChanges();
   });
 

--- a/frontend/src/app/module-blueprint/components/side-bar/item-collection-info/item-collection-info.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/item-collection-info/item-collection-info.component.spec.ts
@@ -35,7 +35,7 @@ describe("ItemCollectionInfoComponent", () => {
         name: "Test",
         zIndex: -1,
       },
-      nbElements: 0,
+      nbElements: [0],
       temperatureWarning: false,
       subscribeSelected: () => {},
     } as unknown as SameItemCollection;

--- a/frontend/src/app/module-blueprint/components/side-bar/pipe-content/pipe-content.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/pipe-content/pipe-content.component.spec.ts
@@ -1,20 +1,37 @@
 import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormsModule } from "@angular/forms";
+import { CheckboxModule } from "primeng/checkbox";
+import { PopoverModule } from "primeng/popover";
 
+import { BuildableElement } from "../../../../../../../lib";
+import { CellElementPickerComponent } from "../cell-element-picker/cell-element-picker.component";
+import { ElementIconComponent } from "../element-icon/element-icon.component";
 import { PipeContentComponent } from "./pipe-content.component";
 
-xdescribe("PipeContentComponent", () => {
+describe("PipeContentComponent", () => {
   let component: PipeContentComponent;
   let fixture: ComponentFixture<PipeContentComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [PipeContentComponent],
+      declarations: [
+        PipeContentComponent,
+        ElementIconComponent,
+        CellElementPickerComponent,
+      ],
+      imports: [FormsModule, CheckboxModule, PopoverModule],
     }).compileComponents();
   }));
 
   beforeEach(() => {
+    BuildableElement.init();
+    BuildableElement.load([]);
     fixture = TestBed.createComponent(PipeContentComponent);
     component = fixture.componentInstance;
+    const element = new BuildableElement();
+    element.id = "None";
+    element.name = "None";
+    component.currentElement = element;
     fixture.detectChanges();
   });
 

--- a/frontend/src/app/module-blueprint/components/side-bar/temperature-picker/temperature-picker.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/temperature-picker/temperature-picker.component.spec.ts
@@ -1,20 +1,30 @@
 import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormsModule } from "@angular/forms";
+import { SliderModule } from "primeng/slider";
 
+import { BlueprintItem } from "../../../../../../../lib/index";
 import { TemperaturePickerComponent } from "./temperature-picker.component";
 
-xdescribe("TemperaturePickerComponent", () => {
+describe("TemperaturePickerComponent", () => {
   let component: TemperaturePickerComponent;
   let fixture: ComponentFixture<TemperaturePickerComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [TemperaturePickerComponent],
+      imports: [FormsModule, SliderModule],
     }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TemperaturePickerComponent);
     component = fixture.componentInstance;
+    component.blueprintItem = {
+      temperature: 293.15,
+      temperatureCelcius: 20,
+      temperatureScale: 50,
+    } as unknown as BlueprintItem;
+    component.temperatureWarning = false;
     fixture.detectChanges();
   });
 

--- a/frontend/src/app/module-blueprint/components/side-bar/temperature-scale/temperature-scale.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/temperature-scale/temperature-scale.component.spec.ts
@@ -1,20 +1,16 @@
 import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from "@angular/common/http";
 
+import { GameStringService } from "../../../services/game-string-service";
 import { TemperatureScaleComponent } from "./temperature-scale.component";
 
-xdescribe("TemperatureScaleComponent", () => {
+describe("TemperatureScaleComponent", () => {
   let component: TemperatureScaleComponent;
   let fixture: ComponentFixture<TemperatureScaleComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [TemperatureScaleComponent],
-      imports: [],
-      providers: [provideHttpClient(withInterceptorsFromDi())],
+      providers: [{ provide: GameStringService, useValue: { dict: {} } }],
     }).compileComponents();
   }));
 

--- a/frontend/src/app/module-blueprint/components/side-bar/ui-screens/single-slider-screen/single-slider-screen.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/ui-screens/single-slider-screen/single-slider-screen.component.spec.ts
@@ -1,20 +1,39 @@
 import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormsModule } from "@angular/forms";
+import { SliderModule } from "primeng/slider";
 
+import {
+  BlueprintItem,
+  BSingleSliderSideScreen,
+} from "../../../../../../../../lib/index";
 import { SingleSliderScreenComponent } from "./single-slider-screen.component";
 
-xdescribe("SingleSliderScreenComponent", () => {
+describe("SingleSliderScreenComponent", () => {
   let component: SingleSliderScreenComponent;
   let fixture: ComponentFixture<SingleSliderScreenComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [SingleSliderScreenComponent],
+      imports: [FormsModule, SliderModule],
     }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SingleSliderScreenComponent);
     component = fixture.componentInstance;
+    component.singleSliderSideScreen = {
+      id: "slider",
+      title: "Slider",
+      sliderUnits: "%",
+      min: 0,
+      max: 100,
+      tooltip: "{0}",
+      sliderDecimalPlaces: 0,
+    } as unknown as BSingleSliderSideScreen;
+    component.blueprintItem = {
+      getUiSettings: () => ({ values: [50] }),
+    } as unknown as BlueprintItem;
     fixture.detectChanges();
   });
 

--- a/frontend/src/app/module-blueprint/components/side-bar/ui-screens/threshold-switch-screen/threshold-switch-screen.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/ui-screens/threshold-switch-screen/threshold-switch-screen.component.spec.ts
@@ -1,20 +1,42 @@
 import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormsModule } from "@angular/forms";
+import { ButtonModule } from "primeng/button";
+import { SliderModule } from "primeng/slider";
 
+import {
+  BlueprintItem,
+  BThresholdSwitchSideScreen,
+} from "../../../../../../../../lib/index";
 import { ThresholdSwhitchScreenComponent } from "./threshold-switch-screen.component";
 
-xdescribe("ThresholdSwhitchScreenComponent", () => {
+describe("ThresholdSwhitchScreenComponent", () => {
   let component: ThresholdSwhitchScreenComponent;
   let fixture: ComponentFixture<ThresholdSwhitchScreenComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ThresholdSwhitchScreenComponent],
+      imports: [FormsModule, ButtonModule, SliderModule],
     }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ThresholdSwhitchScreenComponent);
     component = fixture.componentInstance;
+    component.thresholdSwitchSideScreen = {
+      id: "threshold",
+      title: "Threshold",
+      thresholdValueUnits: "g",
+      rangeMin: 0,
+      rangeMax: 100,
+      incrementScale: 1,
+      aboveToolTip: "Above {0}",
+      belowToolTip: "Below {0}",
+    } as unknown as BThresholdSwitchSideScreen;
+    component.blueprintItem = {
+      id: "TestBuilding",
+      getUiSettings: () => ({ values: [50, true] }),
+    } as unknown as BlueprintItem;
     fixture.detectChanges();
   });
 

--- a/frontend/src/app/module-blueprint/components/side-bar/ui-screens/ui-screen-container/ui-screen-container.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/ui-screens/ui-screen-container/ui-screen-container.component.spec.ts
@@ -1,8 +1,9 @@
 import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
 
+import { BlueprintItem } from "../../../../../../../../lib/index";
 import { UiScreenContainerComponent } from "./ui-screen-container.component";
 
-xdescribe("UiScreenContainerComponent", () => {
+describe("UiScreenContainerComponent", () => {
   let component: UiScreenContainerComponent;
   let fixture: ComponentFixture<UiScreenContainerComponent>;
 
@@ -15,6 +16,9 @@ xdescribe("UiScreenContainerComponent", () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(UiScreenContainerComponent);
     component = fixture.componentInstance;
+    component.blueprintItem = {
+      oniItem: { uiScreens: [] },
+    } as unknown as BlueprintItem;
     fixture.detectChanges();
   });
 


### PR DESCRIPTION
## What

Re-enables the 14 frontend component specs that were marked `xdescribe`/pending on 2023-03-24 in `cfb1590a` ("Mark remaining 17 failing tests pending"). Each spec is unskipped and fixed so it passes against the current Angular 20 / PrimeNG 20 stack, rather than being deleted.

## Why

These specs had been silently skipped for over three years, so every component below shipped with no test coverage. Most failures were not real bugs — they were stale test setups: required `@Input()`s never provided, PrimeNG modules no longer imported, or static game-data registries never initialized. Restoring them gives real smoke coverage of component construction and template binding.

## Specs restored

| Component | Fix applied |
|---|---|
| `AppComponent` | Kept the two real tests; dropped the stale "should render title" assertion against the deleted CLI starter template |
| `ElementIconComponent` | Provide a default `BuildableElement` input before `detectChanges` |
| `UiScreenContainerComponent` | Stub the `blueprintItem` input with empty `uiScreens` |
| `TemperaturePickerComponent` | Stub `blueprintItem`; import `FormsModule`/`SliderModule` for the `p-slider` ngModel binding |
| `PipeContentComponent` | Stub `currentElement`, declare child components (popover content runs `ngOnInit` eagerly), init the `BuildableElement` registry |
| `CellElementPickerComponent` | Init the `BuildableElement` registry (`ngOnInit` filters it); add `FormsModule` + PrimeNG modules |
| `InfoInputComponent` | Stub `blueprintIteminfo` (a real one needs the full game-data registry); import bound modules |
| `SingleSliderScreenComponent` | Stub side-screen config + `blueprintItem.getUiSettings`; import `FormsModule`/`SliderModule` |
| `ThresholdSwitchScreenComponent` | Stub side-screen config + ui settings; import `FormsModule`/`ButtonModule`/`SliderModule` |
| `TemperatureScaleComponent` | Provide a stub `GameStringService.dict` instead of a real `HttpClient` |
| `ComponentMenuComponent` | Shallow test (`NO_ERRORS_SCHEMA`) + stub services; init the `CameraService` singleton the constructor subscribes to |
| `DialogBrowseComponent` | Keep `DialogModule` real (`ngOnInit` subscribes to the dialog ViewChild's `onShow`); shallow-render the rest with stub services |
| `ItemCollectionInfoComponent` | Provide a `SameItemCollection` stub broad enough for template bindings (kept off conduit zIndex values); shallow-render. Follow-up: corrected the stub's `nbElements` to a `number[]` to match the type read by `BuildableElementPickerComponent.showWarning` |
| `ElementReportToolComponent` | Init the `CameraService` singleton; declare the template's custom pipes (schemas don't cover pipes); stub `ToolService.elementReport` |

## Notes

- No production code changed — test-only.
- Recurring techniques: stub required `@Input()`s, initialize the static `BuildableElement`/`CameraService` singletons that constructors and `ngOnInit` touch, and re-import the PrimeNG/Forms modules the templates bind to. Heavily-wired components use `NO_ERRORS_SCHEMA` shallow rendering with stub services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
