### PR TITLE
feat(details): blueprint details page; comments move out of the editor

### DIFF
--- a/__tests__/api/blueprint-details.test.ts
+++ b/__tests__/api/blueprint-details.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load test environment first
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup } from '../setup/testSetup';
+import { BlueprintModel } from '../../app/api/models/blueprint';
+import { CommentModel } from '../../app/api/models/comment';
+import { Types } from 'mongoose';
+
+describe('Blueprint details API', function () {
+  let testData: any;
+  let blueprintId: string;
+
+  beforeEach(async function () {
+    this.timeout(5000);
+    testData = await TestSetup.beforeEach();
+    blueprintId = testData.blueprints.popularBlueprint._id.toString();
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    await TestSetup.afterEach();
+  });
+
+  describe('GET /api/blueprints/:id', function () {
+    it('returns 400 for a malformed id and 404 for unknown or deleted blueprints', async function () {
+      expect((await TestSetup.request().get('/api/blueprints/not-an-id')).status).to.equal(400);
+      expect(
+        (await TestSetup.request().get(`/api/blueprints/${new Types.ObjectId()}`)).status
+      ).to.equal(404);
+
+      await BlueprintModel.model.updateOne({ _id: blueprintId }, { deletedAt: new Date() });
+      expect((await TestSetup.request().get(`/api/blueprints/${blueprintId}`)).status).to.equal(404);
+    });
+
+    it('returns meta without the heavy data payload for anonymous viewers', async function () {
+      const response = await TestSetup.request().get(`/api/blueprints/${blueprintId}`);
+
+      expect(response.status).to.equal(200);
+      expect(response.body.id).to.equal(blueprintId);
+      expect(response.body.name).to.equal('Super Coal Generator Setup');
+      expect(response.body.ownerName).to.equal(testData.users.user1.username);
+      expect(response.body.ownerId).to.equal(testData.users.user1._id.toString());
+      expect(response.body.tags).to.deep.equal(['power', 'coal', 'automation']);
+      expect(response.body.nbLikes).to.equal(2);
+      expect(response.body.likedByMe).to.equal(false);
+      expect(response.body.ownedByMe).to.equal(false);
+      expect(response.body.commentCount).to.equal(0);
+      expect(response.body.createdAt).to.exist;
+      expect(response.body.thumbnail).to.exist;
+      expect(response.body.data).to.equal(undefined);
+    });
+
+    it('personalizes likedByMe and ownedByMe when a token is sent', async function () {
+      // user2 liked popularBlueprint in the seed; user1 owns it
+      const liker = await TestSetup.request()
+        .get(`/api/blueprints/${blueprintId}`)
+        .set('Authorization', `Bearer ${testData.users.user2.generateJwt()}`);
+      expect(liker.body.likedByMe).to.equal(true);
+      expect(liker.body.ownedByMe).to.equal(false);
+
+      const owner = await TestSetup.request()
+        .get(`/api/blueprints/${blueprintId}`)
+        .set('Authorization', `Bearer ${testData.users.user1.generateJwt()}`);
+      expect(owner.body.likedByMe).to.equal(false);
+      expect(owner.body.ownedByMe).to.equal(true);
+    });
+
+    it('counts only visible comments', async function () {
+      const [, kept] = await CommentModel.model.create([
+        {
+          blueprintId,
+          authorId: testData.users.user2._id,
+          body: 'first',
+        },
+        {
+          blueprintId,
+          authorId: testData.users.user3._id,
+          body: 'second',
+        },
+        {
+          blueprintId,
+          authorId: testData.users.user2._id,
+          body: 'deleted',
+          deletedAt: new Date(),
+        },
+      ]);
+      expect(kept).to.exist;
+
+      const response = await TestSetup.request().get(`/api/blueprints/${blueprintId}`);
+      expect(response.body.commentCount).to.equal(2);
+    });
+  });
+
+  describe('commentCount on list responses', function () {
+    it('includes per-blueprint visible comment counts in /api/getblueprints', async function () {
+      await CommentModel.model.create([
+        { blueprintId, authorId: testData.users.user2._id, body: 'works great' },
+        { blueprintId, authorId: testData.users.user3._id, body: 'confirmed' },
+        {
+          blueprintId,
+          authorId: testData.users.user3._id,
+          body: 'removed',
+          deletedAt: new Date(),
+        },
+      ]);
+
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now() });
+
+      expect(response.status).to.equal(200);
+      const byName = new Map(
+        response.body.blueprints.map((b: any) => [b.name, b.commentCount])
+      );
+      expect(byName.get('Super Coal Generator Setup')).to.equal(2);
+      expect(byName.get('Oxygen Production Line')).to.equal(0);
+    });
+  });
+});

--- a/agent/TODO.md
+++ b/agent/TODO.md
@@ -1,11 +1,11 @@
 # Agent TODO - Blueprint Not Included
 
 ## Current Status
-- **Phase**: Social evolution — likes, auto-derived metadata, profiles/follows/activity feed, and blueprint comments all shipped
+- **Phase**: Social evolution — likes, auto-derived metadata, profiles/follows/activity feed, blueprint comments, and the blueprint details page all shipped
 - **Date**: 2026-07-06
 - **Branch**: `master`
 - **Stack**: Node 20.19.4 · TypeScript 5.9.2 strict · Mongoose 8.18.1 · Express 5.1.0 · Canvas 3.2.3 · Angular 20 · PrimeNG 20
-- **Tests**: 315 backend (Mocha + Chai) · 561 frontend (Vitest, 2 skipped) — all green
+- **Tests**: 320 backend (Mocha + Chai) · 567 frontend (Vitest, 2 skipped) — all green
 - **Enforcement**: zero-warning flags enabled backend, lib, and frontend (`strict` + `strictTemplates`); CI improvements all complete (mongo:8.0.23 + mongosh health check)
 
 ## OniExtract2024 follow-ups

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -16,11 +16,14 @@ import {
   SUBCATEGORIES,
   RESEARCH_TIERS,
 } from '../../lib/index';
-import { Blueprint as sharedBlueprint } from '../../lib/index';
+import { Blueprint as sharedBlueprint, BlueprintDetailsResponse } from '../../lib/index';
 import { UserModel, UserJwt } from './models/user';
+import { CommentModel } from './models/comment';
 import { BatchUtils } from './batch/batch-utils';
 import { apiError } from './utils/apiError';
 import { parseOlderThan } from './utils/pagination';
+import { optionalViewer } from './utils/optionalViewer';
+import mongoose from 'mongoose';
 
 const MAX_SKIP = 10000;
 
@@ -441,7 +444,20 @@ export class BlueprintController {
     }
   }
 
