### PR TITLE
feat(social): profile pages, follow, and activity feed

### DIFF
--- a/__tests__/api/social.test.ts
+++ b/__tests__/api/social.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load test environment first
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup } from '../setup/testSetup';
+import { BlueprintModel } from '../../app/api/models/blueprint';
+import { FollowModel } from '../../app/api/models/follow';
+import { Types } from 'mongoose';
+
+describe('Profile, Follow, Feed API', function () {
+  let testData: any;
+
+  beforeEach(async function () {
+    this.timeout(5000);
+    testData = await TestSetup.beforeEach();
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    await TestSetup.afterEach();
+  });
+
+  // ─── GET /api/users/:username/profile(Secure) ───────────────────────────────
+
+  describe('GET /api/users/:username/profile', function () {
+    it('returns 404 for an unknown username', async function () {
+      const response = await TestSetup.request().get('/api/users/no-such-user/profile');
+      expect(response.status).to.equal(404);
+    });
+
+    it('returns anonymous profile payload with followedByMe false', async function () {
+      const response = await TestSetup.request().get(
+        `/api/users/${testData.users.user1.username}/profile`
+      );
+
+      expect(response.status).to.equal(200);
+      expect(response.body.username).to.equal(testData.users.user1.username);
+      expect(response.body.bio).to.equal('');
+      expect(response.body.blueprintCount).to.equal(1); // popularBlueprint
+      expect(response.body.followerCount).to.equal(0);
+      expect(response.body.followingCount).to.equal(0);
+      expect(response.body.followedByMe).to.equal(false);
+      expect(response.body.memberSince).to.exist;
+    });
+
+    it('excludes soft-deleted blueprints from blueprintCount', async function () {
+      await BlueprintModel.model.updateOne(
+        { _id: testData.blueprints.popularBlueprint._id },
+        { deletedAt: new Date() }
+      );
+
+      const response = await TestSetup.request().get(
+        `/api/users/${testData.users.user1.username}/profile`
+      );
+      expect(response.body.blueprintCount).to.equal(0);
+    });
+  });
+
+  describe('GET /api/users/:username/profileSecure', function () {
+    it('returns 401 without a token', async function () {
+      const response = await TestSetup.request().get(
+        `/api/users/${testData.users.user1.username}/profileSecure`
+      );
+      expect(response.status).to.equal(401);
+    });
+
+    it('reflects followedByMe true for the follower, false for others', async function () {
+      await FollowModel.model.create({
+        followerId: testData.users.user2._id,
+        followeeId: testData.users.user1._id,
+      });
+
+      const token2 = testData.users.user2.generateJwt();
+      const response2 = await TestSetup.request()
+        .get(`/api/users/${testData.users.user1.username}/profileSecure`)
+        .set('Authorization', `Bearer ${token2}`);
+      expect(response2.status).to.equal(200);
+      expect(response2.body.followedByMe).to.equal(true);
+      expect(response2.body.followerCount).to.equal(1);
+
+      const token3 = testData.users.user3.generateJwt();
+      const response3 = await TestSetup.request()
+        .get(`/api/users/${testData.users.user1.username}/profileSecure`)
+        .set('Authorization', `Bearer ${token3}`);
+      expect(response3.body.followedByMe).to.equal(false);
+    });
+  });
+
+  // ─── POST /api/follow ────────────────────────────────────────────────────────
+
+  describe('POST /api/follow', function () {
+    it('returns 401 without a token', async function () {
+      const response = await TestSetup.request()
+        .post('/api/follow')
+        .send({ followeeId: testData.users.user1._id.toString(), follow: true });
+      expect(response.status).to.equal(401);
+    });
+
+    it('returns 400 on self-follow', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .post('/api/follow')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ followeeId: testData.users.user1._id.toString(), follow: true });
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 404 for an unknown followeeId', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .post('/api/follow')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ followeeId: new Types.ObjectId().toString(), follow: true });
+      expect(response.status).to.equal(404);
+    });
+
+    it('returns 400 for a missing or malformed followeeId', async function () {
+      const token = testData.users.user1.generateJwt();
+
+      const missing = await TestSetup.request()
+        .post('/api/follow')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ follow: true });
+      expect(missing.status).to.equal(400);
+
+      const malformed = await TestSetup.request()
+        .post('/api/follow')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ followeeId: 'not-an-id', follow: true });
+      expect(malformed.status).to.equal(400);
+    });
+
+    it('follows, is idempotent, then unfollows idempotently', async function () {
+      const token = testData.users.user1.generateJwt();
+      const followeeId = testData.users.user2._id.toString();
+
+      const follow1 = await TestSetup.request()
+        .post('/api/follow')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ followeeId, follow: true });
+      expect(follow1.status).to.equal(200);
+
+      const follow2 = await TestSetup.request()
+        .post('/api/follow')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ followeeId, follow: true });
+      expect(follow2.status).to.equal(200);
+
+      expect(
+        await FollowModel.model.countDocuments({
+          followerId: testData.users.user1._id,
+          followeeId: testData.users.user2._id,
+        })
+      ).to.equal(1);
+
+      const unfollow1 = await TestSetup.request()
+        .post('/api/follow')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ followeeId, follow: false });
+      expect(unfollow1.status).to.equal(200);
+
+      const unfollow2 = await TestSetup.request()
+        .post('/api/follow')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ followeeId, follow: false });
+      expect(unfollow2.status).to.equal(200);
+
+      expect(
+        await FollowModel.model.countDocuments({
+          followerId: testData.users.user1._id,
+          followeeId: testData.users.user2._id,
+        })
+      ).to.equal(0);
+    });
+  });
+
+  // ─── PATCH /api/users/me ─────────────────────────────────────────────────────
+
+  describe('PATCH /api/users/me', function () {
+    it('returns 401 without a token', async function () {
+      const response = await TestSetup.request().patch('/api/users/me').send({ bio: 'hi' });
+      expect(response.status).to.equal(401);
+    });
+
+    it('sets bio and it persists into the profile', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .patch('/api/users/me')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ bio: 'I build coal generators.' });
+
+      expect(response.status).to.equal(200);
+      expect(response.body.bio).to.equal('I build coal generators.');
+
+      const profile = await TestSetup.request().get(
+        `/api/users/${testData.users.user1.username}/profile`
+      );
+      expect(profile.body.bio).to.equal('I build coal generators.');
+    });
+
+    it('rejects a bio over 500 characters', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .patch('/api/users/me')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ bio: 'x'.repeat(501) });
+      expect(response.status).to.equal(400);
+    });
+
+    it('accepts exactly 500 characters', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .patch('/api/users/me')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ bio: 'x'.repeat(500) });
+      expect(response.status).to.equal(200);
+    });
+  });
+
+  // ─── GET /api/feed ────────────────────────────────────────────────────────────
+
+  describe('GET /api/feed', function () {
+    it('returns 401 without a token', async function () {
+      const response = await TestSetup.request().get('/api/feed').query({ olderthan: Date.now() });
+      expect(response.status).to.equal(401);
+    });
+
+    it('returns an empty feed when following no one', async function () {
+      const token = testData.users.user3.generateJwt();
+      const response = await TestSetup.request()
+        .get('/api/feed')
+        .query({ olderthan: Date.now() })
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).to.equal(200);
+      expect(response.body.blueprints).to.deep.equal([]);
+      expect(response.body.remaining).to.equal(0);
+    });
+
+    it('returns only followees blueprints, newest first', async function () {
+      // user2 follows user1 (owner of popularBlueprint) but not user3 (owner of oldBlueprint/copiedBlueprint)
+      await FollowModel.model.create({
+        followerId: testData.users.user2._id,
+        followeeId: testData.users.user1._id,
+      });
+
+      const token = testData.users.user2.generateJwt();
+      const response = await TestSetup.request()
+        .get('/api/feed')
+        .query({ olderthan: Date.now() })
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).to.equal(200);
+      const names = response.body.blueprints.map((b: any) => b.name);
+      expect(names).to.deep.equal(['Super Coal Generator Setup']);
+    });
+
+    it('excludes soft-deleted blueprints', async function () {
+      await FollowModel.model.create({
+        followerId: testData.users.user2._id,
+        followeeId: testData.users.user1._id,
+      });
+      await BlueprintModel.model.updateOne(
+        { _id: testData.blueprints.popularBlueprint._id },
+        { deletedAt: new Date() }
+      );
+
+      const token = testData.users.user2.generateJwt();
+      const response = await TestSetup.request()
+        .get('/api/feed')
+        .query({ olderthan: Date.now() })
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.body.blueprints).to.deep.equal([]);
+    });
+
+    it('paginates with the olderthan cursor', async function () {
+      await FollowModel.model.create({
+        followerId: testData.users.user2._id,
+        followeeId: testData.users.user1._id,
+      });
+
+      // Seed enough additional blueprints from the followed user to exceed BROWSE_INCREMENT (10 in test env)
+      const now = Date.now();
+      const extra = Array.from({ length: 12 }, (_, i) => ({
+        owner: testData.users.user1._id,
+        name: `Feed Item ${i}`,
+        tags: [],
+        likes: [],
+        likeCount: 0,
+        createdAt: new Date(now - (i + 1) * 60 * 1000),
+        modifiedAt: new Date(now - (i + 1) * 60 * 1000),
+        thumbnail: 'x',
+        data: { version: '1.0', buildings: [], info: { name: `Feed Item ${i}` } },
+        deletedAt: null,
+      }));
+      await BlueprintModel.model.insertMany(extra);
+
+      const token = testData.users.user2.generateJwt();
+      const firstPage = await TestSetup.request()
+        .get('/api/feed')
+        .query({ olderthan: now + 1000 })
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(firstPage.status).to.equal(200);
+      expect(firstPage.body.blueprints).to.have.lengthOf(10);
+      expect(firstPage.body.remaining).to.be.greaterThan(0);
+
+      const secondPage = await TestSetup.request()
+        .get('/api/feed')
+        .query({ olderthan: new Date(firstPage.body.oldest).getTime() })
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(secondPage.status).to.equal(200);
+      const firstIds = firstPage.body.blueprints.map((b: any) => b.id);
+      const secondIds = secondPage.body.blueprints.map((b: any) => b.id);
+      expect(secondIds.some((id: string) => firstIds.includes(id))).to.equal(false);
+    });
+  });
+});

