### PR TITLE
feat(comments): blueprint comment threads per COMMENT_SYSTEM spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,10 +165,10 @@ Uses MongoDB 8.0.23 locally and in CI (prod upgrade from 7.0.34 pending) with Mo
 ## Current Status
 
 - **Phase**: OniExtract2024 flat-icon rendering (current asset pipeline)
-- **Date**: 2026-06-24
+- **Date**: 2026-07-06
 - **Node.js**: 20.19.4 (via volta)
 - **Stack**: TypeScript 5.9.2 strict · Mongoose 8.18.1 · Express 5.1.0 · Canvas 3.2.3 · Angular 20 · PrimeNG 20
-- **Tests**: ✅ Backend 204 passing (Mocha + Chai) · Frontend 490 passing (Vitest/jsdom), all green
+- **Tests**: ✅ Backend 315 passing (Mocha + Chai) · Frontend 561 passing (Vitest/jsdom), all green
 - **Build**: ✅ `npm run tsc` clean · `npm run build` clean
 
 ### Asset rendering: OniExtract2024 flat icons
@@ -332,7 +332,17 @@ For a full restore: DO dashboard → Backups → restore the pre-deploy snapshot
 
 ---
 
-## Committing
+## Work Session Lifecycle
+
+Every work session has a defined start and end. AI code review and CI run on pull
+requests, so a session that ends with only local commits is a dead session — the work
+sits invisible until someone comes back and pushes it. Do not stop at "committed".
+
+**Session start:**
+1. `git fetch origin master`
+2. Create a new branch based on `origin/master` (master is push-protected; never work on it)
+
+**During the session — committing:**
 
 Commit autonomously at every logical break point — do NOT pause to ask permission.
 A logical break point is: a feature complete, a refactor complete, tests passing, a migration applied, or any other self-contained unit of work.
@@ -340,9 +350,15 @@ A logical break point is: a feature complete, a refactor complete, tests passing
 Commit message format:
 - Subject: conventional commits style (`feat:`, `fix:`, `chore:`, `refactor:`, `test:`, `docs:`), ≤72 chars
 - Body (when the why is non-obvious): explain motivation and any constraints a future reader would need; skip if the subject is self-explanatory
-- Always append: `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
+- Always append a `Co-Authored-By` trailer with the current model name, e.g. `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
 
 Stage only relevant files — never `git add -A` blindly. Do not skip hooks (`--no-verify`).
+
+**Session end — push and open a PR (autonomously, without asking):**
+1. Update any committed docs that describe shipped state (e.g. `spec/ROADMAP.md`, `agent/TODO.md`) so they reflect what this branch ships
+2. `git push -u origin <branch>`
+3. `gh pr create` with a real description: what shipped, design decisions and spec deviations, how it was verified (test counts, migrations run), and anything deferred
+4. Report the PR URL as the session's final output
 
 ## Important Instructions
 Do what has been asked; nothing more, nothing less.

--- a/__tests__/api/comment-body.test.ts
+++ b/__tests__/api/comment-body.test.ts
@@ -1,0 +1,137 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import {
+  sanitizeCommentBody,
+  extractTokenIds,
+  segmentBody,
+} from '../../app/api/services/comment-body';
+
+const BP_ID = '507f1f77bcf86cd799439011';
+const USER_ID = '61dbae02c147bedd3c952c1a';
+
+// Resolver stub: knows exactly one user, "builder" (case-insensitive)
+const resolver = async (usernames: string[]) => {
+  const map = new Map<string, string>();
+  if (usernames.includes('builder')) map.set('builder', USER_ID);
+  return map;
+};
+
+describe('comment body parse pipeline', function () {
+  it('strips HTML tags, including nested ones', async function () {
+    const result = await sanitizeCommentBody('hello <b>world</b> <<i>script</i>>alert(1)</script>', resolver);
+    expect(result).to.equal('hello world alert(1)');
+  });
+
+  it('strips external URLs silently', async function () {
+    const result = await sanitizeCommentBody(
+      'check https://evil.example.com/phish and www.spam.io for details',
+      resolver
+    );
+    expect(result).to.equal('check and for details');
+  });
+
+  it('converts /b/:id paths and full site URLs into blueprint tokens', async function () {
+    expect(await sanitizeCommentBody(`see /b/${BP_ID} here`, resolver)).to.equal(
+      `see {{blueprint:${BP_ID}}} here`
+    );
+    expect(
+      await sanitizeCommentBody(`see https://blueprintnotincluded.org/b/${BP_ID} here`, resolver)
+    ).to.equal(`see {{blueprint:${BP_ID}}} here`);
+    expect(
+      await sanitizeCommentBody(`see blueprintnotincluded.org/blueprint/${BP_ID}`, resolver)
+    ).to.equal(`see {{blueprint:${BP_ID}}}`);
+  });
+
+  it('does not tokenize /b/ paths with invalid ids', async function () {
+    const result = await sanitizeCommentBody('see /b/not-an-id here', resolver);
+    expect(result).to.equal('see /b/not-an-id here');
+  });
+
+  it('converts known @mentions to user tokens and leaves unknown ones as text', async function () {
+    const result = await sanitizeCommentBody('thanks @builder and @ghost!', resolver);
+    expect(result).to.equal(`thanks {{user:${USER_ID}}} and @ghost!`);
+  });
+
+  it('resolves mentions case-insensitively', async function () {
+    const result = await sanitizeCommentBody('hey @BUILDER', resolver);
+    expect(result).to.equal(`hey {{user:${USER_ID}}}`);
+  });
+
+  it('does not treat email addresses as mentions', async function () {
+    const result = await sanitizeCommentBody('mail me at kevin@builder', resolver);
+    expect(result).to.equal('mail me at kevin@builder');
+  });
+
+  it('converts profile URLs into user tokens', async function () {
+    const result = await sanitizeCommentBody(
+      'ask https://blueprintnotincluded.org/profile/builder or /profile/ghost',
+      resolver
+    );
+    expect(result).to.equal(`ask {{user:${USER_ID}}} or @ghost`);
+  });
+
+  it('neutralizes forged reference tokens', async function () {
+    const result = await sanitizeCommentBody(`{{user:${USER_ID}}}`, resolver);
+    expect(result).to.equal(`user:${USER_ID}`);
+  });
+
+  it('strips zero-width and bidi override characters and normalizes to NFC', async function () {
+    const result = await sanitizeCommentBody('cle\u200Ban\u202Eup e\u0301', resolver);
+    expect(result).to.equal('cleanup \u00e9');
+  });
+
+  it('preserves non-Latin text (CJK, Cyrillic)', async function () {
+    const text = '很好的设计 отличный чертёж';
+    expect(await sanitizeCommentBody(text, resolver)).to.equal(text);
+  });
+
+  it('collapses excess whitespace and trims', async function () {
+    const result = await sanitizeCommentBody('  a    b\n\n\n\nc  ', resolver);
+    expect(result).to.equal('a b\n\nc');
+  });
+
+  it('returns an empty string for content that is only disallowed material', async function () {
+    expect(await sanitizeCommentBody('https://spam.example.com', resolver)).to.equal('');
+    expect(await sanitizeCommentBody('<script>alert(1)</script>', resolver)).to.equal('alert(1)');
+    expect(await sanitizeCommentBody('<b></b>  ', resolver)).to.equal('');
+  });
+});
+
+describe('comment body render pipeline', function () {
+  it('extracts distinct token ids across bodies', function () {
+    const { blueprintIds, userIds } = extractTokenIds([
+      `a {{blueprint:${BP_ID}}} b {{user:${USER_ID}}}`,
+      `c {{blueprint:${BP_ID}}}`,
+    ]);
+    expect(blueprintIds).to.deep.equal([BP_ID]);
+    expect(userIds).to.deep.equal([USER_ID]);
+  });
+
+  it('splits a body into text and reference segments', function () {
+    const segments = segmentBody(`try {{blueprint:${BP_ID}}} by {{user:${USER_ID}}}!`, {
+      blueprints: new Map([[BP_ID, 'Coal Setup']]),
+      users: new Map([[USER_ID, 'builder']]),
+    });
+    expect(segments).to.deep.equal([
+      { type: 'text', text: 'try ' },
+      { type: 'blueprint', id: BP_ID, name: 'Coal Setup' },
+      { type: 'text', text: ' by ' },
+      { type: 'user', id: USER_ID, name: 'builder' },
+      { type: 'text', text: '!' },
+    ]);
+  });
+
+  it('resolves missing targets to a null name', function () {
+    const segments = segmentBody(`{{blueprint:${BP_ID}}}`, {
+      blueprints: new Map(),
+      users: new Map(),
+    });
+    expect(segments).to.deep.equal([{ type: 'blueprint', id: BP_ID, name: null }]);
+  });
+
+  it('returns a single text segment for a body without tokens', function () {
+    expect(segmentBody('plain text', { blueprints: new Map(), users: new Map() })).to.deep.equal([
+      { type: 'text', text: 'plain text' },
+    ]);
+  });
+});

