### PR TITLE
feat(canvas): report blueprint render duration to Google Analytics

### DIFF
--- a/frontend/src/app/module-blueprint/components/component-canvas/component-canvas.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-canvas/component-canvas.component.ts
@@ -30,6 +30,7 @@ import {
 
 import { DrawPixi } from "../../drawing/draw-pixi";
 import { DrawMiniUi } from "../../drawing/draw-mini-ui";
+import { GoogleAnalyticsService } from "ngx-google-analytics";
 import JSZip from "jszip";
 import {
   BlueprintService,
@@ -77,6 +78,7 @@ export class ComponentCanvasComponent
     private ngZone: NgZone,
     private blueprintService: BlueprintService,
     private toolService: ToolService,
+    private gaService: GoogleAnalyticsService,
     drawPixi: DrawPixi
   ) {
     this.drawPixi = drawPixi;
@@ -109,9 +111,100 @@ export class ComponentCanvasComponent
     this.running = false;
   }
 
+  // Render-time telemetry: how long it takes from "a blueprint is handed to the
+  // canvas" to "every item has a PIXI container", reported to GA so we have some
+  // real signal on client-side render performance in prod. Best-effort only -
+  // any failure here must never affect actual loading/rendering.
+  private pendingRenderMetric: {
+    startTime: number;
+    itemCount: number;
+    generation: number;
+  } | null = null;
+  private renderMetricGeneration = 0;
+
+  private startRenderMetric(source: Blueprint) {
+    try {
+      this.renderMetricGeneration++;
+      this.pendingRenderMetric = {
+        startTime: performance.now(),
+        itemCount: source.blueprintItems?.length ?? 0,
+        generation: this.renderMetricGeneration,
+      };
+    } catch (error) {
+      console.warn("startRenderMetric failed", error);
+      this.pendingRenderMetric = null;
+    }
+  }
+
+  private static readonly RENDER_METRIC_TIMEOUT_MS = 20000;
+  private checkRenderMetric() {
+    const pending = this.pendingRenderMetric;
+    if (pending == null) return;
+
+    try {
+      // A newer blueprint was loaded before this one finished rendering; drop it.
+      if (pending.generation !== this.renderMetricGeneration) {
+        this.pendingRenderMetric = null;
+        return;
+      }
+
+      const elapsedMs = performance.now() - pending.startTime;
+      const items = this.blueprint?.blueprintItems;
+      if (items == null) {
+        this.pendingRenderMetric = null;
+        return;
+      }
+
+      if (elapsedMs > ComponentCanvasComponent.RENDER_METRIC_TIMEOUT_MS) {
+        this.reportRenderMetric(
+          "blueprint_render_timeout",
+          pending.itemCount,
+          elapsedMs
+        );
+        this.pendingRenderMetric = null;
+        return;
+      }
+
+      const allReady = items.every((item) => item?.containerCreated);
+      if (allReady) {
+        this.reportRenderMetric(
+          "blueprint_render_complete",
+          pending.itemCount,
+          elapsedMs
+        );
+        this.pendingRenderMetric = null;
+      }
+    } catch (error) {
+      console.warn("checkRenderMetric failed", error);
+      this.pendingRenderMetric = null;
+    }
+  }
+
+  private reportRenderMetric(
+    action: string,
+    itemCount: number,
+    durationMs: number
+  ) {
+    try {
+      this.gaService?.event(
+        action,
+        "blueprint_performance",
+        undefined,
+        Math.round(durationMs),
+        false,
+        {
+          item_count: itemCount,
+        }
+      );
+    } catch (error) {
+      console.warn("reportRenderMetric failed", error);
+    }
+  }
+
   public loadNewBlueprint(source: Blueprint) {
     // TODO make sure nothing creates a "real  blueprint" before this
     // TODO fixme
+    this.startRenderMetric(source);
     this.blueprint.destroyAndCopyItems(source);
 
     this.cameraService.overlay = Overlay.Base;
@@ -928,6 +1021,8 @@ export class ComponentCanvasComponent
 
       this.toolService.draw(this.drawPixi, this.cameraService);
     }
+
+    if (this.pendingRenderMetric != null) this.checkRenderMetric();
 
     if (this.cameraService.triggerSortChildren) {
       this.drawPixi.sortChildren();


### PR DESCRIPTION
## Summary
- No production signal exists for how long it actually takes a visitor's browser to render a blueprint - highly dependent on device/browser/blueprint size/network, and there's currently no way to tell if it's getting better or worse over time.
- GA is already wired into the app (`NgxGoogleAnalyticsModule`) but unused for custom events - cheap to start there: no backend work, dashboards/percentiles for free.
- Times from "a blueprint is handed to the canvas" (`loadNewBlueprint`) to "every item has a PIXI container" (checked once per frame in the existing `drawAll` loop while a measurement is pending), then fires a `blueprint_render_complete` GA event: `value` = duration in ms, `item_count` custom param (duration alone is meaningless without knowing blueprint size). A render that never completes within 20s reports `blueprint_render_timeout` instead - itself a useful signal.
- Defensively written per requirement: every stage is wrapped in try/catch so a bug in the metric code can never break actual loading/rendering, and a generation counter drops stale measurements if a new blueprint loads before the previous one finishes rendering. `GoogleAnalyticsService.event()` itself already never throws (errors are console-only).

This is intentionally isolated to its own branch/PR (zero file overlap with the in-flight perf work in #99) so it can ship and start collecting a baseline independently, before any rendering perf changes land.

## Test plan
- [x] `npx tsc --noEmit` - clean
- [x] Frontend suite - canvas spec + full suite green (494 tests)
- [x] Verified end-to-end via Playwright against a real local blueprint (100 items): `blueprint_render_complete`, `value: 3439`, `item_count: 100` correctly landed in `window.dataLayer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)