--- a/__tests__/helpers/testDb.ts
+++ b/__tests__/helpers/testDb.ts
@@ -1,6 +1,7 @@
 import { UserModel } from '../../app/api/models/user';
 import { BlueprintModel } from '../../app/api/models/blueprint';
 import { FeedbackModel } from '../../app/api/models/feedback';
+import { FollowModel } from '../../app/api/models/follow';
 import { TestDataFactory, TestUser, TestBlueprint } from '../factories/testData';
 import { Types } from 'mongoose';
 
@@ -123,6 +124,7 @@ export class TestDbHelper {
       await BlueprintModel.model.deleteMany({});
       await UserModel.model.deleteMany({});
       await FeedbackModel.model.deleteMany({});
+      await FollowModel.model.deleteMany({});
       TestDataFactory.reset();
     } catch (error) {
       console.error('Error cleaning database:', error);

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -458,7 +458,7 @@ export class BlueprintController {
     }
   }
 
-  private static handleGetBlueprint(
+  public static handleGetBlueprint(
     _req: Request,
     res: Response,
     userId: string,

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -20,6 +20,7 @@ import { Blueprint as sharedBlueprint } from '../../lib/index';
 import { UserModel, UserJwt } from './models/user';
 import { BatchUtils } from './batch/batch-utils';
 import { apiError } from './utils/apiError';
+import { parseOlderThan } from './utils/pagination';
 
 const MAX_SKIP = 10000;
 
@@ -347,7 +348,6 @@ export class BlueprintController {
       let filterGameVersion: string | null = null;
       let filterCategory: string | null = null;
       let filterSubcategory: string | null = null;
-      let dateFilter: Date = new Date();
       let sort: 'recent' | 'popular';
       let skip = 0;
 
@@ -355,27 +355,10 @@ export class BlueprintController {
       let userJwt = req.user as UserJwt;
       if (userJwt != null) userId = userJwt._id;
 
+      const dateFilter = parseOlderThan(req, res);
+      if (dateFilter == null) return;
+
       try {
-        // Check if olderthan parameter exists and is not empty
-        if (!req.query.olderthan || req.query.olderthan === '') {
-          res.status(400).json(apiError(400, 'Missing required parameter: olderthan'));
-          return;
-        }
-
-        let dateInt = parseInt(req.query.olderthan as string);
-        if (isNaN(dateInt)) {
-          res.status(400).json(apiError(400, 'Invalid olderthan parameter: must be a numeric timestamp'));
-          return;
-        }
-
-        dateFilter.setTime(dateInt);
-
-        // Validate that the date is valid after setting time
-        if (isNaN(dateFilter.getTime())) {
-          res.status(400).json(apiError(400, 'Invalid olderthan parameter: timestamp out of range'));
-          return;
-        }
-
         filterUserId = req.query.filterUserId as string;
         const rawFilterName = req.query.filterName as string;
         if (rawFilterName != null && rawFilterName.length > 60) {

--- a/app/api/db.ts
+++ b/app/api/db.ts
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 import { UserModel } from './models/user';
 import { BlueprintModel } from './models/blueprint';
 import { FeedbackModel } from './models/feedback';
+import { FollowModel } from './models/follow';
 
 export class Database {
   constructor() {
@@ -20,6 +21,7 @@ export class Database {
       UserModel.init();
       BlueprintModel.init();
       FeedbackModel.init();
+      FollowModel.init();
     });
     mongoose.connection.on('error', err => {
       if (process.env.NODE_ENV !== 'test') {

--- a/app/api/models/follow.ts
+++ b/app/api/models/follow.ts
@@ -23,6 +23,15 @@ export class FollowModel {
     // My followees, newest first — feed source
     followSchema.index({ followerId: 1, createdAt: -1 });
 
+    // Guards backfills/admin tools, not just the UserController.follow API path
+    followSchema.pre('validate', function (next) {
+      if (this.followerId.equals(this.followeeId)) {
+        next(new Error('Cannot follow yourself'));
+        return;
+      }
+      next();
+    });
+
     FollowModel.model = (mongoose.models['Follow'] as Model<Follow>) ?? mongoose.model<Follow>('Follow', followSchema);
   }
 }

--- a/app/api/models/follow.ts
+++ b/app/api/models/follow.ts
@@ -1,0 +1,28 @@
+import mongoose, { Schema, Document, Model } from 'mongoose';
+
+export interface Follow extends Document {
+  followerId: mongoose.Types.ObjectId;
+  followeeId: mongoose.Types.ObjectId;
+  createdAt: Date;
+}
+
+export class FollowModel {
+  static model: Model<Follow>;
+
+  public static init() {
+    const followSchema = new mongoose.Schema({
+      followerId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+      followeeId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+      createdAt: { type: Date, default: Date.now },
+    });
+
+    // Prevents duplicate follows; also the natural lookup for "does A follow B"
+    followSchema.index({ followerId: 1, followeeId: 1 }, { unique: true });
+    // Follower count / "who follows X"
+    followSchema.index({ followeeId: 1 });
+    // My followees, newest first — feed source
+    followSchema.index({ followerId: 1, createdAt: -1 });
+
+    FollowModel.model = (mongoose.models['Follow'] as Model<Follow>) ?? mongoose.model<Follow>('Follow', followSchema);
+  }
+}

--- a/app/api/models/user.ts
+++ b/app/api/models/user.ts
@@ -22,6 +22,8 @@ export interface User extends Document {
 
   isAlpha?: boolean;
 
+  bio?: string;
+
   setPassword(password: string): void;
   validPassword(password: string): boolean;
   generateJwt(role?: string): string;
@@ -65,6 +67,7 @@ export class UserModel {
       resetToken: String,
       resetTokenExpiration: Date,
       isAlpha: { type: Boolean, default: false },
+      bio: { type: String, maxlength: [500, 'Bio must be 500 characters or fewer'], default: '' },
     });
 
     // Password reset lookup: findOne({ resetToken, resetTokenExpiration: { $gt: ... } })

--- a/app/api/user-controller.ts
+++ b/app/api/user-controller.ts
@@ -1,0 +1,205 @@
+import { Request, Response } from 'express';
+import mongoose from 'mongoose';
+import { UserModel, UserJwt } from './models/user';
+import { FollowModel } from './models/follow';
+import { BlueprintModel } from './models/blueprint';
+import { BlueprintController } from './blueprint-controller';
+import { ProfileResponse, FollowRequest, UpdateBioRequest } from '../../lib/index';
+import { apiError } from './utils/apiError';
+
+export class UserController {
+  constructor() {
+    this.getProfile = this.getProfile.bind(this);
+    this.follow = this.follow.bind(this);
+    this.updateBio = this.updateBio.bind(this);
+    this.getFeed = this.getFeed.bind(this);
+  }
+
+  public getProfile(req: Request, res: Response): void {
+    const username = req.params.username;
+    const userJwt = req.user as UserJwt | undefined;
+
+    UserModel.model
+      .findOne({ username })
+      .then(async targetUser => {
+        if (!targetUser) {
+          res.status(404).json(apiError(404, 'User not found'));
+          return;
+        }
+
+        const targetId = targetUser._id;
+        const [blueprintCount, followerCount, followingCount, followedByMe] = await Promise.all([
+          BlueprintModel.model.countDocuments({ owner: targetId, deletedAt: null }),
+          FollowModel.model.countDocuments({ followeeId: targetId }),
+          FollowModel.model.countDocuments({ followerId: targetId }),
+          userJwt != null
+            ? FollowModel.model
+                .exists({ followerId: userJwt._id, followeeId: targetId })
+                .then(result => result != null)
+            : Promise.resolve(false),
+        ]);
+
+        const response: ProfileResponse = {
+          id: (targetId as mongoose.Types.ObjectId).toString(),
+          username: targetUser.username as string,
+          bio: targetUser.bio ?? '',
+          memberSince: (targetId as mongoose.Types.ObjectId).getTimestamp(),
+          blueprintCount,
+          followerCount,
+          followingCount,
+          followedByMe,
+        };
+        res.json(response);
+      })
+      .catch(err => {
+        console.log('getProfile error');
+        console.log(err);
+        res.status(500).json(apiError(500, 'Failed to retrieve profile'));
+      });
+  }
+
+  public follow(req: Request, res: Response): void {
+    const user = req.user as UserJwt;
+    const { followeeId, follow } = req.body as FollowRequest;
+
+    if (
+      followeeId == null ||
+      typeof followeeId !== 'string' ||
+      !mongoose.Types.ObjectId.isValid(followeeId) ||
+      typeof follow !== 'boolean'
+    ) {
+      res.status(400).json(apiError(400, 'Missing or invalid followeeId or follow'));
+      return;
+    }
+
+    if (followeeId === user._id) {
+      res.status(400).json(apiError(400, 'Cannot follow yourself'));
+      return;
+    }
+
+    UserModel.model
+      .exists({ _id: followeeId })
+      .then(exists => {
+        if (!exists) {
+          res.status(404).json(apiError(404, 'User not found'));
+          return;
+        }
+
+        if (follow) {
+          FollowModel.model
+            .create({ followerId: user._id, followeeId })
+            .then(() => res.json({ follow: 'OK' }))
+            .catch(err => {
+              // Duplicate-key on the unique pair index just means "already following" — idempotent success
+              if (err?.code === 11000) {
+                res.json({ follow: 'OK' });
+                return;
+              }
+              console.log('follow error');
+              console.log(err);
+              res.status(500).json(apiError(500, 'Failed to follow user'));
+            });
+        } else {
+          FollowModel.model
+            .deleteOne({ followerId: user._id, followeeId })
+            .then(() => res.json({ follow: 'OK' }))
+            .catch(err => {
+              console.log('unfollow error');
+              console.log(err);
+              res.status(500).json(apiError(500, 'Failed to unfollow user'));
+            });
+        }
+      })
+      .catch(err => {
+        console.log('follow lookup error');
+        console.log(err);
+        res.status(500).json(apiError(500, 'Failed to process follow request'));
+      });
+  }
+
+  public updateBio(req: Request, res: Response): void {
+    const user = req.user as UserJwt;
+    const { bio } = req.body as UpdateBioRequest;
+
+    if (typeof bio !== 'string' || bio.length > 500) {
+      res.status(400).json(apiError(400, 'bio must be a string of 500 characters or fewer'));
+      return;
+    }
+
+    UserModel.model
+      .findByIdAndUpdate(user._id, { bio }, { new: true })
+      .then(updated => {
+        if (!updated) {
+          res.status(404).json(apiError(404, 'User not found'));
+          return;
+        }
+        res.json({ bio: updated.bio ?? '' });
+      })
+      .catch(err => {
+        console.log('updateBio error');
+        console.log(err);
+        res.status(500).json(apiError(500, 'Failed to update bio'));
+      });
+  }
+
+  public getFeed(req: Request, res: Response): void {
+    const user = req.user as UserJwt;
+    let dateFilter = new Date();
+
+    try {
+      if (!req.query.olderthan || req.query.olderthan === '') {
+        res.status(400).json(apiError(400, 'Missing required parameter: olderthan'));
+        return;
+      }
+
+      const dateInt = parseInt(req.query.olderthan as string);
+      if (isNaN(dateInt)) {
+        res.status(400).json(apiError(400, 'Invalid olderthan parameter: must be a numeric timestamp'));
+        return;
+      }
+
+      dateFilter.setTime(dateInt);
+      if (isNaN(dateFilter.getTime())) {
+        res.status(400).json(apiError(400, 'Invalid olderthan parameter: timestamp out of range'));
+        return;
+      }
+    } catch (error) {
+      console.log(error);
+      res.status(400).json(apiError(400, 'Invalid query parameters'));
+      return;
+    }
+
+    FollowModel.model
+      .find({ followerId: user._id })
+      .select('followeeId')
+      .lean()
+      .then(follows => {
+        const followeeIds = follows.map(f => f.followeeId);
+
+        if (followeeIds.length === 0) {
+          res.json({ blueprints: [], oldest: new Date(), remaining: 0 });
+          return;
+        }
+
+        const browseIncrement = parseInt(process.env.BROWSE_INCREMENT as string);
+        BlueprintModel.model
+          .find({ owner: { $in: followeeIds }, deletedAt: null, createdAt: { $lt: dateFilter } })
+          .sort({ createdAt: -1 })
+          .limit(browseIncrement * 2)
+          .populate('owner')
+          .then(blueprints => {
+            BlueprintController.handleGetBlueprint(req, res, user._id, blueprints);
+          })
+          .catch(err => {
+            console.log('getFeed blueprint find error');
+            console.log(err);
+            res.status(500).json(apiError(500, 'Failed to retrieve feed'));
+          });
+      })
+      .catch(err => {
+        console.log('getFeed follow lookup error');
+        console.log(err);
+        res.status(500).json(apiError(500, 'Failed to retrieve feed'));
+      });
+  }
+}

--- a/app/api/user-controller.ts
+++ b/app/api/user-controller.ts
@@ -8,6 +8,10 @@ import { ProfileResponse, FollowRequest, UpdateBioRequest } from '../../lib/inde
 import { apiError } from './utils/apiError';
 import { parseOlderThan } from './utils/pagination';
 
+// Caps the $in list on the feed's blueprint query so an account following an
+// unusually large number of users can't force an unbounded lookup
+const MAX_FEED_FOLLOWEES = 500;
+
 export class UserController {
   constructor() {
     this.getProfile = this.getProfile.bind(this);
@@ -152,6 +156,8 @@ export class UserController {
     FollowModel.model
       .find({ followerId: user._id })
       .select('followeeId')
+      .sort({ createdAt: -1 })
+      .limit(MAX_FEED_FOLLOWEES)
       .lean()
       .then(follows => {
         const followeeIds = follows.map(f => f.followeeId);

--- a/app/api/user-controller.ts
+++ b/app/api/user-controller.ts
@@ -6,6 +6,7 @@ import { BlueprintModel } from './models/blueprint';
 import { BlueprintController } from './blueprint-controller';
 import { ProfileResponse, FollowRequest, UpdateBioRequest } from '../../lib/index';
 import { apiError } from './utils/apiError';
+import { parseOlderThan } from './utils/pagination';
 
 export class UserController {
   constructor() {
@@ -43,7 +44,7 @@ export class UserController {
           id: (targetId as mongoose.Types.ObjectId).toString(),
           username: targetUser.username as string,
           bio: targetUser.bio ?? '',
-          memberSince: (targetId as mongoose.Types.ObjectId).getTimestamp(),
+          memberSince: (targetId as mongoose.Types.ObjectId).getTimestamp().toISOString(),
           blueprintCount,
           followerCount,
           followingCount,
@@ -144,30 +145,9 @@ export class UserController {
 
   public getFeed(req: Request, res: Response): void {
     const user = req.user as UserJwt;
-    let dateFilter = new Date();
 
-    try {
-      if (!req.query.olderthan || req.query.olderthan === '') {
-        res.status(400).json(apiError(400, 'Missing required parameter: olderthan'));
-        return;
-      }
-
-      const dateInt = parseInt(req.query.olderthan as string);
-      if (isNaN(dateInt)) {
-        res.status(400).json(apiError(400, 'Invalid olderthan parameter: must be a numeric timestamp'));
-        return;
-      }
-
-      dateFilter.setTime(dateInt);
-      if (isNaN(dateFilter.getTime())) {
-        res.status(400).json(apiError(400, 'Invalid olderthan parameter: timestamp out of range'));
-        return;
-      }
-    } catch (error) {
-      console.log(error);
-      res.status(400).json(apiError(400, 'Invalid query parameters'));
-      return;
-    }
+    const dateFilter = parseOlderThan(req, res);
+    if (dateFilter == null) return;
 
     FollowModel.model
       .find({ followerId: user._id })

--- a/app/api/utils/pagination.ts
+++ b/app/api/utils/pagination.ts
@@ -1,0 +1,24 @@
+import { Request, Response } from 'express';
+import { apiError } from './apiError';
+
+export function parseOlderThan(req: Request, res: Response): Date | null {
+  if (!req.query.olderthan || req.query.olderthan === '') {
+    res.status(400).json(apiError(400, 'Missing required parameter: olderthan'));
+    return null;
+  }
+
+  const dateInt = parseInt(req.query.olderthan as string);
+  if (isNaN(dateInt)) {
+    res.status(400).json(apiError(400, 'Invalid olderthan parameter: must be a numeric timestamp'));
+    return null;
+  }
+
+  const dateFilter = new Date();
+  dateFilter.setTime(dateInt);
+  if (isNaN(dateFilter.getTime())) {
+    res.status(400).json(apiError(400, 'Invalid olderthan parameter: timestamp out of range'));
+    return null;
+  }
+
+  return dateFilter;
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -12,6 +12,7 @@ import { MigrationController } from './api/migration-controller';
 import { HealthController } from './api/health-controller';
 import { FeedbackController } from './api/feedback-controller';
 import { AlphaController } from './api/alpha-controller';
+import { UserController } from './api/user-controller';
 export class Routes {
   public staticController = new StaticController();
   public uploadBlueprintController = new BlueprintController();
@@ -21,6 +22,7 @@ export class Routes {
   public healthController = new HealthController();
   public feedbackController = new FeedbackController();
   public alphaController = new AlphaController();
+  public userController = new UserController();
 
   public routes(app: Application): void {
     // Admin-only middleware: requires role === 'admin' in the JWT (set from WorkOS platform org membership)
@@ -71,6 +73,7 @@ export class Routes {
     app.route('/api/getblueprints').get(this.uploadBlueprintController.getBlueprints);
     app.route('/api/version').get(this.versionController.getVersion);
     app.route('/api/health').get(this.healthController.getHealth);
+    app.route('/api/users/:username/profile').get(this.userController.getProfile);
 
     // Logged in access
     app.route('/api/getblueprintsSecure').get(auth, this.uploadBlueprintController.getBlueprints);
@@ -78,6 +81,10 @@ export class Routes {
     app.route('/api/likeblueprint').post(auth, this.uploadBlueprintController.likeBlueprint);
     app.route('/api/deleteblueprint').post(auth, this.uploadBlueprintController.deleteBlueprint);
     app.route('/api/feedback').post(auth, this.feedbackController.submit);
+    app.route('/api/users/:username/profileSecure').get(auth, this.userController.getProfile);
+    app.route('/api/follow').post(auth, this.userController.follow);
+    app.route('/api/users/me').patch(auth, this.userController.updateBio);
+    app.route('/api/feed').get(auth, this.userController.getFeed);
 
     // Admin-only API
     app.route('/api/admin/feedback').get(auth, adminAuth, this.feedbackController.list);

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -9,6 +9,7 @@ import { MagicCallbackComponent } from "./module-blueprint/components/user-auth/
 import { ResetPasswordComponent } from "./module-blueprint/components/user-auth/reset-password/reset-password.component";
 import { VerifyEmailCallbackComponent } from "./module-blueprint/components/user-auth/verify-email-callback/verify-email-callback.component";
 import { BrowsePageComponent } from "./module-blueprint/components/browse-page/browse-page.component";
+import { ProfilePageComponent } from "./module-blueprint/components/profile-page/profile-page.component";
 import { homeRedirectGuard } from "./module-blueprint/guards/home-redirect.guard";
 
 const routes: Routes = [
@@ -20,6 +21,7 @@ const routes: Routes = [
   },
   { path: "editor", component: ComponentBlueprintParentComponent },
   { path: "discover", component: BrowsePageComponent },
+  { path: "profile/:username", component: ProfilePageComponent },
   { path: "b/:id", component: ComponentBlueprintParentComponent },
   {
     path: "b/:id/hideui/:width/:height",

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.css
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.css
@@ -77,6 +77,12 @@
   color: var(--p-red-700, #b91c1c);
 }
 
+.view-mode-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
 .filter-panel {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
@@ -29,6 +29,7 @@
       pButton
       i18n-label
       label="Discover"
+      [attr.aria-pressed]="viewMode === 'discover'"
       [class]="
         viewMode === 'discover'
           ? 'p-button-sm'
@@ -41,6 +42,7 @@
       pButton
       i18n-label
       label="From creators you follow"
+      [attr.aria-pressed]="viewMode === 'feed'"
       [class]="
         viewMode === 'feed' ? 'p-button-sm' : 'p-button-outlined p-button-sm'
       "

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
@@ -23,7 +23,32 @@
     />
   </div>
 
-  <div class="filter-panel">
+  <div class="view-mode-tabs" *ngIf="loggedIn && followingCount > 0">
+    <button
+      type="button"
+      pButton
+      i18n-label
+      label="Discover"
+      [class]="
+        viewMode === 'discover'
+          ? 'p-button-sm'
+          : 'p-button-outlined p-button-sm'
+      "
+      (click)="setViewMode('discover')"
+    ></button>
+    <button
+      type="button"
+      pButton
+      i18n-label
+      label="From creators you follow"
+      [class]="
+        viewMode === 'feed' ? 'p-button-sm' : 'p-button-outlined p-button-sm'
+      "
+      (click)="setViewMode('feed')"
+    ></button>
+  </div>
+
+  <div class="filter-panel" *ngIf="viewMode === 'discover'">
     <p-select
       [(ngModel)]="filterGameVersion"
       [options]="gameVersionOptions"
@@ -135,7 +160,12 @@
           <span *ngIf="!isReal(item.thumbnail)">{{ item.name }}</span>
         </div>
         <div *ngIf="isReal(item.thumbnail)" class="card-meta">
-          <span i18n>by {{ item.ownerName }}</span>
+          <span i18n
+            >by
+            <a [routerLink]="['/profile', item.ownerName]">{{
+              item.ownerName
+            }}</a></span
+          >
           <span class="card-date">{{
             datepipe.transform(item.createdAt, "yyyy-MM-dd")
           }}</span>

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
@@ -47,7 +47,7 @@ describe("BrowsePageComponent", () => {
           id: "u1",
           username: "alice",
           bio: "",
-          memberSince: new Date(),
+          memberSince: new Date().toISOString(),
           blueprintCount: 0,
           followerCount: 0,
           followingCount: 0,

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
@@ -10,6 +10,7 @@ import { By } from "@angular/platform-browser";
 import { BrowsePageComponent } from "./browse-page.component";
 import { BlueprintService } from "src/app/module-blueprint/services/blueprint-service";
 import { AuthenticationService } from "src/app/module-blueprint/services/authentification-service";
+import { UserService } from "src/app/module-blueprint/services/user-service";
 import { BrowseData } from "../user-menu/user-menu.component";
 
 function makeResponse(blueprints: any[] = [], remaining = 0) {
@@ -27,6 +28,7 @@ describe("BrowsePageComponent", () => {
   let fixture: ComponentFixture<BrowsePageComponent>;
   let blueprintService: any;
   let authService: any;
+  let userService: any;
   let router: any;
 
   beforeEach(async () => {
@@ -34,7 +36,26 @@ describe("BrowsePageComponent", () => {
       getBlueprints: vi.fn().mockReturnValue(of(makeResponse())),
     };
 
-    authService = { isLoggedIn: vi.fn().mockReturnValue(true) };
+    authService = {
+      isLoggedIn: vi.fn().mockReturnValue(true),
+      getUserDetails: vi.fn().mockReturnValue({ username: "alice" }),
+    };
+
+    userService = {
+      getProfile: vi.fn().mockReturnValue(
+        of({
+          id: "u1",
+          username: "alice",
+          bio: "",
+          memberSince: new Date(),
+          blueprintCount: 0,
+          followerCount: 0,
+          followingCount: 0,
+          followedByMe: false,
+        })
+      ),
+      getFeed: vi.fn().mockReturnValue(of(makeResponse())),
+    };
 
     router = { navigate: vi.fn() };
 
@@ -44,6 +65,7 @@ describe("BrowsePageComponent", () => {
       providers: [
         { provide: BlueprintService, useValue: blueprintService },
         { provide: AuthenticationService, useValue: authService },
+        { provide: UserService, useValue: userService },
         { provide: Router, useValue: router },
         {
           provide: ActivatedRoute,
@@ -208,6 +230,49 @@ describe("BrowsePageComponent", () => {
       };
       component.ngOnInit();
       expect(component.sort).toBe("popular");
+    });
+  });
+
+  describe("feed view mode", () => {
+    it("fetches following count on init when logged in", () => {
+      fixture.detectChanges();
+      expect(userService.getProfile).toHaveBeenCalledWith("alice");
+      expect(component.followingCount).toBe(0);
+    });
+
+    it("does not fetch following count when logged out", () => {
+      authService.isLoggedIn.mockReturnValue(false);
+      fixture.detectChanges();
+      expect(userService.getProfile).not.toHaveBeenCalled();
+    });
+
+    it("setViewMode('feed') resets the list and calls the feed endpoint", () => {
+      component.blueprintListItems = [{ name: "stale" } as any];
+      component.setViewMode("feed");
+
+      expect(component.viewMode).toBe("feed");
+      expect(userService.getFeed).toHaveBeenCalled();
+      expect(blueprintService.getBlueprints).not.toHaveBeenCalled();
+      expect(
+        component.blueprintListItems.some((i: any) => i.name === "stale")
+      ).toBe(false);
+    });
+
+    it("switching back to discover calls getBlueprints again", () => {
+      component.setViewMode("feed");
+      component.setViewMode("discover");
+
+      expect(component.viewMode).toBe("discover");
+      expect(blueprintService.getBlueprints).toHaveBeenCalled();
+    });
+
+    it("is a no-op when already in the requested mode", () => {
+      component.setViewMode("discover");
+      const callsBefore = blueprintService.getBlueprints.mock.calls.length;
+      component.setViewMode("discover");
+      expect(blueprintService.getBlueprints.mock.calls.length).toBe(
+        callsBefore
+      );
     });
   });
 

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../../../../lib/index";
 import { BlueprintService } from "src/app/module-blueprint/services/blueprint-service";
 import { AuthenticationService } from "src/app/module-blueprint/services/authentification-service";
+import { UserService } from "src/app/module-blueprint/services/user-service";
 import { DatePipe } from "@angular/common";
 import { ActivatedRoute, Router } from "@angular/router";
 import { Subject } from "rxjs";
@@ -50,6 +51,9 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   skipCount = 0;
   private requestId = 0;
 
+  viewMode: "discover" | "feed" = "discover";
+  followingCount = 0;
+
   readonly sortOptions = [
     { label: $localize`:browse.sortNewest:Newest`, value: "recent" },
     { label: $localize`:browse.sortMostLiked:Most liked`, value: "popular" },
@@ -83,6 +87,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   constructor(
     private blueprintService: BlueprintService,
     private authService: AuthenticationService,
+    private userService: UserService,
     public datepipe: DatePipe,
     private route: ActivatedRoute,
     private router: Router
@@ -137,6 +142,23 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     this.filterSubcategory = params.get("subcategory");
     this.sort = params.get("sort") === "popular" ? "popular" : "recent";
     this.appendLoading();
+    this.getBlueprints();
+
+    if (this.loggedIn) {
+      const me = this.authService.getUserDetails()?.username;
+      if (me) {
+        this.userService.getProfile(me).subscribe({
+          next: (profile) => (this.followingCount = profile.followingCount),
+          error: () => {},
+        });
+      }
+    }
+  }
+
+  setViewMode(mode: "discover" | "feed") {
+    if (this.viewMode === mode) return;
+    this.viewMode = mode;
+    this.reset();
     this.getBlueprints();
   }
 
@@ -202,29 +224,32 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   }
 
   getBlueprints() {
-    const name = this.filterName.trim() || null;
     this.loadError = false;
     const requestId = ++this.requestId;
-    this.blueprintService
-      .getBlueprints(
-        this.oldestDate,
-        this.filterUserId,
-        name,
-        false,
-        this.filterGameVersion,
-        this.filterCategory,
-        this.filterSubcategory,
-        this.sort,
-        this.sort === "popular" ? this.skipCount : undefined
-      )
-      .subscribe({
-        next: (r: any) => {
-          if (requestId === this.requestId) this.handleGetBlueprints(r);
-        },
-        error: () => {
-          if (requestId === this.requestId) this.handleError();
-        },
-      });
+
+    const request$ =
+      this.viewMode === "feed"
+        ? this.userService.getFeed(this.oldestDate)
+        : this.blueprintService.getBlueprints(
+            this.oldestDate,
+            this.filterUserId,
+            this.filterName.trim() || null,
+            false,
+            this.filterGameVersion,
+            this.filterCategory,
+            this.filterSubcategory,
+            this.sort,
+            this.sort === "popular" ? this.skipCount : undefined
+          );
+
+    request$.subscribe({
+      next: (r: any) => {
+        if (requestId === this.requestId) this.handleGetBlueprints(r);
+      },
+      error: () => {
+        if (requestId === this.requestId) this.handleError();
+      },
+    });
   }
 
   showMyBlueprints(data: BrowseData) {

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.css
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.css
@@ -1,0 +1,161 @@
+.profile-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.profile-loading,
+.profile-not-found {
+  text-align: center;
+  padding: 3rem 0;
+  color: var(--p-text-muted-color);
+}
+
+.profile-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.avatar {
+  flex: none;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: var(--p-primary-color, #007aff);
+  color: var(--p-primary-contrast-color, #fff);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.profile-details {
+  flex: 1;
+  min-width: 0;
+}
+
+.profile-details h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.5rem;
+}
+
+.bio {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.bio-empty {
+  color: var(--p-text-muted-color);
+  font-style: italic;
+}
+
+.bio-edit textarea {
+  width: 100%;
+  max-width: 500px;
+}
+
+.bio-edit-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.bio-char-count {
+  font-size: 0.8rem;
+  color: var(--p-text-muted-color);
+}
+
+.profile-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  font-size: 0.9rem;
+  color: var(--p-text-muted-color);
+}
+
+.profile-actions {
+  flex: none;
+}
+
+.blueprint-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.blueprint-card {
+  border: 1px solid var(--p-content-border-color);
+  border-radius: 4px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.card-thumbnail img,
+.card-thumbnail .thumbnail-placeholder {
+  width: 100%;
+  height: 200px;
+  display: block;
+  background: #007aff;
+}
+
+.thumbnail-placeholder--empty {
+  background: #6b7280;
+}
+
+.card-info {
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.card-title a {
+  font-weight: bold;
+  color: inherit;
+  text-decoration: none;
+}
+
+.card-title a:hover {
+  text-decoration: underline;
+}
+
+.card-meta {
+  display: flex;
+  justify-content: flex-end;
+  font-size: 0.85rem;
+  color: var(--p-text-muted-color);
+}
+
+.card-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.badge--category {
+  background: var(--p-primary-100, #dbeafe);
+  color: var(--p-primary-700, #1d4ed8);
+}
+
+.badge--version {
+  background: var(--p-surface-200, #e5e7eb);
+  color: var(--p-text-muted-color, #6b7280);
+}

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.html
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.html
@@ -1,0 +1,143 @@
+<div class="profile-page">
+  <div *ngIf="loadingProfile" class="profile-loading" i18n>
+    Loading profile…
+  </div>
+
+  <div *ngIf="!loadingProfile && notFound" class="profile-not-found" i18n>
+    User not found.
+  </div>
+
+  <ng-container *ngIf="!loadingProfile && !notFound && profile">
+    <div class="profile-header">
+      <div class="avatar">{{ avatarLetter }}</div>
+
+      <div class="profile-details">
+        <h1>{{ profile.username }}</h1>
+
+        <div *ngIf="!editingBio" class="bio">
+          <span *ngIf="profile.bio">{{ profile.bio }}</span>
+          <span *ngIf="!profile.bio && !isOwnProfile" class="bio-empty" i18n
+            >No bio yet.</span
+          >
+          <button
+            *ngIf="isOwnProfile"
+            type="button"
+            pButton
+            class="p-button-text p-button-sm"
+            icon="pi pi-pencil"
+            i18n-label
+            label="Edit bio"
+            (click)="startEditingBio()"
+          ></button>
+        </div>
+
+        <div *ngIf="editingBio" class="bio-edit">
+          <textarea
+            pTextarea
+            [(ngModel)]="bioDraft"
+            maxlength="500"
+            rows="3"
+          ></textarea>
+          <div class="bio-edit-actions">
+            <span class="bio-char-count">{{ bioDraft.length }}/500</span>
+            <button
+              type="button"
+              pButton
+              i18n-label
+              label="Cancel"
+              class="p-button-text p-button-sm"
+              [disabled]="savingBio"
+              (click)="cancelEditingBio()"
+            ></button>
+            <button
+              type="button"
+              pButton
+              i18n-label
+              label="Save"
+              class="p-button-sm"
+              [disabled]="savingBio"
+              (click)="saveBio()"
+            ></button>
+          </div>
+        </div>
+
+        <div class="profile-meta">
+          <span i18n
+            >Member since
+            {{ datepipe.transform(profile.memberSince, "yyyy-MM-dd") }}</span
+          >
+          <span
+            >{{ profile.blueprintCount }}
+            <ng-container i18n>blueprints</ng-container></span
+          >
+          <span
+            >{{ profile.followerCount }}
+            <ng-container i18n>followers</ng-container></span
+          >
+          <span
+            >{{ profile.followingCount }}
+            <ng-container i18n>following</ng-container></span
+          >
+        </div>
+      </div>
+
+      <div class="profile-actions" *ngIf="!isOwnProfile">
+        <button
+          type="button"
+          pButton
+          [disabled]="!loggedIn || followWorking"
+          [pTooltip]="loggedIn ? '' : loginPromptText"
+          [label]="profile.followedByMe ? unfollowLabel : followLabel"
+          [icon]="profile.followedByMe ? 'pi pi-user-minus' : 'pi pi-user-plus'"
+          (click)="toggleFollow()"
+        ></button>
+      </div>
+    </div>
+
+    <div class="blueprint-grid">
+      <div class="blueprint-card" *ngFor="let item of blueprintListItems">
+        <div class="card-thumbnail">
+          <img *ngIf="isReal(item.thumbnail)" [src]="item.thumbnail" />
+          <span
+            *ngIf="item.thumbnail === 'svg'"
+            class="thumbnail-placeholder"
+          ></span>
+          <span
+            *ngIf="item.thumbnail === 'svg_nothing'"
+            class="thumbnail-placeholder thumbnail-placeholder--empty"
+          ></span>
+        </div>
+
+        <div class="card-info">
+          <div class="card-title">
+            <a *ngIf="isReal(item.thumbnail)" [routerLink]="['/b', item.id]">{{
+              item.name
+            }}</a>
+            <span *ngIf="!isReal(item.thumbnail)">{{ item.name }}</span>
+          </div>
+          <div *ngIf="isReal(item.thumbnail)" class="card-meta">
+            <span class="card-date">{{
+              datepipe.transform(item.createdAt, "yyyy-MM-dd")
+            }}</span>
+          </div>
+          <div *ngIf="isReal(item.thumbnail)" class="card-badges">
+            <span *ngIf="item.category" class="badge badge--category">{{
+              item.category
+            }}</span>
+            <span *ngIf="item.gameVersion" class="badge badge--version">{{
+              item.gameVersion
+            }}</span>
+          </div>
+          <app-like-widget
+            *ngIf="isReal(item.thumbnail)"
+            class="card-likes"
+            [blueprintId]="item.id"
+            [nbLikes]="item.nbLikes"
+            [likedByMe]="item.likedByMe"
+            [disabled]="!loggedIn"
+          ></app-like-widget>
+        </div>
+      </div>
+    </div>
+  </ng-container>
+</div>

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.spec.ts
@@ -1,0 +1,171 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { DatePipe } from "@angular/common";
+import { ActivatedRoute, convertToParamMap } from "@angular/router";
+import { of, throwError } from "rxjs";
+
+import { ProfilePageComponent } from "./profile-page.component";
+import { UserService } from "../../services/user-service";
+import { BlueprintService } from "../../services/blueprint-service";
+import { AuthenticationService } from "../../services/authentification-service";
+
+function makeProfile(overrides: any = {}) {
+  return {
+    id: "owner-1",
+    username: "alice",
+    bio: "",
+    memberSince: new Date("2024-01-01"),
+    blueprintCount: 0,
+    followerCount: 0,
+    followingCount: 0,
+    followedByMe: false,
+    ...overrides,
+  };
+}
+
+function makeBlueprintResponse(blueprints: any[] = [], remaining = 0) {
+  return { oldest: new Date("2024-01-01").getTime(), remaining, blueprints };
+}
+
+describe("ProfilePageComponent", () => {
+  let component: ProfilePageComponent;
+  let fixture: ComponentFixture<ProfilePageComponent>;
+  let userService: any;
+  let blueprintService: any;
+  let authService: any;
+
+  beforeEach(async () => {
+    userService = {
+      getProfile: vi.fn().mockReturnValue(of(makeProfile())),
+      follow: vi.fn().mockReturnValue(of({ follow: "OK" })),
+      updateBio: vi.fn().mockReturnValue(of({ bio: "updated" })),
+    };
+    blueprintService = {
+      getBlueprints: vi.fn().mockReturnValue(of(makeBlueprintResponse())),
+    };
+    authService = {
+      isLoggedIn: vi.fn().mockReturnValue(true),
+      getUserDetails: vi.fn().mockReturnValue({ username: "bob" }),
+    };
+
+    await TestBed.configureTestingModule({
+      declarations: [ProfilePageComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        { provide: UserService, useValue: userService },
+        { provide: BlueprintService, useValue: blueprintService },
+        { provide: AuthenticationService, useValue: authService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { paramMap: convertToParamMap({ username: "alice" }) },
+          },
+        },
+        DatePipe,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProfilePageComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("creates", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("loads the profile for the routed username", () => {
+    fixture.detectChanges();
+    expect(userService.getProfile).toHaveBeenCalledWith("alice");
+    expect(component.profile?.username).toBe("alice");
+    expect(component.loadingProfile).toBe(false);
+  });
+
+  it("loads that owner's blueprints once the profile resolves", () => {
+    fixture.detectChanges();
+    expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
+      expect.any(Date),
+      "owner-1",
+      null,
+      false
+    );
+  });
+
+  it("sets notFound and stops loading on a 404", () => {
+    userService.getProfile.mockReturnValue(throwError(() => new Error("404")));
+    fixture.detectChanges();
+    expect(component.notFound).toBe(true);
+    expect(component.loadingProfile).toBe(false);
+  });
+
+  describe("isOwnProfile", () => {
+    it("is true when the logged-in username matches the route", () => {
+      authService.getUserDetails.mockReturnValue({ username: "alice" });
+      fixture.detectChanges();
+      expect(component.isOwnProfile).toBe(true);
+    });
+
+    it("is false for another user's profile", () => {
+      authService.getUserDetails.mockReturnValue({ username: "bob" });
+      fixture.detectChanges();
+      expect(component.isOwnProfile).toBe(false);
+    });
+
+    it("is false when logged out even if usernames happen to match", () => {
+      authService.isLoggedIn.mockReturnValue(false);
+      authService.getUserDetails.mockReturnValue({ username: "alice" });
+      fixture.detectChanges();
+      expect(component.isOwnProfile).toBe(false);
+    });
+  });
+
+  describe("toggleFollow", () => {
+    it("optimistically flips followedByMe and followerCount, then calls the service", () => {
+      fixture.detectChanges();
+      component.toggleFollow();
+
+      expect(component.profile?.followedByMe).toBe(true);
+      expect(component.profile?.followerCount).toBe(1);
+      expect(userService.follow).toHaveBeenCalledWith("owner-1", true);
+    });
+
+    it("rolls back on error", () => {
+      userService.follow.mockReturnValue(throwError(() => new Error("fail")));
+      fixture.detectChanges();
+      component.toggleFollow();
+
+      expect(component.profile?.followedByMe).toBe(false);
+      expect(component.profile?.followerCount).toBe(0);
+    });
+  });
+
+  describe("bio editing", () => {
+    it("starts editing with the current bio", () => {
+      userService.getProfile.mockReturnValue(
+        of(makeProfile({ bio: "old bio" }))
+      );
+      fixture.detectChanges();
+      component.startEditingBio();
+      expect(component.editingBio).toBe(true);
+      expect(component.bioDraft).toBe("old bio");
+    });
+
+    it("saves the draft and exits edit mode", () => {
+      fixture.detectChanges();
+      component.editingBio = true;
+      component.bioDraft = "new bio";
+      component.saveBio();
+
+      expect(userService.updateBio).toHaveBeenCalledWith("new bio");
+      expect(component.profile?.bio).toBe("updated");
+      expect(component.editingBio).toBe(false);
+    });
+
+    it("cancelEditingBio exits without saving", () => {
+      fixture.detectChanges();
+      component.editingBio = true;
+      component.cancelEditingBio();
+      expect(component.editingBio).toBe(false);
+      expect(userService.updateBio).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.spec.ts
@@ -14,7 +14,7 @@ function makeProfile(overrides: any = {}) {
     id: "owner-1",
     username: "alice",
     bio: "",
-    memberSince: new Date("2024-01-01"),
+    memberSince: new Date("2024-01-01").toISOString(),
     blueprintCount: 0,
     followerCount: 0,
     followingCount: 0,
@@ -58,7 +58,7 @@ describe("ProfilePageComponent", () => {
         {
           provide: ActivatedRoute,
           useValue: {
-            snapshot: { paramMap: convertToParamMap({ username: "alice" }) },
+            paramMap: of(convertToParamMap({ username: "alice" })),
           },
         },
         DatePipe,

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.ts
@@ -1,0 +1,224 @@
+import { Component, HostListener, OnInit } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
+import { DatePipe } from "@angular/common";
+import { UserService } from "../../services/user-service";
+import { BlueprintService } from "../../services/blueprint-service";
+import { AuthenticationService } from "../../services/authentification-service";
+import {
+  BlueprintListItem,
+  BlueprintListResponse,
+  ProfileResponse,
+} from "../../../../../../lib/index";
+
+const LOADING_STR = $localize`Loading...`;
+const NO_RESULTS_STR = $localize`:profile.noResults:No blueprints yet`;
+const FOLLOW_LABEL = $localize`:profile.follow:Follow`;
+const UNFOLLOW_LABEL = $localize`:profile.unfollow:Unfollow`;
+const LOGIN_PROMPT = $localize`:profile.loginToFollow:Log in to follow`;
+
+@Component({
+  selector: "app-profile-page",
+  templateUrl: "./profile-page.component.html",
+  styleUrls: ["./profile-page.component.css"],
+  standalone: false,
+})
+export class ProfilePageComponent implements OnInit {
+  username = "";
+  profile: ProfileResponse | null = null;
+  loadingProfile = true;
+  notFound = false;
+  followWorking = false;
+
+  editingBio = false;
+  bioDraft = "";
+  savingBio = false;
+
+  blueprintListItems: BlueprintListItem[] = [];
+  working = true;
+  noMoreBlueprints = false;
+  oldestDate = new Date();
+  remaining = 0;
+
+  loadingBlueprintItem: BlueprintListItem;
+  nothingBlueprintItem: BlueprintListItem;
+
+  readonly followLabel = FOLLOW_LABEL;
+  readonly unfollowLabel = UNFOLLOW_LABEL;
+  readonly loginPromptText = LOGIN_PROMPT;
+
+  constructor(
+    private route: ActivatedRoute,
+    private userService: UserService,
+    private blueprintService: BlueprintService,
+    public authService: AuthenticationService,
+    public datepipe: DatePipe
+  ) {
+    const tempDate = new Date();
+    this.loadingBlueprintItem = {
+      id: null as any,
+      name: LOADING_STR,
+      ownerId: "",
+      ownerName: LOADING_STR,
+      createdAt: tempDate,
+      modifiedAt: tempDate,
+      thumbnail: "svg",
+      tags: null as any,
+      likedByMe: false,
+      ownedByMe: false,
+      nbLikes: 0,
+    };
+
+    this.nothingBlueprintItem = {
+      id: null as any,
+      name: NO_RESULTS_STR,
+      ownerId: "",
+      ownerName: "",
+      createdAt: tempDate,
+      modifiedAt: tempDate,
+      thumbnail: "svg_nothing",
+      tags: null as any,
+      likedByMe: false,
+      ownedByMe: false,
+      nbLikes: 0,
+    };
+  }
+
+  ngOnInit() {
+    this.username = this.route.snapshot.paramMap.get("username") ?? "";
+    this.appendLoading();
+    this.loadProfile();
+  }
+
+  get isOwnProfile(): boolean {
+    return (
+      this.loggedIn &&
+      this.authService.getUserDetails()?.username === this.username
+    );
+  }
+
+  get loggedIn(): boolean {
+    return this.authService.isLoggedIn();
+  }
+
+  get avatarLetter(): string {
+    return this.username.charAt(0).toUpperCase();
+  }
+
+  isReal(thumbnail: string): boolean {
+    return thumbnail !== "svg" && thumbnail !== "svg_nothing";
+  }
+
+  loadProfile() {
+    this.loadingProfile = true;
+    this.notFound = false;
+    this.userService.getProfile(this.username).subscribe({
+      next: (profile) => {
+        this.profile = profile;
+        this.bioDraft = profile.bio;
+        this.loadingProfile = false;
+        this.loadBlueprints();
+      },
+      error: () => {
+        this.loadingProfile = false;
+        this.notFound = true;
+        this.working = false;
+        this.blueprintListItems = [];
+      },
+    });
+  }
+
+  toggleFollow() {
+    if (!this.profile || this.followWorking) return;
+    const nextFollowed = !this.profile.followedByMe;
+
+    // Optimistic, mirroring like-widget
+    this.profile.followedByMe = nextFollowed;
+    this.profile.followerCount += nextFollowed ? 1 : -1;
+    this.followWorking = true;
+
+    this.userService.follow(this.profile.id, nextFollowed).subscribe({
+      next: () => {
+        this.followWorking = false;
+      },
+      error: () => {
+        // Roll back on failure
+        if (!this.profile) return;
+        this.profile.followedByMe = !nextFollowed;
+        this.profile.followerCount += nextFollowed ? -1 : 1;
+        this.followWorking = false;
+      },
+    });
+  }
+
+  startEditingBio() {
+    if (!this.profile) return;
+    this.bioDraft = this.profile.bio;
+    this.editingBio = true;
+  }
+
+  cancelEditingBio() {
+    this.editingBio = false;
+  }
+
+  saveBio() {
+    if (!this.profile || this.savingBio) return;
+    this.savingBio = true;
+    this.userService.updateBio(this.bioDraft).subscribe({
+      next: (result) => {
+        if (this.profile) this.profile.bio = result.bio;
+        this.savingBio = false;
+        this.editingBio = false;
+      },
+      error: () => {
+        this.savingBio = false;
+      },
+    });
+  }
+
+  @HostListener("window:scroll")
+  onWindowScroll() {
+    const scrolled = window.scrollY + window.innerHeight;
+    const total = document.documentElement.scrollHeight;
+    if (!this.noMoreBlueprints && !this.working && scrolled > total - 300) {
+      this.loadMore();
+    }
+  }
+
+  loadBlueprints() {
+    if (!this.profile) return;
+    this.blueprintService
+      .getBlueprints(this.oldestDate, this.profile.id, null, false)
+      .subscribe({
+        next: (r: any) => this.handleGetBlueprints(r),
+        error: () => {
+          this.working = false;
+        },
+      });
+  }
+
+  handleGetBlueprints(response: BlueprintListResponse) {
+    this.working = false;
+    this.oldestDate = new Date(response.oldest);
+    this.remaining = response.remaining;
+    if (this.remaining === 0) this.noMoreBlueprints = true;
+
+    this.blueprintListItems = this.blueprintListItems.filter(
+      (i) => i !== this.loadingBlueprintItem
+    );
+    response.blueprints.forEach((item) => this.blueprintListItems.push(item));
+
+    if (this.blueprintListItems.length === 0)
+      this.blueprintListItems.push(this.nothingBlueprintItem);
+  }
+
+  loadMore() {
+    this.working = true;
+    this.appendLoading();
+    this.loadBlueprints();
+  }
+
+  appendLoading() {
+    for (let i = 0; i < 6; i++)
+      this.blueprintListItems.push(this.loadingBlueprintItem);
+  }
+}

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.ts
@@ -84,9 +84,27 @@ export class ProfilePageComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.username = this.route.snapshot.paramMap.get("username") ?? "";
-    this.appendLoading();
-    this.loadProfile();
+    this.route.paramMap.subscribe((paramMap) => {
+      this.username = paramMap.get("username") ?? "";
+      this.resetProfileState();
+      this.appendLoading();
+      this.loadProfile();
+    });
+  }
+
+  private resetProfileState() {
+    this.profile = null;
+    this.loadingProfile = true;
+    this.notFound = false;
+    this.followWorking = false;
+    this.editingBio = false;
+    this.bioDraft = "";
+    this.savingBio = false;
+    this.blueprintListItems = [];
+    this.working = true;
+    this.noMoreBlueprints = false;
+    this.oldestDate = new Date();
+    this.remaining = 0;
   }
 
   get isOwnProfile(): boolean {

--- a/frontend/src/app/module-blueprint/module-blueprint.module.ts
+++ b/frontend/src/app/module-blueprint/module-blueprint.module.ts
@@ -88,6 +88,7 @@ import { VerifyEmailCallbackComponent } from "./components/user-auth/verify-emai
 import { FeedbackDialogComponent } from "./components/dialogs/feedback-dialog/feedback-dialog.component";
 import { FeedbackService } from "./services/feedback.service";
 import { BrowsePageComponent } from "./components/browse-page/browse-page.component";
+import { ProfilePageComponent } from "./components/profile-page/profile-page.component";
 
 @NgModule({
   declarations: [
@@ -137,6 +138,7 @@ import { BrowsePageComponent } from "./components/browse-page/browse-page.compon
     VerifyEmailCallbackComponent,
     FeedbackDialogComponent,
     BrowsePageComponent,
+    ProfilePageComponent,
   ],
   exports: [ComponentBlueprintParentComponent],
   imports: [

--- a/frontend/src/app/module-blueprint/services/user-service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/user-service.spec.ts
@@ -1,0 +1,81 @@
+import { UserService } from "./user-service";
+import { of } from "rxjs";
+
+describe("UserService", () => {
+  let service: UserService;
+  let mockHttp: any;
+  let mockAuth: any;
+
+  beforeEach(() => {
+    mockHttp = {
+      get: vi.fn(() => of({})),
+      post: vi.fn(() => of({})),
+      patch: vi.fn(() => of({})),
+    };
+    mockAuth = {
+      isLoggedIn: vi.fn(() => false),
+      getToken: vi.fn(() => "token123"),
+    };
+    service = new UserService(mockHttp, mockAuth);
+  });
+
+  describe("getProfile", () => {
+    it("hits the anonymous endpoint when logged out", () => {
+      service.getProfile("alice").subscribe();
+      expect(mockHttp.get).toHaveBeenCalledWith(
+        "/api/users/alice/profile",
+        expect.objectContaining({ headers: {} })
+      );
+    });
+
+    it("hits the secure endpoint with an auth header when logged in", () => {
+      mockAuth.isLoggedIn.mockReturnValue(true);
+      service.getProfile("alice").subscribe();
+      expect(mockHttp.get).toHaveBeenCalledWith(
+        "/api/users/alice/profileSecure",
+        expect.objectContaining({
+          headers: { Authorization: "Bearer token123" },
+        })
+      );
+    });
+  });
+
+  describe("follow", () => {
+    it("posts followeeId and the desired follow state", () => {
+      service.follow("user-1", true).subscribe();
+      expect(mockHttp.post).toHaveBeenCalledWith(
+        "/api/follow",
+        { followeeId: "user-1", follow: true },
+        expect.objectContaining({
+          headers: { Authorization: "Bearer token123" },
+        })
+      );
+    });
+  });
+
+  describe("updateBio", () => {
+    it("patches the bio", () => {
+      service.updateBio("hello").subscribe();
+      expect(mockHttp.patch).toHaveBeenCalledWith(
+        "/api/users/me",
+        { bio: "hello" },
+        expect.objectContaining({
+          headers: { Authorization: "Bearer token123" },
+        })
+      );
+    });
+  });
+
+  describe("getFeed", () => {
+    it("requests the feed with an olderthan cursor", () => {
+      const date = new Date("2024-01-01");
+      service.getFeed(date).subscribe();
+      expect(mockHttp.get).toHaveBeenCalledWith(
+        `/api/feed?olderthan=${date.getTime()}`,
+        expect.objectContaining({
+          headers: { Authorization: "Bearer token123" },
+        })
+      );
+    });
+  });
+});

--- a/frontend/src/app/module-blueprint/services/user-service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/user-service.spec.ts
@@ -1,4 +1,5 @@
 import { UserService } from "./user-service";
+import { HttpParams } from "@angular/common/http";
 import { of } from "rxjs";
 
 describe("UserService", () => {
@@ -42,6 +43,7 @@ describe("UserService", () => {
 
   describe("follow", () => {
     it("posts followeeId and the desired follow state", () => {
+      mockAuth.isLoggedIn.mockReturnValue(true);
       service.follow("user-1", true).subscribe();
       expect(mockHttp.post).toHaveBeenCalledWith(
         "/api/follow",
@@ -51,10 +53,18 @@ describe("UserService", () => {
         })
       );
     });
+
+    it("errors without hitting the network when logged out", () => {
+      const onError = vi.fn();
+      service.follow("user-1", true).subscribe({ error: onError });
+      expect(onError).toHaveBeenCalled();
+      expect(mockHttp.post).not.toHaveBeenCalled();
+    });
   });
 
   describe("updateBio", () => {
     it("patches the bio", () => {
+      mockAuth.isLoggedIn.mockReturnValue(true);
       service.updateBio("hello").subscribe();
       expect(mockHttp.patch).toHaveBeenCalledWith(
         "/api/users/me",
@@ -64,6 +74,13 @@ describe("UserService", () => {
         })
       );
     });
+
+    it("errors without hitting the network when logged out", () => {
+      const onError = vi.fn();
+      service.updateBio("hello").subscribe({ error: onError });
+      expect(onError).toHaveBeenCalled();
+      expect(mockHttp.patch).not.toHaveBeenCalled();
+    });
   });
 
   describe("getFeed", () => {
@@ -71,8 +88,9 @@ describe("UserService", () => {
       const date = new Date("2024-01-01");
       service.getFeed(date).subscribe();
       expect(mockHttp.get).toHaveBeenCalledWith(
-        `/api/feed?olderthan=${date.getTime()}`,
+        "/api/feed",
         expect.objectContaining({
+          params: new HttpParams().set("olderthan", date.getTime().toString()),
           headers: { Authorization: "Bearer token123" },
         })
       );

--- a/frontend/src/app/module-blueprint/services/user-service.ts
+++ b/frontend/src/app/module-blueprint/services/user-service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
-import { HttpClient } from "@angular/common/http";
-import { Observable } from "rxjs";
+import { HttpClient, HttpParams } from "@angular/common/http";
+import { Observable, throwError } from "rxjs";
 import { AuthenticationService } from "./authentification-service";
 import {
   ProfileResponse,
@@ -29,6 +29,9 @@ export class UserService {
   }
 
   follow(followeeId: string, follow: boolean): Observable<{ follow: string }> {
+    if (!this.authService.isLoggedIn()) {
+      return throwError(() => new Error("Not authenticated"));
+    }
     const body: FollowRequest = { followeeId, follow };
     return this.http.post<{ follow: string }>("/api/follow", body, {
       headers: { Authorization: `Bearer ${this.authService.getToken()}` },
@@ -36,6 +39,9 @@ export class UserService {
   }
 
   updateBio(bio: string): Observable<{ bio: string }> {
+    if (!this.authService.isLoggedIn()) {
+      return throwError(() => new Error("Not authenticated"));
+    }
     const body: UpdateBioRequest = { bio };
     return this.http.patch<{ bio: string }>("/api/users/me", body, {
       headers: { Authorization: `Bearer ${this.authService.getToken()}` },
@@ -43,8 +49,12 @@ export class UserService {
   }
 
   getFeed(olderThan: Date): Observable<BlueprintListResponse> {
-    const params = "olderthan=" + olderThan.getTime().toString();
-    return this.http.get<BlueprintListResponse>(`/api/feed?${params}`, {
+    const params = new HttpParams().set(
+      "olderthan",
+      olderThan.getTime().toString()
+    );
+    return this.http.get<BlueprintListResponse>("/api/feed", {
+      params,
       headers: { Authorization: `Bearer ${this.authService.getToken()}` },
     });
   }

--- a/frontend/src/app/module-blueprint/services/user-service.ts
+++ b/frontend/src/app/module-blueprint/services/user-service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { Observable } from "rxjs";
+import { AuthenticationService } from "./authentification-service";
+import {
+  ProfileResponse,
+  FollowRequest,
+  UpdateBioRequest,
+  BlueprintListResponse,
+} from "../../../../../lib/index";
+
+@Injectable({ providedIn: "root" })
+export class UserService {
+  constructor(
+    private http: HttpClient,
+    private authService: AuthenticationService
+  ) {}
+
+  getProfile(username: string): Observable<ProfileResponse> {
+    const url = this.authService.isLoggedIn()
+      ? `/api/users/${username}/profileSecure`
+      : `/api/users/${username}/profile`;
+
+    return this.http.get<ProfileResponse>(url, {
+      headers: this.authService.isLoggedIn()
+        ? { Authorization: `Bearer ${this.authService.getToken()}` }
+        : {},
+    });
+  }
+
+  follow(followeeId: string, follow: boolean): Observable<{ follow: string }> {
+    const body: FollowRequest = { followeeId, follow };
+    return this.http.post<{ follow: string }>("/api/follow", body, {
+      headers: { Authorization: `Bearer ${this.authService.getToken()}` },
+    });
+  }
+
+  updateBio(bio: string): Observable<{ bio: string }> {
+    const body: UpdateBioRequest = { bio };
+    return this.http.patch<{ bio: string }>("/api/users/me", body, {
+      headers: { Authorization: `Bearer ${this.authService.getToken()}` },
+    });
+  }
+
+  getFeed(olderThan: Date): Observable<BlueprintListResponse> {
+    const params = "olderthan=" + olderThan.getTime().toString();
+    return this.http.get<BlueprintListResponse>(`/api/feed?${params}`, {
+      headers: { Authorization: `Bearer ${this.authService.getToken()}` },
+    });
+  }
+}

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -26,6 +26,7 @@ export * from './src/b-export/b-sprite-modifier';
 export * from './src/b-export/b-sprite-info';
 export * from './src/b-export/b-ui-screen';
 export * from './src/coms/blueprint-list-response';
+export * from './src/coms/social';
 export * from './src/drawing/sprite-modifier';
 export * from './src/drawing/sprite-modifier-group';
 export * from './src/drawing/sprite-info';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -30,6 +30,7 @@ export * from './src/b-export/b-sprite-info';
 export * from './src/b-export/b-ui-screen';
 
 export * from './src/coms/blueprint-list-response';
+export * from './src/coms/social';
 
 export * from './src/drawing/sprite-modifier';
 export * from './src/drawing/sprite-modifier-group';

--- a/lib/src/coms/social.d.ts
+++ b/lib/src/coms/social.d.ts
@@ -2,7 +2,7 @@ export interface ProfileResponse {
     id: string;
     username: string;
     bio: string;
-    memberSince: Date;
+    memberSince: string;
     blueprintCount: number;
     followerCount: number;
     followingCount: number;

--- a/lib/src/coms/social.d.ts
+++ b/lib/src/coms/social.d.ts
@@ -1,0 +1,18 @@
+export interface ProfileResponse {
+    id: string;
+    username: string;
+    bio: string;
+    memberSince: Date;
+    blueprintCount: number;
+    followerCount: number;
+    followingCount: number;
+    followedByMe: boolean;
+}
+export interface FollowRequest {
+    followeeId: string;
+    follow: boolean;
+}
+export interface UpdateBioRequest {
+    bio: string;
+}
+//# sourceMappingURL=social.d.ts.map

--- a/lib/src/coms/social.ts
+++ b/lib/src/coms/social.ts
@@ -2,7 +2,7 @@ export interface ProfileResponse {
   id: string;
   username: string;
   bio: string;
-  memberSince: Date;
+  memberSince: string;
   blueprintCount: number;
   followerCount: number;
   followingCount: number;

--- a/lib/src/coms/social.ts
+++ b/lib/src/coms/social.ts
@@ -1,0 +1,19 @@
+export interface ProfileResponse {
+  id: string;
+  username: string;
+  bio: string;
+  memberSince: Date;
+  blueprintCount: number;
+  followerCount: number;
+  followingCount: number;
+  followedByMe: boolean;
+}
+
+export interface FollowRequest {
+  followeeId: string;
+  follow: boolean;
+}
+
+export interface UpdateBioRequest {
+  bio: string;
+}

--- a/migrations/20260705010000_add-follow-indexes.js
+++ b/migrations/20260705010000_add-follow-indexes.js
@@ -6,9 +6,9 @@
 module.exports = {
   async up(db) {
     const col = db.collection('follows');
-    await col.createIndex({ followerId: 1, followeeId: 1 }, { unique: true, background: true, name: 'followerId_1_followeeId_1' });
-    await col.createIndex({ followeeId: 1 }, { background: true, name: 'followeeId_1' });
-    await col.createIndex({ followerId: 1, createdAt: -1 }, { background: true, name: 'followerId_1_createdAt_-1' });
+    await col.createIndex({ followerId: 1, followeeId: 1 }, { unique: true, name: 'followerId_1_followeeId_1' });
+    await col.createIndex({ followeeId: 1 }, { name: 'followeeId_1' });
+    await col.createIndex({ followerId: 1, createdAt: -1 }, { name: 'followerId_1_createdAt_-1' });
   },
 
   async down(db) {

--- a/migrations/20260705010000_add-follow-indexes.js
+++ b/migrations/20260705010000_add-follow-indexes.js
@@ -1,0 +1,27 @@
+'use strict';
+
+// Follow collection indexes. New collection — no data migration needed.
+// createIndex is idempotent, safe to re-run.
+
+module.exports = {
+  async up(db) {
+    const col = db.collection('follows');
+    await col.createIndex({ followerId: 1, followeeId: 1 }, { unique: true, background: true, name: 'followerId_1_followeeId_1' });
+    await col.createIndex({ followeeId: 1 }, { background: true, name: 'followeeId_1' });
+    await col.createIndex({ followerId: 1, createdAt: -1 }, { background: true, name: 'followerId_1_createdAt_-1' });
+  },
+
+  async down(db) {
+    const col = db.collection('follows');
+    const dropIfExists = async (name) => {
+      try {
+        await col.dropIndex(name);
+      } catch (err) {
+        if (err.codeName !== 'IndexNotFound') throw err;
+      }
+    };
+    await dropIfExists('followerId_1_followeeId_1');
+    await dropIfExists('followeeId_1');
+    await dropIfExists('followerId_1_createdAt_-1');
+  },
+};


### PR DESCRIPTION
## Summary
- Implements `spec/PROFILES_AND_FOLLOWS.md`: public profile pages, follow/unfollow, editable bio, and a pull-model activity feed — completing the find → like → follow → feed social loop.
- New `Follow` collection (unique follower/followee pair index); follower/following/blueprint counts are computed live via `countDocuments` rather than denormalized onto `User`.
- New endpoints: `GET /api/users/:username/profile(Secure)`, `POST /api/follow`, `PATCH /api/users/me`, `GET /api/feed` — the feed reuses `BlueprintController.handleGetBlueprint` (now `public static`) so list-item mapping isn't duplicated.
- Frontend: `/profile/:username` page (avatar, bio, counts, follow toggle, inline bio editing, blueprint grid), blueprint cards now link the owner name to their profile, and the browse page gets a lightweight Discover/Following tab (shown only once the logged-in user follows someone).
- `avatarUrl`, follower/following list pages, and notifications are explicitly out of scope per the spec.

## Test plan
- [x] `npm run tsc` clean
- [x] Backend: `npm run test` — 275 passing, including 19 new tests in `__tests__/api/social.test.ts` (follow idempotency, self-follow/unknown-followee errors, profile payload anon vs secure, bio validation, feed filtering/pagination/soft-delete exclusion)
- [x] Frontend: `npm test` — 545 passing (2 pre-existing skips), `npm run lint` clean, `npm run build` clean
- [x] `add-follow-indexes` migration applied to local dev DB and indexes verified live on the `follows` collection