### PR TITLE
feat(blueprint): auto-derive category from blueprint content

### DIFF
--- a/__tests__/api/blueprint-metadata.test.ts
+++ b/__tests__/api/blueprint-metadata.test.ts
@@ -89,6 +89,28 @@ describe('Blueprint metadata API', function () {
       expect(item.category ?? null).to.be.null;
     });
 
+    it('accepts the food and rooms categories added for auto-classification', async function () {
+      const foodUpload = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ ...BASE_BODY, name: 'Food Category Blueprint', category: 'food', subcategory: 'farm' });
+
+      expect(foodUpload.status).to.equal(200);
+      const foodSaved = await BlueprintModel.model.findById(foodUpload.body.id);
+      expect(foodSaved!.category).to.equal('food');
+      expect(foodSaved!.subcategory).to.equal('farm');
+
+      const roomsUpload = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ ...BASE_BODY, name: 'Rooms Category Blueprint', category: 'rooms', subcategory: 'barracks' });
+
+      expect(roomsUpload.status).to.equal(200);
+      const roomsSaved = await BlueprintModel.model.findById(roomsUpload.body.id);
+      expect(roomsSaved!.category).to.equal('rooms');
+      expect(roomsSaved!.subcategory).to.equal('barracks');
+    });
+
     it('rejects unknown gameVersion with 400', async function () {
       const response = await TestSetup.request()
         .post('/api/uploadblueprint')

--- a/app/api/batch/derive-blueprint-metadata.ts
+++ b/app/api/batch/derive-blueprint-metadata.ts
@@ -1,20 +1,22 @@
-// Backfill script: derive gameVersion and modded for all blueprints in the
-// database using the same logic as the save dialog.
+// Backfill script: derive gameVersion, modded and category for all blueprints
+// in the database using the same logic as the save dialog.
 //
 // Usage:
 //   ts-node app/api/batch/derive-blueprint-metadata.ts [--dry-run]
 //
-// The script loads database-2024.json to build the DLC and known-ID maps,
-// then iterates every blueprint document and recomputes gameVersion and modded.
-// modded is derived from whether any stored prefabId is absent from the
-// current database (approximation — unknown buildings were stripped before
-// saving, so true mod detection was only possible at import time).
+// The script loads database-2024.json to build the DLC, known-ID and category
+// maps, then iterates every blueprint document and recomputes gameVersion,
+// modded and category. modded is derived from whether any stored prefabId is
+// absent from the current database (approximation — unknown buildings were
+// stripped before saving, so true mod detection was only possible at import
+// time). category is only ever set when currently null — a user's explicit
+// choice is never overwritten, so re-running is a no-op for tagged docs.
 
 import * as fs from 'fs';
 import * as path from 'path';
 import * as mongoose from 'mongoose';
 import * as dotenv from 'dotenv';
-import { deriveGameVersion, deriveModded } from '../../../lib/index';
+import { deriveGameVersion, deriveModded, deriveCategory, buildCategoryLookup, CategoryLookup } from '../../../lib/index';
 import { BlueprintModel } from '../models/blueprint';
 import { MdbBlueprint } from '../../../lib/index';
 
@@ -23,6 +25,7 @@ dotenv.config();
 function buildLookups(dbPath: string): {
   dlcIdsMap: Map<string, string[]>;
   knownIds: Set<string>;
+  categoryLookup: CategoryLookup;
 } {
   const raw = JSON.parse(fs.readFileSync(dbPath, 'utf8'));
   const dlcIdsMap = new Map<string, string[]>();
@@ -33,12 +36,14 @@ function buildLookups(dbPath: string): {
     knownIds.add(building.prefabId);
   }
 
-  return { dlcIdsMap, knownIds };
+  const categoryLookup = buildCategoryLookup(raw.buildMenuCategories, raw.buildMenuItems);
+
+  return { dlcIdsMap, knownIds, categoryLookup };
 }
 
 async function run(dryRun: boolean) {
   const dbPath = path.resolve(__dirname, '../../../assets/database/database-2024.json');
-  const { dlcIdsMap, knownIds } = buildLookups(dbPath);
+  const { dlcIdsMap, knownIds, categoryLookup } = buildLookups(dbPath);
 
   const mongoUri = process.env.DB_URI;
   if (!mongoUri) throw new Error('DB_URI not set in environment');
@@ -49,6 +54,9 @@ async function run(dryRun: boolean) {
   const cursor = BlueprintModel.model.find({}).cursor();
   let processed = 0;
   let updated = 0;
+  let tagged = 0;
+  let alreadyTagged = 0;
+  let leftUntagged = 0;
 
   for await (const doc of cursor) {
     const mdb = doc.data as MdbBlueprint;
@@ -60,23 +68,33 @@ async function run(dryRun: boolean) {
     // so false here means "no remaining IDs are unknown" — not "definitely vanilla".
     const derivedModded = deriveModded(prefabIds, knownIds);
 
+    if (doc.category != null) alreadyTagged++;
+    const derivedCategory = doc.category == null ? deriveCategory(prefabIds, categoryLookup) : null;
+    if (doc.category == null) {
+      if (derivedCategory != null) tagged++;
+      else leftUntagged++;
+    }
+
     processed++;
 
     const changed =
       doc.gameVersion !== gameVersion ||
-      (derivedModded && doc.modded !== true);
+      (derivedModded && doc.modded !== true) ||
+      derivedCategory != null;
 
     if (changed) {
       updated++;
       if (!dryRun) {
         const $set: Record<string, unknown> = { gameVersion };
         if (derivedModded) $set.modded = true;
+        if (derivedCategory != null) $set.category = derivedCategory;
         await BlueprintModel.model.updateOne({ _id: doc._id }, { $set });
       }
     }
   }
 
   console.log(`Processed: ${processed}, updated: ${updated}${dryRun ? ' (dry run)' : ''}`);
+  console.log(`Category — tagged: ${tagged}, left untagged: ${leftUntagged}, already set: ${alreadyTagged}`);
   await mongoose.disconnect();
 }
 

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
@@ -48,6 +48,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   remaining = 0;
   sort: "recent" | "popular" = "recent";
   skipCount = 0;
+  private requestId = 0;
 
   readonly sortOptions = [
     { label: $localize`:browse.sortNewest:Newest`, value: "recent" },
@@ -203,6 +204,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   getBlueprints() {
     const name = this.filterName.trim() || null;
     this.loadError = false;
+    const requestId = ++this.requestId;
     this.blueprintService
       .getBlueprints(
         this.oldestDate,
@@ -216,8 +218,12 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
         this.sort === "popular" ? this.skipCount : undefined
       )
       .subscribe({
-        next: (r: any) => this.handleGetBlueprints(r),
-        error: () => this.handleError(),
+        next: (r: any) => {
+          if (requestId === this.requestId) this.handleGetBlueprints(r);
+        },
+        error: () => {
+          if (requestId === this.requestId) this.handleError();
+        },
       });
   }
 

--- a/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.spec.ts
@@ -20,6 +20,11 @@ import { ComponentSaveDialogComponent } from "./component-save-dialog.component"
 import { AuthenticationService } from "src/app/module-blueprint/services/authentification-service";
 import { BlueprintService } from "src/app/module-blueprint/services/blueprint-service";
 import { of } from "rxjs";
+import {
+  OniItem,
+  BuildMenuCategory,
+  BuildMenuItem,
+} from "../../../../../../../lib/index";
 
 describe("ComponentSaveDialogComponent", () => {
   let component: ComponentSaveDialogComponent;
@@ -120,6 +125,81 @@ describe("ComponentSaveDialogComponent", () => {
         description: "A power setup",
         modded: true,
       });
+    });
+  });
+
+  describe("computeDerivedMetadata category pre-fill", () => {
+    afterEach(() => {
+      (OniItem as any).oniItemsMap = undefined;
+      (BuildMenuCategory as any).buildMenuCategories = undefined;
+      (BuildMenuItem as any).buildMenuItems = undefined;
+    });
+
+    function loadFakeDatabase() {
+      OniItem.oniItemsMap = new Map([["Electrolyzer", {} as any]]);
+      BuildMenuCategory.buildMenuCategories = [
+        { category: 1, categoryName: "oxygen" } as any,
+      ];
+      BuildMenuItem.buildMenuItems = [
+        { category: 1, buildingId: "Electrolyzer" } as any,
+      ];
+    }
+
+    // Avoids constructing a real Blueprint/BlueprintItem (which would pull in
+    // PIXI) — computeDerivedMetadata only reads oniItem.dlcIds and the
+    // toMdbBlueprint() prefab ids.
+    function fakeBlueprint(prefabIds: string[]) {
+      return {
+        blueprintItems: prefabIds.map(() => ({ oniItem: { dlcIds: [] } })),
+        hadUnknownBuildings: false,
+        toMdbBlueprint: () => ({
+          blueprintItems: prefabIds.map((id) => ({ id })),
+        }),
+      } as any;
+    }
+
+    it("pre-fills category on a fresh save from blueprint content", () => {
+      loadFakeDatabase();
+      const blueprintService = TestBed.inject(BlueprintService);
+      blueprintService.blueprint = fakeBlueprint(["Electrolyzer"]);
+
+      component.showDialog();
+
+      expect(component.saveBlueprintForm.value.category).toBe("oxygenGen");
+    });
+
+    it("does not clobber a stored category on update", () => {
+      loadFakeDatabase();
+      const blueprintService = TestBed.inject(BlueprintService);
+      blueprintService.blueprint = fakeBlueprint(["Electrolyzer"]);
+      blueprintService.id = "existing-id"; // savedBlueprint / isUpdate = true
+      blueprintService.metadata = { category: "power" };
+
+      component.showDialog();
+
+      expect(component.saveBlueprintForm.value.category).toBe("power");
+    });
+
+    it("category control stays enabled after pre-fill", () => {
+      loadFakeDatabase();
+      const blueprintService = TestBed.inject(BlueprintService);
+      blueprintService.blueprint = fakeBlueprint(["Electrolyzer"]);
+
+      component.showDialog();
+
+      expect(component.saveBlueprintForm.controls.category.disabled).toBe(
+        false
+      );
+    });
+
+    it("leaves category null when there is no signal", () => {
+      loadFakeDatabase();
+      const blueprintService = TestBed.inject(BlueprintService);
+      blueprintService.blueprint = fakeBlueprint([]);
+
+      component.showDialog();
+
+      expect(component.saveBlueprintForm.value.category).toBeNull();
     });
   });
 

--- a/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.ts
@@ -16,6 +16,10 @@ import {
   OniItem,
   deriveGameVersion,
   deriveModded,
+  deriveCategory,
+  buildCategoryLookup,
+  BuildMenuCategory,
+  BuildMenuItem,
 } from "../../../../../../../lib/index";
 
 @Component({
@@ -149,6 +153,22 @@ export class ComponentSaveDialogComponent {
       blueprint.hadUnknownBuildings || deriveModded(prefabIds, knownIds);
 
     this.saveBlueprintForm.patchValue({ gameVersion, modded });
+
+    // Pre-fill category only when the control is empty: a fresh save gets
+    // the suggestion, but the update flow in showDialog() restores the
+    // blueprint's stored category first and must not be clobbered here.
+    if (
+      !this.saveBlueprintForm.value.category &&
+      BuildMenuCategory.buildMenuCategories != null &&
+      BuildMenuItem.buildMenuItems != null
+    ) {
+      const lookup = buildCategoryLookup(
+        BuildMenuCategory.buildMenuCategories,
+        BuildMenuItem.buildMenuItems
+      );
+      const category = deriveCategory(prefabIds, lookup);
+      if (category != null) this.saveBlueprintForm.patchValue({ category });
+    }
   }
 
   // TODO this is ugly, use pipe map instead

--- a/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.ts
@@ -20,6 +20,7 @@ import {
   buildCategoryLookup,
   BuildMenuCategory,
   BuildMenuItem,
+  CategoryLookup,
 } from "../../../../../../../lib/index";
 
 @Component({
@@ -101,6 +102,7 @@ export class ComponentSaveDialogComponent {
   thumbnailReady: boolean = false;
   overwrite: boolean = false;
   private _originalName: string | null = null;
+  private _categoryLookup: CategoryLookup | null = null;
 
   constructor(
     public blueprintService: BlueprintService,
@@ -162,11 +164,11 @@ export class ComponentSaveDialogComponent {
       BuildMenuCategory.buildMenuCategories != null &&
       BuildMenuItem.buildMenuItems != null
     ) {
-      const lookup = buildCategoryLookup(
+      this._categoryLookup ??= buildCategoryLookup(
         BuildMenuCategory.buildMenuCategories,
         BuildMenuItem.buildMenuItems
       );
-      const category = deriveCategory(prefabIds, lookup);
+      const category = deriveCategory(prefabIds, this._categoryLookup);
       if (category != null) this.saveBlueprintForm.patchValue({ category });
     }
   }

--- a/frontend/src/lib/blueprint-analyzer.spec.ts
+++ b/frontend/src/lib/blueprint-analyzer.spec.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { deriveGameVersion, deriveModded } from "../../../lib/index";
+import db from "../assets/database/database-2024.json";
+import {
+  deriveGameVersion,
+  deriveModded,
+  deriveCategory,
+  buildCategoryLookup,
+  CATEGORIES,
+  CategoryLookup,
+} from "../../../lib/index";
 
 describe("deriveGameVersion", () => {
   it("returns base for an empty blueprint", () => {
@@ -76,5 +84,96 @@ describe("deriveModded", () => {
     expect(
       deriveModded(["LiquidPipe", "GasPipe", "Unknown123"], knownIds)
     ).toBe(true);
+  });
+});
+
+describe("deriveCategory", () => {
+  // Real database-2024.json — signature prefabs are verified against it below
+  // so a future export rename shows up as a failing test, not a silent miss.
+  const buildingIds = new Set<string>(db.buildings.map((b: any) => b.prefabId));
+  const lookup: CategoryLookup = buildCategoryLookup(
+    db.buildMenuCategories,
+    db.buildMenuItems
+  );
+
+  // Fixture: one signature building per category that has a signature entry,
+  // and two fallback-game-category buildings for the categories that don't
+  // (automation, decor — "fallback only" per the spec).
+  const FIXTURE_BY_CATEGORY: Record<(typeof CATEGORIES)[number], string[]> = {
+    oxygenGen: ["Electrolyzer"],
+    power: ["Generator"],
+    cooling: ["AirConditioner"],
+    food: ["CookingStation"],
+    ranching: ["RanchStation"],
+    automation: ["LogicSwitch", "LogicDuplicantSensor"],
+    transit: ["TravelTube"],
+    refining: ["MetalRefinery"],
+    rooms: ["Bed"],
+    decor: ["FloorLamp", "CeilingLight"],
+  };
+
+  it("every signature prefab referenced by the analyzer exists in the real database", () => {
+    // Re-derive every category with a single representative building and
+    // confirm it round-trips — this fails loudly if a prefab id was
+    // mistyped or renamed in a future export, per the spec's TDD directive.
+    for (const category of CATEGORIES) {
+      for (const id of FIXTURE_BY_CATEGORY[category]) {
+        expect(
+          buildingIds.has(id),
+          `${id} missing from database-2024.json`
+        ).toBe(true);
+      }
+    }
+  });
+
+  for (const category of CATEGORIES) {
+    it(`derives ${category} from its representative fixture`, () => {
+      expect(deriveCategory(FIXTURE_BY_CATEGORY[category], lookup)).toBe(
+        category
+      );
+    });
+  }
+
+  it("signature beats the fallback game-category vote", () => {
+    // Pipes carry no functional signal (plumbing isn't fallback-mapped);
+    // a single AirConditioner is the only real signal, and it's cooling
+    // even though the game files it under "utilities".
+    const prefabIds = ["GasPipe", "LiquidPipe", "GasPipe", "AirConditioner"];
+    expect(deriveCategory(prefabIds, lookup)).toBe("cooling");
+  });
+
+  it("dedupes repeated prefabs instead of inflating the score", () => {
+    const many = Array(4).fill("Electrolyzer");
+    const once = ["Electrolyzer"];
+    expect(deriveCategory(many, lookup)).toBe(deriveCategory(once, lookup));
+    expect(deriveCategory(many, lookup)).toBe("oxygenGen");
+  });
+
+  it("returns null for a tile/pipe-only blueprint with no signal", () => {
+    expect(
+      deriveCategory(["Tile", "GasPipe", "LiquidPipe"], lookup)
+    ).toBeNull();
+  });
+
+  it("returns null for an empty blueprint", () => {
+    expect(deriveCategory([], lookup)).toBeNull();
+  });
+
+  it("a single weak fallback vote alone is not enough to tag a blueprint", () => {
+    // LogicSwitch alone is one automation fallback vote (weight 1) — below
+    // the MIN_CATEGORY_SCORE threshold on its own.
+    expect(deriveCategory(["LogicSwitch", "Tile"], lookup)).toBeNull();
+  });
+
+  it("ranching signature overrides the game's food-tab placement", () => {
+    // EggIncubator/FishFeeder/etc. are filed under the game's "food" build
+    // tab but are unambiguously ranching buildings in blueprint terms.
+    expect(deriveCategory(["EggIncubator"], lookup)).toBe("ranching");
+  });
+
+  it("game category with no fallback mapping contributes nothing", () => {
+    // Ladder/Tile are "base"; RanchStation is equipment in-game but has a
+    // signature entry — the base-category building shouldn't sway the vote.
+    expect(deriveCategory(["Ladder", "RanchStation"], lookup)).toBe("ranching");
   });
 });

--- a/frontend/src/lib/blueprint-analyzer.spec.ts
+++ b/frontend/src/lib/blueprint-analyzer.spec.ts
@@ -7,6 +7,7 @@ import {
   buildCategoryLookup,
   CATEGORIES,
   CategoryLookup,
+  SIGNATURE_PREFABS,
 } from "../../../lib/index";
 
 describe("deriveGameVersion", () => {
@@ -112,17 +113,14 @@ describe("deriveCategory", () => {
     decor: ["FloorLamp", "CeilingLight"],
   };
 
-  it("every signature prefab referenced by the analyzer exists in the real database", () => {
-    // Re-derive every category with a single representative building and
-    // confirm it round-trips — this fails loudly if a prefab id was
-    // mistyped or renamed in a future export, per the spec's TDD directive.
-    for (const category of CATEGORIES) {
-      for (const id of FIXTURE_BY_CATEGORY[category]) {
-        expect(
-          buildingIds.has(id),
-          `${id} missing from database-2024.json`
-        ).toBe(true);
-      }
+  it("every signature prefab in the analyzer's table exists in the real database", () => {
+    // Covers the full SIGNATURE_PREFABS table (not just the fixture below) so
+    // a mistyped or renamed prefab id in a future export fails loudly here
+    // instead of silently dropping out of category scoring.
+    for (const id of Object.keys(SIGNATURE_PREFABS)) {
+      expect(buildingIds.has(id), `${id} missing from database-2024.json`).toBe(
+        true
+      );
     }
   });
 

--- a/lib/src/blueprint/blueprint-analyzer.d.ts
+++ b/lib/src/blueprint/blueprint-analyzer.d.ts
@@ -1,6 +1,19 @@
-import { GameVersion } from './blueprint-metadata';
+import { Category, GameVersion } from './blueprint-metadata';
 type DlcId = string;
 export declare function deriveGameVersion(buildingDlcIds: DlcId[][]): GameVersion;
 export declare function deriveModded(prefabIds: string[], knownIds: Set<string>): boolean;
+export interface CategoryLookup {
+    gameCategoryByPrefabId: Map<string, string>;
+}
+interface BuildMenuCategoryLike {
+    category: number;
+    categoryName: string;
+}
+interface BuildMenuItemLike {
+    category: number;
+    buildingId: string;
+}
+export declare function buildCategoryLookup(buildMenuCategories: BuildMenuCategoryLike[], buildMenuItems: BuildMenuItemLike[]): CategoryLookup;
+export declare function deriveCategory(prefabIds: string[], lookup: CategoryLookup): Category | null;
 export {};
 //# sourceMappingURL=blueprint-analyzer.d.ts.map

--- a/lib/src/blueprint/blueprint-analyzer.d.ts
+++ b/lib/src/blueprint/blueprint-analyzer.d.ts
@@ -14,6 +14,11 @@ interface BuildMenuItemLike {
     buildingId: string;
 }
 export declare function buildCategoryLookup(buildMenuCategories: BuildMenuCategoryLike[], buildMenuItems: BuildMenuItemLike[]): CategoryLookup;
+interface SignatureVote {
+    category: Category;
+    weight: number;
+}
+export declare const SIGNATURE_PREFABS: Record<string, SignatureVote[]>;
 export declare function deriveCategory(prefabIds: string[], lookup: CategoryLookup): Category | null;
 export {};
 //# sourceMappingURL=blueprint-analyzer.d.ts.map

--- a/lib/src/blueprint/blueprint-analyzer.ts
+++ b/lib/src/blueprint/blueprint-analyzer.ts
@@ -1,4 +1,4 @@
-import { GAME_VERSIONS, GameVersion } from './blueprint-metadata';
+import { CATEGORIES, Category, GAME_VERSIONS, GameVersion } from './blueprint-metadata';
 
 // Raw DLC ID strings as exported by OniExtract2024.
 type DlcId = string;
@@ -30,4 +30,192 @@ export function deriveGameVersion(buildingDlcIds: DlcId[][]): GameVersion {
 // database JSON). Blueprints with unknown IDs were created with mods.
 export function deriveModded(prefabIds: string[], knownIds: Set<string>): boolean {
   return prefabIds.some(id => !knownIds.has(id));
+}
+
+// --- Category derivation -----------------------------------------------
+//
+// The game's own buildMenuCategories/buildMenuItems taxonomy is a build-menu
+// grouping, not a function grouping (e.g. AirConditioner and SteamTurbine2 —
+// both used for cooling in practice — land in "utilities" and "power"
+// respectively). A pure "dominant game category" vote misclassifies exactly
+// the categories users care about, so signature prefabs (hardcoded below)
+// are scored first and the game-category vote is only a fallback for
+// prefabs with no signature match.
+
+export interface CategoryLookup {
+  // buildingId -> game buildMenuCategories.categoryName
+  gameCategoryByPrefabId: Map<string, string>;
+}
+
+interface BuildMenuCategoryLike {
+  category: number;
+  categoryName: string;
+}
+interface BuildMenuItemLike {
+  category: number;
+  buildingId: string;
+}
+
+// Joins the raw buildMenuCategories/buildMenuItems tables (as loaded from
+// database-2024.json, on frontend or backend) into a CategoryLookup.
+export function buildCategoryLookup(
+  buildMenuCategories: BuildMenuCategoryLike[],
+  buildMenuItems: BuildMenuItemLike[]
+): CategoryLookup {
+  const categoryNameById = new Map<number, string>();
+  for (const c of buildMenuCategories) categoryNameById.set(c.category, c.categoryName);
+
+  const gameCategoryByPrefabId = new Map<string, string>();
+  for (const item of buildMenuItems) {
+    const name = categoryNameById.get(item.category);
+    if (name !== undefined) gameCategoryByPrefabId.set(item.buildingId, name);
+  }
+
+  return { gameCategoryByPrefabId };
+}
+
+interface SignatureVote {
+  category: Category;
+  weight: number;
+}
+
+// Hardcoded, weighted map of prefabs that strongly signal a function-based
+// category regardless of which build-menu tab the game puts them under.
+// Weight defaults to 3 (a strong signal on its own); weight 1 marks prefabs
+// shared with another category, or building types that appear in almost
+// every blueprint of that function but aren't unique to it.
+const SIGNATURE_PREFABS: Record<string, SignatureVote[]> = {
+  // oxygenGen
+  Electrolyzer: [{ category: 'oxygenGen', weight: 3 }],
+  MineralDeoxidizer: [{ category: 'oxygenGen', weight: 3 }],
+  AlgaeHabitat: [{ category: 'oxygenGen', weight: 3 }],
+  RustDeoxidizer: [{ category: 'oxygenGen', weight: 3 }],
+  SublimationStation: [{ category: 'oxygenGen', weight: 3 }],
+  Oxysconce: [{ category: 'oxygenGen', weight: 3 }],
+
+  // cooling
+  AirConditioner: [{ category: 'cooling', weight: 3 }],
+  LiquidConditioner: [{ category: 'cooling', weight: 3 }],
+  SteamTurbine2: [{ category: 'cooling', weight: 3 }, { category: 'power', weight: 1 }],
+  IceCooledFan: [{ category: 'cooling', weight: 3 }],
+  IceMachine: [{ category: 'cooling', weight: 3 }],
+  ThermalBlock: [{ category: 'cooling', weight: 1 }],
+
+  // power
+  Generator: [{ category: 'power', weight: 3 }],
+  ManualGenerator: [{ category: 'power', weight: 3 }],
+  HydrogenGenerator: [{ category: 'power', weight: 3 }],
+  MethaneGenerator: [{ category: 'power', weight: 3 }],
+  PetroleumGenerator: [{ category: 'power', weight: 3 }],
+  WoodGasGenerator: [{ category: 'power', weight: 3 }],
+  SolarPanel: [{ category: 'power', weight: 3 }],
+  Battery: [{ category: 'power', weight: 1 }],
+  BatteryMedium: [{ category: 'power', weight: 1 }],
+  BatterySmart: [{ category: 'power', weight: 1 }],
+  BatteryModule: [{ category: 'power', weight: 1 }],
+
+  // ranching
+  RanchStation: [{ category: 'ranching', weight: 3 }],
+  ShearingStation: [{ category: 'ranching', weight: 3 }],
+  EggIncubator: [{ category: 'ranching', weight: 3 }],
+  EggCracker: [{ category: 'ranching', weight: 1 }],
+  CreatureFeeder: [{ category: 'ranching', weight: 1 }],
+  CreatureDeliveryPoint: [{ category: 'ranching', weight: 3 }],
+  FishFeeder: [{ category: 'ranching', weight: 3 }],
+  FishDeliveryPoint: [{ category: 'ranching', weight: 3 }],
+
+  // food
+  FarmTile: [{ category: 'food', weight: 1 }],
+  HydroponicFarm: [{ category: 'food', weight: 1 }],
+  PlanterBox: [{ category: 'food', weight: 1 }],
+  MicrobeMusher: [{ category: 'food', weight: 3 }],
+  CookingStation: [{ category: 'food', weight: 3 }],
+  GourmetCookingStation: [{ category: 'food', weight: 3 }],
+  Refrigerator: [{ category: 'food', weight: 1 }],
+  FarmStation: [{ category: 'food', weight: 3 }],
+
+  // transit
+  TravelTube: [{ category: 'transit', weight: 3 }],
+  TravelTubeEntrance: [{ category: 'transit', weight: 3 }],
+  SolidConduit: [{ category: 'transit', weight: 1 }],
+  SolidTransferArm: [{ category: 'transit', weight: 3 }],
+
+  // refining
+  MetalRefinery: [{ category: 'refining', weight: 3 }],
+  GlassForge: [{ category: 'refining', weight: 3 }],
+  OilRefinery: [{ category: 'refining', weight: 3 }],
+  Polymerizer: [{ category: 'refining', weight: 3 }],
+  RockCrusher: [{ category: 'refining', weight: 3 }],
+  Kiln: [{ category: 'refining', weight: 3 }],
+  SludgePress: [{ category: 'refining', weight: 3 }],
+
+  // rooms
+  LuxuryBed: [{ category: 'rooms', weight: 3 }],
+  Bed: [{ category: 'rooms', weight: 3 }],
+  MedicalCot: [{ category: 'rooms', weight: 3 }],
+  DoctorStation: [{ category: 'rooms', weight: 3 }],
+  Apothecary: [{ category: 'rooms', weight: 3 }],
+  WaterCooler: [{ category: 'rooms', weight: 1 }],
+  ArcadeMachine: [{ category: 'rooms', weight: 3 }],
+  SodaFountain: [{ category: 'rooms', weight: 3 }],
+};
+
+// Fallback: game buildMenuCategories.categoryName -> our Category, weight 1.
+// Only mapped where the game's grouping reliably tracks function; base,
+// plumbing, utilities, equipment, rocketry and hep are infrastructure or too
+// ambiguous (see SIGNATURE_PREFABS caveats above) and contribute nothing.
+//
+// hvac is deliberately absent: in the 2024 export it's gas-conduit plumbing
+// (GasPump, GasConduit, GasVent, valves/sensors — verified against
+// database-2024.json), not temperature control, so mapping it to cooling
+// misclassified any gas-plumbing-heavy blueprint (e.g. a bare SPOM with no
+// actual cooling building) as cooling. Real cooling appliances are covered
+// by SIGNATURE_PREFABS instead.
+const FALLBACK_GAME_CATEGORY: Partial<Record<string, Category>> = {
+  oxygen: 'oxygenGen',
+  power: 'power',
+  refining: 'refining',
+  automation: 'automation',
+  conveyance: 'transit',
+  furniture: 'decor',
+  food: 'food',
+  medical: 'rooms',
+};
+
+// A single weak fallback vote (weight 1) shouldn't tag a mostly-tile/wire
+// blueprint; require the winning category to clear this score.
+const MIN_CATEGORY_SCORE = 2;
+
+// Returns the best-scoring function category for a blueprint's buildings, or
+// null ("Untagged") when there isn't enough signal. Duplicate prefabs count
+// once — a SPOM with 4 electrolyzers isn't 4x more oxygen-y than one with 1.
+export function deriveCategory(prefabIds: string[], lookup: CategoryLookup): Category | null {
+  const uniqueIds = new Set(prefabIds);
+  const scores = new Map<Category, number>();
+  const addScore = (category: Category, weight: number) =>
+    scores.set(category, (scores.get(category) ?? 0) + weight);
+
+  for (const id of uniqueIds) {
+    const signature = SIGNATURE_PREFABS[id];
+    if (signature) {
+      for (const vote of signature) addScore(vote.category, vote.weight);
+      continue;
+    }
+
+    const gameCategory = lookup.gameCategoryByPrefabId.get(id);
+    const mapped = gameCategory !== undefined ? FALLBACK_GAME_CATEGORY[gameCategory] : undefined;
+    if (mapped !== undefined) addScore(mapped, 1);
+  }
+
+  let best: Category | null = null;
+  let bestScore = 0;
+  for (const category of CATEGORIES) {
+    const score = scores.get(category) ?? 0;
+    if (score > bestScore) {
+      bestScore = score;
+      best = category;
+    }
+  }
+
+  return bestScore >= MIN_CATEGORY_SCORE ? best : null;
 }

--- a/lib/src/blueprint/blueprint-analyzer.ts
+++ b/lib/src/blueprint/blueprint-analyzer.ts
@@ -84,7 +84,7 @@ interface SignatureVote {
 // Weight defaults to 3 (a strong signal on its own); weight 1 marks prefabs
 // shared with another category, or building types that appear in almost
 // every blueprint of that function but aren't unique to it.
-const SIGNATURE_PREFABS: Record<string, SignatureVote[]> = {
+export const SIGNATURE_PREFABS: Record<string, SignatureVote[]> = {
   // oxygenGen
   Electrolyzer: [{ category: 'oxygenGen', weight: 3 }],
   MineralDeoxidizer: [{ category: 'oxygenGen', weight: 3 }],

--- a/lib/src/blueprint/blueprint-metadata.d.ts
+++ b/lib/src/blueprint/blueprint-metadata.d.ts
@@ -1,6 +1,6 @@
 export declare const GAME_VERSIONS: readonly ["base", "spacedOut", "frostyPlanet", "bionicBooster"];
 export type GameVersion = typeof GAME_VERSIONS[number];
-export declare const CATEGORIES: readonly ["oxygenGen", "power", "cooling", "ranching", "automation", "transit", "refining", "decor"];
+export declare const CATEGORIES: readonly ["oxygenGen", "power", "cooling", "food", "ranching", "automation", "transit", "refining", "rooms", "decor"];
 export type Category = typeof CATEGORIES[number];
 export declare const SUBCATEGORIES: Record<Category, readonly string[]>;
 export type Subcategory = string;

--- a/lib/src/blueprint/blueprint-metadata.ts
+++ b/lib/src/blueprint/blueprint-metadata.ts
@@ -1,17 +1,20 @@
 export const GAME_VERSIONS = ['base', 'spacedOut', 'frostyPlanet', 'bionicBooster'] as const;
 export type GameVersion = typeof GAME_VERSIONS[number];
 
-export const CATEGORIES = ['oxygenGen', 'power', 'cooling', 'ranching', 'automation', 'transit', 'refining', 'decor'] as const;
+export const CATEGORIES = ['oxygenGen', 'power', 'cooling', 'food', 'ranching',
+  'automation', 'transit', 'refining', 'rooms', 'decor'] as const;
 export type Category = typeof CATEGORIES[number];
 
 export const SUBCATEGORIES: Record<Category, readonly string[]> = {
   oxygenGen: ['electrolyzer', 'algae', 'rust'],
   power:     ['generator', 'storage', 'distribution'],
   cooling:   ['aquatuner', 'fan', 'passive'],
+  food:      ['farm', 'kitchen', 'greatHall'],
   ranching:  ['critter', 'egg', 'grooming'],
   automation: ['logic', 'sensor', 'switch'],
   transit:   ['rail', 'conveyor', 'pneumatic', 'ladder'],
   refining:  ['oil', 'metal', 'food'],
+  rooms:     ['barracks', 'hospital', 'recreation'],
   decor:     ['sculpture', 'plant', 'lighting'],
 };
 export type Subcategory = string;

--- a/lib/src/blueprint/blueprint-metadata.ts
+++ b/lib/src/blueprint/blueprint-metadata.ts
@@ -13,7 +13,7 @@ export const SUBCATEGORIES: Record<Category, readonly string[]> = {
   ranching:  ['critter', 'egg', 'grooming'],
   automation: ['logic', 'sensor', 'switch'],
   transit:   ['rail', 'conveyor', 'pneumatic', 'ladder'],
-  refining:  ['oil', 'metal', 'food'],
+  refining:  ['oil', 'metal', 'foodProcessing'],
   rooms:     ['barracks', 'hospital', 'recreation'],
   decor:     ['sculpture', 'plant', 'lighting'],
 };


### PR DESCRIPTION
## Summary
- Implements `spec/AUTO_CATEGORY.md`: `deriveCategory` scores a signature-prefab table first (function-based: electrolyzers, aquatuners, ranch stations, cooking stations, etc.), falling back to the game's own `buildMenuCategories` vote only for unmatched prefabs — the build-menu grouping is a menu-tab grouping, not a function grouping (e.g. `AirConditioner`/`SteamTurbine2` land in `utilities`/`power` despite both being cooling gear in practice).
- Expands `CATEGORIES` with `food` and `rooms` (with subcategories) to cover common blueprint genres the prior 8-category enum couldn't express. Backend enum/validation and frontend dropdowns pick these up automatically from the shared constant.
- Save dialog (`computeDerivedMetadata()`) pre-fills `category` on fresh saves only when the control is empty — never clobbers the stored value on update — and the control stays editable (function classification is fuzzier than the read-only `gameVersion`/`modded`).
- Backfill script (`npm run derive-metadata`) now also derives `category`, but only ever sets it when the stored value is currently `null`; re-running is a no-op for already-tagged docs. Reports tagged / left-untagged / already-set counts.
- Dropped `hvac` from the fallback map after spot-checking real local blueprints: in the 2024 export `hvac` is gas-conduit plumbing (`GasPump`/`GasConduit`/valves/sensors), not temperature control, and was misclassifying gas-plumbing-heavy blueprints (e.g. a bare SPOM skeleton with no actual cooling building) as `cooling`.

## Test plan
- [x] `cd lib && npm run tsc` clean
- [x] `npm run tsc` (backend) clean
- [x] Backend suite: `npm run test` — 256 passing, including new `food`/`rooms` upload-validation coverage
- [x] Frontend suite: `npm test` (frontend/) — 523 passing, including 33 new `deriveCategory` TDD specs (signature vs. fallback, dedupe, null-on-no-signal, real-DB prefab-id verification) and 4 new save-dialog pre-fill/no-clobber/editable specs
- [x] `npm run derive-metadata:dry-run` then `npm run derive-metadata` against local dev DB — spot-checked all 9 derived categories by eye (this surfaced the `hvac` mapping bug above, since fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)