-  public static handleGetBlueprint(
+  // Visible (non-deleted) comment counts for a page of blueprints, one aggregate.
+  // The {blueprintId, parentId, lastActivityAt} index covers the match prefix.
+  public static async getCommentCounts(
+    blueprintIds: mongoose.Types.ObjectId[]
+  ): Promise<Map<string, number>> {
+    if (blueprintIds.length === 0 || CommentModel.model == null) return new Map();
+    const rows: { _id: mongoose.Types.ObjectId; count: number }[] = await CommentModel.model.aggregate([
+      { $match: { blueprintId: { $in: blueprintIds }, deletedAt: null } },
+      { $group: { _id: '$blueprintId', count: { $sum: 1 } } },
+    ]);
+    return new Map(rows.map(row => [row._id.toString(), row.count]));
+  }
+
+  public static async handleGetBlueprint(
     _req: Request,
     res: Response,
     userId: string,
@@ -458,12 +474,20 @@ export class BlueprintController {
       returnValue.remaining = blueprints.length - browseIncrement;
       if (returnValue.remaining < 0) returnValue.remaining = 0;
 
-      for (
-        let indexBlueprint = 0;
-        indexBlueprint < Math.min(browseIncrement, blueprints.length);
-        indexBlueprint++
-      ) {
-        let blueprint = blueprints[indexBlueprint];
+      const page = blueprints.slice(0, Math.min(browseIncrement, blueprints.length));
+
+      let commentCounts = new Map<string, number>();
+      try {
+        commentCounts = await BlueprintController.getCommentCounts(
+          page.map(blueprint => blueprint._id as mongoose.Types.ObjectId)
+        );
+      } catch (err) {
+        // Counts are decoration on the list — never fail the browse for them
+        console.log('comment count aggregate error');
+        console.log(err);
+      }
+
+      for (const blueprint of page) {
         if (blueprint.createdAt < returnValue.oldest) returnValue.oldest = blueprint.createdAt;
 
         let ownerId = '';
@@ -479,7 +503,6 @@ export class BlueprintController {
 
         let ownedByMe = false;
         if (userId != null && ownerId == userId) ownedByMe = true;
-        //console.log(userId + '_' + ownerId)
 
         let nbLikes = blueprint.likeCount ?? blueprint.likes?.length ?? 0;
 
@@ -495,6 +518,7 @@ export class BlueprintController {
           nbLikes: nbLikes,
           likedByMe: likedByMe,
           ownedByMe: ownedByMe,
+          commentCount: commentCounts.get((blueprint._id as any).toString()) ?? 0,
           gameVersion: blueprint.gameVersion ?? null,
           category: blueprint.category ?? null,
           subcategory: blueprint.subcategory ?? null,
@@ -503,10 +527,69 @@ export class BlueprintController {
         });
       }
 
-      // Long timeout for debug
-      //setTimeout(() => { res.json(returnValue); }, 2000)
       res.json(returnValue);
     } else res.json(returnValue);
+  }
+
+  // Meta-only payload for the details page: everything the card shows plus
+  // description/research tier, without the heavy blueprint `data` the editor
+  // fetches via /api/getblueprint/:id
+  public async getBlueprintDetails(req: Request, res: Response): Promise<void> {
+    try {
+      const blueprintId = req.params.id;
+      if (!mongoose.Types.ObjectId.isValid(blueprintId)) {
+        res.status(400).json(apiError(400, 'Invalid blueprint id'));
+        return;
+      }
+
+      const blueprint = await BlueprintModel.model
+        .findOne({ _id: blueprintId, deletedAt: null })
+        .populate('owner');
+      if (!blueprint) {
+        res.status(404).json(apiError(404, 'Blueprint not found'));
+        return;
+      }
+
+      const viewer = optionalViewer(req);
+      const viewerId = viewer?._id ?? null;
+
+      let ownerId = '';
+      let ownerName = '';
+      if (UserModel.isUser(blueprint.owner)) {
+        ownerName = blueprint.owner.username as string;
+        ownerId = blueprint.owner.id as string;
+      }
+
+      const commentCounts = await BlueprintController.getCommentCounts([
+        blueprint._id as mongoose.Types.ObjectId,
+      ]);
+
+      const response: BlueprintDetailsResponse = {
+        id: (blueprint._id as any).toString(),
+        name: blueprint.name,
+        ownerId,
+        ownerName,
+        tags: blueprint.tags,
+        createdAt: blueprint.createdAt,
+        modifiedAt: blueprint.modifiedAt,
+        thumbnail: blueprint.thumbnail,
+        nbLikes: blueprint.likeCount ?? blueprint.likes?.length ?? 0,
+        likedByMe: viewerId != null && (blueprint.likes ?? []).indexOf(viewerId) !== -1,
+        ownedByMe: viewerId != null && ownerId === viewerId,
+        commentCount: commentCounts.get((blueprint._id as any).toString()) ?? 0,
+        gameVersion: blueprint.gameVersion ?? null,
+        category: blueprint.category ?? null,
+        subcategory: blueprint.subcategory ?? null,
+        description: blueprint.description ?? null,
+        researchTier: blueprint.researchTier ?? null,
+        modded: blueprint.modded ?? null,
+      };
+      res.json(response);
+    } catch (err) {
+      console.log('getBlueprintDetails error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to retrieve blueprint details'));
+    }
   }
 
   private static saveBlueprint(

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -560,9 +560,16 @@ export class BlueprintController {
         ownerId = blueprint.owner.id as string;
       }
 
-      const commentCounts = await BlueprintController.getCommentCounts([
-        blueprint._id as mongoose.Types.ObjectId,
-      ]);
+      let commentCounts = new Map<string, number>();
+      try {
+        commentCounts = await BlueprintController.getCommentCounts([
+          blueprint._id as mongoose.Types.ObjectId,
+        ]);
+      } catch (err) {
+        // Counts are decoration on the details page — never fail the fetch for them
+        console.log('comment count aggregate error');
+        console.log(err);
+      }
 
       const response: BlueprintDetailsResponse = {
         id: (blueprint._id as any).toString(),

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -536,6 +536,11 @@ export class BlueprintController {
   // fetches via /api/getblueprint/:id
   public async getBlueprintDetails(req: Request, res: Response): Promise<void> {
     try {
+      if (BlueprintModel.model == null) {
+        res.status(503).send();
+        return;
+      }
+
       const blueprintId = req.params.id;
       if (!mongoose.Types.ObjectId.isValid(blueprintId)) {
         res.status(400).json(apiError(400, 'Invalid blueprint id'));

--- a/app/api/comment-controller.ts
+++ b/app/api/comment-controller.ts
@@ -1,10 +1,10 @@
 import { Request, Response } from 'express';
 import mongoose from 'mongoose';
-import jwt from 'jsonwebtoken';
 import { CommentModel, Comment } from './models/comment';
 import { BlueprintModel } from './models/blueprint';
 import { UserModel, UserJwt } from './models/user';
 import { apiError } from './utils/apiError';
+import { optionalViewer } from './utils/optionalViewer';
 import { sanitizeCommentBody, extractTokenIds, segmentBody } from './services/comment-body';
 import {
   CommentDto,
@@ -27,18 +27,6 @@ function cooldownSeconds(): number {
     return parseInt(process.env.COMMENT_COOLDOWN_SECONDS, 10) || 0;
   }
   return process.env.NODE_ENV === 'test' ? 0 : 10;
-}
-
-// The list route is anonymous, so express-jwt never runs there; decode the
-// token opportunistically to compute per-comment canDelete for logged-in viewers
-function optionalViewer(req: Request): UserJwt | null {
-  const header = req.headers.authorization;
-  if (!header?.startsWith('Bearer ')) return null;
-  try {
-    return jwt.verify(header.slice(7), process.env.JWT_SECRET as string) as UserJwt;
-  } catch {
-    return null;
-  }
 }
 
 async function resolveMentions(usernames: string[]): Promise<Map<string, string>> {

--- a/app/api/utils/optionalViewer.ts
+++ b/app/api/utils/optionalViewer.ts
@@ -9,7 +9,7 @@ export function optionalViewer(req: Request): UserJwt | null {
   const header = req.headers.authorization;
   if (!header?.startsWith('Bearer ')) return null;
   try {
-    return jwt.verify(header.slice(7), process.env.JWT_SECRET as string) as UserJwt;
+    return jwt.verify(header.slice(7), process.env.JWT_SECRET as string, { algorithms: ['HS256'] }) as UserJwt;
   } catch {
     return null;
   }

--- a/app/api/utils/optionalViewer.ts
+++ b/app/api/utils/optionalViewer.ts
@@ -1,0 +1,16 @@
+import { Request } from 'express';
+import jwt from 'jsonwebtoken';
+import { UserJwt } from '../models/user';
+
+// For anonymous routes (no express-jwt middleware) that still personalize
+// their response when a valid Bearer token is present — likedByMe, canDelete,
+// ownedByMe. Invalid or absent tokens just mean an anonymous viewer.
+export function optionalViewer(req: Request): UserJwt | null {
+  const header = req.headers.authorization;
+  if (!header?.startsWith('Bearer ')) return null;
+  try {
+    return jwt.verify(header.slice(7), process.env.JWT_SECRET as string) as UserJwt;
+  } catch {
+    return null;
+  }
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -76,6 +76,7 @@ export class Routes {
     app.route('/api/version').get(this.versionController.getVersion);
     app.route('/api/health').get(this.healthController.getHealth);
     app.route('/api/users/:username/profile').get(this.userController.getProfile);
+    app.route('/api/blueprints/:id').get(this.uploadBlueprintController.getBlueprintDetails);
     app.route('/api/blueprints/:id/comments').get(this.commentController.list);
 
     // Logged in access

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -10,6 +10,7 @@ import { ResetPasswordComponent } from "./module-blueprint/components/user-auth/
 import { VerifyEmailCallbackComponent } from "./module-blueprint/components/user-auth/verify-email-callback/verify-email-callback.component";
 import { BrowsePageComponent } from "./module-blueprint/components/browse-page/browse-page.component";
 import { ProfilePageComponent } from "./module-blueprint/components/profile-page/profile-page.component";
+import { BlueprintDetailsPageComponent } from "./module-blueprint/components/blueprint-details-page/blueprint-details-page.component";
 import { homeRedirectGuard } from "./module-blueprint/guards/home-redirect.guard";
 
 const routes: Routes = [
@@ -22,6 +23,7 @@ const routes: Routes = [
   { path: "editor", component: ComponentBlueprintParentComponent },
   { path: "discover", component: BrowsePageComponent },
   { path: "profile/:username", component: ProfilePageComponent },
+  { path: "blueprint/:id", component: BlueprintDetailsPageComponent },
   { path: "b/:id", component: ComponentBlueprintParentComponent },
   {
     path: "b/:id/hideui/:width/:height",

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.css
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.css
@@ -1,0 +1,116 @@
+.details-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.details-status {
+  margin: 2rem 0;
+  text-align: center;
+  opacity: 0.75;
+}
+
+.details-header {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.details-thumbnail {
+  flex: 0 0 320px;
+  max-width: 100%;
+}
+
+.details-thumbnail img {
+  width: 100%;
+  border-radius: 6px;
+  display: block;
+}
+
+.thumbnail-placeholder {
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 6px;
+  background: var(--p-surface-200, #e5e7eb);
+}
+
+.details-meta {
+  flex: 1 1 320px;
+  min-width: 0;
+}
+
+.details-meta h1 {
+  margin: 0 0 0.35rem;
+  font-size: 1.6rem;
+  word-break: break-word;
+}
+
+.details-byline {
+  display: flex;
+  gap: 0.75rem;
+  align-items: baseline;
+  margin-bottom: 0.5rem;
+}
+
+.details-date {
+  font-size: 0.85rem;
+  opacity: 0.6;
+}
+
+.details-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  border-radius: 3px;
+  font-size: 0.75rem;
+}
+
+.badge--category {
+  background: var(--p-primary-100, #dbeafe);
+  color: var(--p-primary-700, #1d4ed8);
+}
+
+.badge--version {
+  background: var(--p-surface-200, #e5e7eb);
+  color: var(--p-text-muted-color, #6b7280);
+}
+
+.badge--modded {
+  background: var(--p-orange-100, #ffedd5);
+  color: var(--p-orange-700, #c2410c);
+}
+
+.details-description {
+  margin: 0 0 0.75rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.details-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 1rem;
+}
+
+.tag {
+  font-size: 0.8rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  background: var(--p-surface-100, #f3f4f6);
+  color: var(--p-text-muted-color, #6b7280);
+}
+
+.details-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
@@ -1,0 +1,77 @@
+<div class="details-page">
+  <div *ngIf="loading" class="details-status" i18n>Loading blueprint…</div>
+
+  <div *ngIf="!loading && notFound" class="details-status" i18n>
+    Blueprint not found.
+  </div>
+
+  <ng-container *ngIf="!loading && details">
+    <div class="details-header">
+      <div class="details-thumbnail">
+        <img
+          *ngIf="hasRealThumbnail()"
+          [src]="details.thumbnail"
+          [alt]="details.name"
+        />
+        <div *ngIf="!hasRealThumbnail()" class="thumbnail-placeholder"></div>
+      </div>
+
+      <div class="details-meta">
+        <h1>{{ details.name }}</h1>
+
+        <div class="details-byline">
+          <span i18n
+            >by
+            <a [routerLink]="['/profile', details.ownerName]">{{
+              details.ownerName
+            }}</a></span
+          >
+          <span class="details-date">{{
+            details.createdAt | date : "yyyy-MM-dd"
+          }}</span>
+        </div>
+
+        <div class="details-badges">
+          <span *ngIf="details.category" class="badge badge--category">{{
+            details.category
+          }}</span>
+          <span *ngIf="details.subcategory" class="badge badge--category">{{
+            details.subcategory
+          }}</span>
+          <span *ngIf="details.gameVersion" class="badge badge--version">{{
+            details.gameVersion
+          }}</span>
+          <span *ngIf="details.modded" class="badge badge--modded" i18n
+            >Modded</span
+          >
+        </div>
+
+        <p *ngIf="details.description" class="details-description">
+          {{ details.description }}
+        </p>
+
+        <div *ngIf="details.tags.length > 0" class="details-tags">
+          <span class="tag" *ngFor="let tag of details.tags">{{ tag }}</span>
+        </div>
+
+        <div class="details-actions">
+          <a
+            pButton
+            i18n-label
+            label="Open in editor"
+            icon="pi pi-pencil"
+            [routerLink]="['/b', details.id]"
+          ></a>
+          <app-like-widget
+            [blueprintId]="details.id"
+            [nbLikes]="details.nbLikes"
+            [likedByMe]="details.likedByMe"
+            [disabled]="!loggedIn"
+          ></app-like-widget>
+        </div>
+      </div>
+    </div>
+
+    <app-comment-section [blueprintId]="blueprintId"></app-comment-section>
+  </ng-container>
+</div>

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
@@ -5,6 +5,10 @@
     Blueprint not found.
   </div>
 
+  <div *ngIf="!loading && loadError" class="details-status" i18n>
+    Something went wrong loading this blueprint. Please try again.
+  </div>
+
   <ng-container *ngIf="!loading && details">
     <div class="details-header">
       <div class="details-thumbnail">

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
@@ -1,0 +1,107 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { ActivatedRoute, convertToParamMap } from "@angular/router";
+import { of, throwError } from "rxjs";
+
+import { BlueprintDetailsPageComponent } from "./blueprint-details-page.component";
+import { BlueprintService } from "../../services/blueprint-service";
+import { AuthenticationService } from "../../services/authentification-service";
+
+function makeDetails(overrides: any = {}) {
+  return {
+    id: "bp1",
+    name: "Super Coal Generator Setup",
+    ownerId: "owner-1",
+    ownerName: "alice",
+    tags: ["power", "coal"],
+    createdAt: new Date("2026-07-01").toISOString(),
+    modifiedAt: new Date("2026-07-01").toISOString(),
+    thumbnail: "data:image/png;base64,xyz",
+    nbLikes: 2,
+    likedByMe: false,
+    ownedByMe: false,
+    commentCount: 3,
+    gameVersion: "spacedOut",
+    category: "power",
+    subcategory: null,
+    description: "A tidy coal setup",
+    researchTier: null,
+    modded: false,
+    ...overrides,
+  };
+}
+
+describe("BlueprintDetailsPageComponent", () => {
+  let component: BlueprintDetailsPageComponent;
+  let fixture: ComponentFixture<BlueprintDetailsPageComponent>;
+  let blueprintService: any;
+  let authService: any;
+
+  beforeEach(async () => {
+    blueprintService = {
+      getBlueprintDetails: vi.fn().mockReturnValue(of(makeDetails())),
+    };
+    authService = { isLoggedIn: vi.fn().mockReturnValue(true) };
+
+    await TestBed.configureTestingModule({
+      declarations: [BlueprintDetailsPageComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        { provide: BlueprintService, useValue: blueprintService },
+        { provide: AuthenticationService, useValue: authService },
+        {
+          provide: ActivatedRoute,
+          useValue: { paramMap: of(convertToParamMap({ id: "bp1" })) },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BlueprintDetailsPageComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("creates", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("loads details for the routed blueprint id", () => {
+    fixture.detectChanges();
+
+    expect(blueprintService.getBlueprintDetails).toHaveBeenCalledWith("bp1");
+    expect(component.details?.name).toBe("Super Coal Generator Setup");
+    expect(component.blueprintId).toBe("bp1");
+    expect(component.loading).toBe(false);
+    expect(component.notFound).toBe(false);
+  });
+
+  it("shows not-found when the blueprint does not exist", () => {
+    blueprintService.getBlueprintDetails.mockReturnValue(
+      throwError(() => ({ status: 404 }))
+    );
+    fixture.detectChanges();
+
+    expect(component.notFound).toBe(true);
+    expect(component.details).toBe(null);
+    expect(component.loading).toBe(false);
+  });
+
+  it("detects placeholder thumbnails", () => {
+    blueprintService.getBlueprintDetails.mockReturnValue(
+      of(makeDetails({ thumbnail: "svg" }))
+    );
+    fixture.detectChanges();
+
+    expect(component.hasRealThumbnail()).toBe(false);
+  });
+
+  it("renders the details and passes the blueprint id to the comment section", () => {
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+
+    expect(el.querySelector("h1")?.textContent).toContain(
+      "Super Coal Generator Setup"
+    );
+    expect(el.querySelector("app-comment-section")).toBeTruthy();
+    expect(el.textContent).toContain("A tidy coal setup");
+  });
+});

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
+import { EMPTY, Observable } from "rxjs";
+import { catchError, switchMap } from "rxjs/operators";
 import { BlueprintDetailsResponse } from "../../../../../../lib/index";
 import { BlueprintService } from "../../services/blueprint-service";
 import { AuthenticationService } from "../../services/authentification-service";
@@ -15,6 +17,7 @@ export class BlueprintDetailsPageComponent implements OnInit {
   blueprintId: string | null = null;
   loading = true;
   notFound = false;
+  loadError = false;
 
   constructor(
     private route: ActivatedRoute,
@@ -23,28 +26,36 @@ export class BlueprintDetailsPageComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.route.paramMap.subscribe((params) => {
-      const id = params.get("id");
-      if (id != null) this.load(id);
-    });
-  }
-
-  private load(id: string) {
-    this.loading = true;
-    this.notFound = false;
-    this.details = null;
-    this.blueprintId = null;
-    this.blueprintService.getBlueprintDetails(id).subscribe({
-      next: (details) => {
+    this.route.paramMap
+      .pipe(switchMap((params) => this.load(params.get("id"))))
+      .subscribe((details) => {
+        if (details == null) return;
         this.details = details;
         this.blueprintId = details.id;
         this.loading = false;
-      },
-      error: () => {
-        this.notFound = true;
+      });
+  }
+
+  private load(id: string | null): Observable<BlueprintDetailsResponse | null> {
+    this.details = null;
+    this.blueprintId = null;
+    this.notFound = false;
+    this.loadError = false;
+
+    if (id == null) {
+      this.loading = false;
+      return EMPTY;
+    }
+
+    this.loading = true;
+    return this.blueprintService.getBlueprintDetails(id).pipe(
+      catchError((err) => {
+        if (err?.status === 404) this.notFound = true;
+        else this.loadError = true;
         this.loading = false;
-      },
-    });
+        return EMPTY;
+      })
+    );
   }
 
   get loggedIn() {

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
@@ -1,0 +1,61 @@
+import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
+import { BlueprintDetailsResponse } from "../../../../../../lib/index";
+import { BlueprintService } from "../../services/blueprint-service";
+import { AuthenticationService } from "../../services/authentification-service";
+
+@Component({
+  selector: "app-blueprint-details-page",
+  templateUrl: "./blueprint-details-page.component.html",
+  styleUrls: ["./blueprint-details-page.component.css"],
+  standalone: false,
+})
+export class BlueprintDetailsPageComponent implements OnInit {
+  details: BlueprintDetailsResponse | null = null;
+  blueprintId: string | null = null;
+  loading = true;
+  notFound = false;
+
+  constructor(
+    private route: ActivatedRoute,
+    private blueprintService: BlueprintService,
+    public authService: AuthenticationService
+  ) {}
+
+  ngOnInit() {
+    this.route.paramMap.subscribe((params) => {
+      const id = params.get("id");
+      if (id != null) this.load(id);
+    });
+  }
+
+  private load(id: string) {
+    this.loading = true;
+    this.notFound = false;
+    this.details = null;
+    this.blueprintId = null;
+    this.blueprintService.getBlueprintDetails(id).subscribe({
+      next: (details) => {
+        this.details = details;
+        this.blueprintId = details.id;
+        this.loading = false;
+      },
+      error: () => {
+        this.notFound = true;
+        this.loading = false;
+      },
+    });
+  }
+
+  get loggedIn() {
+    return this.authService.isLoggedIn();
+  }
+
+  hasRealThumbnail(): boolean {
+    return (
+      this.details != null &&
+      this.details.thumbnail !== "svg" &&
+      this.details.thumbnail !== "svg_nothing"
+    );
+  }
+}

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.css
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.css
@@ -128,3 +128,27 @@
   background: var(--p-orange-100, #ffedd5);
   color: var(--p-orange-700, #c2410c);
 }
+
+.card-social {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.card-comments {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  text-decoration: none;
+  color: var(--p-text-muted-color, #6b7280);
+}
+
+.card-comments:hover {
+  color: var(--p-primary-color, inherit);
+}
+
+.card-thumbnail a {
+  display: block;
+}

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
@@ -113,7 +113,9 @@
   <div class="blueprint-grid">
     <div class="blueprint-card" *ngFor="let item of blueprintListItems">
       <div class="card-thumbnail">
-        <img *ngIf="isReal(item.thumbnail)" [src]="item.thumbnail" />
+        <a *ngIf="isReal(item.thumbnail)" [routerLink]="['/blueprint', item.id]"
+          ><img [src]="item.thumbnail"
+        /></a>
         <svg
           *ngIf="item.thumbnail === 'svg'"
           width="200"
@@ -156,9 +158,11 @@
 
       <div class="card-info">
         <div class="card-title">
-          <a *ngIf="isReal(item.thumbnail)" [routerLink]="['/b', item.id]">{{
-            item.name
-          }}</a>
+          <a
+            *ngIf="isReal(item.thumbnail)"
+            [routerLink]="['/blueprint', item.id]"
+            >{{ item.name }}</a
+          >
           <span *ngIf="!isReal(item.thumbnail)">{{ item.name }}</span>
         </div>
         <div *ngIf="isReal(item.thumbnail)" class="card-meta">
@@ -186,14 +190,24 @@
             >Modded</span
           >
         </div>
-        <app-like-widget
-          *ngIf="isReal(item.thumbnail)"
-          class="card-likes"
-          [blueprintId]="item.id"
-          [nbLikes]="item.nbLikes"
-          [likedByMe]="item.likedByMe"
-          [disabled]="!loggedIn"
-        ></app-like-widget>
+        <div *ngIf="isReal(item.thumbnail)" class="card-social">
+          <app-like-widget
+            class="card-likes"
+            [blueprintId]="item.id"
+            [nbLikes]="item.nbLikes"
+            [likedByMe]="item.likedByMe"
+            [disabled]="!loggedIn"
+          ></app-like-widget>
+          <a
+            class="card-comments"
+            [routerLink]="['/blueprint', item.id]"
+            i18n-title
+            title="View comments"
+          >
+            <i class="pi pi-comments" aria-hidden="true"></i>
+            {{ item.commentCount }}
+          </a>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
@@ -105,6 +105,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
       likedByMe: false,
       ownedByMe: false,
       nbLikes: 0,
+      commentCount: 0,
     };
 
     this.nothingBlueprintItem = {
@@ -119,6 +120,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
       likedByMe: false,
       ownedByMe: false,
       nbLikes: 0,
+      commentCount: 0,
     };
 
     this.filterNameSubject.pipe(debounceTime(600)).subscribe(() => {

--- a/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.css
+++ b/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.css
@@ -101,3 +101,20 @@
   font-size: 0.8rem;
   opacity: 0.6;
 }
+
+.comments-heading {
+  font-size: 1.15rem;
+  margin: 0 0 0.5rem;
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+}
+
+.comments-count {
+  font-weight: 400;
+  opacity: 0.6;
+}
+
+.comment-new-form {
+  margin-top: 0.75rem;
+}

--- a/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.html
+++ b/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.html
@@ -1,12 +1,11 @@
-<p-dialog
-  header="Comments"
-  i18n-header
-  [(visible)]="visible"
-  [modal]="true"
-  [style]="{ width: '560px' }"
-  [draggable]="false"
-  styleClass="comments-dialog"
->
+<section class="comment-section">
+  <h2 class="comments-heading">
+    <ng-container i18n>Comments</ng-container>
+    <span class="comments-count" *ngIf="!loading && !loadError"
+      >({{ total }})</span
+    >
+  </h2>
+
   <p *ngIf="loading" class="comments-status" i18n>Loading comments…</p>
   <p *ngIf="loadError" class="comments-status comments-error" i18n>
     Could not load comments. Please try again.
@@ -69,36 +68,34 @@
 
   <p *ngIf="postError" class="comments-error">{{ postError }}</p>
 
-  <ng-template pTemplate="footer">
-    <div class="comment-new-form" *ngIf="authService.isLoggedIn()">
-      <textarea
-        pTextarea
-        [(ngModel)]="newComment"
-        [rows]="3"
-        [maxlength]="maxLength"
-        placeholder="Give the author feedback — links to other blueprints and @mentions work, external links are removed"
-        i18n-placeholder
-        [disabled]="posting"
-      ></textarea>
-      <div class="comment-form-actions">
-        <span class="comment-char-count"
-          >{{ newComment.length }}/{{ maxLength }}</span
-        >
-        <p-button
-          label="Post comment"
-          i18n-label
-          [loading]="posting"
-          [disabled]="!newComment.trim()"
-          (onClick)="postTopLevel()"
-        ></p-button>
-      </div>
+  <div class="comment-new-form" *ngIf="authService.isLoggedIn()">
+    <textarea
+      pTextarea
+      [(ngModel)]="newComment"
+      [rows]="3"
+      [maxlength]="maxLength"
+      placeholder="Give the author feedback — links to other blueprints and @mentions work, external links are removed"
+      i18n-placeholder
+      [disabled]="posting"
+    ></textarea>
+    <div class="comment-form-actions">
+      <span class="comment-char-count"
+        >{{ newComment.length }}/{{ maxLength }}</span
+      >
+      <p-button
+        label="Post comment"
+        i18n-label
+        [loading]="posting"
+        [disabled]="!newComment.trim()"
+        (onClick)="postTopLevel()"
+      ></p-button>
     </div>
-    <p *ngIf="!authService.isLoggedIn()" class="comments-status">
-      <a routerLink="/login" (click)="visible = false" i18n>Log in</a
-      ><ng-container i18n> to join the conversation.</ng-container>
-    </p>
-  </ng-template>
-</p-dialog>
+  </div>
+  <p *ngIf="!authService.isLoggedIn()" class="comments-status">
+    <a routerLink="/login" i18n>Log in</a
+    ><ng-container i18n> to join the conversation.</ng-container>
+  </p>
+</section>
 
 <ng-template #commentTpl let-comment="comment" let-isReply="isReply">
   <div class="comment" [class.comment-reply]="isReply">
@@ -108,7 +105,6 @@
           *ngIf="comment.author"
           class="comment-author"
           [routerLink]="['/profile', comment.author.username]"
-          (click)="onLinkClicked()"
           >{{ comment.author.username }}</a
         >
         <span *ngIf="!comment.author" class="comment-author-deleted" i18n
@@ -131,8 +127,7 @@
           }}</span>
           <a
             *ngIf="segment.type === 'blueprint' && segment.name !== null"
-            [routerLink]="['/b', segment.id]"
-            (click)="onLinkClicked()"
+            [routerLink]="['/blueprint', segment.id]"
             >{{ segment.name }}</a
           >
           <span
@@ -144,7 +139,6 @@
           <a
             *ngIf="segment.type === 'user' && segment.name !== null"
             [routerLink]="['/profile', segment.name]"
-            (click)="onLinkClicked()"
             >@{{ segment.name }}</a
           >
           <span

--- a/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.spec.ts
@@ -2,10 +2,9 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { of, throwError } from "rxjs";
 
-import { CommentsDialogComponent } from "./comments-dialog.component";
-import { CommentService } from "../../../services/comment.service";
-import { AuthenticationService } from "../../../services/authentification-service";
-import { BlueprintService } from "../../../services/blueprint-service";
+import { CommentSectionComponent } from "./comment-section.component";
+import { CommentService } from "../../services/comment.service";
+import { AuthenticationService } from "../../services/authentification-service";
 
 function makeComment(overrides: any = {}) {
   return {
@@ -21,12 +20,16 @@ function makeComment(overrides: any = {}) {
   };
 }
 
-describe("CommentsDialogComponent", () => {
-  let component: CommentsDialogComponent;
-  let fixture: ComponentFixture<CommentsDialogComponent>;
+describe("CommentSectionComponent", () => {
+  let component: CommentSectionComponent;
+  let fixture: ComponentFixture<CommentSectionComponent>;
   let commentService: any;
   let authService: any;
-  let blueprintService: any;
+
+  function bindBlueprint(id: string | null) {
+    component.blueprintId = id;
+    component.ngOnChanges();
+  }
 
   beforeEach(async () => {
     commentService = {
@@ -39,19 +42,17 @@ describe("CommentsDialogComponent", () => {
       deleteComment: vi.fn().mockReturnValue(of({ delete: "OK" })),
     };
     authService = { isLoggedIn: vi.fn().mockReturnValue(true) };
-    blueprintService = { id: "bp1" };
 
     await TestBed.configureTestingModule({
-      declarations: [CommentsDialogComponent],
+      declarations: [CommentSectionComponent],
       schemas: [NO_ERRORS_SCHEMA],
       providers: [
         { provide: CommentService, useValue: commentService },
         { provide: AuthenticationService, useValue: authService },
-        { provide: BlueprintService, useValue: blueprintService },
       ],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(CommentsDialogComponent);
+    fixture = TestBed.createComponent(CommentSectionComponent);
     component = fixture.componentInstance;
   });
 
@@ -59,22 +60,18 @@ describe("CommentsDialogComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  describe("open", () => {
-    it("loads comments for the current blueprint", () => {
-      component.open();
+  describe("blueprintId binding", () => {
+    it("loads comments when the blueprint id is bound", () => {
+      bindBlueprint("bp1");
 
-      expect(component.visible).toBe(true);
       expect(commentService.getComments).toHaveBeenCalledWith("bp1");
       expect(component.threads).toHaveLength(1);
       expect(component.total).toBe(1);
       expect(component.loading).toBe(false);
     });
 
-    it("does nothing when no blueprint is loaded", () => {
-      blueprintService.id = null;
-      component.open();
-
-      expect(component.visible).toBe(false);
+    it("does nothing without a blueprint id", () => {
+      bindBlueprint(null);
       expect(commentService.getComments).not.toHaveBeenCalled();
     });
 
@@ -82,15 +79,26 @@ describe("CommentsDialogComponent", () => {
       commentService.getComments.mockReturnValue(
         throwError(() => new Error("boom"))
       );
-      component.open();
+      bindBlueprint("bp1");
 
       expect(component.loadError).toBe(true);
       expect(component.loading).toBe(false);
     });
+
+    it("resets in-progress form state when the blueprint changes", () => {
+      bindBlueprint("bp1");
+      component.newComment = "draft";
+      component.startReply(makeComment({ id: "parent1" }) as any);
+
+      bindBlueprint("bp2");
+      expect(component.newComment).toBe("");
+      expect(component.replyingTo).toBe(null);
+      expect(commentService.getComments).toHaveBeenLastCalledWith("bp2");
+    });
   });
 
   describe("posting", () => {
-    beforeEach(() => component.open());
+    beforeEach(() => bindBlueprint("bp1"));
 
     it("posts a top-level comment, clears the input, and reloads", () => {
       component.newComment = "this breaks in Spaced Out";
@@ -141,7 +149,7 @@ describe("CommentsDialogComponent", () => {
 
   describe("delete", () => {
     it("deletes and reloads", () => {
-      component.open();
+      bindBlueprint("bp1");
       component.delete(makeComment({ canDelete: true }) as any);
 
       expect(commentService.deleteComment).toHaveBeenCalledWith("c1");

--- a/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.ts
+++ b/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.ts
@@ -1,21 +1,21 @@
-import { Component } from "@angular/core";
+import { Component, Input, OnChanges } from "@angular/core";
 import {
   CommentDto,
   CommentThread,
   COMMENT_MAX_LENGTH,
-} from "../../../../../../../lib/index";
-import { CommentService } from "../../../services/comment.service";
-import { AuthenticationService } from "../../../services/authentification-service";
-import { BlueprintService } from "../../../services/blueprint-service";
+} from "../../../../../../lib/index";
+import { CommentService } from "../../services/comment.service";
+import { AuthenticationService } from "../../services/authentification-service";
 
 @Component({
-  selector: "app-comments-dialog",
-  templateUrl: "./comments-dialog.component.html",
-  styleUrls: ["./comments-dialog.component.css"],
+  selector: "app-comment-section",
+  templateUrl: "./comment-section.component.html",
+  styleUrls: ["./comment-section.component.css"],
   standalone: false,
 })
-export class CommentsDialogComponent {
-  visible = false;
+export class CommentSectionComponent implements OnChanges {
+  @Input() blueprintId: string | null = null;
+
   loading = false;
   loadError = false;
   threads: CommentThread[] = [];
@@ -29,18 +29,12 @@ export class CommentsDialogComponent {
 
   readonly maxLength = COMMENT_MAX_LENGTH;
 
-  private blueprintId: string | null = null;
-
   constructor(
     private commentService: CommentService,
-    public authService: AuthenticationService,
-    private blueprintService: BlueprintService
+    public authService: AuthenticationService
   ) {}
 
-  public open() {
-    this.blueprintId = this.blueprintService.id;
-    if (this.blueprintId == null) return;
-    this.visible = true;
+  ngOnChanges() {
     this.newComment = "";
     this.replyingTo = null;
     this.replyText = "";
@@ -112,11 +106,5 @@ export class CommentsDialogComponent {
       next: () => this.reload(),
       error: () => this.reload(),
     });
-  }
-
-  onLinkClicked() {
-    // Internal reference links navigate away; close so the dialog isn't
-    // stranded over the newly loaded blueprint
-    this.visible = false;
   }
 }

--- a/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.html
+++ b/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.html
@@ -48,4 +48,3 @@
   (saveImages)="saveImages($event)"
 ></app-dialog-export-images>
 <app-feedback-dialog *ngIf="!forceSize" #feedbackDialog></app-feedback-dialog>
-<app-comments-dialog *ngIf="!forceSize" #commentsDialog></app-comments-dialog>

--- a/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.ts
@@ -49,7 +49,6 @@ import { DialogBrowseComponent } from "../dialogs/dialog-browse/dialog-browse.co
 import { DialogExportImagesComponent } from "../dialogs/dialog-export-images/dialog-export-images.component";
 import { DialogShareUrlComponent } from "../dialogs/dialog-share-url/dialog-share-url.component";
 import { FeedbackDialogComponent } from "../dialogs/feedback-dialog/feedback-dialog.component";
-import { CommentsDialogComponent } from "../dialogs/comments-dialog/comments-dialog.component";
 import { ComponentSideBuildToolComponent } from "../side-bar/build-tool/build-tool.component";
 import { ComponentSideSelectionToolComponent } from "../side-bar/selection-tool/selection-tool.component";
 var sanitize = require("sanitize-filename");
@@ -104,9 +103,6 @@ export class ComponentBlueprintParentComponent
 
   @ViewChild("feedbackDialog", { static: false })
   feedbackDialog!: FeedbackDialogComponent;
-
-  @ViewChild("commentsDialog", { static: false })
-  commentsDialog!: CommentsDialogComponent;
 
   // The left ui panel is not static, because when in a iframe we don't load it
   @ViewChild("sidePanelLeft", { static: false })
@@ -355,8 +351,6 @@ export class ComponentBlueprintParentComponent
       this.addElementsTiles();
     else if (menuCommand.type == MenuCommandType.sendFeedback)
       this.feedbackDialog.open();
-    else if (menuCommand.type == MenuCommandType.showComments)
-      this.commentsDialog.open();
   }
 
   saveImages(exportOptions: ExportImageOptions) {

--- a/frontend/src/app/module-blueprint/components/component-menu/component-menu.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-menu/component-menu.component.ts
@@ -86,10 +86,6 @@ export class ComponentMenuComponent
     if (blueprintMenuItems) {
       const saveItem = blueprintMenuItems.find((i) => i.id == "save");
       if (saveItem) saveItem.disabled = !this.authService.isLoggedIn();
-      const commentsItem = blueprintMenuItems.find((i) => i.id == "comments");
-      // Comments only exist for saved blueprints
-      if (commentsItem)
-        commentsItem.disabled = this.blueprintService.id == null;
     }
     return this.menuItems;
   }
@@ -265,17 +261,6 @@ export class ComponentMenuComponent
             command: (_event: any) => {
               this.menuCommand.emit({
                 type: MenuCommandType.browseBlueprints,
-                data: null,
-              });
-            },
-          },
-          {
-            id: "comments",
-            label: $localize`Comments`,
-            icon: "pi pi-comments",
-            command: (_event: any) => {
-              this.menuCommand.emit({
-                type: MenuCommandType.showComments,
                 data: null,
               });
             },
@@ -527,7 +512,6 @@ export enum MenuCommandType {
   addElementsTiles,
 
   sendFeedback,
-  showComments,
 }
 
 export class MenuCommand {

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.ts
@@ -58,6 +58,7 @@ export class DialogBrowseComponent implements OnInit {
       likedByMe: false,
       ownedByMe: false,
       nbLikes: 0,
+      commentCount: 0,
     };
 
     this.nothingBlueprintItem = {
@@ -72,6 +73,7 @@ export class DialogBrowseComponent implements OnInit {
       likedByMe: false,
       ownedByMe: false,
       nbLikes: 0,
+      commentCount: 0,
     };
 
     this.filterNameSubject

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.ts
@@ -66,6 +66,7 @@ export class ProfilePageComponent implements OnInit {
       likedByMe: false,
       ownedByMe: false,
       nbLikes: 0,
+      commentCount: 0,
     };
 
     this.nothingBlueprintItem = {
@@ -80,6 +81,7 @@ export class ProfilePageComponent implements OnInit {
       likedByMe: false,
       ownedByMe: false,
       nbLikes: 0,
+      commentCount: 0,
     };
   }
 

--- a/frontend/src/app/module-blueprint/module-blueprint.module.ts
+++ b/frontend/src/app/module-blueprint/module-blueprint.module.ts
@@ -87,7 +87,8 @@ import { ResetPasswordComponent } from "./components/user-auth/reset-password/re
 import { VerifyEmailCallbackComponent } from "./components/user-auth/verify-email-callback/verify-email-callback.component";
 import { FeedbackDialogComponent } from "./components/dialogs/feedback-dialog/feedback-dialog.component";
 import { FeedbackService } from "./services/feedback.service";
-import { CommentsDialogComponent } from "./components/dialogs/comments-dialog/comments-dialog.component";
+import { CommentSectionComponent } from "./components/comment-section/comment-section.component";
+import { BlueprintDetailsPageComponent } from "./components/blueprint-details-page/blueprint-details-page.component";
 import { CommentService } from "./services/comment.service";
 import { BrowsePageComponent } from "./components/browse-page/browse-page.component";
 import { ProfilePageComponent } from "./components/profile-page/profile-page.component";
@@ -139,7 +140,8 @@ import { ProfilePageComponent } from "./components/profile-page/profile-page.com
     ResetPasswordComponent,
     VerifyEmailCallbackComponent,
     FeedbackDialogComponent,
-    CommentsDialogComponent,
+    CommentSectionComponent,
+    BlueprintDetailsPageComponent,
     BrowsePageComponent,
     ProfilePageComponent,
   ],

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -15,6 +15,7 @@ import {
   BlueprintListItem,
   BlueprintLike,
   BlueprintResponse,
+  BlueprintDetailsResponse,
   BlueprintDelete,
 } from "../../../../../lib/index";
 import * as yaml from "js-yaml";
@@ -296,6 +297,21 @@ export class BlueprintService implements IObsBlueprintChange {
       );
 
     return request;
+  }
+
+  // Meta only (no blueprint data) — for the details page. Token is optional;
+  // the backend uses it to personalize likedByMe/ownedByMe.
+  getBlueprintDetails(id: string) {
+    return this.http.get<BlueprintDetailsResponse>(
+      `/api/blueprints/${id}`,
+      this.authService.isLoggedIn()
+        ? {
+            headers: {
+              Authorization: `Bearer ${this.authService.getToken()}`,
+            },
+          }
+        : {}
+    );
   }
 
   getBlueprints(

--- a/lib/src/coms/blueprint-list-response.d.ts
+++ b/lib/src/coms/blueprint-list-response.d.ts
@@ -15,11 +15,15 @@ export interface BlueprintListItem {
     nbLikes: number;
     likedByMe: boolean;
     ownedByMe: boolean;
+    commentCount: number;
     gameVersion?: string | null;
     category?: string | null;
     subcategory?: string | null;
     description?: string | null;
     modded?: boolean | null;
+}
+export interface BlueprintDetailsResponse extends BlueprintListItem {
+    researchTier?: string | null;
 }
 export interface BlueprintLike {
     blueprintId: string;

--- a/lib/src/coms/blueprint-list-response.ts
+++ b/lib/src/coms/blueprint-list-response.ts
@@ -16,11 +16,18 @@ export interface BlueprintListItem {
   nbLikes: number;
   likedByMe: boolean;
   ownedByMe: boolean;
+  commentCount: number;
   gameVersion?: string | null;
   category?: string | null;
   subcategory?: string | null;
   description?: string | null;
   modded?: boolean | null;
+}
+
+// Meta-only view for the blueprint details page — everything the list item
+// carries, without the heavy `data` payload the editor loads separately
+export interface BlueprintDetailsResponse extends BlueprintListItem {
+  researchTier?: string | null;
 }
 
 export interface BlueprintLike {


### PR DESCRIPTION
> **Stacked on #105** (comment system) — merge that first; this PR's diff is only the details-page work.

## What this ships

The social surface for a blueprint moves from the editor to a dedicated **details page** (`/blueprint/:id`). Discover was a list that linked straight into the canvas editor, which meant the only way to read or leave comments was inside the editor — the wrong place for discussion, and a cluttered dead end as the catalog grows.

### Details page (`/blueprint/:id`)
- Thumbnail, name, author (profile link), created date, category/subcategory/version/modded badges, description, tags
- Prominent **"Open in editor"** button → `/b/:id` (the editor keeps its job; discussion doesn't live there)
- Like widget and the full **comment thread inline**
- 404s render "Blueprint not found"; the page personalizes likedByMe/ownedByMe when a token is present

### Comments leave the editor
- The comments dialog, its Blueprint-menu entry, and `MenuCommandType.showComments` are **removed** from the editor
- The dialog is reworked into a reusable `app-comment-section` component driven by a `blueprintId` input (git-mv rename, history preserved)
- Blueprint links rendered inside comments now resolve to **details pages** instead of the editor

### Discover page
- Card title and thumbnail now link to the details page (was: editor)
- Each card shows a **comment count** (pi-comments icon) linking to the details page

### Backend
- `GET /api/blueprints/:id` — meta-only details payload (everything the card shows + researchTier), **without** the multi-hundred-KB `data` field the editor fetches separately; optional Bearer token personalizes likedByMe/ownedByMe
- `commentCount` added to `BlueprintListItem`: one aggregate per page of results (visible comments only, covered by the existing `{blueprintId, parentId, …}` index), never fails the browse if the aggregate errors
- `optionalViewer` token decoding extracted to a shared util (was private to the comment controller)

## Design decisions
- **Counts are computed, not denormalized** — no drift risk, no write-path coupling; one indexed aggregate per page of 10 cards. If comment-count sorting is ever wanted, denormalize then (the "future optimisation" noted in the request).
- **Route split**: `/blueprint/:id` = details (human-readable hub), `/b/:id` = editor. The comment pipeline already recognized both URL shapes as internal blueprint references, so old and new links keep working.
- **No site-nav on the details page** — follows the profile-page pattern; nav unification across pages is a separate piece of work.

## Verification
- Backend: **320 tests green** (5 new: details 400/404/personalization, visible-only comment counts, list counts)
- Frontend: **567 tests green** (9 new/adapted specs for `comment-section` and the details page), `ng lint` clean
- `tsc -b` clean; no new migration needed (indexes shipped with #105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)