### PR TITLE
perf(blueprint-item): cache rotated utility connection offsets

### DIFF
--- a/frontend/src/app/module-blueprint/common/tools/build-tool.ts
+++ b/frontend/src/app/module-blueprint/common/tools/build-tool.ts
@@ -79,24 +79,22 @@ export class BuildTool implements ITool {
       }
     }
 
-    for (let connectionToBuild of this.templateItemToBuild.oniItem
-      .utilityConnections) {
-      // We rotate and scale the offset, and add to the position
-      let connectionToBuildPosition = Vector2.cloneNullToZero(
-        connectionToBuild.offset
+    const utilityConnections =
+      this.templateItemToBuild.oniItem.utilityConnections;
+    for (
+      let connectionIndex = 0;
+      connectionIndex < utilityConnections.length;
+      connectionIndex++
+    ) {
+      let connectionToBuild = utilityConnections[connectionIndex];
+      // Rotation/scale are baked into this cache whenever the candidate's orientation changes;
+      // only the (cheap) position offset needs to happen per hover.
+      let cachedOffset =
+        this.templateItemToBuild.utilityConnectionOffsets[connectionIndex];
+      let connectionToBuildPosition = new Vector2(
+        cachedOffset.x + this.templateItemToBuild.position.x,
+        cachedOffset.y + this.templateItemToBuild.position.y
       );
-      connectionToBuildPosition = DrawHelpers.rotateVector2(
-        connectionToBuildPosition,
-        Vector2.Zero,
-        this.templateItemToBuild.rotation
-      );
-      connectionToBuildPosition = DrawHelpers.scaleVector2(
-        connectionToBuildPosition,
-        Vector2.Zero,
-        this.templateItemToBuild.scale
-      );
-      connectionToBuildPosition.x += this.templateItemToBuild.position.x;
-      connectionToBuildPosition.y += this.templateItemToBuild.position.y;
 
       let utilitiesAtIndex =
         this.blueprintService.blueprint.getUtilityConnectionsAtIndex(

--- a/lib/src/blueprint/blueprint-item.d.ts
+++ b/lib/src/blueprint/blueprint-item.d.ts
@@ -39,6 +39,7 @@ export declare class BlueprintItem {
     topLeft: Vector2;
     bottomRight: Vector2;
     drawParts: DrawPart[];
+    utilityConnectionOffsets: Vector2[];
     depth: number;
     alpha: number;
     visible: boolean;
@@ -55,6 +56,7 @@ export declare class BlueprintItem {
     importBniBuilding(building: BniBuilding): void;
     importMdbBuilding(original: MdbBuilding): void;
     private updateRotationScale;
+    private updateUtilityConnectionOffsets;
     nextOrientation(): void;
     changeOrientation(newOrientation: Orientation | undefined): void;
     cleanUp(): void;

--- a/lib/src/blueprint/blueprint-item.ts
+++ b/lib/src/blueprint/blueprint-item.ts
@@ -87,6 +87,11 @@ export class BlueprintItem {
 
   drawParts: DrawPart[] = [];
 
+  // Rotated + scaled utility connection offsets (position-independent), indexed to match
+  // oniItem.utilityConnections. Recomputed only when rotation/scale change (updateRotationScale),
+  // instead of every frame in drawPixiUtility / every hover in BuildTool.updateBuildCandidateResult.
+  public utilityConnectionOffsets: Vector2[] = [];
+
   depth: number = 0;
   alpha: number = 0;
   visible: boolean = false;
@@ -247,7 +252,19 @@ export class BlueprintItem {
         break;
     }
 
+    this.updateUtilityConnectionOffsets();
     this.prepareBoundingBox();
+  }
+
+  private updateUtilityConnectionOffsets() {
+    this.utilityConnectionOffsets = this.oniItem.utilityConnections.map(connection => {
+      let offset = DrawHelpers.rotateVector2(
+        Vector2.cloneNullToZero(connection.offset),
+        Vector2.Zero,
+        this.rotation
+      );
+      return DrawHelpers.scaleVector2(offset, Vector2.Zero, this.scale);
+    });
   }
 
   nextOrientation() {
@@ -705,12 +722,7 @@ export class BlueprintItem {
       } else if (this.utilitySprites[connexionIndex] != null)
         this.utilitySprites[connexionIndex].visible = true;
 
-      let connectionPosition = DrawHelpers.rotateVector2(
-        connection.offset,
-        Vector2.Zero,
-        this.rotation
-      );
-      connectionPosition = DrawHelpers.scaleVector2(connectionPosition, Vector2.Zero, this.scale);
+      let connectionPosition = this.utilityConnectionOffsets[connexionIndex];
 
       let drawPos = new Vector2(
         (this.position.x + connectionPosition.x + camera.cameraOffset.x + 0.25) *


### PR DESCRIPTION
## Summary
- Profiled the editor's hot interaction paths (hover/pan/drag/zoom) against a synthetic 15,000-item dense blueprint using Chrome via Playwright, before changing anything.
- `BlueprintItem.drawPixiUtility` runs unconditionally for every item every frame (60fps); `BuildTool.updateBuildCandidateResult` runs on every hover mousemove. Both recomputed each utility connection's rotated+scaled offset from scratch via `DrawHelpers.rotateVector2`/`scaleVector2` — real trig plus two fresh `Vector2` allocations per connection, per call, for rotated items.
- Cache the rotated+scaled offsets once in `updateRotationScale()` (only fires on orientation change), and have both hot paths read the cache instead of recomputing it every call.

## Profiling notes
- `cameraChanged` turned out **not** to run per-frame at all (0 calls during a scripted pan — it only fires on overlay/display/visualization change), so that candidate needed no change.
- The single `appRef.tick()` call site in `BuildTool` is already gated on an actual build-candidate-result change, so no change needed there either.
- Unrotated items were already allocation-free (an existing `rotation==0`/`scale==identity` fast path in `DrawHelpers` returns the input `Vector2` directly) — caching adds no measurable benefit there, confirmed via isolated tight-loop microbenchmark.
- For **rotated** items (the actual target case), isolated per-call cost of `drawPixiUtility` dropped from ~374ns to ~222ns (-40%), tight loop, N=200k, post-warmup, measured back-to-back in the same session to rule out environment drift.
- `BuildTool.hover` (AirConditioner candidate, dense-grid lookups, N=20,000 after warmup): median 800us→700us, p90 900us→800us, worst-case latency spike 46.8ms→36.6ms (fewer/smaller GC pauses from reduced Vector2 churn).

## Test plan
- [x] `TS_NODE_TRANSPILE_ONLY=true npx mocha` — 244 passing
- [x] `cd frontend && npm test` — 494 passing (2 pre-existing skips)
- [x] `npm run tsc` and `npm run build:lib` — clean
- [x] Manually verified in-browser via Playwright that the dense-grid build/select/hover flow still renders and behaves correctly before and after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)