--- a/__tests__/api/comments.test.ts
+++ b/__tests__/api/comments.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load test environment first
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup } from '../setup/testSetup';
+import { CommentModel } from '../../app/api/models/comment';
+import { BlueprintModel } from '../../app/api/models/blueprint';
+import { Types } from 'mongoose';
+
+describe('Comments API', function () {
+  let testData: any;
+  let blueprintId: string;
+
+  beforeEach(async function () {
+    this.timeout(5000);
+    testData = await TestSetup.beforeEach();
+    blueprintId = testData.blueprints.popularBlueprint._id.toString();
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    delete process.env.COMMENT_COOLDOWN_SECONDS;
+    await TestSetup.afterEach();
+  });
+
+  function post(token: string, body: string, parentId?: string | null) {
+    return TestSetup.request()
+      .post(`/api/blueprints/${blueprintId}/comments`)
+      .set('Authorization', `Bearer ${token}`)
+      .send(parentId !== undefined ? { body, parentId } : { body });
+  }
+
+  // ─── POST /api/blueprints/:id/comments ───────────────────────────────────────
+
+  describe('POST /api/blueprints/:id/comments', function () {
+    it('returns 401 without a token', async function () {
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/comments`)
+        .send({ body: 'hello' });
+      expect(response.status).to.equal(401);
+    });
+
+    it('returns 404 for an unknown or deleted blueprint', async function () {
+      const token = testData.users.user2.generateJwt();
+      const unknown = await TestSetup.request()
+        .post(`/api/blueprints/${new Types.ObjectId().toString()}/comments`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ body: 'hello' });
+      expect(unknown.status).to.equal(404);
+
+      await BlueprintModel.model.updateOne({ _id: blueprintId }, { deletedAt: new Date() });
+      const deleted = await post(token, 'hello');
+      expect(deleted.status).to.equal(404);
+    });
+
+    it('returns 400 for a missing or empty body', async function () {
+      const token = testData.users.user2.generateJwt();
+      expect((await post(token, '')).status).to.equal(400);
+      const missing = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/comments`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({});
+      expect(missing.status).to.equal(400);
+    });
+
+    it('returns 400 when the body sanitizes to nothing', async function () {
+      const token = testData.users.user2.generateJwt();
+      const response = await post(token, 'https://external.example.com/only-a-link');
+      expect(response.status).to.equal(400);
+    });
+
+    it('returns 400 when the sanitized body exceeds 2000 characters', async function () {
+      const token = testData.users.user2.generateJwt();
+      const response = await post(token, 'x'.repeat(2001));
+      expect(response.status).to.equal(400);
+    });
+
+    it('creates a top-level comment and returns its rendered form', async function () {
+      const token = testData.users.user2.generateJwt();
+      const response = await post(token, 'this breaks in <b>Spaced Out</b>, see https://evil.example.com');
+
+      expect(response.status).to.equal(200);
+      const comment = response.body.comment;
+      expect(comment.parentId).to.equal(null);
+      expect(comment.deleted).to.equal(false);
+      expect(comment.author.username).to.equal(testData.users.user2.username);
+      expect(comment.canDelete).to.equal(true);
+      expect(comment.segments).to.deep.equal([
+        { type: 'text', text: 'this breaks in Spaced Out, see' },
+      ]);
+
+      const stored = await CommentModel.model.findById(comment.id);
+      expect(stored!.body).to.equal('this breaks in Spaced Out, see');
+      expect(stored!.lastActivityAt.getTime()).to.equal(stored!.createdAt.getTime());
+    });
+
+    it('stores mentions and blueprint links as reference tokens and renders them resolved', async function () {
+      const token = testData.users.user2.generateJwt();
+      const otherBlueprintId = testData.blueprints.recentBlueprint._id.toString();
+      const response = await post(
+        token,
+        `@${testData.users.user1.username} try /b/${otherBlueprintId} instead`
+      );
+
+      expect(response.status).to.equal(200);
+      const stored = await CommentModel.model.findById(response.body.comment.id);
+      expect(stored!.body).to.equal(
+        `{{user:${testData.users.user1._id.toString()}}} try {{blueprint:${otherBlueprintId}}} instead`
+      );
+      expect(response.body.comment.segments).to.deep.equal([
+        { type: 'user', id: testData.users.user1._id.toString(), name: testData.users.user1.username },
+        { type: 'text', text: ' try ' },
+        { type: 'blueprint', id: otherBlueprintId, name: 'Oxygen Production Line' },
+        { type: 'text', text: ' instead' },
+      ]);
+    });
+
+    it('creates a reply and bumps the parent lastActivityAt', async function () {
+      const token1 = testData.users.user1.generateJwt();
+      const token2 = testData.users.user2.generateJwt();
+      const parent = (await post(token2, 'does this work on Terra?')).body.comment;
+
+      const reply = await post(token1, 'yes, tested on cycle 200', parent.id);
+      expect(reply.status).to.equal(200);
+      expect(reply.body.comment.parentId).to.equal(parent.id);
+
+      const storedParent = await CommentModel.model.findById(parent.id);
+      const storedReply = await CommentModel.model.findById(reply.body.comment.id);
+      expect(storedParent!.lastActivityAt.getTime()).to.equal(storedReply!.createdAt.getTime());
+    });
+
+    it('rejects replies to replies', async function () {
+      const token = testData.users.user2.generateJwt();
+      const parent = (await post(token, 'top level')).body.comment;
+      const reply = (await post(token, 'a reply', parent.id)).body.comment;
+
+      const grandchild = await post(token, 'reply to reply', reply.id);
+      expect(grandchild.status).to.equal(400);
+    });
+
+    it('rejects replies to deleted parents and parents on other blueprints', async function () {
+      const token = testData.users.user2.generateJwt();
+      const parent = (await post(token, 'top level')).body.comment;
+      await CommentModel.model.updateOne({ _id: parent.id }, { deletedAt: new Date() });
+      expect((await post(token, 'too late', parent.id)).status).to.equal(404);
+
+      const otherBlueprint = await CommentModel.model.create({
+        blueprintId: testData.blueprints.recentBlueprint._id,
+        authorId: testData.users.user1._id,
+        parentId: null,
+        body: 'on another blueprint',
+      });
+      const otherId = (otherBlueprint._id as Types.ObjectId).toString();
+      expect((await post(token, 'cross-blueprint', otherId)).status).to.equal(404);
+    });
+
+    it('enforces the posting cooldown when configured', async function () {
+      process.env.COMMENT_COOLDOWN_SECONDS = '60';
+      const token = testData.users.user2.generateJwt();
+
+      expect((await post(token, 'first comment')).status).to.equal(200);
+      const second = await post(token, 'second comment too fast');
+      expect(second.status).to.equal(429);
+
+      // A different user is unaffected
+      const otherToken = testData.users.user3.generateJwt();
+      expect((await post(otherToken, 'different user')).status).to.equal(200);
+    });
+  });
+
+  // ─── GET /api/blueprints/:id/comments ────────────────────────────────────────
+
+  describe('GET /api/blueprints/:id/comments', function () {
+    it('returns 404 for an unknown blueprint', async function () {
+      const response = await TestSetup.request().get(
+        `/api/blueprints/${new Types.ObjectId().toString()}/comments`
+      );
+      expect(response.status).to.equal(404);
+    });
+
+    it('returns an empty list for a blueprint without comments', async function () {
+      const response = await TestSetup.request().get(`/api/blueprints/${blueprintId}/comments`);
+      expect(response.status).to.equal(200);
+      expect(response.body).to.deep.equal({ threads: [], total: 0 });
+    });
+
+    it('orders threads by most recent activity and replies chronologically', async function () {
+      const token = testData.users.user2.generateJwt();
+      const base = Date.now();
+      const [commentA, commentB] = await CommentModel.model.create([
+        {
+          blueprintId,
+          authorId: testData.users.user2._id,
+          body: 'comment A',
+          createdAt: new Date(base - 60000),
+          lastActivityAt: new Date(base - 60000),
+        },
+        {
+          blueprintId,
+          authorId: testData.users.user2._id,
+          body: 'comment B',
+          createdAt: new Date(base - 30000),
+          lastActivityAt: new Date(base - 30000),
+        },
+      ]);
+
+      const idA = (commentA._id as Types.ObjectId).toString();
+      const idB = (commentB._id as Types.ObjectId).toString();
+
+      // Replying to the older comment A moves its thread to the top
+      const reply = await post(token, 'reply to A', idA);
+      expect(reply.status).to.equal(200);
+
+      const response = await TestSetup.request().get(`/api/blueprints/${blueprintId}/comments`);
+      expect(response.status).to.equal(200);
+      expect(response.body.total).to.equal(3);
+      expect(response.body.threads).to.have.lengthOf(2);
+      expect(response.body.threads[0].comment.id).to.equal(idA);
+      expect(response.body.threads[0].replies).to.have.lengthOf(1);
+      expect(response.body.threads[1].comment.id).to.equal(idB);
+      expect(response.body.threads[0].comment.canDelete).to.equal(false); // anonymous
+    });
+
+    it('hides deleted comments without replies and placeholders deleted ones with replies', async function () {
+      const token = testData.users.user2.generateJwt();
+      const lonely = (await post(token, 'deleted lonely comment')).body.comment;
+      const parent = (await post(testData.users.user3.generateJwt(), 'deleted parent')).body.comment;
+      const reply = (await post(token, 'still visible reply', parent.id)).body.comment;
+      await CommentModel.model.updateMany(
+        { _id: { $in: [lonely.id, parent.id] } },
+        { deletedAt: new Date() }
+      );
+
+      const response = await TestSetup.request().get(`/api/blueprints/${blueprintId}/comments`);
+      expect(response.body.threads).to.have.lengthOf(1);
+      const thread = response.body.threads[0];
+      expect(thread.comment.deleted).to.equal(true);
+      expect(thread.comment.author).to.equal(null);
+      expect(thread.comment.segments).to.deep.equal([]);
+      expect(thread.replies[0].id).to.equal(reply.id);
+      expect(response.body.total).to.equal(1); // only the visible reply
+    });
+
+    it('hides deleted replies entirely', async function () {
+      const token = testData.users.user2.generateJwt();
+      const parent = (await post(token, 'parent')).body.comment;
+      const reply = (await post(testData.users.user3.generateJwt(), 'bad reply', parent.id)).body
+        .comment;
+      await CommentModel.model.updateOne({ _id: reply.id }, { deletedAt: new Date() });
+
+      const response = await TestSetup.request().get(`/api/blueprints/${blueprintId}/comments`);
+      expect(response.body.threads).to.have.lengthOf(1);
+      expect(response.body.threads[0].replies).to.deep.equal([]);
+    });
+
+    it('computes canDelete for the author and the blueprint owner', async function () {
+      const authorToken = testData.users.user2.generateJwt();
+      await post(authorToken, 'my comment');
+
+      const asAuthor = await TestSetup.request()
+        .get(`/api/blueprints/${blueprintId}/comments`)
+        .set('Authorization', `Bearer ${authorToken}`);
+      expect(asAuthor.body.threads[0].comment.canDelete).to.equal(true);
+
+      // user1 owns popularBlueprint — moderation right over all its comments
+      const ownerToken = testData.users.user1.generateJwt();
+      const asOwner = await TestSetup.request()
+        .get(`/api/blueprints/${blueprintId}/comments`)
+        .set('Authorization', `Bearer ${ownerToken}`);
+      expect(asOwner.body.threads[0].comment.canDelete).to.equal(true);
+
+      const bystanderToken = testData.users.user3.generateJwt();
+      const asBystander = await TestSetup.request()
+        .get(`/api/blueprints/${blueprintId}/comments`)
+        .set('Authorization', `Bearer ${bystanderToken}`);
+      expect(asBystander.body.threads[0].comment.canDelete).to.equal(false);
+    });
+
+    it('renders references to since-deleted targets with a null name', async function () {
+      const token = testData.users.user2.generateJwt();
+      const otherBlueprintId = testData.blueprints.recentBlueprint._id.toString();
+      await post(token, `try /b/${otherBlueprintId}`);
+      await BlueprintModel.model.updateOne({ _id: otherBlueprintId }, { deletedAt: new Date() });
+
+      const response = await TestSetup.request().get(`/api/blueprints/${blueprintId}/comments`);
+      const segments = response.body.threads[0].comment.segments;
+      expect(segments[1]).to.deep.equal({ type: 'blueprint', id: otherBlueprintId, name: null });
+    });
+  });
+
+  // ─── DELETE /api/comments/:id ────────────────────────────────────────────────
+
+  describe('DELETE /api/comments/:id', function () {
+    it('returns 401 without a token and 404 for an unknown comment', async function () {
+      expect((await TestSetup.request().delete(`/api/comments/${new Types.ObjectId()}`)).status).to.equal(401);
+
+      const token = testData.users.user2.generateJwt();
+      const response = await TestSetup.request()
+        .delete(`/api/comments/${new Types.ObjectId()}`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(response.status).to.equal(404);
+    });
+
+    it('forbids deletion by unrelated users', async function () {
+      const comment = (await post(testData.users.user2.generateJwt(), 'hands off')).body.comment;
+      const response = await TestSetup.request()
+        .delete(`/api/comments/${comment.id}`)
+        .set('Authorization', `Bearer ${testData.users.user3.generateJwt()}`);
+      expect(response.status).to.equal(403);
+
+      const stored = await CommentModel.model.findById(comment.id);
+      expect(stored!.deletedAt).to.equal(null);
+    });
+
+    it('lets the author soft-delete their own comment, idempotently', async function () {
+      const token = testData.users.user2.generateJwt();
+      const comment = (await post(token, 'regret')).body.comment;
+
+      const first = await TestSetup.request()
+        .delete(`/api/comments/${comment.id}`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(first.status).to.equal(200);
+
+      const stored = await CommentModel.model.findById(comment.id);
+      expect(stored!.deletedAt).to.not.equal(null);
+
+      const second = await TestSetup.request()
+        .delete(`/api/comments/${comment.id}`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(second.status).to.equal(200);
+    });
+
+    it('lets the blueprint owner delete comments on their blueprint', async function () {
+      const comment = (await post(testData.users.user2.generateJwt(), 'spam-ish')).body.comment;
+      const response = await TestSetup.request()
+        .delete(`/api/comments/${comment.id}`)
+        .set('Authorization', `Bearer ${testData.users.user1.generateJwt()}`);
+      expect(response.status).to.equal(200);
+
+      const stored = await CommentModel.model.findById(comment.id);
+      expect(stored!.deletedAt).to.not.equal(null);
+    });
+
+    it('lets an admin delete any comment', async function () {
+      const comment = (await post(testData.users.user2.generateJwt(), 'abuse')).body.comment;
+      const adminToken = testData.users.user3.generateJwt('admin');
+      const response = await TestSetup.request()
+        .delete(`/api/comments/${comment.id}`)
+        .set('Authorization', `Bearer ${adminToken}`);
+      expect(response.status).to.equal(200);
+    });
+  });
+});

--- a/__tests__/helpers/testDb.ts
+++ b/__tests__/helpers/testDb.ts
@@ -2,6 +2,7 @@ import { UserModel } from '../../app/api/models/user';
 import { BlueprintModel } from '../../app/api/models/blueprint';
 import { FeedbackModel } from '../../app/api/models/feedback';
 import { FollowModel } from '../../app/api/models/follow';
+import { CommentModel } from '../../app/api/models/comment';
 import { TestDataFactory, TestUser, TestBlueprint } from '../factories/testData';
 import { Types } from 'mongoose';
 
@@ -125,6 +126,7 @@ export class TestDbHelper {
       await UserModel.model.deleteMany({});
       await FeedbackModel.model.deleteMany({});
       await FollowModel.model.deleteMany({});
+      await CommentModel.model.deleteMany({});
       TestDataFactory.reset();
     } catch (error) {
       console.error('Error cleaning database:', error);

--- a/agent/TODO.md
+++ b/agent/TODO.md
@@ -1,11 +1,11 @@
 # Agent TODO - Blueprint Not Included
 
 ## Current Status
-- **Phase**: Social evolution — likes, auto-derived metadata, profiles/follows/activity feed all shipped
-- **Date**: 2026-07-05
+- **Phase**: Social evolution — likes, auto-derived metadata, profiles/follows/activity feed, and blueprint comments all shipped
+- **Date**: 2026-07-06
 - **Branch**: `master`
 - **Stack**: Node 20.19.4 · TypeScript 5.9.2 strict · Mongoose 8.18.1 · Express 5.1.0 · Canvas 3.2.3 · Angular 20 · PrimeNG 20
-- **Tests**: 275 backend (Mocha + Chai) · 547 frontend (Vitest, 2 skipped) — all green
+- **Tests**: 315 backend (Mocha + Chai) · 561 frontend (Vitest, 2 skipped) — all green
 - **Enforcement**: zero-warning flags enabled backend, lib, and frontend (`strict` + `strictTemplates`); CI improvements all complete (mongo:8.0.23 + mongosh health check)
 
 ## OniExtract2024 follow-ups
@@ -63,5 +63,7 @@ WorkOS in-app auth work; rate limiting is Cloudflare's job — do not add expres
 2. Export side: emit `uiImageRect` for the ~107 buildings still missing it.
 3. Monitor WorkOS legacy-user migration (`GET /api/migration/status`); retire the legacy
    migration path when counts hit zero — see `agent/WORKOS_PLAN.md`.
-4. Pick the next product increment: blueprint forks, or wiring one of the unread export
-   JSONs (critters/recipes/i18n).
+4. Pick the next product increment: blueprint forks (`spec/FORKS.md`), or wiring one of the
+   unread export JSONs (critters/recipes/i18n).
+5. Comment system follow-ups (deferred per `spec/COMMENT_SYSTEM.md`): tile-pinned comments,
+   edit window, in-app notifications, "hidden by author" state.

--- a/app/api/comment-controller.ts
+++ b/app/api/comment-controller.ts
@@ -1,0 +1,309 @@
+import { Request, Response } from 'express';
+import mongoose from 'mongoose';
+import jwt from 'jsonwebtoken';
+import { CommentModel, Comment } from './models/comment';
+import { BlueprintModel } from './models/blueprint';
+import { UserModel, UserJwt } from './models/user';
+import { apiError } from './utils/apiError';
+import { sanitizeCommentBody, extractTokenIds, segmentBody } from './services/comment-body';
+import {
+  CommentDto,
+  CommentThread,
+  ListCommentsResponse,
+  PostCommentRequest,
+  COMMENT_MAX_LENGTH,
+} from '../../lib/index';
+
+// Guards regex work on pathological input; well over the stored cap
+const MAX_RAW_BODY_LENGTH = 20000;
+// Comments per blueprint returned in one response; no pagination at launch —
+// real blueprints see orders of magnitude fewer comments than this
+const MAX_COMMENTS_PER_BLUEPRINT = 1000;
+
+// Cloudflare handles real rate limiting; this is just a per-user posting
+// cooldown to blunt copy-paste spam. Off in tests unless explicitly set.
+function cooldownSeconds(): number {
+  if (process.env.COMMENT_COOLDOWN_SECONDS != null) {
+    return parseInt(process.env.COMMENT_COOLDOWN_SECONDS, 10) || 0;
+  }
+  return process.env.NODE_ENV === 'test' ? 0 : 10;
+}
+
+// The list route is anonymous, so express-jwt never runs there; decode the
+// token opportunistically to compute per-comment canDelete for logged-in viewers
+function optionalViewer(req: Request): UserJwt | null {
+  const header = req.headers.authorization;
+  if (!header?.startsWith('Bearer ')) return null;
+  try {
+    return jwt.verify(header.slice(7), process.env.JWT_SECRET as string) as UserJwt;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveMentions(usernames: string[]): Promise<Map<string, string>> {
+  const users = await UserModel.model
+    .find({ username: { $in: usernames.map(u => new RegExp(`^${u}$`, 'i')) } })
+    .select('username')
+    .lean();
+  const map = new Map<string, string>();
+  for (const user of users) {
+    map.set((user.username as string).toLowerCase(), user._id.toString());
+  }
+  return map;
+}
+
+interface RenderContext {
+  authors: Map<string, string>; // authorId -> username
+  blueprints: Map<string, string>; // referenced blueprintId -> name
+  users: Map<string, string>; // referenced userId -> username
+  blueprintOwnerId: string;
+  viewer: UserJwt | null;
+}
+
+async function buildRenderContext(
+  comments: Comment[],
+  blueprintOwnerId: string,
+  viewer: UserJwt | null
+): Promise<RenderContext> {
+  const visibleBodies = comments.filter(c => c.deletedAt == null).map(c => c.body);
+  const { blueprintIds, userIds } = extractTokenIds(visibleBodies);
+  const authorIds = [...new Set(comments.map(c => c.authorId.toString()))];
+
+  const [authorDocs, blueprintDocs, userDocs] = await Promise.all([
+    UserModel.model.find({ _id: { $in: authorIds } }).select('username').lean(),
+    blueprintIds.length > 0
+      ? BlueprintModel.model.find({ _id: { $in: blueprintIds }, deletedAt: null }).select('name').lean()
+      : Promise.resolve([]),
+    userIds.length > 0
+      ? UserModel.model.find({ _id: { $in: userIds } }).select('username').lean()
+      : Promise.resolve([]),
+  ]);
+
+  return {
+    authors: new Map(authorDocs.map(u => [u._id.toString(), u.username as string])),
+    blueprints: new Map(blueprintDocs.map(b => [b._id.toString(), b.name as string])),
+    users: new Map(userDocs.map(u => [u._id.toString(), u.username as string])),
+    blueprintOwnerId,
+    viewer,
+  };
+}
+
+function toDto(comment: Comment, context: RenderContext): CommentDto {
+  const deleted = comment.deletedAt != null;
+  const authorId = comment.authorId.toString();
+  const username = context.authors.get(authorId);
+  const viewerId = context.viewer?._id;
+  const canDelete =
+    !deleted &&
+    viewerId != null &&
+    (viewerId === authorId || viewerId === context.blueprintOwnerId || context.viewer?.role === 'admin');
+
+  return {
+    id: (comment._id as mongoose.Types.ObjectId).toString(),
+    parentId: comment.parentId != null ? comment.parentId.toString() : null,
+    author: deleted || username == null ? null : { id: authorId, username },
+    segments: deleted
+      ? []
+      : segmentBody(comment.body, { blueprints: context.blueprints, users: context.users }),
+    deleted,
+    createdAt: comment.createdAt.toISOString(),
+    lastActivityAt: comment.lastActivityAt.toISOString(),
+    canDelete,
+  };
+}
+
+export class CommentController {
+  constructor() {
+    this.list = this.list.bind(this);
+    this.create = this.create.bind(this);
+    this.remove = this.remove.bind(this);
+  }
+
+  public async list(req: Request, res: Response): Promise<void> {
+    try {
+      const blueprintId = req.params.id;
+      if (!mongoose.Types.ObjectId.isValid(blueprintId)) {
+        res.status(400).json(apiError(400, 'Invalid blueprint id'));
+        return;
+      }
+
+      const blueprint = await BlueprintModel.model
+        .findOne({ _id: blueprintId, deletedAt: null })
+        .select('owner')
+        .lean();
+      if (!blueprint) {
+        res.status(404).json(apiError(404, 'Blueprint not found'));
+        return;
+      }
+
+      const comments = await CommentModel.model
+        .find({ blueprintId })
+        .sort({ createdAt: 1 })
+        .limit(MAX_COMMENTS_PER_BLUEPRINT)
+        .lean<Comment[]>();
+
+      const repliesByParent = new Map<string, Comment[]>();
+      for (const comment of comments) {
+        if (comment.parentId == null || comment.deletedAt != null) continue;
+        const key = comment.parentId.toString();
+        const bucket = repliesByParent.get(key);
+        if (bucket) bucket.push(comment);
+        else repliesByParent.set(key, [comment]);
+      }
+
+      // Visible top-level: not deleted, or deleted-with-visible-replies
+      // (rendered as "[comment removed]" to preserve thread continuity)
+      const topLevel = comments
+        .filter(c => c.parentId == null)
+        .filter(c => c.deletedAt == null || repliesByParent.has((c._id as mongoose.Types.ObjectId).toString()))
+        .sort((a, b) => b.lastActivityAt.getTime() - a.lastActivityAt.getTime());
+
+      const visible = [...topLevel, ...topLevel.flatMap(c => repliesByParent.get((c._id as mongoose.Types.ObjectId).toString()) ?? [])];
+      const context = await buildRenderContext(visible, blueprint.owner.toString(), optionalViewer(req));
+
+      const threads: CommentThread[] = topLevel.map(comment => ({
+        comment: toDto(comment, context),
+        replies: (repliesByParent.get((comment._id as mongoose.Types.ObjectId).toString()) ?? []).map(reply =>
+          toDto(reply, context)
+        ),
+      }));
+
+      const response: ListCommentsResponse = {
+        threads,
+        total: visible.filter(c => c.deletedAt == null).length,
+      };
+      res.json(response);
+    } catch (err) {
+      console.log('comment list error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to retrieve comments'));
+    }
+  }
+
+  public async create(req: Request, res: Response): Promise<void> {
+    try {
+      const user = req.user as UserJwt;
+      const blueprintId = req.params.id;
+      const { body, parentId } = req.body as PostCommentRequest;
+
+      if (!mongoose.Types.ObjectId.isValid(blueprintId)) {
+        res.status(400).json(apiError(400, 'Invalid blueprint id'));
+        return;
+      }
+      if (typeof body !== 'string' || body.length === 0 || body.length > MAX_RAW_BODY_LENGTH) {
+        res.status(400).json(apiError(400, 'Comment body is required'));
+        return;
+      }
+      if (parentId != null && (typeof parentId !== 'string' || !mongoose.Types.ObjectId.isValid(parentId))) {
+        res.status(400).json(apiError(400, 'Invalid parentId'));
+        return;
+      }
+
+      const blueprint = await BlueprintModel.model
+        .findOne({ _id: blueprintId, deletedAt: null })
+        .select('owner')
+        .lean();
+      if (!blueprint) {
+        res.status(404).json(apiError(404, 'Blueprint not found'));
+        return;
+      }
+
+      let parent: Comment | null = null;
+      if (parentId != null) {
+        parent = await CommentModel.model.findOne({ _id: parentId, deletedAt: null });
+        if (!parent || parent.blueprintId.toString() !== blueprintId) {
+          res.status(404).json(apiError(404, 'Parent comment not found'));
+          return;
+        }
+        // Two levels only: replies to replies are rejected at the API layer
+        if (parent.parentId != null) {
+          res.status(400).json(apiError(400, 'Cannot reply to a reply'));
+          return;
+        }
+      }
+
+      const cooldown = cooldownSeconds();
+      if (cooldown > 0) {
+        const recent = await CommentModel.model.exists({
+          authorId: user._id,
+          createdAt: { $gt: new Date(Date.now() - cooldown * 1000) },
+        });
+        if (recent) {
+          res.status(429).json(apiError(429, 'You are commenting too quickly — try again shortly'));
+          return;
+        }
+      }
+
+      const sanitized = await sanitizeCommentBody(body, resolveMentions);
+      if (sanitized.length === 0) {
+        res.status(400).json(apiError(400, 'Comment is empty after removing disallowed content'));
+        return;
+      }
+      if (sanitized.length > COMMENT_MAX_LENGTH) {
+        res.status(400).json(apiError(400, `Comment must be ${COMMENT_MAX_LENGTH} characters or fewer`));
+        return;
+      }
+
+      const now = new Date();
+      const comment = await CommentModel.model.create({
+        blueprintId,
+        authorId: user._id,
+        parentId: parentId ?? null,
+        body: sanitized,
+        createdAt: now,
+        lastActivityAt: now,
+      });
+
+      if (parent != null) {
+        // Active threads surface first in the feed
+        await CommentModel.model.updateOne({ _id: parent._id }, { $max: { lastActivityAt: now } });
+      }
+
+      const context = await buildRenderContext([comment], blueprint.owner.toString(), user);
+      res.json({ comment: toDto(comment, context) });
+    } catch (err) {
+      console.log('comment create error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to post comment'));
+    }
+  }
+
+  public async remove(req: Request, res: Response): Promise<void> {
+    try {
+      const user = req.user as UserJwt;
+      const commentId = req.params.id;
+      if (!mongoose.Types.ObjectId.isValid(commentId)) {
+        res.status(400).json(apiError(400, 'Invalid comment id'));
+        return;
+      }
+
+      const comment = await CommentModel.model.findById(commentId);
+      if (!comment) {
+        res.status(404).json(apiError(404, 'Comment not found'));
+        return;
+      }
+      if (comment.deletedAt != null) {
+        res.json({ delete: 'OK' });
+        return;
+      }
+
+      const blueprint = await BlueprintModel.model.findById(comment.blueprintId).select('owner').lean();
+      const isAuthor = comment.authorId.toString() === user._id;
+      const isBlueprintOwner = blueprint != null && blueprint.owner.toString() === user._id;
+      const isAdmin = user.role === 'admin';
+      if (!isAuthor && !isBlueprintOwner && !isAdmin) {
+        res.status(403).json(apiError(403, 'Not allowed to delete this comment'));
+        return;
+      }
+
+      comment.deletedAt = new Date();
+      await comment.save();
+      res.json({ delete: 'OK' });
+    } catch (err) {
+      console.log('comment delete error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to delete comment'));
+    }
+  }
+}

--- a/app/api/db.ts
+++ b/app/api/db.ts
@@ -3,6 +3,7 @@ import { UserModel } from './models/user';
 import { BlueprintModel } from './models/blueprint';
 import { FeedbackModel } from './models/feedback';
 import { FollowModel } from './models/follow';
+import { CommentModel } from './models/comment';
 
 export class Database {
   constructor() {
@@ -22,6 +23,7 @@ export class Database {
       BlueprintModel.init();
       FeedbackModel.init();
       FollowModel.init();
+      CommentModel.init();
     });
     mongoose.connection.on('error', err => {
       if (process.env.NODE_ENV !== 'test') {

--- a/app/api/models/comment.ts
+++ b/app/api/models/comment.ts
@@ -1,0 +1,40 @@
+import mongoose, { Schema, Document, Model } from 'mongoose';
+
+export interface Comment extends Document {
+  blueprintId: mongoose.Types.ObjectId;
+  authorId: mongoose.Types.ObjectId;
+  // null = top-level; must reference a top-level comment (no grandchildren)
+  parentId: mongoose.Types.ObjectId | null;
+  // Sanitized plain text with internal reference tokens — never raw user input
+  body: string;
+  createdAt: Date;
+  // Bumped on each reply; equals createdAt while a comment has no replies
+  lastActivityAt: Date;
+  deletedAt?: Date | null;
+}
+
+export class CommentModel {
+  static model: Model<Comment>;
+
+  public static init() {
+    const commentSchema = new mongoose.Schema({
+      blueprintId: { type: Schema.Types.ObjectId, ref: 'Blueprint', required: true },
+      authorId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+      parentId: { type: Schema.Types.ObjectId, ref: 'Comment', default: null },
+      body: { type: String, required: true, maxlength: 2000 },
+      createdAt: { type: Date, default: Date.now },
+      lastActivityAt: { type: Date, default: Date.now },
+      deletedAt: { type: Date, default: null },
+    });
+
+    // Primary feed: top-level comments by most recent activity
+    commentSchema.index({ blueprintId: 1, parentId: 1, lastActivityAt: -1 });
+    // Reply thread read order
+    commentSchema.index({ blueprintId: 1, parentId: 1, createdAt: 1 });
+    // Profile activity + posting-cooldown lookup
+    commentSchema.index({ authorId: 1, createdAt: -1 });
+
+    CommentModel.model =
+      (mongoose.models['Comment'] as Model<Comment>) ?? mongoose.model<Comment>('Comment', commentSchema);
+  }
+}

--- a/app/api/services/comment-body.ts
+++ b/app/api/services/comment-body.ts
@@ -1,0 +1,120 @@
+import { CommentSegment } from '../../../lib/index';
+
+// Comment body parse pipeline (spec/COMMENT_SYSTEM.md — Content Model).
+// The stored body is never raw user input: HTML is stripped, external URLs are
+// removed, and internal references are stored as {{blueprint:id}} / {{user:id}}
+// tokens so they survive site URL refactors. Resolvers are injected so the
+// pipeline stays unit-testable without a database.
+
+const OBJECT_ID = '[0-9a-fA-F]{24}';
+const USERNAME = '[a-zA-Z0-9_-]{1,30}';
+const SITE_HOST = String.raw`(?:https?:\/\/)?(?:www\.)?blueprintnotincluded\.org`;
+
+// Control chars (keep \n), zero-width/invisible chars, bidi overrides, soft hyphen
+const INVISIBLE_CHARS =
+  // eslint-disable-next-line no-control-regex
+  /[\u0000-\u0008\u000B-\u001F\u007F-\u009F\u00AD\u200B-\u200F\u202A-\u202E\u2060-\u2064\uFEFF]/g;
+
+const TOKEN_PATTERN = /\{\{(blueprint|user):([0-9a-fA-F]{24})\}\}/g;
+
+/** username (lowercased) -> userId, for the usernames that actually exist */
+export type MentionResolver = (usernames: string[]) => Promise<Map<string, string>>;
+
+function stripHtml(text: string): string {
+  // Repeat until stable so nested constructs like "<<b>script>" fully collapse
+  let previous;
+  do {
+    previous = text;
+    text = text.replace(/<[^<>]*>/g, '');
+  } while (text !== previous);
+  return text;
+}
+
+export async function sanitizeCommentBody(raw: string, resolveMentions: MentionResolver): Promise<string> {
+  let text = raw.normalize('NFC').replace(/\r\n?/g, '\n').replace(INVISIBLE_CHARS, '');
+
+  // Neutralize token delimiters so users cannot forge reference tokens
+  text = text.replace(/\{\{|\}\}/g, '');
+
+  text = stripHtml(text);
+
+  // Internal blueprint links (full URL or site-relative path; /b/ is the live
+  // route, /blueprint/ kept for forward compatibility) -> reference tokens
+  text = text.replace(
+    new RegExp(String.raw`${SITE_HOST}\/(?:b|blueprint)\/(${OBJECT_ID})\b`, 'g'),
+    '{{blueprint:$1}}'
+  );
+  text = text.replace(
+    new RegExp(String.raw`(^|[\s(])\/(?:b|blueprint)\/(${OBJECT_ID})\b`, 'gm'),
+    '$1{{blueprint:$2}}'
+  );
+
+  // Profile links become @mentions, resolved with the rest below
+  text = text.replace(new RegExp(String.raw`${SITE_HOST}\/profile\/(${USERNAME})\b`, 'g'), '@$1');
+  text = text.replace(new RegExp(String.raw`(^|[\s(])\/profile\/(${USERNAME})\b`, 'gm'), '$1@$2');
+
+  // Any remaining URL is external: stripped silently, per policy
+  text = text.replace(/(?:https?:\/\/|www\.)[^\s)]+/gi, '');
+
+  // @mentions -> {{user:id}} for usernames that exist; unknown ones stay literal
+  const mentionRegex = new RegExp(String.raw`(^|[^a-zA-Z0-9_-])@(${USERNAME})`, 'g');
+  const candidates = new Set<string>();
+  for (const match of text.matchAll(mentionRegex)) {
+    candidates.add(match[2].toLowerCase());
+  }
+  if (candidates.size > 0) {
+    const resolved = await resolveMentions([...candidates]);
+    text = text.replace(mentionRegex, (whole, prefix: string, username: string) => {
+      const userId = resolved.get(username.toLowerCase());
+      return userId ? `${prefix}{{user:${userId}}}` : whole;
+    });
+  }
+
+  // Tidy whitespace left behind by stripped content
+  text = text
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
+
+  return text;
+}
+
+/** Distinct entity ids referenced by a set of stored bodies, for batch resolution */
+export function extractTokenIds(bodies: string[]): { blueprintIds: string[]; userIds: string[] } {
+  const blueprintIds = new Set<string>();
+  const userIds = new Set<string>();
+  for (const body of bodies) {
+    for (const match of body.matchAll(TOKEN_PATTERN)) {
+      (match[1] === 'blueprint' ? blueprintIds : userIds).add(match[2].toLowerCase());
+    }
+  }
+  return { blueprintIds: [...blueprintIds], userIds: [...userIds] };
+}
+
+/**
+ * Render pipeline: split a stored body into display segments. Reference names
+ * come pre-resolved (id -> display name, or absent/null when the target is gone).
+ */
+export function segmentBody(
+  body: string,
+  names: { blueprints: Map<string, string>; users: Map<string, string> }
+): CommentSegment[] {
+  const segments: CommentSegment[] = [];
+  let cursor = 0;
+  TOKEN_PATTERN.lastIndex = 0;
+  for (const match of body.matchAll(TOKEN_PATTERN)) {
+    if (match.index! > cursor) {
+      segments.push({ type: 'text', text: body.slice(cursor, match.index) });
+    }
+    const kind = match[1] as 'blueprint' | 'user';
+    const id = match[2].toLowerCase();
+    const name = (kind === 'blueprint' ? names.blueprints : names.users).get(id) ?? null;
+    segments.push({ type: kind, id, name });
+    cursor = match.index! + match[0].length;
+  }
+  if (cursor < body.length) {
+    segments.push({ type: 'text', text: body.slice(cursor) });
+  }
+  return segments;
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -13,6 +13,7 @@ import { HealthController } from './api/health-controller';
 import { FeedbackController } from './api/feedback-controller';
 import { AlphaController } from './api/alpha-controller';
 import { UserController } from './api/user-controller';
+import { CommentController } from './api/comment-controller';
 export class Routes {
   public staticController = new StaticController();
   public uploadBlueprintController = new BlueprintController();
@@ -23,6 +24,7 @@ export class Routes {
   public feedbackController = new FeedbackController();
   public alphaController = new AlphaController();
   public userController = new UserController();
+  public commentController = new CommentController();
 
   public routes(app: Application): void {
     // Admin-only middleware: requires role === 'admin' in the JWT (set from WorkOS platform org membership)
@@ -74,6 +76,7 @@ export class Routes {
     app.route('/api/version').get(this.versionController.getVersion);
     app.route('/api/health').get(this.healthController.getHealth);
     app.route('/api/users/:username/profile').get(this.userController.getProfile);
+    app.route('/api/blueprints/:id/comments').get(this.commentController.list);
 
     // Logged in access
     app.route('/api/getblueprintsSecure').get(auth, this.uploadBlueprintController.getBlueprints);
@@ -85,6 +88,8 @@ export class Routes {
     app.route('/api/follow').post(auth, this.userController.follow);
     app.route('/api/users/me').patch(auth, this.userController.updateBio);
     app.route('/api/feed').get(auth, this.userController.getFeed);
+    app.route('/api/blueprints/:id/comments').post(auth, this.commentController.create);
+    app.route('/api/comments/:id').delete(auth, this.commentController.remove);
 
     // Admin-only API
     app.route('/api/admin/feedback').get(auth, adminAuth, this.feedbackController.list);

--- a/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.html
+++ b/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.html
@@ -48,3 +48,4 @@
   (saveImages)="saveImages($event)"
 ></app-dialog-export-images>
 <app-feedback-dialog *ngIf="!forceSize" #feedbackDialog></app-feedback-dialog>
+<app-comments-dialog *ngIf="!forceSize" #commentsDialog></app-comments-dialog>

--- a/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.ts
@@ -49,6 +49,7 @@ import { DialogBrowseComponent } from "../dialogs/dialog-browse/dialog-browse.co
 import { DialogExportImagesComponent } from "../dialogs/dialog-export-images/dialog-export-images.component";
 import { DialogShareUrlComponent } from "../dialogs/dialog-share-url/dialog-share-url.component";
 import { FeedbackDialogComponent } from "../dialogs/feedback-dialog/feedback-dialog.component";
+import { CommentsDialogComponent } from "../dialogs/comments-dialog/comments-dialog.component";
 import { ComponentSideBuildToolComponent } from "../side-bar/build-tool/build-tool.component";
 import { ComponentSideSelectionToolComponent } from "../side-bar/selection-tool/selection-tool.component";
 var sanitize = require("sanitize-filename");
@@ -103,6 +104,9 @@ export class ComponentBlueprintParentComponent
 
   @ViewChild("feedbackDialog", { static: false })
   feedbackDialog!: FeedbackDialogComponent;
+
+  @ViewChild("commentsDialog", { static: false })
+  commentsDialog!: CommentsDialogComponent;
 
   // The left ui panel is not static, because when in a iframe we don't load it
   @ViewChild("sidePanelLeft", { static: false })
@@ -351,6 +355,8 @@ export class ComponentBlueprintParentComponent
       this.addElementsTiles();
     else if (menuCommand.type == MenuCommandType.sendFeedback)
       this.feedbackDialog.open();
+    else if (menuCommand.type == MenuCommandType.showComments)
+      this.commentsDialog.open();
   }
 
   saveImages(exportOptions: ExportImageOptions) {

--- a/frontend/src/app/module-blueprint/components/component-menu/component-menu.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-menu/component-menu.component.ts
@@ -86,6 +86,10 @@ export class ComponentMenuComponent
     if (blueprintMenuItems) {
       const saveItem = blueprintMenuItems.find((i) => i.id == "save");
       if (saveItem) saveItem.disabled = !this.authService.isLoggedIn();
+      const commentsItem = blueprintMenuItems.find((i) => i.id == "comments");
+      // Comments only exist for saved blueprints
+      if (commentsItem)
+        commentsItem.disabled = this.blueprintService.id == null;
     }
     return this.menuItems;
   }
@@ -261,6 +265,17 @@ export class ComponentMenuComponent
             command: (_event: any) => {
               this.menuCommand.emit({
                 type: MenuCommandType.browseBlueprints,
+                data: null,
+              });
+            },
+          },
+          {
+            id: "comments",
+            label: $localize`Comments`,
+            icon: "pi pi-comments",
+            command: (_event: any) => {
+              this.menuCommand.emit({
+                type: MenuCommandType.showComments,
                 data: null,
               });
             },
@@ -512,6 +527,7 @@ export enum MenuCommandType {
   addElementsTiles,
 
   sendFeedback,
+  showComments,
 }
 
 export class MenuCommand {

--- a/frontend/src/app/module-blueprint/components/dialogs/comments-dialog/comments-dialog.component.css
+++ b/frontend/src/app/module-blueprint/components/dialogs/comments-dialog/comments-dialog.component.css
@@ -1,0 +1,103 @@
+.comments-status {
+  margin: 0.5rem 0;
+  opacity: 0.85;
+}
+
+.comments-error {
+  color: var(--p-red-500);
+  margin: 0.5rem 0;
+}
+
+.comment-thread {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid
+    var(--p-content-border-color, rgba(128, 128, 128, 0.25));
+}
+
+.comment-thread:last-child {
+  border-bottom: none;
+}
+
+.comment-replies {
+  margin-left: 1.5rem;
+}
+
+.comment {
+  padding: 0.35rem 0;
+}
+
+.comment-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.comment-author {
+  font-weight: 600;
+}
+
+.comment-author-deleted,
+.comment-ref-deleted,
+.comment-removed {
+  opacity: 0.6;
+  font-style: italic;
+}
+
+.comment-date {
+  font-size: 0.8rem;
+  opacity: 0.6;
+}
+
+.comment-body {
+  margin: 0.15rem 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.comment-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.comment-action-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 0.8rem;
+  cursor: pointer;
+  color: var(--p-primary-color, inherit);
+  opacity: 0.8;
+}
+
+.comment-action-link:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
+
+.comment-action-delete {
+  color: var(--p-red-500);
+}
+
+.comment-new-form,
+.comment-reply-form {
+  width: 100%;
+}
+
+.comment-new-form textarea,
+.comment-reply-form textarea {
+  width: 100%;
+  resize: vertical;
+}
+
+.comment-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.35rem;
+}
+
+.comment-char-count {
+  font-size: 0.8rem;
+  opacity: 0.6;
+}

--- a/frontend/src/app/module-blueprint/components/dialogs/comments-dialog/comments-dialog.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/comments-dialog/comments-dialog.component.html
@@ -1,0 +1,181 @@
+<p-dialog
+  header="Comments"
+  i18n-header
+  [(visible)]="visible"
+  [modal]="true"
+  [style]="{ width: '560px' }"
+  [draggable]="false"
+  styleClass="comments-dialog"
+>
+  <p *ngIf="loading" class="comments-status" i18n>Loading comments…</p>
+  <p *ngIf="loadError" class="comments-status comments-error" i18n>
+    Could not load comments. Please try again.
+  </p>
+
+  <ng-container *ngIf="!loading && !loadError">
+    <p *ngIf="threads.length === 0" class="comments-status" i18n>
+      No comments yet. Be the first to give the author feedback!
+    </p>
+
+    <div class="comment-thread" *ngFor="let thread of threads">
+      <ng-container
+        [ngTemplateOutlet]="commentTpl"
+        [ngTemplateOutletContext]="{ comment: thread.comment, isReply: false }"
+      ></ng-container>
+
+      <div class="comment-replies">
+        <ng-container *ngFor="let reply of thread.replies">
+          <ng-container
+            [ngTemplateOutlet]="commentTpl"
+            [ngTemplateOutletContext]="{ comment: reply, isReply: true }"
+          ></ng-container>
+        </ng-container>
+
+        <div
+          class="comment-reply-form"
+          *ngIf="replyingTo === thread.comment.id"
+        >
+          <textarea
+            pTextarea
+            [(ngModel)]="replyText"
+            [rows]="3"
+            [maxlength]="maxLength"
+            placeholder="Write a reply…"
+            i18n-placeholder
+            [disabled]="posting"
+          ></textarea>
+          <div class="comment-form-actions">
+            <p-button
+              label="Cancel"
+              i18n-label
+              severity="secondary"
+              size="small"
+              (onClick)="cancelReply()"
+              [disabled]="posting"
+            ></p-button>
+            <p-button
+              label="Reply"
+              i18n-label
+              size="small"
+              [loading]="posting"
+              [disabled]="!replyText.trim()"
+              (onClick)="postReply()"
+            ></p-button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </ng-container>
+
+  <p *ngIf="postError" class="comments-error">{{ postError }}</p>
+
+  <ng-template pTemplate="footer">
+    <div class="comment-new-form" *ngIf="authService.isLoggedIn()">
+      <textarea
+        pTextarea
+        [(ngModel)]="newComment"
+        [rows]="3"
+        [maxlength]="maxLength"
+        placeholder="Give the author feedback — links to other blueprints and @mentions work, external links are removed"
+        i18n-placeholder
+        [disabled]="posting"
+      ></textarea>
+      <div class="comment-form-actions">
+        <span class="comment-char-count"
+          >{{ newComment.length }}/{{ maxLength }}</span
+        >
+        <p-button
+          label="Post comment"
+          i18n-label
+          [loading]="posting"
+          [disabled]="!newComment.trim()"
+          (onClick)="postTopLevel()"
+        ></p-button>
+      </div>
+    </div>
+    <p *ngIf="!authService.isLoggedIn()" class="comments-status">
+      <a routerLink="/login" (click)="visible = false" i18n>Log in</a
+      ><ng-container i18n> to join the conversation.</ng-container>
+    </p>
+  </ng-template>
+</p-dialog>
+
+<ng-template #commentTpl let-comment="comment" let-isReply="isReply">
+  <div class="comment" [class.comment-reply]="isReply">
+    <div class="comment-meta">
+      <ng-container *ngIf="!comment.deleted">
+        <a
+          *ngIf="comment.author"
+          class="comment-author"
+          [routerLink]="['/profile', comment.author.username]"
+          (click)="onLinkClicked()"
+          >{{ comment.author.username }}</a
+        >
+        <span *ngIf="!comment.author" class="comment-author-deleted" i18n
+          >[deleted user]</span
+        >
+        <span class="comment-date">{{
+          comment.createdAt | date : "medium"
+        }}</span>
+      </ng-container>
+    </div>
+
+    <div class="comment-body">
+      <em *ngIf="comment.deleted" class="comment-removed" i18n
+        >[comment removed]</em
+      >
+      <ng-container *ngIf="!comment.deleted">
+        <ng-container *ngFor="let segment of comment.segments">
+          <span *ngIf="segment.type === 'text'" class="comment-text">{{
+            segment.text
+          }}</span>
+          <a
+            *ngIf="segment.type === 'blueprint' && segment.name !== null"
+            [routerLink]="['/b', segment.id]"
+            (click)="onLinkClicked()"
+            >{{ segment.name }}</a
+          >
+          <span
+            *ngIf="segment.type === 'blueprint' && segment.name === null"
+            class="comment-ref-deleted"
+            i18n
+            >[deleted blueprint]</span
+          >
+          <a
+            *ngIf="segment.type === 'user' && segment.name !== null"
+            [routerLink]="['/profile', segment.name]"
+            (click)="onLinkClicked()"
+            >@{{ segment.name }}</a
+          >
+          <span
+            *ngIf="segment.type === 'user' && segment.name === null"
+            class="comment-ref-deleted"
+            i18n
+            >[deleted user]</span
+          >
+        </ng-container>
+      </ng-container>
+    </div>
+
+    <div class="comment-actions" *ngIf="!comment.deleted">
+      <button
+        *ngIf="!isReply && authService.isLoggedIn()"
+        type="button"
+        class="comment-action-link"
+        (click)="startReply(comment)"
+        i18n
+      >
+        Reply
+      </button>
+      <button
+        *ngIf="comment.canDelete"
+        type="button"
+        class="comment-action-link comment-action-delete"
+        (click)="delete(comment)"
+        i18n
+      >
+        Delete
+      </button>
+    </div>
+  </div>
+</ng-template>

--- a/frontend/src/app/module-blueprint/components/dialogs/comments-dialog/comments-dialog.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/comments-dialog/comments-dialog.component.spec.ts
@@ -1,0 +1,151 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { of, throwError } from "rxjs";
+
+import { CommentsDialogComponent } from "./comments-dialog.component";
+import { CommentService } from "../../../services/comment.service";
+import { AuthenticationService } from "../../../services/authentification-service";
+import { BlueprintService } from "../../../services/blueprint-service";
+
+function makeComment(overrides: any = {}) {
+  return {
+    id: "c1",
+    parentId: null,
+    author: { id: "u1", username: "alice" },
+    segments: [{ type: "text", text: "nice build" }],
+    deleted: false,
+    createdAt: new Date("2026-07-01").toISOString(),
+    lastActivityAt: new Date("2026-07-01").toISOString(),
+    canDelete: false,
+    ...overrides,
+  };
+}
+
+describe("CommentsDialogComponent", () => {
+  let component: CommentsDialogComponent;
+  let fixture: ComponentFixture<CommentsDialogComponent>;
+  let commentService: any;
+  let authService: any;
+  let blueprintService: any;
+
+  beforeEach(async () => {
+    commentService = {
+      getComments: vi
+        .fn()
+        .mockReturnValue(
+          of({ threads: [{ comment: makeComment(), replies: [] }], total: 1 })
+        ),
+      postComment: vi.fn().mockReturnValue(of({ comment: makeComment() })),
+      deleteComment: vi.fn().mockReturnValue(of({ delete: "OK" })),
+    };
+    authService = { isLoggedIn: vi.fn().mockReturnValue(true) };
+    blueprintService = { id: "bp1" };
+
+    await TestBed.configureTestingModule({
+      declarations: [CommentsDialogComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        { provide: CommentService, useValue: commentService },
+        { provide: AuthenticationService, useValue: authService },
+        { provide: BlueprintService, useValue: blueprintService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CommentsDialogComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("creates", () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe("open", () => {
+    it("loads comments for the current blueprint", () => {
+      component.open();
+
+      expect(component.visible).toBe(true);
+      expect(commentService.getComments).toHaveBeenCalledWith("bp1");
+      expect(component.threads).toHaveLength(1);
+      expect(component.total).toBe(1);
+      expect(component.loading).toBe(false);
+    });
+
+    it("does nothing when no blueprint is loaded", () => {
+      blueprintService.id = null;
+      component.open();
+
+      expect(component.visible).toBe(false);
+      expect(commentService.getComments).not.toHaveBeenCalled();
+    });
+
+    it("flags a load error on failure", () => {
+      commentService.getComments.mockReturnValue(
+        throwError(() => new Error("boom"))
+      );
+      component.open();
+
+      expect(component.loadError).toBe(true);
+      expect(component.loading).toBe(false);
+    });
+  });
+
+  describe("posting", () => {
+    beforeEach(() => component.open());
+
+    it("posts a top-level comment, clears the input, and reloads", () => {
+      component.newComment = "this breaks in Spaced Out";
+      component.postTopLevel();
+
+      expect(commentService.postComment).toHaveBeenCalledWith(
+        "bp1",
+        "this breaks in Spaced Out",
+        undefined
+      );
+      expect(component.newComment).toBe("");
+      expect(commentService.getComments).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not post blank comments", () => {
+      component.newComment = "   ";
+      component.postTopLevel();
+      expect(commentService.postComment).not.toHaveBeenCalled();
+    });
+
+    it("posts a reply to the thread being replied to and closes the reply form", () => {
+      component.startReply(makeComment({ id: "parent1" }) as any);
+      component.replyText = "works for me";
+      component.postReply();
+
+      expect(commentService.postComment).toHaveBeenCalledWith(
+        "bp1",
+        "works for me",
+        "parent1"
+      );
+      expect(component.replyingTo).toBe(null);
+      expect(component.replyText).toBe("");
+    });
+
+    it("surfaces the API error message when posting fails", () => {
+      commentService.postComment.mockReturnValue(
+        throwError(() => ({
+          error: { errors: [{ status: "429", title: "Too fast" }] },
+        }))
+      );
+      component.newComment = "spam spam";
+      component.postTopLevel();
+
+      expect(component.postError).toBe("Too fast");
+      expect(component.posting).toBe(false);
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes and reloads", () => {
+      component.open();
+      component.delete(makeComment({ canDelete: true }) as any);
+
+      expect(commentService.deleteComment).toHaveBeenCalledWith("c1");
+      expect(commentService.getComments).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/frontend/src/app/module-blueprint/components/dialogs/comments-dialog/comments-dialog.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/comments-dialog/comments-dialog.component.ts
@@ -1,0 +1,122 @@
+import { Component } from "@angular/core";
+import {
+  CommentDto,
+  CommentThread,
+  COMMENT_MAX_LENGTH,
+} from "../../../../../../../lib/index";
+import { CommentService } from "../../../services/comment.service";
+import { AuthenticationService } from "../../../services/authentification-service";
+import { BlueprintService } from "../../../services/blueprint-service";
+
+@Component({
+  selector: "app-comments-dialog",
+  templateUrl: "./comments-dialog.component.html",
+  styleUrls: ["./comments-dialog.component.css"],
+  standalone: false,
+})
+export class CommentsDialogComponent {
+  visible = false;
+  loading = false;
+  loadError = false;
+  threads: CommentThread[] = [];
+  total = 0;
+
+  newComment = "";
+  replyingTo: string | null = null;
+  replyText = "";
+  posting = false;
+  postError: string | null = null;
+
+  readonly maxLength = COMMENT_MAX_LENGTH;
+
+  private blueprintId: string | null = null;
+
+  constructor(
+    private commentService: CommentService,
+    public authService: AuthenticationService,
+    private blueprintService: BlueprintService
+  ) {}
+
+  public open() {
+    this.blueprintId = this.blueprintService.id;
+    if (this.blueprintId == null) return;
+    this.visible = true;
+    this.newComment = "";
+    this.replyingTo = null;
+    this.replyText = "";
+    this.postError = null;
+    this.reload();
+  }
+
+  private reload() {
+    if (this.blueprintId == null) return;
+    this.loading = true;
+    this.loadError = false;
+    this.commentService.getComments(this.blueprintId).subscribe({
+      next: (response) => {
+        this.threads = response.threads;
+        this.total = response.total;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+        this.loadError = true;
+      },
+    });
+  }
+
+  postTopLevel() {
+    this.post(this.newComment);
+  }
+
+  startReply(comment: CommentDto) {
+    this.replyingTo = comment.id;
+    this.replyText = "";
+    this.postError = null;
+  }
+
+  cancelReply() {
+    this.replyingTo = null;
+    this.replyText = "";
+  }
+
+  postReply() {
+    if (this.replyingTo == null) return;
+    this.post(this.replyText, this.replyingTo);
+  }
+
+  private post(body: string, parentId?: string) {
+    if (this.blueprintId == null || !body.trim() || this.posting) return;
+    this.posting = true;
+    this.postError = null;
+    this.commentService
+      .postComment(this.blueprintId, body, parentId)
+      .subscribe({
+        next: () => {
+          this.posting = false;
+          this.newComment = "";
+          this.cancelReply();
+          this.reload();
+        },
+        error: (err) => {
+          this.posting = false;
+          this.postError =
+            err?.error?.errors?.[0]?.title ??
+            $localize`Could not post your comment. Please try again.`;
+        },
+      });
+  }
+
+  delete(comment: CommentDto) {
+    this.commentService.deleteComment(comment.id).subscribe({
+      next: () => this.reload(),
+      error: () => this.reload(),
+    });
+  }
+
+  onLinkClicked() {
+    // Internal reference links navigate away; close so the dialog isn't
+    // stranded over the newly loaded blueprint
+    this.visible = false;
+  }
+}

--- a/frontend/src/app/module-blueprint/module-blueprint.module.ts
+++ b/frontend/src/app/module-blueprint/module-blueprint.module.ts
@@ -87,6 +87,8 @@ import { ResetPasswordComponent } from "./components/user-auth/reset-password/re
 import { VerifyEmailCallbackComponent } from "./components/user-auth/verify-email-callback/verify-email-callback.component";
 import { FeedbackDialogComponent } from "./components/dialogs/feedback-dialog/feedback-dialog.component";
 import { FeedbackService } from "./services/feedback.service";
+import { CommentsDialogComponent } from "./components/dialogs/comments-dialog/comments-dialog.component";
+import { CommentService } from "./services/comment.service";
 import { BrowsePageComponent } from "./components/browse-page/browse-page.component";
 import { ProfilePageComponent } from "./components/profile-page/profile-page.component";
 
@@ -137,6 +139,7 @@ import { ProfilePageComponent } from "./components/profile-page/profile-page.com
     ResetPasswordComponent,
     VerifyEmailCallbackComponent,
     FeedbackDialogComponent,
+    CommentsDialogComponent,
     BrowsePageComponent,
     ProfilePageComponent,
   ],
@@ -176,6 +179,7 @@ import { ProfilePageComponent } from "./components/profile-page/profile-page.com
   providers: [
     AuthenticationService,
     FeedbackService,
+    CommentService,
     BlueprintService,
     ToolService,
     SelectTool,

--- a/frontend/src/app/module-blueprint/services/comment.service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/comment.service.spec.ts
@@ -1,0 +1,97 @@
+import { TestBed } from "@angular/core/testing";
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from "@angular/common/http/testing";
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from "@angular/common/http";
+
+import { CommentService } from "./comment.service";
+import { AuthenticationService } from "./authentification-service";
+
+describe("CommentService", () => {
+  let service: CommentService;
+  let httpMock: HttpTestingController;
+  let mockAuth: any;
+
+  beforeEach(() => {
+    mockAuth = {
+      getToken: vi.fn().mockReturnValue("test-jwt"),
+      isLoggedIn: vi.fn().mockReturnValue(true),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        CommentService,
+        { provide: AuthenticationService, useValue: mockAuth },
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    });
+    service = TestBed.inject(CommentService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe("getComments", () => {
+    it("fetches comments with the auth header when logged in", () => {
+      let result: any;
+      service.getComments("bp1").subscribe((r) => (result = r));
+
+      const req = httpMock.expectOne("/api/blueprints/bp1/comments");
+      expect(req.request.method).toBe("GET");
+      expect(req.request.headers.get("Authorization")).toBe("Bearer test-jwt");
+
+      req.flush({ threads: [], total: 0 });
+      expect(result).toEqual({ threads: [], total: 0 });
+    });
+
+    it("omits the auth header when anonymous", () => {
+      mockAuth.isLoggedIn.mockReturnValue(false);
+      service.getComments("bp1").subscribe();
+
+      const req = httpMock.expectOne("/api/blueprints/bp1/comments");
+      expect(req.request.headers.has("Authorization")).toBe(false);
+      req.flush({ threads: [], total: 0 });
+    });
+  });
+
+  describe("postComment", () => {
+    it("posts a top-level comment without parentId", () => {
+      service.postComment("bp1", "hello").subscribe();
+
+      const req = httpMock.expectOne("/api/blueprints/bp1/comments");
+      expect(req.request.method).toBe("POST");
+      expect(req.request.body).toEqual({ body: "hello" });
+      expect(req.request.headers.get("Authorization")).toBe("Bearer test-jwt");
+      req.flush({ comment: {} });
+    });
+
+    it("includes parentId for replies", () => {
+      service.postComment("bp1", "a reply", "parent1").subscribe();
+
+      const req = httpMock.expectOne("/api/blueprints/bp1/comments");
+      expect(req.request.body).toEqual({
+        body: "a reply",
+        parentId: "parent1",
+      });
+      req.flush({ comment: {} });
+    });
+  });
+
+  describe("deleteComment", () => {
+    it("issues an authenticated DELETE", () => {
+      service.deleteComment("c1").subscribe();
+
+      const req = httpMock.expectOne("/api/comments/c1");
+      expect(req.request.method).toBe("DELETE");
+      expect(req.request.headers.get("Authorization")).toBe("Bearer test-jwt");
+      req.flush({ delete: "OK" });
+    });
+  });
+});

--- a/frontend/src/app/module-blueprint/services/comment.service.ts
+++ b/frontend/src/app/module-blueprint/services/comment.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { Observable } from "rxjs";
+import {
+  ListCommentsResponse,
+  PostCommentResponse,
+} from "../../../../../lib/index";
+import { AuthenticationService } from "./authentification-service";
+
+@Injectable()
+export class CommentService {
+  constructor(private http: HttpClient, private auth: AuthenticationService) {}
+
+  // Token is optional on the list call: the backend uses it to compute
+  // per-comment delete rights for the viewer
+  public getComments(blueprintId: string): Observable<ListCommentsResponse> {
+    return this.http.get<ListCommentsResponse>(
+      `/api/blueprints/${blueprintId}/comments`,
+      this.auth.isLoggedIn() ? { headers: this.authHeaders() } : {}
+    );
+  }
+
+  public postComment(
+    blueprintId: string,
+    body: string,
+    parentId?: string
+  ): Observable<PostCommentResponse> {
+    return this.http.post<PostCommentResponse>(
+      `/api/blueprints/${blueprintId}/comments`,
+      parentId != null ? { body, parentId } : { body },
+      { headers: this.authHeaders() }
+    );
+  }
+
+  public deleteComment(commentId: string): Observable<{ delete: string }> {
+    return this.http.delete<{ delete: string }>(`/api/comments/${commentId}`, {
+      headers: this.authHeaders(),
+    });
+  }
+
+  private authHeaders() {
+    return { Authorization: `Bearer ${this.auth.getToken()}` };
+  }
+}

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -27,6 +27,7 @@ export * from './src/b-export/b-sprite-info';
 export * from './src/b-export/b-ui-screen';
 export * from './src/coms/blueprint-list-response';
 export * from './src/coms/social';
+export * from './src/coms/comments';
 export * from './src/drawing/sprite-modifier';
 export * from './src/drawing/sprite-modifier-group';
 export * from './src/drawing/sprite-info';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -31,6 +31,7 @@ export * from './src/b-export/b-ui-screen';
 
 export * from './src/coms/blueprint-list-response';
 export * from './src/coms/social';
+export * from './src/coms/comments';
 
 export * from './src/drawing/sprite-modifier';
 export * from './src/drawing/sprite-modifier-group';

--- a/lib/src/coms/comments.d.ts
+++ b/lib/src/coms/comments.d.ts
@@ -1,0 +1,37 @@
+export type CommentSegmentType = 'text' | 'blueprint' | 'user';
+export interface CommentSegment {
+    type: CommentSegmentType;
+    text?: string;
+    id?: string;
+    name?: string | null;
+}
+export interface CommentDto {
+    id: string;
+    parentId: string | null;
+    author: {
+        id: string;
+        username: string;
+    } | null;
+    segments: CommentSegment[];
+    deleted: boolean;
+    createdAt: string;
+    lastActivityAt: string;
+    canDelete: boolean;
+}
+export interface CommentThread {
+    comment: CommentDto;
+    replies: CommentDto[];
+}
+export interface ListCommentsResponse {
+    threads: CommentThread[];
+    total: number;
+}
+export interface PostCommentRequest {
+    body: string;
+    parentId?: string | null;
+}
+export interface PostCommentResponse {
+    comment: CommentDto;
+}
+export declare const COMMENT_MAX_LENGTH = 2000;
+//# sourceMappingURL=comments.d.ts.map

--- a/lib/src/coms/comments.ts
+++ b/lib/src/coms/comments.ts
@@ -1,0 +1,52 @@
+// Comment system API shapes. Bodies are stored as sanitized plain text with
+// internal reference tokens ({{blueprint:id}} / {{user:id}}); the API always
+// returns pre-resolved segments so clients never parse tokens or render HTML.
+
+export type CommentSegmentType = 'text' | 'blueprint' | 'user';
+
+export interface CommentSegment {
+  type: CommentSegmentType;
+  // type 'text': the literal text to display (client must escape/interpolate)
+  text?: string;
+  // type 'blueprint' | 'user': internal entity reference
+  id?: string;
+  // Resolved display name (blueprint name or username); null when the target
+  // no longer exists — render as "[deleted blueprint]" / "[deleted user]"
+  name?: string | null;
+}
+
+export interface CommentDto {
+  id: string;
+  parentId: string | null;
+  // null when the comment is soft-deleted (rendered as "[comment removed]")
+  author: { id: string; username: string } | null;
+  segments: CommentSegment[];
+  deleted: boolean;
+  createdAt: string;
+  lastActivityAt: string;
+  // Only meaningful when the request carried a valid token
+  canDelete: boolean;
+}
+
+export interface CommentThread {
+  comment: CommentDto;
+  replies: CommentDto[];
+}
+
+export interface ListCommentsResponse {
+  threads: CommentThread[];
+  // Visible comments incl. replies (excludes hidden deleted ones)
+  total: number;
+}
+
+export interface PostCommentRequest {
+  body: string;
+  // Omit or null for a top-level comment; must reference a top-level comment
+  parentId?: string | null;
+}
+
+export interface PostCommentResponse {
+  comment: CommentDto;
+}
+
+export const COMMENT_MAX_LENGTH = 2000;

--- a/migrations/20260706000000_add-comment-indexes.js
+++ b/migrations/20260706000000_add-comment-indexes.js
@@ -1,0 +1,36 @@
+'use strict';
+
+// Comment collection indexes (spec/COMMENT_SYSTEM.md). New collection — no
+// data migration needed. createIndex is idempotent, safe to re-run.
+
+module.exports = {
+  async up(db) {
+    const col = db.collection('comments');
+    // Primary feed: top-level comments by most recent activity
+    await col.createIndex(
+      { blueprintId: 1, parentId: 1, lastActivityAt: -1 },
+      { name: 'blueprintId_1_parentId_1_lastActivityAt_-1' }
+    );
+    // Reply thread read order
+    await col.createIndex(
+      { blueprintId: 1, parentId: 1, createdAt: 1 },
+      { name: 'blueprintId_1_parentId_1_createdAt_1' }
+    );
+    // Profile activity + posting-cooldown lookup
+    await col.createIndex({ authorId: 1, createdAt: -1 }, { name: 'authorId_1_createdAt_-1' });
+  },
+
+  async down(db) {
+    const col = db.collection('comments');
+    const dropIfExists = async (name) => {
+      try {
+        await col.dropIndex(name);
+      } catch (err) {
+        if (err.codeName !== 'IndexNotFound' && err.codeName !== 'NamespaceNotFound') throw err;
+      }
+    };
+    await dropIfExists('blueprintId_1_parentId_1_lastActivityAt_-1');
+    await dropIfExists('blueprintId_1_parentId_1_createdAt_1');
+    await dropIfExists('authorId_1_createdAt_-1');
+  },
+};


### PR DESCRIPTION
## What this ships

A comment system for blueprints — the community-feedback loop from the comment system design spec: readers post structured feedback on a blueprint, others (or the author) reply within the thread.

### Backend
- **`Comment` model** (`app/api/models/comment.ts`): `blueprintId`, `authorId`, `parentId`, sanitized `body`, `createdAt`, `lastActivityAt`, `deletedAt`, with the spec's three indexes (feed by activity, thread read order, per-author activity/cooldown). Migration `20260706000000_add-comment-indexes.js` included (applied + verified locally).
- **Endpoints**:
  - `GET /api/blueprints/:id/comments` — anonymous; optional Bearer token computes per-comment `canDelete` for the viewer
  - `POST /api/blueprints/:id/comments` — authenticated; top-level or reply via `parentId`
  - `DELETE /api/comments/:id` — soft-delete by comment author, blueprint owner, or admin
- **Threading**: two levels only, enforced at the API (`400` on reply-to-reply). Threads ordered by most recent activity (replies bump the parent's `lastActivityAt` via `$max`), replies chronological.
- **Deletion semantics**: deleted comment with no replies is hidden; deleted comment with replies renders as a `[comment removed]` placeholder so threads stay coherent.

### Content pipeline (bodies never store raw input)
On write: NFC normalization; invisible/zero-width/bidi-override chars stripped; HTML stripped (loop until stable); external URLs removed silently; internal references stored as `{{blueprint:id}}` / `{{user:id}}` tokens (survive future URL refactors); pre-existing `{{`/`}}` neutralized so tokens can't be forged; whitespace tidied; 2000-char cap.

On read: the API resolves tokens in batch and returns display **segments** (`text` / `blueprint` / `user`), so the client never parses tokens or renders HTML — deleted targets come back as `name: null` and render as `[deleted blueprint]` / `[deleted user]`.

Bonus recognitions: bare `/b/:id` paths, full site URLs, `/profile/:username` links → @mentions, case-insensitive mention resolution. Emails are not treated as mentions.

### Frontend
- **Comments dialog** on the blueprint editor: new "Comments" entry in the Blueprint menu (disabled until the blueprint is saved). Threaded list, reply and delete actions, mention/blueprint router links (dialog closes on navigate), char counter, and a login prompt for anonymous viewers.
- `CommentService` + shared API types in `lib/src/coms/comments.ts`.

## Spec deviations (assumptions checked against the repo)
- Spec's example URL pattern was `/blueprint/:id`; the live route is `/b/:id` — the pipeline accepts both.
- Spec assumed a ban state on `User`; none exists, so none is enforced (noted for whenever moderation lands).
- Spec asks for rate limiting; CLAUDE.md rules that out (Cloudflare's job) — added only a light per-user posting cooldown (`429`, 10s, env-tunable via `COMMENT_COOLDOWN_SECONDS`).
- Spec's "lookalike character" stripping was skipped deliberately: the site serves zh/ru/ko users and stripping non-Latin ranges would mangle their comments. Invisible/bidi stripping kept.

## Deferred per spec
Tile-pinned comments, edit window, notifications, "hidden by author" state, external-link allowlist.

## Verification
- Backend: **315 tests green** (~30 new: full sanitization matrix + API integration incl. ordering, deletion visibility, permission matrix, cooldown)
- Frontend: **561 tests green** (14 new), `ng lint` clean
- `tsc -b` clean; `migrate:up` run against local DB
- No pagination on the list endpoint at launch (capped at 1000/blueprint) — trivial to add when a blueprint ever needs it

🤖 Generated with [Claude Code](https://claude.com/claude-code)