### PR TITLE
feat: Fork/Remix + BlueprintVersion (spec/FORKS.md)

### DIFF
--- a/__tests__/api/blueprint-forks.test.ts
+++ b/__tests__/api/blueprint-forks.test.ts
@@ -267,6 +267,66 @@ describe('Fork + BlueprintVersion API', function () {
     });
   });
 
+  // ─── POST /api/blueprints/:id/versions/:versionId/restore ────────────────────
+
+  describe('POST /api/blueprints/:id/versions/:versionId/restore', function () {
+    it('returns 401 without a token and 403 for a non-owner', async function () {
+      const ownerToken = testData.users.user1.generateJwt();
+      const version = (
+        await TestSetup.request()
+          .post(`/api/blueprints/${popularId}/versions`)
+          .set('Authorization', `Bearer ${ownerToken}`)
+      ).body.version;
+
+      const anon = await TestSetup.request().post(
+        `/api/blueprints/${popularId}/versions/${version.id}/restore`
+      );
+      expect(anon.status).to.equal(401);
+
+      const otherToken = testData.users.user2.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/versions/${version.id}/restore`)
+        .set('Authorization', `Bearer ${otherToken}`);
+      expect(response.status).to.equal(403);
+    });
+
+    it('returns 404 for an unknown version', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/versions/${new Types.ObjectId().toString()}/restore`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(response.status).to.equal(404);
+    });
+
+    it('points currentVersionId back at an earlier live version without creating a new one', async function () {
+      const token = testData.users.user1.generateJwt();
+      const first = (
+        await TestSetup.request()
+          .post(`/api/blueprints/${popularId}/versions`)
+          .set('Authorization', `Bearer ${token}`)
+          .send({ name: 'first' })
+      ).body.version;
+      await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/versions`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'second' });
+
+      const countBefore = await BlueprintVersionModel.model.countDocuments({ blueprintId: popularId });
+
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/versions/${first.id}/restore`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(response.status).to.equal(200);
+      expect(response.body.version.id).to.equal(first.id);
+
+      const blueprint = await BlueprintModel.model.findById(popularId);
+      expect(blueprint!.currentVersionId!.toString()).to.equal(first.id);
+
+      const countAfter = await BlueprintVersionModel.model.countDocuments({ blueprintId: popularId });
+      expect(countAfter).to.equal(countBefore);
+    });
+  });
+
   // ─── Migration 2a/2b idempotency ──────────────────────────────────────────────
 
   describe('migration 20260707000000_blueprint-version-init', function () {

--- a/__tests__/api/blueprint-forks.test.ts
+++ b/__tests__/api/blueprint-forks.test.ts
@@ -349,9 +349,19 @@ describe('Fork + BlueprintVersion API', function () {
       expect(copied!.forkedFrom).to.not.equal(null);
       expect(copied!.forkedFrom!.blueprintId.toString()).to.equal(popularId);
       expect(copied!.forkedFrom!.versionId.toString()).to.equal(popular!.currentVersionId!.toString());
+      expect(popular!.forkCount).to.equal(1);
     });
 
-    it('down removes currentVersionId/forkedFrom and drops the versions collection', async function () {
+    it('backfills the parent forkCount exactly once across re-runs', async function () {
+      await versionInitMigration.up(mongoose.connection.db!);
+      await versionInitMigration.up(mongoose.connection.db!);
+      await versionInitMigration.up(mongoose.connection.db!);
+
+      const popular = await BlueprintModel.model.findById(popularId);
+      expect(popular!.forkCount).to.equal(1);
+    });
+
+    it('down removes currentVersionId/forkedFrom, drops the versions collection, and reverts forkCount', async function () {
       const db = mongoose.connection.db!;
       await versionInitMigration.up(db);
       await versionInitMigration.down(db);
@@ -359,6 +369,7 @@ describe('Fork + BlueprintVersion API', function () {
       const popular = await db.collection('blueprints').findOne({ _id: new Types.ObjectId(popularId) });
       expect(popular).to.not.have.property('currentVersionId');
       expect(popular).to.not.have.property('forkedFrom');
+      expect(popular!.forkCount).to.equal(0);
 
       const versionCount = await BlueprintVersionModel.model.countDocuments({});
       expect(versionCount).to.equal(0);

--- a/__tests__/api/blueprint-forks.test.ts
+++ b/__tests__/api/blueprint-forks.test.ts
@@ -68,6 +68,8 @@ describe('Fork + BlueprintVersion API', function () {
       expect(fork!.name).to.equal('Super Coal Generator Setup fork');
       expect(fork!.currentVersionId).to.not.equal(null);
       expect(fork!.forkedFrom!.blueprintId.toString()).to.equal(popularId);
+      expect(fork!.likes).to.deep.equal([testData.users.user2._id.toString()]);
+      expect(fork!.likeCount).to.equal(1);
 
       const forkVersion = await BlueprintVersionModel.model.findById(fork!.currentVersionId);
       expect(forkVersion).to.not.equal(null);
@@ -218,6 +220,14 @@ describe('Fork + BlueprintVersion API', function () {
       expect(response.status).to.equal(404);
     });
 
+    it('returns 400 for a malformed version id', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .delete(`/api/blueprints/${popularId}/versions/not-an-object-id`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(response.status).to.equal(400);
+    });
+
     it('advances currentVersionId to the next non-deleted version when the current one is deleted', async function () {
       const token = testData.users.user1.generateJwt();
       const first = (
@@ -298,6 +308,14 @@ describe('Fork + BlueprintVersion API', function () {
       expect(response.status).to.equal(404);
     });
 
+    it('returns 400 for a malformed version id', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/versions/not-an-object-id/restore`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(response.status).to.equal(400);
+    });
+
     it('points currentVersionId back at an earlier live version without creating a new one', async function () {
       const token = testData.users.user1.generateJwt();
       const first = (
@@ -333,9 +351,11 @@ describe('Fork + BlueprintVersion API', function () {
     it('is idempotent and migrates isCopy/copyOf fork provenance', async function () {
       const db = mongoose.connection.db!;
 
+      const blueprintCount = await BlueprintModel.model.countDocuments({});
+
       await versionInitMigration.up(db);
       const countAfterFirst = await BlueprintVersionModel.model.countDocuments({});
-      expect(countAfterFirst).to.equal(4); // one per seeded blueprint
+      expect(countAfterFirst).to.equal(blueprintCount); // one per seeded blueprint
 
       await versionInitMigration.up(db);
       const countAfterSecond = await BlueprintVersionModel.model.countDocuments({});
@@ -350,6 +370,30 @@ describe('Fork + BlueprintVersion API', function () {
       expect(copied!.forkedFrom!.blueprintId.toString()).to.equal(popularId);
       expect(copied!.forkedFrom!.versionId.toString()).to.equal(popular!.currentVersionId!.toString());
       expect(popular!.forkCount).to.equal(1);
+    });
+
+    it('reuses an orphaned version left by a crashed run instead of duplicating it', async function () {
+      const db = mongoose.connection.db!;
+      // Simulate a run that inserted the version but crashed before linking currentVersionId.
+      const orphan = await db.collection('blueprintversions').insertOne({
+        blueprintId: new Types.ObjectId(popularId),
+        name: null,
+        data: testData.blueprints.popularBlueprint.data,
+        thumbnail: null,
+        modVersion: null,
+        createdAt: new Date(),
+        deletedAt: null,
+      });
+
+      await versionInitMigration.up(db);
+
+      const versionCount = await BlueprintVersionModel.model.countDocuments({
+        blueprintId: new Types.ObjectId(popularId),
+      });
+      expect(versionCount).to.equal(1);
+
+      const popular = await BlueprintModel.model.findById(popularId);
+      expect(popular!.currentVersionId!.toString()).to.equal(orphan.insertedId.toString());
     });
 
     it('backfills the parent forkCount exactly once across re-runs', async function () {

--- a/__tests__/api/blueprint-forks.test.ts
+++ b/__tests__/api/blueprint-forks.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load test environment first
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import mongoose, { Types } from 'mongoose';
+import { TestSetup } from '../setup/testSetup';
+import { BlueprintModel } from '../../app/api/models/blueprint';
+import { BlueprintVersionModel } from '../../app/api/models/blueprint-version';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const versionInitMigration = require('../../migrations/20260707000000_blueprint-version-init.js');
+
+describe('Fork + BlueprintVersion API', function () {
+  let testData: any;
+  let popularId: string;
+
+  beforeEach(async function () {
+    this.timeout(5000);
+    testData = await TestSetup.beforeEach();
+    popularId = testData.blueprints.popularBlueprint._id.toString();
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    await TestSetup.afterEach();
+  });
+
+  // ─── POST /api/blueprints/:id/fork ───────────────────────────────────────────
+
+  describe('POST /api/blueprints/:id/fork', function () {
+    it('returns 401 without a token', async function () {
+      const response = await TestSetup.request().post(`/api/blueprints/${popularId}/fork`);
+      expect(response.status).to.equal(401);
+    });
+
+    it('returns 404 for an unknown or soft-deleted blueprint', async function () {
+      const token = testData.users.user2.generateJwt();
+      const unknown = await TestSetup.request()
+        .post(`/api/blueprints/${new Types.ObjectId().toString()}/fork`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(unknown.status).to.equal(404);
+
+      await BlueprintModel.model.updateOne({ _id: popularId }, { deletedAt: new Date() });
+      const deleted = await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/fork`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(deleted.status).to.equal(404);
+    });
+
+    it('creates an independent Blueprint + BlueprintVersion, increments source forkCount, and records forkedFrom', async function () {
+      const token = testData.users.user2.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/fork`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).to.equal(200);
+      const forkId = response.body.id;
+      expect(forkId).to.be.a('string');
+
+      const fork = await BlueprintModel.model.findById(forkId);
+      expect(fork).to.not.equal(null);
+      expect(fork!.owner.toString()).to.equal(testData.users.user2._id.toString());
+      expect(fork!.name).to.equal('Super Coal Generator Setup fork');
+      expect(fork!.currentVersionId).to.not.equal(null);
+      expect(fork!.forkedFrom!.blueprintId.toString()).to.equal(popularId);
+
+      const forkVersion = await BlueprintVersionModel.model.findById(fork!.currentVersionId);
+      expect(forkVersion).to.not.equal(null);
+      expect(forkVersion!.blueprintId.toString()).to.equal(forkId);
+      expect(forkVersion!.data).to.deep.equal(testData.blueprints.popularBlueprint.data);
+
+      const source = await BlueprintModel.model.findById(popularId);
+      expect(source!.forkCount).to.equal(1);
+      expect(fork!.forkedFrom!.versionId.toString()).to.equal(source!.currentVersionId!.toString());
+    });
+
+    it('leaves the fork loadable and unaffected after the parent is deleted', async function () {
+      const token = testData.users.user2.generateJwt();
+      const forkId = (
+        await TestSetup.request()
+          .post(`/api/blueprints/${popularId}/fork`)
+          .set('Authorization', `Bearer ${token}`)
+      ).body.id;
+
+      const ownerToken = testData.users.user1.generateJwt();
+      const deleteResponse = await TestSetup.request()
+        .post('/api/deleteblueprint')
+        .set('Authorization', `Bearer ${ownerToken}`)
+        .send({ blueprintId: popularId });
+      expect(deleteResponse.status).to.equal(200);
+
+      const getFork = await TestSetup.request().get(`/api/getblueprint/${forkId}`);
+      expect(getFork.status).to.equal(200);
+      expect(getFork.body.data).to.deep.equal(testData.blueprints.popularBlueprint.data);
+    });
+  });
+
+  // ─── GET /api/blueprints/:id/versions ────────────────────────────────────────
+
+  describe('GET /api/blueprints/:id/versions', function () {
+    it('returns 404 for an unknown blueprint', async function () {
+      const response = await TestSetup.request().get(
+        `/api/blueprints/${new Types.ObjectId().toString()}/versions`
+      );
+      expect(response.status).to.equal(404);
+    });
+
+    it('returns an empty list for a blueprint with no explicit versions yet', async function () {
+      const response = await TestSetup.request().get(`/api/blueprints/${popularId}/versions`);
+      expect(response.status).to.equal(200);
+      expect(response.body.versions).to.deep.equal([]);
+    });
+
+    it('lists versions newest first and excludes soft-deleted ones', async function () {
+      const token = testData.users.user1.generateJwt();
+      await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/versions`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'first' });
+      const second = await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/versions`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'second' });
+
+      await TestSetup.request()
+        .delete(`/api/blueprints/${popularId}/versions/${second.body.version.id}`)
+        .set('Authorization', `Bearer ${token}`);
+
+      const response = await TestSetup.request().get(`/api/blueprints/${popularId}/versions`);
+      expect(response.status).to.equal(200);
+      const names = response.body.versions.map((v: any) => v.name);
+      expect(names).to.deep.equal(['first']);
+    });
+  });
+
+  // ─── POST /api/blueprints/:id/versions ───────────────────────────────────────
+
+  describe('POST /api/blueprints/:id/versions', function () {
+    it('returns 401 without a token and 403 for a non-owner', async function () {
+      const anon = await TestSetup.request().post(`/api/blueprints/${popularId}/versions`);
+      expect(anon.status).to.equal(401);
+
+      const token = testData.users.user2.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/versions`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(response.status).to.equal(403);
+    });
+
+    it('returns 404 for an unknown or soft-deleted blueprint', async function () {
+      const token = testData.users.user1.generateJwt();
+      const unknown = await TestSetup.request()
+        .post(`/api/blueprints/${new Types.ObjectId().toString()}/versions`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(unknown.status).to.equal(404);
+    });
+
+    it('returns 400 for an over-long name', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/versions`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'x'.repeat(61) });
+      expect(response.status).to.equal(400);
+    });
+
+    it('creates a named snapshot from the current data and becomes currentVersionId', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/versions`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'stable' });
+
+      expect(response.status).to.equal(200);
+      expect(response.body.version.name).to.equal('stable');
+
+      const blueprint = await BlueprintModel.model.findById(popularId);
+      expect(blueprint!.currentVersionId!.toString()).to.equal(response.body.version.id);
+
+      const version = await BlueprintVersionModel.model.findById(response.body.version.id);
+      expect(version!.data).to.deep.equal(testData.blueprints.popularBlueprint.data);
+    });
+  });
+
+  // ─── DELETE /api/blueprints/:id/versions/:versionId ──────────────────────────
+
+  describe('DELETE /api/blueprints/:id/versions/:versionId', function () {
+    it('returns 401 without a token and 403 for a non-owner', async function () {
+      const ownerToken = testData.users.user1.generateJwt();
+      const version = (
+        await TestSetup.request()
+          .post(`/api/blueprints/${popularId}/versions`)
+          .set('Authorization', `Bearer ${ownerToken}`)
+      ).body.version;
+
+      const anon = await TestSetup.request().delete(
+        `/api/blueprints/${popularId}/versions/${version.id}`
+      );
+      expect(anon.status).to.equal(401);
+
+      const otherToken = testData.users.user2.generateJwt();
+      const response = await TestSetup.request()
+        .delete(`/api/blueprints/${popularId}/versions/${version.id}`)
+        .set('Authorization', `Bearer ${otherToken}`);
+      expect(response.status).to.equal(403);
+    });
+
+    it('returns 404 for an unknown version', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .delete(`/api/blueprints/${popularId}/versions/${new Types.ObjectId().toString()}`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(response.status).to.equal(404);
+    });
+
+    it('advances currentVersionId to the next non-deleted version when the current one is deleted', async function () {
+      const token = testData.users.user1.generateJwt();
+      const first = (
+        await TestSetup.request()
+          .post(`/api/blueprints/${popularId}/versions`)
+          .set('Authorization', `Bearer ${token}`)
+          .send({ name: 'first' })
+      ).body.version;
+      const second = (
+        await TestSetup.request()
+          .post(`/api/blueprints/${popularId}/versions`)
+          .set('Authorization', `Bearer ${token}`)
+          .send({ name: 'second' })
+      ).body.version;
+
+      let blueprint = await BlueprintModel.model.findById(popularId);
+      expect(blueprint!.currentVersionId!.toString()).to.equal(second.id);
+
+      const deleteResponse = await TestSetup.request()
+        .delete(`/api/blueprints/${popularId}/versions/${second.id}`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(deleteResponse.status).to.equal(200);
+
+      blueprint = await BlueprintModel.model.findById(popularId);
+      expect(blueprint!.currentVersionId!.toString()).to.equal(first.id);
+
+      const deletedVersion = await BlueprintVersionModel.model.findById(second.id);
+      expect(deletedVersion!.deletedAt).to.not.equal(null);
+    });
+
+    it('rejects deleting the only remaining version', async function () {
+      const token = testData.users.user1.generateJwt();
+      const only = (
+        await TestSetup.request()
+          .post(`/api/blueprints/${popularId}/versions`)
+          .set('Authorization', `Bearer ${token}`)
+          .send({ name: 'only' })
+      ).body.version;
+
+      const response = await TestSetup.request()
+        .delete(`/api/blueprints/${popularId}/versions/${only.id}`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(response.status).to.equal(400);
+
+      const version = await BlueprintVersionModel.model.findById(only.id);
+      expect(version!.deletedAt).to.equal(null);
+    });
+  });
+
+  // ─── Migration 2a/2b idempotency ──────────────────────────────────────────────
+
+  describe('migration 20260707000000_blueprint-version-init', function () {
+    it('is idempotent and migrates isCopy/copyOf fork provenance', async function () {
+      const db = mongoose.connection.db!;
+
+      await versionInitMigration.up(db);
+      const countAfterFirst = await BlueprintVersionModel.model.countDocuments({});
+      expect(countAfterFirst).to.equal(4); // one per seeded blueprint
+
+      await versionInitMigration.up(db);
+      const countAfterSecond = await BlueprintVersionModel.model.countDocuments({});
+      expect(countAfterSecond).to.equal(countAfterFirst);
+
+      const popular = await BlueprintModel.model.findById(popularId);
+      expect(popular!.currentVersionId).to.not.equal(null);
+
+      const copiedId = testData.blueprints.copiedBlueprint._id.toString();
+      const copied = await BlueprintModel.model.findById(copiedId);
+      expect(copied!.forkedFrom).to.not.equal(null);
+      expect(copied!.forkedFrom!.blueprintId.toString()).to.equal(popularId);
+      expect(copied!.forkedFrom!.versionId.toString()).to.equal(popular!.currentVersionId!.toString());
+    });
+
+    it('down removes currentVersionId/forkedFrom and drops the versions collection', async function () {
+      const db = mongoose.connection.db!;
+      await versionInitMigration.up(db);
+      await versionInitMigration.down(db);
+
+      const popular = await db.collection('blueprints').findOne({ _id: new Types.ObjectId(popularId) });
+      expect(popular).to.not.have.property('currentVersionId');
+      expect(popular).to.not.have.property('forkedFrom');
+
+      const versionCount = await BlueprintVersionModel.model.countDocuments({});
+      expect(versionCount).to.equal(0);
+    });
+  });
+});

--- a/__tests__/api/blueprints.test.ts
+++ b/__tests__/api/blueprints.test.ts
@@ -94,7 +94,7 @@ describe('Blueprint API (Mocha)', function () {
       expect(popularBlueprint.nbLikes).to.equal(2);
     });
 
-    it('should exclude copied blueprints by default', async function () {
+    it('includes forks/copies — the silent isCopy hide was removed (issue #8: forks are now an explicit, visible relationship via forkCount/forkedFrom)', async function () {
       const response = await TestSetup.request()
         .get('/api/getblueprints')
         .query({ olderthan: Date.now() });
@@ -102,20 +102,7 @@ describe('Blueprint API (Mocha)', function () {
       expect(response.status).to.equal(200);
 
       const blueprintNames = response.body.blueprints.map((bp: any) => bp.name);
-      expect(blueprintNames).to.not.include('Modified Coal Generator'); // This is a copy
-      expect(blueprintNames).to.include('Super Coal Generator Setup'); // Original should be included
-    });
-
-    it('should include copied blueprints when getDuplicates=true', async function () {
-      const response = await TestSetup.request().get('/api/getblueprints').query({
-        olderthan: Date.now(),
-        getDuplicates: true,
-      });
-
-      expect(response.status).to.equal(200);
-
-      const blueprintNames = response.body.blueprints.map((bp: any) => bp.name);
-      expect(blueprintNames).to.include('Modified Coal Generator'); // Copy should be included
+      expect(blueprintNames).to.include('Modified Coal Generator'); // Copy is now visible
       expect(blueprintNames).to.include('Super Coal Generator Setup'); // Original should still be included
     });
 
@@ -209,10 +196,12 @@ describe('Blueprint API (Mocha)', function () {
 
       expect(response.status).to.equal(200);
       const names = response.body.blueprints.map((bp: any) => bp.name);
-      // Seeded: Super Coal (2 likes), Oxygen (1), Legacy (0)
-      expect(names.slice(0, 3)).to.deep.equal([
+      // Seeded: Super Coal (2 likes), Oxygen (1), then 0-like ties broken by
+      // createdAt desc: Modified Coal Generator (2 days ago) before Legacy (30 days ago)
+      expect(names.slice(0, 4)).to.deep.equal([
         'Super Coal Generator Setup',
         'Oxygen Production Line',
+        'Modified Coal Generator',
         'Legacy Food System',
       ]);
       const likes = response.body.blueprints.map((bp: any) => bp.nbLikes);

--- a/__tests__/helpers/testDb.ts
+++ b/__tests__/helpers/testDb.ts
@@ -1,5 +1,6 @@
 import { UserModel } from '../../app/api/models/user';
 import { BlueprintModel } from '../../app/api/models/blueprint';
+import { BlueprintVersionModel } from '../../app/api/models/blueprint-version';
 import { FeedbackModel } from '../../app/api/models/feedback';
 import { FollowModel } from '../../app/api/models/follow';
 import { CommentModel } from '../../app/api/models/comment';
@@ -123,6 +124,7 @@ export class TestDbHelper {
   static async cleanDatabase() {
     try {
       await BlueprintModel.model.deleteMany({});
+      await BlueprintVersionModel.model.deleteMany({});
       await UserModel.model.deleteMany({});
       await FeedbackModel.model.deleteMany({});
       await FollowModel.model.deleteMany({});

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -699,28 +699,34 @@ export class BlueprintController {
     if (overwriteCreateDate || blueprint.createdAt == null) blueprint.createdAt = new Date();
     blueprint.modifiedAt = new Date();
 
+    let newBlueprint;
     try {
-      const newBlueprint = await blueprint.save();
+      newBlueprint = await blueprint.save();
       // Keeps currentVersionId's data in sync with every save — the common read
       // path (load blueprint -> render current data) must never see stale data.
       await syncCurrentVersion(newBlueprint, data, thumbnail);
-
-      let id = newBlueprint.id;
-      res.json({ id: id });
-
-      BatchUtils.UpdatePositionCorrection(newBlueprint);
-
-      // TODO: duplicate detection
-      // The old approach (UpdateBasedOn) loaded every blueprint into memory on each upload — removed due to OOM crashes.
-      // Proper approach: at upload time, compute a stable hash of the canonical blueprint content
-      // (sorted blueprintItems by id+position, excluding metadata like name/thumbnail) and store it
-      // on the document. Duplicate detection then becomes a single indexed query: find({ owner, contentHash }).
-      // The batch script update-based-on.ts can be repurposed to backfill hashes on existing documents.
     } catch (error) {
       console.log('Blueprint save error');
       console.log(error);
 
       res.status(500).json(apiError(500, 'Failed to save blueprint'));
+      return;
     }
+
+    res.json({ id: newBlueprint.id });
+
+    try {
+      BatchUtils.UpdatePositionCorrection(newBlueprint);
+    } catch (error) {
+      console.log('Position correction error');
+      console.log(error);
+    }
+
+    // TODO: duplicate detection
+    // The old approach (UpdateBasedOn) loaded every blueprint into memory on each upload — removed due to OOM crashes.
+    // Proper approach: at upload time, compute a stable hash of the canonical blueprint content
+    // (sorted blueprintItems by id+position, excluding metadata like name/thumbnail) and store it
+    // on the document. Duplicate detection then becomes a single indexed query: find({ owner, contentHash }).
+    // The batch script update-based-on.ts can be repurposed to backfill hashes on existing documents.
   }
 }

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -23,6 +23,7 @@ import { BatchUtils } from './batch/batch-utils';
 import { apiError } from './utils/apiError';
 import { parseOlderThan } from './utils/pagination';
 import { optionalViewer } from './utils/optionalViewer';
+import { resolveCurrentData, syncCurrentVersion } from './services/blueprint-version-service';
 import mongoose from 'mongoose';
 
 const MAX_SKIP = 10000;
@@ -230,82 +231,82 @@ export class BlueprintController {
     }
   }
 
-  public getBlueprint(req: Request, res: Response) {
+  public async getBlueprint(req: Request, res: Response): Promise<void> {
     console.log('getBlueprint' + req.clientIp);
-    if (BlueprintModel.model == null) res.status(503).send();
-    else {
-      // TODO checks here
-      let id = req.params.id;
-      let userId = req.query.userId;
+    if (BlueprintModel.model == null) {
+      res.status(503).send();
+      return;
+    }
+    // TODO checks here
+    let id = req.params.id;
+    let userId = req.query.userId;
 
-      BlueprintModel.model
-        .find({ _id: id })
-        .then(blueprints => {
-          if (blueprints.length > 0) {
-            let blueprint = blueprints[0];
+    try {
+      const blueprint = await BlueprintModel.model.findOne({ _id: id });
+      if (blueprint == null) {
+        res.status(404).json(apiError(404, 'Blueprint not found'));
+        return;
+      }
 
-            let likedByMe = false;
-            if (
-              userId != null &&
-              blueprint.likes != null &&
-              blueprint.likes.indexOf(userId as string) != -1
-            )
-              likedByMe = true;
+      let likedByMe = false;
+      if (
+        userId != null &&
+        blueprint.likes != null &&
+        blueprint.likes.indexOf(userId as string) != -1
+      )
+        likedByMe = true;
 
-            // Fallback covers docs the migration hasn't touched yet
-            let nbLikes = blueprint.likeCount ?? blueprint.likes?.length ?? 0;
+      // Fallback covers docs the migration hasn't touched yet
+      let nbLikes = blueprint.likeCount ?? blueprint.likes?.length ?? 0;
 
-            let response: BlueprintResponse = {
-              id: (blueprint._id as any).toString(),
-              name: blueprint.name,
-              data: blueprint.data,
-              likedByMe: likedByMe,
-              nbLikes: nbLikes,
-              gameVersion: blueprint.gameVersion ?? null,
-              category: blueprint.category ?? null,
-              subcategory: blueprint.subcategory ?? null,
-              description: blueprint.description ?? null,
-              researchTier: blueprint.researchTier ?? null,
-              modded: blueprint.modded ?? null,
-            };
-            res.json(response);
-          } else res.status(404).json(apiError(404, 'Blueprint not found'));
-        })
-        .catch(err => {
-          console.log('Blueprint find error');
-          console.log(err);
-          res.status(500).json(apiError(500, 'Failed to retrieve blueprint'));
-        });
+      let response: BlueprintResponse = {
+        id: (blueprint._id as any).toString(),
+        name: blueprint.name,
+        data: await resolveCurrentData(blueprint),
+        likedByMe: likedByMe,
+        nbLikes: nbLikes,
+        gameVersion: blueprint.gameVersion ?? null,
+        category: blueprint.category ?? null,
+        subcategory: blueprint.subcategory ?? null,
+        description: blueprint.description ?? null,
+        researchTier: blueprint.researchTier ?? null,
+        modded: blueprint.modded ?? null,
+      };
+      res.json(response);
+    } catch (err) {
+      console.log('Blueprint find error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to retrieve blueprint'));
     }
   }
 
-  public getBlueprintMod(req: Request, res: Response) {
+  public async getBlueprintMod(req: Request, res: Response): Promise<void> {
     console.log('getBlueprintMod' + req.clientIp);
-    if (BlueprintModel.model == null) res.status(503).send();
-    else {
-      // TODO checks here
-      let id = req.params.id;
+    if (BlueprintModel.model == null) {
+      res.status(503).send();
+      return;
+    }
+    // TODO checks here
+    let id = req.params.id;
 //       let _userId = req.query.userId;
 
-      BlueprintModel.model
-        .find({ _id: id })
-        .then(blueprints => {
-          if (blueprints.length > 0) {
-            let blueprint = blueprints[0];
+    try {
+      const blueprint = await BlueprintModel.model.findOne({ _id: id });
+      if (blueprint == null) {
+        res.status(404).json(apiError(404, 'Blueprint not found'));
+        return;
+      }
 
-            let mdbBlueprint = blueprint.data as MdbBlueprint;
-            let angularBlueprint = new sharedBlueprint();
-            angularBlueprint.importFromMdb(mdbBlueprint);
-            let bniBlueprint = angularBlueprint.toBniBlueprint(blueprint.name);
+      let mdbBlueprint = (await resolveCurrentData(blueprint)) as MdbBlueprint;
+      let angularBlueprint = new sharedBlueprint();
+      angularBlueprint.importFromMdb(mdbBlueprint);
+      let bniBlueprint = angularBlueprint.toBniBlueprint(blueprint.name);
 
-            res.json(bniBlueprint);
-          } else res.status(404).json(apiError(404, 'Blueprint not found'));
-        })
-        .catch(err => {
-          console.log('Blueprint find error');
-          console.log(err);
-          res.status(500).json(apiError(500, 'Failed to retrieve blueprint'));
-        });
+      res.json(bniBlueprint);
+    } catch (err) {
+      console.log('Blueprint find error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to retrieve blueprint'));
     }
   }
 
@@ -347,11 +348,10 @@ export class BlueprintController {
     else {
       let filterUserId: string;
       let filterName: string;
-      let getDuplicates: boolean;
       let filterGameVersion: string | null = null;
       let filterCategory: string | null = null;
       let filterSubcategory: string | null = null;
-      let sort: 'recent' | 'popular';
+      let sort: 'recent' | 'popular' | 'mostForked';
       let skip = 0;
 
       let userId = '';
@@ -369,7 +369,6 @@ export class BlueprintController {
           return;
         }
         filterName = rawFilterName;
-        getDuplicates = req.query.getDuplicates as any;
 
         const rawGameVersion = req.query.gameVersion as string | undefined;
         if (rawGameVersion != null && !(GAME_VERSIONS as readonly string[]).includes(rawGameVersion)) {
@@ -388,11 +387,11 @@ export class BlueprintController {
         filterSubcategory = req.query.subcategory as string ?? null;
 
         const rawSort = req.query.sort as string | undefined;
-        if (rawSort != null && rawSort !== 'recent' && rawSort !== 'popular') {
-          res.status(400).json(apiError(400, "Invalid sort: must be one of recent, popular"));
+        if (rawSort != null && rawSort !== 'recent' && rawSort !== 'popular' && rawSort !== 'mostForked') {
+          res.status(400).json(apiError(400, "Invalid sort: must be one of recent, popular, mostForked"));
           return;
         }
-        sort = (rawSort as 'recent' | 'popular') ?? 'recent';
+        sort = (rawSort as 'recent' | 'popular' | 'mostForked') ?? 'recent';
 
         const rawSkip = req.query.skip as string | undefined;
         if (rawSkip != null) {
@@ -410,25 +409,28 @@ export class BlueprintController {
         return;
       }
 
-      // popular ignores the olderthan cursor (offset pagination via skip instead);
+      // popular/mostForked ignore the olderthan cursor (offset pagination via skip instead);
       // the param stays accepted so the existing client call shape keeps working
-      let filter: any =
-        sort === 'popular'
-          ? { $and: [{ deletedAt: null }] }
-          : { $and: [{ createdAt: { $lt: dateFilter } }, { deletedAt: null }] };
+      const usesOffsetPagination = sort === 'popular' || sort === 'mostForked';
+      let filter: any = usesOffsetPagination
+        ? { $and: [{ deletedAt: null }] }
+        : { $and: [{ createdAt: { $lt: dateFilter } }, { deletedAt: null }] };
 
       if (filterUserId != null) filter.$and.push({ owner: filterUserId });
       if (filterName != null) filter.$and.push({ name: { $regex: filterName, $options: 'i' } });
-      if (!getDuplicates) filter.$and.push({ $or: [{ isCopy: null }, { isCopy: false }] });
       if (filterGameVersion != null) filter.$and.push({ gameVersion: filterGameVersion });
       if (filterCategory != null) filter.$and.push({ category: filterCategory });
       if (filterSubcategory != null) filter.$and.push({ subcategory: filterSubcategory });
 
+      let sortSpec: Record<string, 1 | -1> = { createdAt: -1 };
+      if (sort === 'popular') sortSpec = { likeCount: -1, createdAt: -1 };
+      else if (sort === 'mostForked') sortSpec = { forkCount: -1, createdAt: -1 };
+
       let browseIncrement = parseInt(process.env.BROWSE_INCREMENT as string);
       let query = BlueprintModel.model
         .find(filter)
-        .sort(sort === 'popular' ? { likeCount: -1, createdAt: -1 } : { createdAt: -1 })
-        .skip(sort === 'popular' ? skip : 0)
+        .sort(sortSpec)
+        .skip(usesOffsetPagination ? skip : 0)
         .limit(browseIncrement * 2)
         .populate('owner');
 
@@ -455,6 +457,24 @@ export class BlueprintController {
       { $group: { _id: '$blueprintId', count: { $sum: 1 } } },
     ]);
     return new Map(rows.map(row => [row._id.toString(), row.count]));
+  }
+
+  // Names (or soft-deleted status) of the parent blueprints referenced by forkedFrom
+  // for a page of blueprints, one batched query. null name = parent soft-deleted.
+  public static async getForkedFromNames(
+    blueprintIds: mongoose.Types.ObjectId[]
+  ): Promise<Map<string, string | null>> {
+    if (blueprintIds.length === 0) return new Map();
+    const parents = await BlueprintModel.model
+      .find({ _id: { $in: blueprintIds } })
+      .select('name deletedAt')
+      .lean();
+    return new Map(
+      parents.map(parent => [
+        (parent._id as mongoose.Types.ObjectId).toString(),
+        parent.deletedAt != null ? null : (parent.name as string),
+      ])
+    );
   }
 
   public static async handleGetBlueprint(
@@ -484,6 +504,19 @@ export class BlueprintController {
       } catch (err) {
         // Counts are decoration on the list — never fail the browse for them
         console.log('comment count aggregate error');
+        console.log(err);
+      }
+
+      let forkedFromNames = new Map<string, string | null>();
+      try {
+        forkedFromNames = await BlueprintController.getForkedFromNames(
+          page
+            .filter(blueprint => blueprint.forkedFrom != null)
+            .map(blueprint => blueprint.forkedFrom!.blueprintId)
+        );
+      } catch (err) {
+        // Decoration on the list — never fail the browse for it
+        console.log('forkedFrom name lookup error');
         console.log(err);
       }
 
@@ -524,6 +557,14 @@ export class BlueprintController {
           subcategory: blueprint.subcategory ?? null,
           description: blueprint.description ?? null,
           modded: blueprint.modded ?? null,
+          nbForks: blueprint.forkCount ?? 0,
+          forkedFrom:
+            blueprint.forkedFrom != null
+              ? {
+                  blueprintId: blueprint.forkedFrom.blueprintId.toString(),
+                  blueprintName: forkedFromNames.get(blueprint.forkedFrom.blueprintId.toString()) ?? null,
+                }
+              : null,
         });
       }
 
@@ -576,6 +617,17 @@ export class BlueprintController {
         console.log(err);
       }
 
+      let forkedFromName: string | null = null;
+      if (blueprint.forkedFrom != null) {
+        try {
+          const names = await BlueprintController.getForkedFromNames([blueprint.forkedFrom.blueprintId]);
+          forkedFromName = names.get(blueprint.forkedFrom.blueprintId.toString()) ?? null;
+        } catch (err) {
+          console.log('forkedFrom name lookup error');
+          console.log(err);
+        }
+      }
+
       const response: BlueprintDetailsResponse = {
         id: (blueprint._id as any).toString(),
         name: blueprint.name,
@@ -595,6 +647,11 @@ export class BlueprintController {
         description: blueprint.description ?? null,
         researchTier: blueprint.researchTier ?? null,
         modded: blueprint.modded ?? null,
+        nbForks: blueprint.forkCount ?? 0,
+        forkedFrom:
+          blueprint.forkedFrom != null
+            ? { blueprintId: blueprint.forkedFrom.blueprintId.toString(), blueprintName: forkedFromName }
+            : null,
       };
       res.json(response);
     } catch (err) {
@@ -604,7 +661,7 @@ export class BlueprintController {
     }
   }
 
-  private static saveBlueprint(
+  private static async saveBlueprint(
     _req: Request,
     res: Response,
     blueprint: Blueprint,
@@ -621,7 +678,7 @@ export class BlueprintController {
       researchTier: string | null;
       modded: boolean | null;
     }
-  ) {
+  ): Promise<void> {
     blueprint.owner = ownerId;
     blueprint.name = name;
     // TODO tags
@@ -642,26 +699,28 @@ export class BlueprintController {
     if (overwriteCreateDate || blueprint.createdAt == null) blueprint.createdAt = new Date();
     blueprint.modifiedAt = new Date();
 
-    blueprint
-      .save()
-      .then(newBlueprint => {
-        let id = newBlueprint.id;
-        res.json({ id: id });
+    try {
+      const newBlueprint = await blueprint.save();
+      // Keeps currentVersionId's data in sync with every save — the common read
+      // path (load blueprint -> render current data) must never see stale data.
+      await syncCurrentVersion(newBlueprint, data, thumbnail);
 
-        BatchUtils.UpdatePositionCorrection(newBlueprint);
+      let id = newBlueprint.id;
+      res.json({ id: id });
 
-        // TODO: duplicate detection
-        // The old approach (UpdateBasedOn) loaded every blueprint into memory on each upload — removed due to OOM crashes.
-        // Proper approach: at upload time, compute a stable hash of the canonical blueprint content
-        // (sorted blueprintItems by id+position, excluding metadata like name/thumbnail) and store it
-        // on the document. Duplicate detection then becomes a single indexed query: find({ owner, contentHash }).
-        // The batch script update-based-on.ts can be repurposed to backfill hashes on existing documents.
-      })
-      .catch(error => {
-        console.log('Blueprint save error');
-        console.log(error);
+      BatchUtils.UpdatePositionCorrection(newBlueprint);
 
-        res.status(500).json(apiError(500, 'Failed to save blueprint'));
-      });
+      // TODO: duplicate detection
+      // The old approach (UpdateBasedOn) loaded every blueprint into memory on each upload — removed due to OOM crashes.
+      // Proper approach: at upload time, compute a stable hash of the canonical blueprint content
+      // (sorted blueprintItems by id+position, excluding metadata like name/thumbnail) and store it
+      // on the document. Duplicate detection then becomes a single indexed query: find({ owner, contentHash }).
+      // The batch script update-based-on.ts can be repurposed to backfill hashes on existing documents.
+    } catch (error) {
+      console.log('Blueprint save error');
+      console.log(error);
+
+      res.status(500).json(apiError(500, 'Failed to save blueprint'));
+    }
   }
 }

--- a/app/api/blueprint-version-controller.ts
+++ b/app/api/blueprint-version-controller.ts
@@ -1,0 +1,246 @@
+import { Request, Response } from 'express';
+import mongoose from 'mongoose';
+import { BlueprintModel } from './models/blueprint';
+import { BlueprintVersionModel, BlueprintVersion } from './models/blueprint-version';
+import { UserJwt } from './models/user';
+import { apiError } from './utils/apiError';
+import {
+  ensureCurrentVersion,
+  resolveCurrentData,
+  getCurrentVersion,
+} from './services/blueprint-version-service';
+import {
+  BlueprintVersionDto,
+  ListBlueprintVersionsResponse,
+  CreateBlueprintVersionRequest,
+  CreateBlueprintVersionResponse,
+  ForkBlueprintResponse,
+} from '../../lib/index';
+
+const NAME_MAX_LENGTH = 60;
+const FORK_SUFFIX = ' fork';
+
+// "<name> fork", truncated so the total respects the same 60-char cap as
+// Blueprint.name — the suffix uses only letters/space so the result stays
+// valid against the name regex as long as the source name was valid.
+function forkName(originalName: string): string {
+  const maxBase = NAME_MAX_LENGTH - FORK_SUFFIX.length;
+  const base = originalName.length > maxBase ? originalName.slice(0, maxBase) : originalName;
+  return `${base}${FORK_SUFFIX}`;
+}
+
+function toVersionDto(version: BlueprintVersion): BlueprintVersionDto {
+  return {
+    id: (version._id as mongoose.Types.ObjectId).toString(),
+    name: version.name ?? null,
+    createdAt: version.createdAt.toISOString(),
+    thumbnail: version.thumbnail ?? null,
+  };
+}
+
+export class BlueprintVersionController {
+  constructor() {
+    this.fork = this.fork.bind(this);
+    this.listVersions = this.listVersions.bind(this);
+    this.createVersion = this.createVersion.bind(this);
+    this.deleteVersion = this.deleteVersion.bind(this);
+  }
+
+  public async fork(req: Request, res: Response): Promise<void> {
+    try {
+      const user = req.user as UserJwt;
+      const sourceId = req.params.id;
+      if (!mongoose.Types.ObjectId.isValid(sourceId)) {
+        res.status(400).json(apiError(400, 'Invalid blueprint id'));
+        return;
+      }
+
+      const source = await BlueprintModel.model.findOne({ _id: sourceId, deletedAt: null });
+      if (!source) {
+        res.status(404).json(apiError(404, 'Blueprint not found'));
+        return;
+      }
+
+      const sourceVersion = await ensureCurrentVersion(source);
+
+      const now = new Date();
+      const forked = new BlueprintModel.model({
+        owner: user._id,
+        name: forkName(source.name),
+        tags: source.tags ?? [],
+        likes: [],
+        likeCount: 0,
+        data: sourceVersion.data,
+        thumbnail: sourceVersion.thumbnail,
+        createdAt: now,
+        modifiedAt: now,
+        deletedAt: null,
+        gameVersion: source.gameVersion ?? null,
+        category: source.category ?? null,
+        subcategory: source.subcategory ?? null,
+        description: source.description ?? null,
+        researchTier: source.researchTier ?? null,
+        modded: source.modded ?? null,
+        forkedFrom: {
+          blueprintId: source._id,
+          versionId: sourceVersion._id,
+          forkedAt: now,
+        },
+      });
+
+      const forkedVersion = new BlueprintVersionModel.model({
+        blueprintId: forked._id,
+        data: sourceVersion.data,
+        thumbnail: sourceVersion.thumbnail,
+        modVersion: sourceVersion.modVersion ?? null,
+        createdAt: now,
+      });
+      await forkedVersion.save();
+      forked.currentVersionId = forkedVersion._id as mongoose.Types.ObjectId;
+      await forked.save();
+
+      await BlueprintModel.model.updateOne({ _id: source._id }, { $inc: { forkCount: 1 } });
+
+      const response: ForkBlueprintResponse = { id: forked.id };
+      res.json(response);
+    } catch (err) {
+      console.log('fork blueprint error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to fork blueprint'));
+    }
+  }
+
+  public async listVersions(req: Request, res: Response): Promise<void> {
+    try {
+      const blueprintId = req.params.id;
+      if (!mongoose.Types.ObjectId.isValid(blueprintId)) {
+        res.status(400).json(apiError(400, 'Invalid blueprint id'));
+        return;
+      }
+
+      const blueprint = await BlueprintModel.model.findOne({ _id: blueprintId }).select('_id').lean();
+      if (!blueprint) {
+        res.status(404).json(apiError(404, 'Blueprint not found'));
+        return;
+      }
+
+      const versions = await BlueprintVersionModel.model
+        .find({ blueprintId, deletedAt: null })
+        .sort({ createdAt: -1 })
+        .select('name createdAt thumbnail');
+
+      const response: ListBlueprintVersionsResponse = { versions: versions.map(toVersionDto) };
+      res.json(response);
+    } catch (err) {
+      console.log('list blueprint versions error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to retrieve versions'));
+    }
+  }
+
+  public async createVersion(req: Request, res: Response): Promise<void> {
+    try {
+      const user = req.user as UserJwt;
+      const blueprintId = req.params.id;
+      if (!mongoose.Types.ObjectId.isValid(blueprintId)) {
+        res.status(400).json(apiError(400, 'Invalid blueprint id'));
+        return;
+      }
+
+      const { name } = (req.body ?? {}) as CreateBlueprintVersionRequest;
+      if (name != null && (typeof name !== 'string' || name.length > NAME_MAX_LENGTH)) {
+        res.status(400).json(apiError(400, `Version name must be ${NAME_MAX_LENGTH} characters or fewer`));
+        return;
+      }
+
+      const blueprint = await BlueprintModel.model.findOne({ _id: blueprintId, deletedAt: null });
+      if (!blueprint) {
+        res.status(404).json(apiError(404, 'Blueprint not found'));
+        return;
+      }
+      if (blueprint.owner.toString() !== user._id) {
+        res.status(403).json(apiError(403, 'Only the owner can create a version'));
+        return;
+      }
+
+      const currentData = await resolveCurrentData(blueprint);
+      const currentVersion = await getCurrentVersion(blueprint);
+
+      const version = new BlueprintVersionModel.model({
+        blueprintId: blueprint._id,
+        name: name ?? null,
+        data: currentData,
+        thumbnail: currentVersion?.thumbnail ?? blueprint.thumbnail,
+        modVersion: currentVersion?.modVersion ?? null,
+        createdAt: new Date(),
+      });
+      await version.save();
+
+      blueprint.currentVersionId = version._id as mongoose.Types.ObjectId;
+      await blueprint.save();
+
+      const response: CreateBlueprintVersionResponse = { version: toVersionDto(version) };
+      res.json(response);
+    } catch (err) {
+      console.log('create blueprint version error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to create version'));
+    }
+  }
+
+  public async deleteVersion(req: Request, res: Response): Promise<void> {
+    try {
+      const user = req.user as UserJwt;
+      const blueprintId = req.params.id;
+      const versionId = req.params.versionId;
+      if (!mongoose.Types.ObjectId.isValid(blueprintId) || !mongoose.Types.ObjectId.isValid(versionId)) {
+        res.status(400).json(apiError(400, 'Invalid blueprint or version id'));
+        return;
+      }
+
+      const blueprint = await BlueprintModel.model.findOne({ _id: blueprintId, deletedAt: null });
+      if (!blueprint) {
+        res.status(404).json(apiError(404, 'Blueprint not found'));
+        return;
+      }
+      if (blueprint.owner.toString() !== user._id) {
+        res.status(403).json(apiError(403, 'Only the owner can delete a version'));
+        return;
+      }
+
+      const version = await BlueprintVersionModel.model.findOne({
+        _id: versionId,
+        blueprintId,
+        deletedAt: null,
+      });
+      if (!version) {
+        res.status(404).json(apiError(404, 'Version not found'));
+        return;
+      }
+
+      const liveCount = await BlueprintVersionModel.model.countDocuments({ blueprintId, deletedAt: null });
+      if (liveCount <= 1) {
+        res.status(400).json(apiError(400, 'Cannot delete the only remaining version'));
+        return;
+      }
+
+      version.deletedAt = new Date();
+      await version.save();
+
+      if (blueprint.currentVersionId?.toString() === versionId) {
+        const next = await BlueprintVersionModel.model
+          .findOne({ blueprintId, deletedAt: null })
+          .sort({ createdAt: -1 });
+        // liveCount > 1 guarantees a next version exists
+        blueprint.currentVersionId = next!._id as mongoose.Types.ObjectId;
+        await blueprint.save();
+      }
+
+      res.json({ deleteVersion: 'OK' });
+    } catch (err) {
+      console.log('delete blueprint version error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to delete version'));
+    }
+  }
+}

--- a/app/api/blueprint-version-controller.ts
+++ b/app/api/blueprint-version-controller.ts
@@ -44,6 +44,7 @@ export class BlueprintVersionController {
     this.listVersions = this.listVersions.bind(this);
     this.createVersion = this.createVersion.bind(this);
     this.deleteVersion = this.deleteVersion.bind(this);
+    this.restoreVersion = this.restoreVersion.bind(this);
   }
 
   public async fork(req: Request, res: Response): Promise<void> {
@@ -241,6 +242,50 @@ export class BlueprintVersionController {
       console.log('delete blueprint version error');
       console.log(err);
       res.status(500).json(apiError(500, 'Failed to delete version'));
+    }
+  }
+
+  // Points currentVersionId back at an earlier live version — the simpler of the
+  // two restore semantics floated in spec/FORKS.md (no new version is created).
+  public async restoreVersion(req: Request, res: Response): Promise<void> {
+    try {
+      const user = req.user as UserJwt;
+      const blueprintId = req.params.id;
+      const versionId = req.params.versionId;
+      if (!mongoose.Types.ObjectId.isValid(blueprintId) || !mongoose.Types.ObjectId.isValid(versionId)) {
+        res.status(400).json(apiError(400, 'Invalid blueprint or version id'));
+        return;
+      }
+
+      const blueprint = await BlueprintModel.model.findOne({ _id: blueprintId, deletedAt: null });
+      if (!blueprint) {
+        res.status(404).json(apiError(404, 'Blueprint not found'));
+        return;
+      }
+      if (blueprint.owner.toString() !== user._id) {
+        res.status(403).json(apiError(403, 'Only the owner can restore a version'));
+        return;
+      }
+
+      const version = await BlueprintVersionModel.model.findOne({
+        _id: versionId,
+        blueprintId,
+        deletedAt: null,
+      });
+      if (!version) {
+        res.status(404).json(apiError(404, 'Version not found'));
+        return;
+      }
+
+      blueprint.currentVersionId = version._id as mongoose.Types.ObjectId;
+      await blueprint.save();
+
+      const response: CreateBlueprintVersionResponse = { version: toVersionDto(version) };
+      res.json(response);
+    } catch (err) {
+      console.log('restore blueprint version error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to restore version'));
     }
   }
 }

--- a/app/api/blueprint-version-controller.ts
+++ b/app/api/blueprint-version-controller.ts
@@ -15,6 +15,7 @@ import {
   CreateBlueprintVersionRequest,
   CreateBlueprintVersionResponse,
   ForkBlueprintResponse,
+  DeleteBlueprintVersionResponse,
 } from '../../lib/index';
 
 const NAME_MAX_LENGTH = 60;
@@ -69,8 +70,9 @@ export class BlueprintVersionController {
         owner: user._id,
         name: forkName(source.name),
         tags: source.tags ?? [],
-        likes: [],
-        likeCount: 0,
+        // Every blueprint starts with the author's like (GitHub-star semantics) — see uploadBlueprint
+        likes: [user._id],
+        likeCount: 1,
         data: sourceVersion.data,
         thumbnail: sourceVersion.thumbnail,
         createdAt: now,
@@ -237,7 +239,8 @@ export class BlueprintVersionController {
         await blueprint.save();
       }
 
-      res.json({ deleteVersion: 'OK' });
+      const response: DeleteBlueprintVersionResponse = { deleteVersion: 'OK' };
+      res.json(response);
     } catch (err) {
       console.log('delete blueprint version error');
       console.log(err);

--- a/app/api/db.ts
+++ b/app/api/db.ts
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose';
 import { UserModel } from './models/user';
 import { BlueprintModel } from './models/blueprint';
+import { BlueprintVersionModel } from './models/blueprint-version';
 import { FeedbackModel } from './models/feedback';
 import { FollowModel } from './models/follow';
 import { CommentModel } from './models/comment';
@@ -21,6 +22,7 @@ export class Database {
       }
       UserModel.init();
       BlueprintModel.init();
+      BlueprintVersionModel.init();
       FeedbackModel.init();
       FollowModel.init();
       CommentModel.init();

--- a/app/api/models/blueprint-version.ts
+++ b/app/api/models/blueprint-version.ts
@@ -25,10 +25,9 @@ export class BlueprintVersionModel {
       deletedAt: { type: Date, default: null },
     });
 
-    // Version history list, newest first
-    blueprintVersionSchema.index({ blueprintId: 1, createdAt: -1 });
-    // Find current version (latest where deletedAt is null)
-    blueprintVersionSchema.index({ blueprintId: 1, deletedAt: 1 });
+    // Backs listVersions/deleteVersion/restoreVersion: filter { blueprintId, deletedAt: null },
+    // sort/find-latest by createdAt desc — one compound index serves both.
+    blueprintVersionSchema.index({ blueprintId: 1, deletedAt: 1, createdAt: -1 });
 
     BlueprintVersionModel.model =
       (mongoose.models['BlueprintVersion'] as Model<BlueprintVersion>) ??

--- a/app/api/models/blueprint-version.ts
+++ b/app/api/models/blueprint-version.ts
@@ -1,0 +1,37 @@
+import mongoose, { Schema, Document, Model } from 'mongoose';
+
+export interface BlueprintVersion extends Document {
+  blueprintId: mongoose.Types.ObjectId;
+  // Optional user label: "stable", "v2", "post-optimization"
+  name?: string | null;
+  data: any;
+  thumbnail?: string | null;
+  modVersion?: string | null;
+  createdAt: Date;
+  deletedAt?: Date | null;
+}
+
+export class BlueprintVersionModel {
+  static model: Model<BlueprintVersion>;
+
+  public static init() {
+    const blueprintVersionSchema = new mongoose.Schema({
+      blueprintId: { type: Schema.Types.ObjectId, ref: 'Blueprint', required: true },
+      name: { type: String, default: null, maxlength: 60 },
+      data: Object,
+      thumbnail: String,
+      modVersion: String,
+      createdAt: { type: Date, default: Date.now },
+      deletedAt: { type: Date, default: null },
+    });
+
+    // Version history list, newest first
+    blueprintVersionSchema.index({ blueprintId: 1, createdAt: -1 });
+    // Find current version (latest where deletedAt is null)
+    blueprintVersionSchema.index({ blueprintId: 1, deletedAt: 1 });
+
+    BlueprintVersionModel.model =
+      (mongoose.models['BlueprintVersion'] as Model<BlueprintVersion>) ??
+      mongoose.model<BlueprintVersion>('BlueprintVersion', blueprintVersionSchema);
+  }
+}

--- a/app/api/models/blueprint.ts
+++ b/app/api/models/blueprint.ts
@@ -22,6 +22,13 @@ export interface Blueprint extends Document {
   description?: string | null;
   researchTier?: string | null;
   modded?: boolean | null;
+  currentVersionId?: mongoose.Types.ObjectId | null;
+  forkedFrom?: {
+    blueprintId: mongoose.Types.ObjectId;
+    versionId: mongoose.Types.ObjectId;
+    forkedAt: Date;
+  } | null;
+  forkCount?: number;
 }
 
 export class BlueprintModel {
@@ -59,6 +66,23 @@ export class BlueprintModel {
       description: { type: String, maxlength: 500 },
       researchTier: { type: String, enum: [...RESEARCH_TIERS, null] },
       modded: { type: Boolean },
+      currentVersionId: {
+        type: Schema.Types.ObjectId,
+        ref: 'BlueprintVersion',
+        default: null,
+      },
+      forkedFrom: {
+        type: new Schema(
+          {
+            blueprintId: { type: Schema.Types.ObjectId, ref: 'Blueprint', required: true },
+            versionId: { type: Schema.Types.ObjectId, ref: 'BlueprintVersion', required: true },
+            forkedAt: { type: Date, required: true },
+          },
+          { _id: false }
+        ),
+        default: null,
+      },
+      forkCount: { type: Number, default: 0 },
     });
 
     // Listing query: filter by createdAt range, sort by createdAt desc
@@ -75,6 +99,8 @@ export class BlueprintModel {
     blueprintSchema.index({ deletedAt: 1, gameVersion: 1, category: 1, createdAt: -1 });
     // "Most liked" sort on the public feed
     blueprintSchema.index({ deletedAt: 1, likeCount: -1, createdAt: -1 });
+    // "Most forked" sort
+    blueprintSchema.index({ forkCount: -1 });
 
     BlueprintModel.model = mongoose.model<Blueprint>('Blueprint', blueprintSchema);
   }

--- a/app/api/models/blueprint.ts
+++ b/app/api/models/blueprint.ts
@@ -100,7 +100,7 @@ export class BlueprintModel {
     // "Most liked" sort on the public feed
     blueprintSchema.index({ deletedAt: 1, likeCount: -1, createdAt: -1 });
     // "Most forked" sort
-    blueprintSchema.index({ forkCount: -1 });
+    blueprintSchema.index({ deletedAt: 1, forkCount: -1, createdAt: -1 });
 
     BlueprintModel.model = mongoose.model<Blueprint>('Blueprint', blueprintSchema);
   }

--- a/app/api/services/blueprint-version-service.ts
+++ b/app/api/services/blueprint-version-service.ts
@@ -1,0 +1,73 @@
+import mongoose from 'mongoose';
+import { Blueprint, BlueprintModel } from '../models/blueprint';
+import { BlueprintVersion, BlueprintVersionModel } from '../models/blueprint-version';
+
+// data/thumbnail/modVersion stay on Blueprint as a read cache during the
+// currentVersionId transition (spec/FORKS.md) — resolving through the version
+// keeps the invariant that currentVersionId always reflects the latest saved data.
+
+// Loads the data a blueprint currently renders. Falls back to the Blueprint's own
+// (cached) `data` for documents that predate BlueprintVersion and haven't been
+// saved since — normal saves always create/sync a current version going forward.
+export async function resolveCurrentData(blueprint: Blueprint): Promise<any> {
+  if (blueprint.currentVersionId != null) {
+    const version = await BlueprintVersionModel.model.findById(blueprint.currentVersionId);
+    if (version != null) return version.data;
+  }
+  return blueprint.data;
+}
+
+export async function getCurrentVersion(blueprint: Blueprint): Promise<BlueprintVersion | null> {
+  if (blueprint.currentVersionId == null) return null;
+  return BlueprintVersionModel.model.findById(blueprint.currentVersionId);
+}
+
+// Ensures a blueprint has a currentVersionId, creating an initial version from its
+// cached `data` if one is missing (documents saved before this feature shipped).
+export async function ensureCurrentVersion(blueprint: Blueprint): Promise<BlueprintVersion> {
+  const existing = await getCurrentVersion(blueprint);
+  if (existing != null) return existing;
+
+  const version = new BlueprintVersionModel.model({
+    blueprintId: blueprint._id,
+    data: blueprint.data,
+    thumbnail: blueprint.thumbnail,
+    createdAt: blueprint.createdAt ?? new Date(),
+  });
+  await version.save();
+  await BlueprintModel.model.updateOne(
+    { _id: blueprint._id },
+    { $set: { currentVersionId: version._id } }
+  );
+  blueprint.currentVersionId = version._id as mongoose.Types.ObjectId;
+  return version;
+}
+
+// Called on every regular save (upload/autosave): keeps the current version's data
+// mirroring the just-saved Blueprint.data, creating the initial version on first save.
+export async function syncCurrentVersion(
+  blueprint: Blueprint,
+  data: any,
+  thumbnail: string
+): Promise<void> {
+  if (blueprint.currentVersionId != null) {
+    const result = await BlueprintVersionModel.model.updateOne(
+      { _id: blueprint.currentVersionId },
+      { $set: { data, thumbnail } }
+    );
+    if (result.matchedCount > 0) return;
+  }
+
+  const version = new BlueprintVersionModel.model({
+    blueprintId: blueprint._id,
+    data,
+    thumbnail,
+    createdAt: new Date(),
+  });
+  await version.save();
+  await BlueprintModel.model.updateOne(
+    { _id: blueprint._id },
+    { $set: { currentVersionId: version._id } }
+  );
+  blueprint.currentVersionId = version._id as mongoose.Types.ObjectId;
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -6,6 +6,7 @@ import { expressjwt as expressJwt } from 'express-jwt';
 
 import { StaticController } from './static-controller';
 import { BlueprintController } from './api/blueprint-controller';
+import { BlueprintVersionController } from './api/blueprint-version-controller';
 import { VersionController } from './api/version-controller';
 import { AuthController } from './api/auth-controller';
 import { MigrationController } from './api/migration-controller';
@@ -17,6 +18,7 @@ import { CommentController } from './api/comment-controller';
 export class Routes {
   public staticController = new StaticController();
   public uploadBlueprintController = new BlueprintController();
+  public blueprintVersionController = new BlueprintVersionController();
   public versionController = new VersionController();
   public authController = new AuthController();
   public migrationController = new MigrationController();
@@ -78,6 +80,7 @@ export class Routes {
     app.route('/api/users/:username/profile').get(this.userController.getProfile);
     app.route('/api/blueprints/:id').get(this.uploadBlueprintController.getBlueprintDetails);
     app.route('/api/blueprints/:id/comments').get(this.commentController.list);
+    app.route('/api/blueprints/:id/versions').get(this.blueprintVersionController.listVersions);
 
     // Logged in access
     app.route('/api/getblueprintsSecure').get(auth, this.uploadBlueprintController.getBlueprints);
@@ -92,6 +95,11 @@ export class Routes {
     app.route('/api/blueprints/:id/comments').post(auth, this.commentController.create);
     app.route('/api/comments/:id').patch(auth, this.commentController.edit);
     app.route('/api/comments/:id').delete(auth, this.commentController.remove);
+    app.route('/api/blueprints/:id/fork').post(auth, this.blueprintVersionController.fork);
+    app.route('/api/blueprints/:id/versions').post(auth, this.blueprintVersionController.createVersion);
+    app
+      .route('/api/blueprints/:id/versions/:versionId')
+      .delete(auth, this.blueprintVersionController.deleteVersion);
 
     // Admin-only API
     app.route('/api/admin/feedback').get(auth, adminAuth, this.feedbackController.list);

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -100,6 +100,9 @@ export class Routes {
     app
       .route('/api/blueprints/:id/versions/:versionId')
       .delete(auth, this.blueprintVersionController.deleteVersion);
+    app
+      .route('/api/blueprints/:id/versions/:versionId/restore')
+      .post(auth, this.blueprintVersionController.restoreVersion);
 
     // Admin-only API
     app.route('/api/admin/feedback').get(auth, adminAuth, this.feedbackController.list);

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.css
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.css
@@ -113,4 +113,16 @@
   display: flex;
   align-items: center;
   gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.details-forked-from {
+  font-size: 0.85rem;
+  opacity: 0.75;
+  margin-bottom: 0.5rem;
+}
+
+.details-fork-count {
+  font-size: 0.85rem;
+  opacity: 0.75;
 }

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
@@ -90,8 +90,8 @@
             [blueprintId]="details.id"
             [disabled]="!loggedIn"
           ></app-fork-button>
-          <span class="details-fork-count" i18n
-            >{{ details.nbForks }} forks</span
+          <span class="details-fork-count"
+            >{{ details.nbForks }}&nbsp;{{ nbForksString }}</span
           >
           <button
             pButton

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
@@ -35,6 +35,20 @@
           }}</span>
         </div>
 
+        <div *ngIf="details.forkedFrom" class="details-forked-from">
+          <span i18n>Forked from</span>&nbsp;<a
+            *ngIf="
+              details.forkedFrom.blueprintName as parentName;
+              else removedParent
+            "
+            [routerLink]="['/blueprint', details.forkedFrom.blueprintId]"
+            >{{ parentName }}</a
+          >
+          <ng-template #removedParent
+            ><span i18n>[original removed by author]</span></ng-template
+          >
+        </div>
+
         <div class="details-badges">
           <span *ngIf="details.category" class="badge badge--category">{{
             details.category
@@ -72,10 +86,29 @@
             [likedByMe]="details.likedByMe"
             [disabled]="!loggedIn"
           ></app-like-widget>
+          <app-fork-button
+            [blueprintId]="details.id"
+            [disabled]="!loggedIn"
+          ></app-fork-button>
+          <span class="details-fork-count" i18n
+            >{{ details.nbForks }} forks</span
+          >
+          <button
+            pButton
+            type="button"
+            class="p-button-text"
+            icon="pi pi-clock"
+            i18n-label
+            label="Version History"
+            (click)="openVersionHistory()"
+          ></button>
         </div>
       </div>
     </div>
 
     <app-comment-section [blueprintId]="blueprintId"></app-comment-section>
+    <app-version-history-dialog
+      #versionHistoryDialog
+    ></app-version-history-dialog>
   </ng-container>
 </div>

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
@@ -27,6 +27,8 @@ function makeDetails(overrides: any = {}) {
     description: "A tidy coal setup",
     researchTier: null,
     modded: false,
+    nbForks: 0,
+    forkedFrom: null,
     ...overrides,
   };
 }
@@ -103,5 +105,49 @@ describe("BlueprintDetailsPageComponent", () => {
     );
     expect(el.querySelector("app-comment-section")).toBeTruthy();
     expect(el.textContent).toContain("A tidy coal setup");
+  });
+
+  it("renders the forked-from link when forkedFrom is set", () => {
+    blueprintService.getBlueprintDetails.mockReturnValue(
+      of(
+        makeDetails({
+          forkedFrom: {
+            blueprintId: "parent-1",
+            blueprintName: "Original Setup",
+          },
+        })
+      )
+    );
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+
+    expect(el.textContent).toContain("Forked from");
+    expect(el.textContent).toContain("Original Setup");
+  });
+
+  it("renders the removed-parent placeholder when the fork's parent is soft-deleted", () => {
+    blueprintService.getBlueprintDetails.mockReturnValue(
+      of(
+        makeDetails({
+          forkedFrom: { blueprintId: "parent-1", blueprintName: null },
+        })
+      )
+    );
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+
+    expect(el.textContent).toContain("[original removed by author]");
+  });
+
+  it("opens the version history dialog with ownership passed through", () => {
+    fixture.detectChanges();
+    component.versionHistoryDialog = { showDialog: vi.fn() } as any;
+
+    component.openVersionHistory();
+
+    expect(component.versionHistoryDialog.showDialog).toHaveBeenCalledWith(
+      "bp1",
+      false
+    );
   });
 });

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, OnInit, ViewChild } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { EMPTY, Observable } from "rxjs";
 import { catchError, switchMap } from "rxjs/operators";
 import { BlueprintDetailsResponse } from "../../../../../../lib/index";
 import { BlueprintService } from "../../services/blueprint-service";
 import { AuthenticationService } from "../../services/authentification-service";
+import { VersionHistoryDialogComponent } from "../dialogs/version-history-dialog/version-history-dialog.component";
 
 @Component({
   selector: "app-blueprint-details-page",
@@ -13,6 +14,9 @@ import { AuthenticationService } from "../../services/authentification-service";
   standalone: false,
 })
 export class BlueprintDetailsPageComponent implements OnInit {
+  @ViewChild("versionHistoryDialog")
+  versionHistoryDialog!: VersionHistoryDialogComponent;
+
   details: BlueprintDetailsResponse | null = null;
   blueprintId: string | null = null;
   loading = true;
@@ -67,6 +71,14 @@ export class BlueprintDetailsPageComponent implements OnInit {
       this.details != null &&
       this.details.thumbnail !== "svg" &&
       this.details.thumbnail !== "svg_nothing"
+    );
+  }
+
+  openVersionHistory() {
+    if (this.details == null) return;
+    this.versionHistoryDialog.showDialog(
+      this.details.id,
+      this.details.ownedByMe
     );
   }
 }

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
@@ -29,6 +29,11 @@ export class BlueprintDetailsPageComponent implements OnInit {
     public authService: AuthenticationService
   ) {}
 
+  get nbForksString() {
+    const nbForks = this.details?.nbForks ?? 0;
+    return $localize`fork${nbForks !== 1 ? "s" : ""}`;
+  }
+
   ngOnInit() {
     this.route.paramMap
       .pipe(switchMap((params) => this.load(params.get("id"))))

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.css
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.css
@@ -149,6 +149,19 @@
   color: var(--p-primary-color, inherit);
 }
 
+.card-forks {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  text-decoration: none;
+  color: var(--p-text-muted-color, #6b7280);
+}
+
+.card-forks:hover {
+  color: var(--p-primary-color, inherit);
+}
+
 .card-thumbnail a {
   display: block;
 }

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
@@ -207,6 +207,15 @@
             <i class="pi pi-comments" aria-hidden="true"></i>
             {{ item.commentCount }}
           </a>
+          <a
+            class="card-forks"
+            [routerLink]="['/blueprint', item.id]"
+            i18n-title
+            title="Fork count"
+          >
+            <i class="pi pi-copy" aria-hidden="true"></i>
+            {{ item.nbForks }}
+          </a>
         </div>
       </div>
     </div>

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
@@ -124,9 +124,16 @@ describe("BrowsePageComponent", () => {
       component.showMyBlueprints(data);
 
       expect(component.filterUserId).toBe("user-123");
-      // second positional arg is filterUserId
-      const lastCall = blueprintService.getBlueprints.mock.calls.at(-1);
-      expect(lastCall[1]).toBe("user-123");
+      expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
+        expect.any(Date),
+        "user-123",
+        null,
+        null,
+        null,
+        null,
+        "recent",
+        undefined
+      );
     });
   });
 
@@ -135,16 +142,32 @@ describe("BrowsePageComponent", () => {
       component.filterGameVersion = "spacedOut";
       component.getBlueprints();
 
-      const lastCall = blueprintService.getBlueprints.mock.calls.at(-1);
-      expect(lastCall[3]).toBe("spacedOut");
+      expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
+        expect.any(Date),
+        null,
+        null,
+        "spacedOut",
+        null,
+        null,
+        "recent",
+        undefined
+      );
     });
 
     it("passes category filter to getBlueprints", () => {
       component.filterCategory = "power";
       component.getBlueprints();
 
-      const lastCall = blueprintService.getBlueprints.mock.calls.at(-1);
-      expect(lastCall[4]).toBe("power");
+      expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
+        expect.any(Date),
+        null,
+        null,
+        null,
+        "power",
+        null,
+        "recent",
+        undefined
+      );
     });
 
     it("passes subcategory filter to getBlueprints", () => {
@@ -152,8 +175,16 @@ describe("BrowsePageComponent", () => {
       component.filterSubcategory = "generator";
       component.getBlueprints();
 
-      const lastCall = blueprintService.getBlueprints.mock.calls.at(-1);
-      expect(lastCall[5]).toBe("generator");
+      expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
+        expect.any(Date),
+        null,
+        null,
+        null,
+        "power",
+        "generator",
+        "recent",
+        undefined
+      );
     });
 
     it("clearFilters resets all facets and refetches", () => {

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
@@ -120,7 +120,6 @@ describe("BrowsePageComponent", () => {
       const data: BrowseData = {
         filterUserId: "user-123",
         filterUserName: "alice",
-        getDuplicates: true,
       };
       component.showMyBlueprints(data);
 
@@ -137,7 +136,7 @@ describe("BrowsePageComponent", () => {
       component.getBlueprints();
 
       const lastCall = blueprintService.getBlueprints.mock.calls.at(-1);
-      expect(lastCall[4]).toBe("spacedOut");
+      expect(lastCall[3]).toBe("spacedOut");
     });
 
     it("passes category filter to getBlueprints", () => {
@@ -145,7 +144,7 @@ describe("BrowsePageComponent", () => {
       component.getBlueprints();
 
       const lastCall = blueprintService.getBlueprints.mock.calls.at(-1);
-      expect(lastCall[5]).toBe("power");
+      expect(lastCall[4]).toBe("power");
     });
 
     it("passes subcategory filter to getBlueprints", () => {
@@ -154,7 +153,7 @@ describe("BrowsePageComponent", () => {
       component.getBlueprints();
 
       const lastCall = blueprintService.getBlueprints.mock.calls.at(-1);
-      expect(lastCall[6]).toBe("generator");
+      expect(lastCall[5]).toBe("generator");
     });
 
     it("clearFilters resets all facets and refetches", () => {
@@ -194,8 +193,8 @@ describe("BrowsePageComponent", () => {
       component.onSortChange();
 
       const lastCall = blueprintService.getBlueprints.mock.calls.at(-1);
-      expect(lastCall[7]).toBe("popular");
-      expect(lastCall[8]).toBe(0); // skip reset before refetch
+      expect(lastCall[6]).toBe("popular");
+      expect(lastCall[7]).toBe(0); // skip reset before refetch
       expect(
         component.blueprintListItems.some((i: any) => i.name === "stale")
       ).toBe(false);
@@ -210,8 +209,8 @@ describe("BrowsePageComponent", () => {
       component.getBlueprints();
 
       const lastCall = blueprintService.getBlueprints.mock.calls.at(-1);
-      expect(lastCall[7]).toBe("recent");
-      expect(lastCall[8]).toBeUndefined();
+      expect(lastCall[6]).toBe("recent");
+      expect(lastCall[7]).toBeUndefined();
     });
 
     it("advances skip by the number of blueprints received", () => {
@@ -230,6 +229,29 @@ describe("BrowsePageComponent", () => {
       };
       component.ngOnInit();
       expect(component.sort).toBe("popular");
+    });
+
+    it("calls the service with sort=mostForked and skip=0, and updates the URL", () => {
+      component.skipCount = 7;
+      component.sort = "mostForked";
+      component.onSortChange();
+
+      const lastCall = blueprintService.getBlueprints.mock.calls.at(-1);
+      expect(lastCall[6]).toBe("mostForked");
+      expect(lastCall[7]).toBe(0);
+      expect(router.navigate).toHaveBeenCalledWith([], {
+        queryParams: { sort: "mostForked" },
+        replaceUrl: true,
+      });
+    });
+
+    it("initializes sort=mostForked from the URL query param", () => {
+      const route = TestBed.inject(ActivatedRoute) as any;
+      route.snapshot = {
+        queryParamMap: convertToParamMap({ sort: "mostForked" }),
+      };
+      component.ngOnInit();
+      expect(component.sort).toBe("mostForked");
     });
   });
 
@@ -289,6 +311,7 @@ describe("BrowsePageComponent", () => {
       nbLikes: 7,
       likedByMe: true,
       ownedByMe: false,
+      nbForks: 3,
     } as any;
 
     function renderWithItem() {
@@ -318,6 +341,32 @@ describe("BrowsePageComponent", () => {
       component.blueprintListItems = [component.loadingBlueprintItem];
       fixture.detectChanges();
       expect(fixture.debugElement.query(By.css("app-like-widget"))).toBeNull();
+    });
+  });
+
+  describe("fork count", () => {
+    const realItem = {
+      id: "bp-1",
+      name: "Real Blueprint",
+      ownerId: "u1",
+      ownerName: "alice",
+      createdAt: new Date(),
+      modifiedAt: new Date(),
+      thumbnail: "data:image/png;base64,xyz",
+      tags: [],
+      nbLikes: 7,
+      likedByMe: true,
+      ownedByMe: false,
+      nbForks: 3,
+    } as any;
+
+    it("renders the fork count on cards", () => {
+      fixture.detectChanges();
+      component.blueprintListItems = [realItem];
+      fixture.detectChanges();
+
+      const forkLink = fixture.debugElement.query(By.css(".card-forks"));
+      expect(forkLink.nativeElement.textContent).toContain("3");
     });
   });
 });

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
@@ -47,7 +47,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   filterCategory: string | null = null;
   filterSubcategory: string | null = null;
   remaining = 0;
-  sort: "recent" | "popular" = "recent";
+  sort: "recent" | "popular" | "mostForked" = "recent";
   skipCount = 0;
   private requestId = 0;
 
@@ -57,6 +57,10 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   readonly sortOptions = [
     { label: $localize`:browse.sortNewest:Newest`, value: "recent" },
     { label: $localize`:browse.sortMostLiked:Most liked`, value: "popular" },
+    {
+      label: $localize`:browse.sortMostForked:Most forked`,
+      value: "mostForked",
+    },
   ];
 
   readonly gameVersionOptions = [
@@ -106,6 +110,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
       ownedByMe: false,
       nbLikes: 0,
       commentCount: 0,
+      nbForks: 0,
     };
 
     this.nothingBlueprintItem = {
@@ -121,6 +126,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
       ownedByMe: false,
       nbLikes: 0,
       commentCount: 0,
+      nbForks: 0,
     };
 
     this.filterNameSubject.pipe(debounceTime(600)).subscribe(() => {
@@ -142,7 +148,9 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     this.filterGameVersion = params.get("gameVersion");
     this.filterCategory = params.get("category");
     this.filterSubcategory = params.get("subcategory");
-    this.sort = params.get("sort") === "popular" ? "popular" : "recent";
+    const rawSort = params.get("sort");
+    this.sort =
+      rawSort === "popular" || rawSort === "mostForked" ? rawSort : "recent";
     this.appendLoading();
     this.getBlueprints();
 
@@ -198,7 +206,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     if (this.filterCategory) queryParams["category"] = this.filterCategory;
     if (this.filterSubcategory)
       queryParams["subcategory"] = this.filterSubcategory;
-    if (this.sort === "popular") queryParams["sort"] = this.sort;
+    if (this.sort !== "recent") queryParams["sort"] = this.sort;
     this.router.navigate([], { queryParams, replaceUrl: true });
   }
 
@@ -236,12 +244,11 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
             this.oldestDate,
             this.filterUserId,
             this.filterName.trim() || null,
-            false,
             this.filterGameVersion,
             this.filterCategory,
             this.filterSubcategory,
             this.sort,
-            this.sort === "popular" ? this.skipCount : undefined
+            this.sort !== "recent" ? this.skipCount : undefined
           );
 
     request$.subscribe({

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
@@ -279,7 +279,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     this.working = false;
     this.loadError = false;
     this.oldestDate = new Date(response.oldest);
-    // popular paginates by offset — advance past what we just received
+    // non-"recent" sorts (popular, mostForked) paginate by offset — advance past what we just received
     this.skipCount += response.blueprints.length;
     this.remaining = response.remaining;
     if (this.remaining === 0) this.noMoreBlueprints = true;

--- a/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.ts
@@ -434,8 +434,7 @@ export class ComponentBlueprintParentComponent
     if (browseData != null)
       this.browseDialog.showDialog(
         browseData.filterUserId,
-        browseData.filterUserName,
-        browseData.getDuplicates
+        browseData.filterUserName
       );
     else this.browseDialog.showDialog();
   }

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.html
@@ -26,14 +26,6 @@
   </div>
 
   <p-checkbox
-    [(ngModel)]="getDuplicates"
-    binary="true"
-    inputId="getDuplicates"
-    (onChange)="duplicateChange()"
-  ></p-checkbox>
-  <label for="getDuplicates" i18n>Show duplicate blueprints</label>
-  <br />
-  <p-checkbox
     *ngIf="filterUserName !== null"
     [(ngModel)]="filterUser"
     binary="true"

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.ts
@@ -33,7 +33,6 @@ export class DialogBrowseComponent implements OnInit {
   remaining!: number;
 
   filterUser!: boolean;
-  getDuplicates!: boolean;
   filterNameSubject = new Subject<string>();
   filterName!: string;
 
@@ -59,6 +58,7 @@ export class DialogBrowseComponent implements OnInit {
       ownedByMe: false,
       nbLikes: 0,
       commentCount: 0,
+      nbForks: 0,
     };
 
     this.nothingBlueprintItem = {
@@ -74,6 +74,7 @@ export class DialogBrowseComponent implements OnInit {
       ownedByMe: false,
       nbLikes: 0,
       commentCount: 0,
+      nbForks: 0,
     };
 
     this.filterNameSubject
@@ -98,12 +99,6 @@ export class DialogBrowseComponent implements OnInit {
     });
 
     this.reset();
-  }
-
-  duplicateChange() {
-    this.removeAll();
-    this.oldestDate = new Date();
-    this.getBlueprints();
   }
 
   // This is used when clicking on the checkbox
@@ -138,12 +133,7 @@ export class DialogBrowseComponent implements OnInit {
       filterName = this.filterName;
 
     this.blueprintService
-      .getBlueprints(
-        this.oldestDate,
-        this.filterUserId || null,
-        filterName,
-        this.getDuplicates
-      )
+      .getBlueprints(this.oldestDate, this.filterUserId || null, filterName)
       .subscribe({
         next: (r: any) => this.handleGetBlueprints(r),
       });
@@ -171,7 +161,6 @@ export class DialogBrowseComponent implements OnInit {
     this.filterUser = false;
     this.filterUserId = null as any;
     this.filterUserName = null as any;
-    this.getDuplicates = false;
     this.filterName = null as any;
 
     this.removeAll();
@@ -212,8 +201,7 @@ export class DialogBrowseComponent implements OnInit {
 
   showDialog(
     filterUserId: string | null = null,
-    filterUserName: string | null = null,
-    getDuplicates: boolean = false
+    filterUserName: string | null = null
   ) {
     this.reset();
     if (filterUserId != null) {
@@ -221,7 +209,6 @@ export class DialogBrowseComponent implements OnInit {
       this.filterUserName = filterUserName!;
       this.filterUser = true;
     }
-    this.getDuplicates = getDuplicates;
     this.getBlueprints();
     this.visible = true;
   }

--- a/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.css
+++ b/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.css
@@ -1,0 +1,56 @@
+.new-version-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.version-status {
+  opacity: 0.75;
+  margin: 1rem 0;
+}
+
+.version-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 50vh;
+  overflow-y: auto;
+}
+
+.version-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem;
+  border-radius: 4px;
+  background: var(--p-surface-100, #f3f4f6);
+}
+
+.version-thumbnail {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border-radius: 4px;
+  flex: 0 0 auto;
+}
+
+.version-info {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.version-name {
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.version-date {
+  font-size: 0.8rem;
+  opacity: 0.7;
+}
+
+.version-actions {
+  display: flex;
+  gap: 0.35rem;
+  flex: 0 0 auto;
+}

--- a/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.css
+++ b/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.css
@@ -41,7 +41,7 @@
 
 .version-name {
   font-weight: 600;
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .version-date {

--- a/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.html
@@ -26,6 +26,7 @@
       icon="pi pi-camera"
       i18n-label
       label="Save snapshot"
+      [disabled]="creatingVersion"
       (click)="createVersion()"
     ></button>
   </div>
@@ -56,6 +57,8 @@
           icon="pi pi-history"
           i18n-pTooltip
           pTooltip="Restore this version"
+          i18n-aria-label
+          aria-label="Restore this version"
           [disabled]="busyVersionId === version.id"
           (click)="restoreVersion(version)"
         ></button>
@@ -66,6 +69,8 @@
           icon="pi pi-trash"
           i18n-pTooltip
           pTooltip="Delete this version"
+          i18n-aria-label
+          aria-label="Delete this version"
           [disabled]="busyVersionId === version.id"
           (click)="deleteVersion(version)"
         ></button>

--- a/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.html
@@ -1,0 +1,75 @@
+<p-dialog
+  #versionHistoryDialog
+  i18n-header
+  header="Version History"
+  [(visible)]="visible"
+  [modal]="true"
+  [dismissableMask]="true"
+  [closable]="true"
+  [focusOnShow]="false"
+  [maximizable]="false"
+  [draggable]="false"
+  [resizable]="false"
+>
+  <div *ngIf="isOwner" class="new-version-row">
+    <input
+      type="text"
+      size="30"
+      i18n-placeholder
+      placeholder="Name this snapshot (optional)"
+      [(ngModel)]="newVersionName"
+      pInputText
+    />
+    <button
+      pButton
+      type="button"
+      icon="pi pi-camera"
+      i18n-label
+      label="Save snapshot"
+      (click)="createVersion()"
+    ></button>
+  </div>
+
+  <div *ngIf="loading" class="version-status" i18n>Loading versions…</div>
+  <div *ngIf="!loading && versions.length === 0" class="version-status" i18n>
+    No saved versions yet.
+  </div>
+
+  <div class="version-list">
+    <div class="version-row" *ngFor="let version of versions">
+      <img
+        *ngIf="version.thumbnail"
+        class="version-thumbnail"
+        [src]="version.thumbnail"
+        alt=""
+      />
+      <div class="version-info">
+        <div class="version-name">{{ version.name ?? "(unnamed)" }}</div>
+        <div class="version-date">
+          {{ version.createdAt | date : "yyyy-MM-dd HH:mm" }}
+        </div>
+      </div>
+      <div *ngIf="isOwner" class="version-actions">
+        <button
+          pButton
+          type="button"
+          icon="pi pi-history"
+          i18n-pTooltip
+          pTooltip="Restore this version"
+          [disabled]="busyVersionId === version.id"
+          (click)="restoreVersion(version)"
+        ></button>
+        <button
+          pButton
+          type="button"
+          class="p-button-danger"
+          icon="pi pi-trash"
+          i18n-pTooltip
+          pTooltip="Delete this version"
+          [disabled]="busyVersionId === version.id"
+          (click)="deleteVersion(version)"
+        ></button>
+      </div>
+    </div>
+  </div>
+</p-dialog>

--- a/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.spec.ts
@@ -1,0 +1,130 @@
+import { DatePipe } from "@angular/common";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { of, throwError } from "rxjs";
+import { MessageService } from "primeng/api";
+
+import { VersionHistoryDialogComponent } from "./version-history-dialog.component";
+import { BlueprintVersionService } from "src/app/module-blueprint/services/blueprint-version.service";
+
+function makeVersion(overrides: any = {}) {
+  return {
+    id: "v1",
+    name: "stable",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    thumbnail: null,
+    ...overrides,
+  };
+}
+
+describe("VersionHistoryDialogComponent", () => {
+  let component: VersionHistoryDialogComponent;
+  let fixture: ComponentFixture<VersionHistoryDialogComponent>;
+  let versionService: any;
+  let messageService: any;
+
+  beforeEach(async () => {
+    versionService = {
+      getVersions: vi.fn().mockReturnValue(of({ versions: [makeVersion()] })),
+      createVersion: vi
+        .fn()
+        .mockReturnValue(of({ version: makeVersion({ id: "v2" }) })),
+      restoreVersion: vi.fn().mockReturnValue(of({ version: makeVersion() })),
+      deleteVersion: vi.fn().mockReturnValue(of({ deleteVersion: "OK" })),
+    };
+    messageService = { add: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      declarations: [VersionHistoryDialogComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        DatePipe,
+        { provide: BlueprintVersionService, useValue: versionService },
+        { provide: MessageService, useValue: messageService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(VersionHistoryDialogComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("loads versions when shown", () => {
+    component.showDialog("bp-1", true);
+
+    expect(versionService.getVersions).toHaveBeenCalledWith("bp-1");
+    expect(component.versions.length).toBe(1);
+    expect(component.loading).toBe(false);
+    expect(component.visible).toBe(true);
+  });
+
+  it("creates a named snapshot, trims the name, and reloads the list", () => {
+    component.blueprintId = "bp-1";
+    component.newVersionName = "  my snapshot  ";
+
+    component.createVersion();
+
+    expect(versionService.createVersion).toHaveBeenCalledWith(
+      "bp-1",
+      "my snapshot"
+    );
+    expect(component.newVersionName).toBe("");
+    expect(versionService.getVersions).toHaveBeenCalledWith("bp-1");
+  });
+
+  it("sends null for a blank snapshot name", () => {
+    component.blueprintId = "bp-1";
+    component.newVersionName = "   ";
+
+    component.createVersion();
+
+    expect(versionService.createVersion).toHaveBeenCalledWith("bp-1", null);
+  });
+
+  it("restores a version and reloads", () => {
+    component.blueprintId = "bp-1";
+    const version = makeVersion();
+
+    component.restoreVersion(version);
+
+    expect(versionService.restoreVersion).toHaveBeenCalledWith("bp-1", "v1");
+    expect(component.busyVersionId).toBe(null);
+    expect(versionService.getVersions).toHaveBeenCalledWith("bp-1");
+  });
+
+  it("shows a specific toast when deleting the only remaining version fails with 400", () => {
+    versionService.deleteVersion.mockReturnValue(
+      throwError(() => ({ status: 400 }))
+    );
+    component.blueprintId = "bp-1";
+
+    component.deleteVersion(makeVersion());
+
+    expect(component.busyVersionId).toBe(null);
+    expect(messageService.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: "error",
+        detail: "Cannot delete the only remaining version",
+      })
+    );
+  });
+
+  it("shows a generic toast for other delete failures", () => {
+    versionService.deleteVersion.mockReturnValue(
+      throwError(() => ({ status: 500 }))
+    );
+    component.blueprintId = "bp-1";
+
+    component.deleteVersion(makeVersion());
+
+    expect(messageService.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: "error",
+        detail: "Could not delete this version",
+      })
+    );
+  });
+});

--- a/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.spec.ts
@@ -1,7 +1,7 @@
 import { DatePipe } from "@angular/common";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { of, throwError } from "rxjs";
+import { of, throwError, Subject } from "rxjs";
 import { MessageService } from "primeng/api";
 
 import { VersionHistoryDialogComponent } from "./version-history-dialog.component";
@@ -33,6 +33,7 @@ describe("VersionHistoryDialogComponent", () => {
       deleteVersion: vi.fn().mockReturnValue(of({ deleteVersion: "OK" })),
     };
     messageService = { add: vi.fn() };
+    vi.spyOn(window, "confirm").mockReturnValue(true);
 
     await TestBed.configureTestingModule({
       declarations: [VersionHistoryDialogComponent],
@@ -84,6 +85,49 @@ describe("VersionHistoryDialogComponent", () => {
     expect(versionService.createVersion).toHaveBeenCalledWith("bp-1", null);
   });
 
+  it("guards against a second createVersion call while one is in flight", () => {
+    component.blueprintId = "bp-1";
+    versionService.createVersion.mockReturnValue(new Subject());
+
+    component.createVersion();
+    expect(component.creatingVersion).toBe(true);
+    component.createVersion();
+
+    expect(versionService.createVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a stale getVersions response from an earlier load", () => {
+    const first$ = new Subject<{ versions: any[] }>();
+    const second$ = new Subject<{ versions: any[] }>();
+    versionService.getVersions
+      .mockReturnValueOnce(first$)
+      .mockReturnValueOnce(second$);
+
+    component.showDialog("bp-1", true);
+    component.load();
+
+    second$.next({ versions: [makeVersion({ id: "v2" })] });
+    first$.next({ versions: [makeVersion({ id: "v1-stale" })] });
+
+    expect(component.versions).toEqual([makeVersion({ id: "v2" })]);
+  });
+
+  it("shows an error toast when loading versions fails", () => {
+    versionService.getVersions.mockReturnValue(
+      throwError(() => new Error("network"))
+    );
+
+    component.showDialog("bp-1", true);
+
+    expect(component.loading).toBe(false);
+    expect(messageService.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: "error",
+        detail: "Could not load version history",
+      })
+    );
+  });
+
   it("restores a version and reloads", () => {
     component.blueprintId = "bp-1";
     const version = makeVersion();
@@ -93,6 +137,15 @@ describe("VersionHistoryDialogComponent", () => {
     expect(versionService.restoreVersion).toHaveBeenCalledWith("bp-1", "v1");
     expect(component.busyVersionId).toBe(null);
     expect(versionService.getVersions).toHaveBeenCalledWith("bp-1");
+  });
+
+  it("does not call deleteVersion when the confirmation is declined", () => {
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    component.blueprintId = "bp-1";
+
+    component.deleteVersion(makeVersion());
+
+    expect(versionService.deleteVersion).not.toHaveBeenCalled();
   });
 
   it("shows a specific toast when deleting the only remaining version fails with 400", () => {

--- a/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.ts
@@ -21,6 +21,9 @@ export class VersionHistoryDialogComponent {
   versions: BlueprintVersionDto[] = [];
   newVersionName = "";
   busyVersionId: string | null = null;
+  creatingVersion = false;
+
+  private requestId = 0;
 
   constructor(
     private blueprintVersionService: BlueprintVersionService,
@@ -41,31 +44,42 @@ export class VersionHistoryDialogComponent {
 
   load() {
     this.loading = true;
+    const requestId = ++this.requestId;
     this.blueprintVersionService.getVersions(this.blueprintId).subscribe({
       next: (response) => {
+        if (requestId !== this.requestId) return;
         this.versions = response.versions;
         this.loading = false;
       },
       error: () => {
+        if (requestId !== this.requestId) return;
         this.loading = false;
+        this.showError(
+          $localize`:versionHistory.loadError:Could not load version history`
+        );
       },
     });
   }
 
   createVersion() {
+    if (this.creatingVersion) return;
     const name =
       this.newVersionName.trim().length > 0 ? this.newVersionName.trim() : null;
+    this.creatingVersion = true;
     this.blueprintVersionService
       .createVersion(this.blueprintId, name)
       .subscribe({
         next: () => {
+          this.creatingVersion = false;
           this.newVersionName = "";
           this.load();
         },
-        error: () =>
+        error: () => {
+          this.creatingVersion = false;
           this.showError(
             $localize`:versionHistory.createError:Could not create a version`
-          ),
+          );
+        },
       });
   }
 
@@ -88,6 +102,11 @@ export class VersionHistoryDialogComponent {
   }
 
   deleteVersion(version: BlueprintVersionDto) {
+    const confirmed = window.confirm(
+      $localize`:versionHistory.deleteConfirm:Delete this version? This cannot be undone.`
+    );
+    if (!confirmed) return;
+
     this.busyVersionId = version.id;
     this.blueprintVersionService
       .deleteVersion(this.blueprintId, version.id)

--- a/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.ts
@@ -1,0 +1,121 @@
+import { Component, ViewChild } from "@angular/core";
+import { Dialog } from "primeng/dialog";
+import { MessageService } from "primeng/api";
+import { BlueprintVersionDto } from "../../../../../../../lib/index";
+import { BlueprintVersionService } from "../../../services/blueprint-version.service";
+
+@Component({
+  selector: "app-version-history-dialog",
+  templateUrl: "./version-history-dialog.component.html",
+  styleUrls: ["./version-history-dialog.component.css"],
+  standalone: false,
+})
+export class VersionHistoryDialogComponent {
+  @ViewChild("versionHistoryDialog", { static: true })
+  versionHistoryDialog!: Dialog;
+
+  visible = false;
+  loading = false;
+  isOwner = false;
+  blueprintId!: string;
+  versions: BlueprintVersionDto[] = [];
+  newVersionName = "";
+  busyVersionId: string | null = null;
+
+  constructor(
+    private blueprintVersionService: BlueprintVersionService,
+    private messageService: MessageService
+  ) {}
+
+  showDialog(blueprintId: string, isOwner: boolean) {
+    this.blueprintId = blueprintId;
+    this.isOwner = isOwner;
+    this.newVersionName = "";
+    this.visible = true;
+    this.load();
+  }
+
+  hideDialog() {
+    this.visible = false;
+  }
+
+  load() {
+    this.loading = true;
+    this.blueprintVersionService.getVersions(this.blueprintId).subscribe({
+      next: (response) => {
+        this.versions = response.versions;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+      },
+    });
+  }
+
+  createVersion() {
+    const name =
+      this.newVersionName.trim().length > 0 ? this.newVersionName.trim() : null;
+    this.blueprintVersionService
+      .createVersion(this.blueprintId, name)
+      .subscribe({
+        next: () => {
+          this.newVersionName = "";
+          this.load();
+        },
+        error: () =>
+          this.showError(
+            $localize`:versionHistory.createError:Could not create a version`
+          ),
+      });
+  }
+
+  restoreVersion(version: BlueprintVersionDto) {
+    this.busyVersionId = version.id;
+    this.blueprintVersionService
+      .restoreVersion(this.blueprintId, version.id)
+      .subscribe({
+        next: () => {
+          this.busyVersionId = null;
+          this.load();
+        },
+        error: () => {
+          this.busyVersionId = null;
+          this.showError(
+            $localize`:versionHistory.restoreError:Could not restore this version`
+          );
+        },
+      });
+  }
+
+  deleteVersion(version: BlueprintVersionDto) {
+    this.busyVersionId = version.id;
+    this.blueprintVersionService
+      .deleteVersion(this.blueprintId, version.id)
+      .subscribe({
+        next: () => {
+          this.busyVersionId = null;
+          this.load();
+        },
+        error: (err) => {
+          this.busyVersionId = null;
+          if (err?.status === 400) {
+            this.showError(
+              $localize`:versionHistory.lastVersionError:Cannot delete the only remaining version`
+            );
+          } else {
+            this.showError(
+              $localize`:versionHistory.deleteError:Could not delete this version`
+            );
+          }
+        },
+      });
+  }
+
+  private showError(detail: string) {
+    this.messageService.add({
+      severity: "error",
+      summary: $localize`:versionHistory.errorSummary:Version history`,
+      detail,
+    });
+  }
+}

--- a/frontend/src/app/module-blueprint/components/fork-button/fork-button.component.html
+++ b/frontend/src/app/module-blueprint/components/fork-button/fork-button.component.html
@@ -1,0 +1,11 @@
+<button
+  pButton
+  type="button"
+  icon="pi pi-copy"
+  i18n-label
+  label="Fork"
+  i18n-pTooltip
+  pTooltip="Create your own editable copy of this blueprint"
+  [disabled]="disabled || forking"
+  (click)="fork()"
+></button>

--- a/frontend/src/app/module-blueprint/components/fork-button/fork-button.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/fork-button/fork-button.component.spec.ts
@@ -1,0 +1,69 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { Router } from "@angular/router";
+import { of, throwError } from "rxjs";
+import { MessageService } from "primeng/api";
+
+import { ForkButtonComponent } from "./fork-button.component";
+import { BlueprintVersionService } from "src/app/module-blueprint/services/blueprint-version.service";
+
+describe("ForkButtonComponent", () => {
+  let component: ForkButtonComponent;
+  let fixture: ComponentFixture<ForkButtonComponent>;
+  let blueprintVersionService: any;
+  let router: any;
+  let messageService: any;
+
+  beforeEach(async () => {
+    blueprintVersionService = {
+      fork: vi.fn().mockReturnValue(of({ id: "new-fork-id" })),
+    };
+    router = { navigate: vi.fn() };
+    messageService = { add: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      declarations: [ForkButtonComponent],
+      providers: [
+        { provide: BlueprintVersionService, useValue: blueprintVersionService },
+        { provide: Router, useValue: router },
+        { provide: MessageService, useValue: messageService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ForkButtonComponent);
+    component = fixture.componentInstance;
+    component.blueprintId = "source-id";
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("calls the fork endpoint and navigates to the new blueprint on success", () => {
+    component.fork();
+
+    expect(blueprintVersionService.fork).toHaveBeenCalledWith("source-id");
+    expect(router.navigate).toHaveBeenCalledWith(["/b", "new-fork-id"]);
+    expect(component.forking).toBe(false);
+  });
+
+  it("resets forking state and shows a toast on error, without navigating", () => {
+    blueprintVersionService.fork.mockReturnValue(
+      throwError(() => new Error("fail"))
+    );
+
+    component.fork();
+
+    expect(component.forking).toBe(false);
+    expect(router.navigate).not.toHaveBeenCalled();
+    expect(messageService.add).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: "error" })
+    );
+  });
+
+  it("ignores repeated clicks while a fork request is in flight", () => {
+    component.forking = true;
+    component.fork();
+
+    expect(blueprintVersionService.fork).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/module-blueprint/components/fork-button/fork-button.component.ts
+++ b/frontend/src/app/module-blueprint/components/fork-button/fork-button.component.ts
@@ -1,0 +1,42 @@
+import { Component, Input } from "@angular/core";
+import { Router } from "@angular/router";
+import { MessageService } from "primeng/api";
+import { BlueprintVersionService } from "../../services/blueprint-version.service";
+
+@Component({
+  selector: "app-fork-button",
+  templateUrl: "./fork-button.component.html",
+  styleUrls: ["./fork-button.component.css"],
+  standalone: false,
+})
+export class ForkButtonComponent {
+  @Input() blueprintId!: string;
+  @Input() disabled!: boolean;
+
+  forking = false;
+
+  constructor(
+    private blueprintVersionService: BlueprintVersionService,
+    private router: Router,
+    private messageService: MessageService
+  ) {}
+
+  fork() {
+    if (this.forking) return;
+    this.forking = true;
+    this.blueprintVersionService.fork(this.blueprintId).subscribe({
+      next: (response) => {
+        this.forking = false;
+        this.router.navigate(["/b", response.id]);
+      },
+      error: () => {
+        this.forking = false;
+        this.messageService.add({
+          severity: "error",
+          summary: $localize`:forkButton.error:Could not fork this blueprint`,
+          detail: $localize`Please try again.`,
+        });
+      },
+    });
+  }
+}

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.spec.ts
@@ -85,8 +85,7 @@ describe("ProfilePageComponent", () => {
     expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
       expect.any(Date),
       "owner-1",
-      null,
-      false
+      null
     );
   });
 

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.ts
@@ -67,6 +67,7 @@ export class ProfilePageComponent implements OnInit {
       ownedByMe: false,
       nbLikes: 0,
       commentCount: 0,
+      nbForks: 0,
     };
 
     this.nothingBlueprintItem = {
@@ -82,6 +83,7 @@ export class ProfilePageComponent implements OnInit {
       ownedByMe: false,
       nbLikes: 0,
       commentCount: 0,
+      nbForks: 0,
     };
   }
 
@@ -207,7 +209,7 @@ export class ProfilePageComponent implements OnInit {
   loadBlueprints() {
     if (!this.profile) return;
     this.blueprintService
-      .getBlueprints(this.oldestDate, this.profile.id, null, false)
+      .getBlueprints(this.oldestDate, this.profile.id, null)
       .subscribe({
         next: (r: any) => this.handleGetBlueprints(r),
         error: () => {

--- a/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.spec.ts
@@ -103,7 +103,6 @@ describe("UserMenuComponent", () => {
       const expected: BrowseData = {
         filterUserId: "u1",
         filterUserName: "alice",
-        getDuplicates: true,
       };
       expect(component.myBlueprintsRequested.emit).toHaveBeenCalledWith(
         expected

--- a/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.ts
+++ b/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.ts
@@ -13,7 +13,6 @@ import { AuthenticationService } from "../../services/authentification-service";
 export interface BrowseData {
   filterUserId: string;
   filterUserName: string;
-  getDuplicates: boolean;
 }
 
 @Component({
@@ -90,7 +89,6 @@ export class UserMenuComponent implements OnInit {
     this.myBlueprintsRequested.emit({
       filterUserId: user._id,
       filterUserName: user.username,
-      getDuplicates: true,
     });
   }
 

--- a/frontend/src/app/module-blueprint/module-blueprint.module.ts
+++ b/frontend/src/app/module-blueprint/module-blueprint.module.ts
@@ -58,6 +58,8 @@ import { DialogBrowseComponent } from "./components/dialogs/dialog-browse/dialog
 import { DialogExportImagesComponent } from "./components/dialogs/dialog-export-images/dialog-export-images.component";
 import { BlueprintNameValidationDirective } from "./directives/blueprint-name-validation.directive";
 import { LikeWidgetComponent } from "./components/like-widget/like-widget.component";
+import { ForkButtonComponent } from "./components/fork-button/fork-button.component";
+import { VersionHistoryDialogComponent } from "./components/dialogs/version-history-dialog/version-history-dialog.component";
 import { BuildableElementPickerComponent } from "./components/side-bar/buildable-element-picker/buildable-element-picker.component";
 import { ElementReport } from "./common/tools/element-report";
 import { ElementReportToolComponent } from "./components/side-bar/element-report-tool/element-report-tool.component";
@@ -90,6 +92,7 @@ import { FeedbackService } from "./services/feedback.service";
 import { CommentSectionComponent } from "./components/comment-section/comment-section.component";
 import { BlueprintDetailsPageComponent } from "./components/blueprint-details-page/blueprint-details-page.component";
 import { CommentService } from "./services/comment.service";
+import { BlueprintVersionService } from "./services/blueprint-version.service";
 import { BrowsePageComponent } from "./components/browse-page/browse-page.component";
 import { ProfilePageComponent } from "./components/profile-page/profile-page.component";
 
@@ -113,6 +116,8 @@ import { ProfilePageComponent } from "./components/profile-page/profile-page.com
     DialogBrowseComponent,
     DialogExportImagesComponent,
     LikeWidgetComponent,
+    ForkButtonComponent,
+    VersionHistoryDialogComponent,
     BuildableElementPickerComponent,
     ElementReportToolComponent,
     UiScreenContainerComponent,
@@ -182,6 +187,7 @@ import { ProfilePageComponent } from "./components/profile-page/profile-page.com
     AuthenticationService,
     FeedbackService,
     CommentService,
+    BlueprintVersionService,
     BlueprintService,
     ToolService,
     SelectTool,

--- a/frontend/src/app/module-blueprint/services/blueprint-service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.spec.ts
@@ -363,39 +363,47 @@ describe("BlueprintService", () => {
 
     it("includes olderthan in the query string", () => {
       const date = new Date(1_000_000);
-      service.getBlueprints(date, null, null, false);
+      service.getBlueprints(date, null, null);
       const url: string = mockHttp.get.mock.calls[0][0];
       expect(url).toContain("olderthan=" + date.getTime());
     });
 
     it("includes filterUserId when provided", () => {
-      service.getBlueprints(new Date(), "user123", null, false);
+      service.getBlueprints(new Date(), "user123", null);
       const url: string = mockHttp.get.mock.calls[0][0];
       expect(url).toContain("filterUserId=user123");
     });
 
     it("includes filterName when provided", () => {
-      service.getBlueprints(new Date(), null, "my-bp", false);
+      service.getBlueprints(new Date(), null, "my-bp");
       const url: string = mockHttp.get.mock.calls[0][0];
       expect(url).toContain("filterName=my-bp");
     });
 
-    it("includes getDuplicates when true", () => {
-      service.getBlueprints(new Date(), null, null, true);
+    it("includes sort=mostForked when provided", () => {
+      service.getBlueprints(
+        new Date(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        "mostForked"
+      );
       const url: string = mockHttp.get.mock.calls[0][0];
-      expect(url).toContain("getDuplicates=true");
+      expect(url).toContain("sort=mostForked");
     });
 
     it("uses getblueprintsSecure when logged in", () => {
       mockAuth.isLoggedIn.mockReturnValue(true);
-      service.getBlueprints(new Date(), null, null, false);
+      service.getBlueprints(new Date(), null, null);
       const url: string = mockHttp.get.mock.calls[0][0];
       expect(url).toContain("getblueprintsSecure");
     });
 
     it("uses getblueprints when not logged in", () => {
       mockAuth.isLoggedIn.mockReturnValue(false);
-      service.getBlueprints(new Date(), null, null, false);
+      service.getBlueprints(new Date(), null, null);
       const url: string = mockHttp.get.mock.calls[0][0];
       expect(url).toContain("/api/getblueprints?");
     });

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -318,11 +318,10 @@ export class BlueprintService implements IObsBlueprintChange {
     olderThan: Date,
     filterUserId: string | null,
     filterName: string | null,
-    getDuplicates: boolean,
     filterGameVersion?: string | null,
     filterCategory?: string | null,
     filterSubcategory?: string | null,
-    sort?: "recent" | "popular",
+    sort?: "recent" | "popular" | "mostForked",
     skip?: number
   ) {
     let parameterOlderThan = "olderthan=" + olderThan.getTime().toString();
@@ -333,10 +332,6 @@ export class BlueprintService implements IObsBlueprintChange {
 
     let parameterFilterName = "";
     if (filterName != null) parameterFilterName = "&filterName=" + filterName;
-
-    let parameterGetDuplicates = "";
-    if (getDuplicates)
-      parameterGetDuplicates = "&getDuplicates=" + getDuplicates;
 
     let parameterGameVersion = "";
     if (filterGameVersion != null)
@@ -359,7 +354,6 @@ export class BlueprintService implements IObsBlueprintChange {
     let parameters =
       parameterOlderThan +
       parameterFilterUserId +
-      parameterGetDuplicates +
       parameterFilterName +
       parameterGameVersion +
       parameterCategory +

--- a/frontend/src/app/module-blueprint/services/blueprint-version.service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-version.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { Observable } from "rxjs";
+import {
+  ForkBlueprintResponse,
+  ListBlueprintVersionsResponse,
+  CreateBlueprintVersionResponse,
+} from "../../../../../lib/index";
+import { AuthenticationService } from "./authentification-service";
+
+@Injectable()
+export class BlueprintVersionService {
+  constructor(private http: HttpClient, private auth: AuthenticationService) {}
+
+  public fork(blueprintId: string): Observable<ForkBlueprintResponse> {
+    return this.http.post<ForkBlueprintResponse>(
+      `/api/blueprints/${blueprintId}/fork`,
+      {},
+      { headers: this.authHeaders() }
+    );
+  }
+
+  public getVersions(
+    blueprintId: string
+  ): Observable<ListBlueprintVersionsResponse> {
+    return this.http.get<ListBlueprintVersionsResponse>(
+      `/api/blueprints/${blueprintId}/versions`
+    );
+  }
+
+  public createVersion(
+    blueprintId: string,
+    name?: string | null
+  ): Observable<CreateBlueprintVersionResponse> {
+    return this.http.post<CreateBlueprintVersionResponse>(
+      `/api/blueprints/${blueprintId}/versions`,
+      name != null ? { name } : {},
+      { headers: this.authHeaders() }
+    );
+  }
+
+  public restoreVersion(
+    blueprintId: string,
+    versionId: string
+  ): Observable<CreateBlueprintVersionResponse> {
+    return this.http.post<CreateBlueprintVersionResponse>(
+      `/api/blueprints/${blueprintId}/versions/${versionId}/restore`,
+      {},
+      { headers: this.authHeaders() }
+    );
+  }
+
+  public deleteVersion(
+    blueprintId: string,
+    versionId: string
+  ): Observable<{ deleteVersion: string }> {
+    return this.http.delete<{ deleteVersion: string }>(
+      `/api/blueprints/${blueprintId}/versions/${versionId}`,
+      { headers: this.authHeaders() }
+    );
+  }
+
+  private authHeaders() {
+    return { Authorization: `Bearer ${this.auth.getToken()}` };
+  }
+}

--- a/frontend/src/app/module-blueprint/services/blueprint-version.service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-version.service.ts
@@ -5,6 +5,7 @@ import {
   ForkBlueprintResponse,
   ListBlueprintVersionsResponse,
   CreateBlueprintVersionResponse,
+  DeleteBlueprintVersionResponse,
 } from "../../../../../lib/index";
 import { AuthenticationService } from "./authentification-service";
 
@@ -53,8 +54,8 @@ export class BlueprintVersionService {
   public deleteVersion(
     blueprintId: string,
     versionId: string
-  ): Observable<{ deleteVersion: string }> {
-    return this.http.delete<{ deleteVersion: string }>(
+  ): Observable<DeleteBlueprintVersionResponse> {
+    return this.http.delete<DeleteBlueprintVersionResponse>(
       `/api/blueprints/${blueprintId}/versions/${versionId}`,
       { headers: this.authHeaders() }
     );

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -28,6 +28,7 @@ export * from './src/b-export/b-ui-screen';
 export * from './src/coms/blueprint-list-response';
 export * from './src/coms/social';
 export * from './src/coms/comments';
+export * from './src/coms/blueprint-version';
 export * from './src/drawing/sprite-modifier';
 export * from './src/drawing/sprite-modifier-group';
 export * from './src/drawing/sprite-info';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -32,6 +32,7 @@ export * from './src/b-export/b-ui-screen';
 export * from './src/coms/blueprint-list-response';
 export * from './src/coms/social';
 export * from './src/coms/comments';
+export * from './src/coms/blueprint-version';
 
 export * from './src/drawing/sprite-modifier';
 export * from './src/drawing/sprite-modifier-group';

--- a/lib/src/coms/blueprint-list-response.d.ts
+++ b/lib/src/coms/blueprint-list-response.d.ts
@@ -1,3 +1,4 @@
+import { ForkedFromDto } from './blueprint-version';
 export interface BlueprintListResponse {
     blueprints: BlueprintListItem[];
     oldest: Date;
@@ -22,10 +23,7 @@ export interface BlueprintListItem {
     description?: string | null;
     modded?: boolean | null;
     nbForks: number;
-    forkedFrom?: {
-        blueprintId: string;
-        blueprintName: string | null;
-    } | null;
+    forkedFrom?: ForkedFromDto | null;
 }
 export interface BlueprintDetailsResponse extends BlueprintListItem {
     researchTier?: string | null;

--- a/lib/src/coms/blueprint-list-response.d.ts
+++ b/lib/src/coms/blueprint-list-response.d.ts
@@ -21,6 +21,11 @@ export interface BlueprintListItem {
     subcategory?: string | null;
     description?: string | null;
     modded?: boolean | null;
+    nbForks: number;
+    forkedFrom?: {
+        blueprintId: string;
+        blueprintName: string | null;
+    } | null;
 }
 export interface BlueprintDetailsResponse extends BlueprintListItem {
     researchTier?: string | null;

--- a/lib/src/coms/blueprint-list-response.ts
+++ b/lib/src/coms/blueprint-list-response.ts
@@ -22,6 +22,10 @@ export interface BlueprintListItem {
   subcategory?: string | null;
   description?: string | null;
   modded?: boolean | null;
+  nbForks: number;
+  // Present when this blueprint is a fork; null blueprintName means the
+  // parent has been soft-deleted ("[original removed by author]")
+  forkedFrom?: { blueprintId: string; blueprintName: string | null } | null;
 }
 
 // Meta-only view for the blueprint details page — everything the list item

--- a/lib/src/coms/blueprint-list-response.ts
+++ b/lib/src/coms/blueprint-list-response.ts
@@ -1,3 +1,5 @@
+import { ForkedFromDto } from './blueprint-version';
+
 export interface BlueprintListResponse {
   blueprints: BlueprintListItem[];
   oldest: Date;
@@ -25,7 +27,7 @@ export interface BlueprintListItem {
   nbForks: number;
   // Present when this blueprint is a fork; null blueprintName means the
   // parent has been soft-deleted ("[original removed by author]")
-  forkedFrom?: { blueprintId: string; blueprintName: string | null } | null;
+  forkedFrom?: ForkedFromDto | null;
 }
 
 // Meta-only view for the blueprint details page — everything the list item

--- a/lib/src/coms/blueprint-version.d.ts
+++ b/lib/src/coms/blueprint-version.d.ts
@@ -16,6 +16,9 @@ export interface CreateBlueprintVersionResponse {
 export interface ForkBlueprintResponse {
     id: string;
 }
+export interface DeleteBlueprintVersionResponse {
+    deleteVersion: string;
+}
 export interface ForkedFromDto {
     blueprintId: string;
     blueprintName: string | null;

--- a/lib/src/coms/blueprint-version.d.ts
+++ b/lib/src/coms/blueprint-version.d.ts
@@ -1,0 +1,23 @@
+export interface BlueprintVersionDto {
+    id: string;
+    name: string | null;
+    createdAt: string;
+    thumbnail: string | null;
+}
+export interface ListBlueprintVersionsResponse {
+    versions: BlueprintVersionDto[];
+}
+export interface CreateBlueprintVersionRequest {
+    name?: string | null;
+}
+export interface CreateBlueprintVersionResponse {
+    version: BlueprintVersionDto;
+}
+export interface ForkBlueprintResponse {
+    id: string;
+}
+export interface ForkedFromDto {
+    blueprintId: string;
+    blueprintName: string | null;
+}
+//# sourceMappingURL=blueprint-version.d.ts.map

--- a/lib/src/coms/blueprint-version.ts
+++ b/lib/src/coms/blueprint-version.ts
@@ -25,6 +25,10 @@ export interface ForkBlueprintResponse {
   id: string;
 }
 
+export interface DeleteBlueprintVersionResponse {
+  deleteVersion: string;
+}
+
 // Provenance shown on the details page / card. `null` blueprintName means the
 // parent blueprint has been soft-deleted — render "[original removed by author]".
 export interface ForkedFromDto {

--- a/lib/src/coms/blueprint-version.ts
+++ b/lib/src/coms/blueprint-version.ts
@@ -1,0 +1,33 @@
+// Fork + version-history API shapes (spec/FORKS.md). Version list/detail payloads are
+// metadata-only — the heavy `data` blob is never sent except through the existing
+// getblueprint/getblueprintmod editor-load endpoints.
+
+export interface BlueprintVersionDto {
+  id: string;
+  name: string | null;
+  createdAt: string;
+  thumbnail: string | null;
+}
+
+export interface ListBlueprintVersionsResponse {
+  versions: BlueprintVersionDto[];
+}
+
+export interface CreateBlueprintVersionRequest {
+  name?: string | null;
+}
+
+export interface CreateBlueprintVersionResponse {
+  version: BlueprintVersionDto;
+}
+
+export interface ForkBlueprintResponse {
+  id: string;
+}
+
+// Provenance shown on the details page / card. `null` blueprintName means the
+// parent blueprint has been soft-deleted — render "[original removed by author]".
+export interface ForkedFromDto {
+  blueprintId: string;
+  blueprintName: string | null;
+}

--- a/migrations/20260707000000_blueprint-version-init.js
+++ b/migrations/20260707000000_blueprint-version-init.js
@@ -1,0 +1,99 @@
+'use strict';
+
+// Migration 2: isCopy/copyOf -> forkedFrom; data -> BlueprintVersion (spec/FORKS.md).
+//
+// Step 2a: for every Blueprint missing currentVersionId, create one BlueprintVersion
+//          from its current `data` and point currentVersionId at it. `data` is left in
+//          place on Blueprint as a read cache during the transition (removed in a
+//          later, separate migration once all read paths go through currentVersionId).
+// Step 2b: for every Blueprint with isCopy:true and copyOf set (and no forkedFrom yet),
+//          set forkedFrom to the copyOf blueprint's initial version (created in 2a).
+//          2a runs to completion for all documents before 2b starts, so every copyOf
+//          target already has currentVersionId by the time 2b reads it.
+//
+// Neither isCopy/copyOf nor data is unset here — that is a separate follow-up
+// migration after this code path has soaked in production for one release.
+//
+// Both directions are idempotent — safe to re-run if interrupted.
+
+module.exports = {
+  async up(db) {
+    const blueprints = db.collection('blueprints');
+    const versions = db.collection('blueprintversions');
+
+    // Step 2a
+    const cursor = blueprints.find(
+      { currentVersionId: null },
+      { projection: { data: 1, thumbnail: 1, createdAt: 1 } }
+    );
+    while (await cursor.hasNext()) {
+      const blueprint = await cursor.next();
+      const version = await versions.insertOne({
+        blueprintId: blueprint._id,
+        name: null,
+        data: blueprint.data ?? null,
+        thumbnail: blueprint.thumbnail ?? null,
+        modVersion: null,
+        createdAt: blueprint.createdAt ?? new Date(),
+        deletedAt: null,
+      });
+      await blueprints.updateOne(
+        { _id: blueprint._id, currentVersionId: null },
+        { $set: { currentVersionId: version.insertedId } }
+      );
+    }
+
+    // Step 2b
+    const copyCursor = blueprints.find(
+      { isCopy: true, copyOf: { $exists: true, $ne: null }, forkedFrom: null },
+      { projection: { copyOf: 1, createdAt: 1 } }
+    );
+    while (await copyCursor.hasNext()) {
+      const blueprint = await copyCursor.next();
+      const parent = await blueprints.findOne(
+        { _id: blueprint.copyOf },
+        { projection: { currentVersionId: 1 } }
+      );
+      if (!parent || !parent.currentVersionId) continue;
+
+      await blueprints.updateOne(
+        { _id: blueprint._id, forkedFrom: null },
+        {
+          $set: {
+            forkedFrom: {
+              blueprintId: blueprint.copyOf,
+              versionId: parent.currentVersionId,
+              forkedAt: blueprint.createdAt ?? new Date(),
+            },
+          },
+        }
+      );
+    }
+
+    // Indexes
+    await versions.createIndex(
+      { blueprintId: 1, createdAt: -1 },
+      { name: 'blueprintId_1_createdAt_-1' }
+    );
+    await versions.createIndex(
+      { blueprintId: 1, deletedAt: 1 },
+      { name: 'blueprintId_1_deletedAt_1' }
+    );
+    await blueprints.createIndex({ forkCount: -1 }, { name: 'forkCount_-1' });
+  },
+
+  async down(db) {
+    const blueprints = db.collection('blueprints');
+    await blueprints.updateMany({}, { $unset: { currentVersionId: '', forkedFrom: '' } });
+    try {
+      await blueprints.dropIndex('forkCount_-1');
+    } catch (err) {
+      if (err.codeName !== 'IndexNotFound') throw err;
+    }
+    try {
+      await db.collection('blueprintversions').drop();
+    } catch (err) {
+      if (err.codeName !== 'NamespaceNotFound') throw err;
+    }
+  },
+};

--- a/migrations/20260707000000_blueprint-version-init.js
+++ b/migrations/20260707000000_blueprint-version-init.js
@@ -6,6 +6,9 @@
 //          from its current `data` and point currentVersionId at it. `data` is left in
 //          place on Blueprint as a read cache during the transition (removed in a
 //          later, separate migration once all read paths go through currentVersionId).
+//          Retry-safe: if a prior run inserted the version but crashed before linking
+//          it (currentVersionId still null), the version lookup below finds and reuses
+//          it instead of inserting a duplicate.
 // Step 2b: for every Blueprint with isCopy:true and copyOf set (and no forkedFrom yet),
 //          set forkedFrom to the copyOf blueprint's initial version (created in 2a), and
 //          bump the parent's forkCount so legacy forks (predating the fork feature) are
@@ -32,18 +35,24 @@ module.exports = {
     );
     while (await cursor.hasNext()) {
       const blueprint = await cursor.next();
-      const version = await versions.insertOne({
-        blueprintId: blueprint._id,
-        name: null,
-        data: blueprint.data ?? null,
-        thumbnail: blueprint.thumbnail ?? null,
-        modVersion: null,
-        createdAt: blueprint.createdAt ?? new Date(),
-        deletedAt: null,
-      });
+      // A prior interrupted run may have inserted this blueprint's version already
+      // (currentVersionId is only set after insertOne, in a separate write below).
+      let versionId = (await versions.findOne({ blueprintId: blueprint._id }, { projection: { _id: 1 } }))?._id;
+      if (versionId == null) {
+        const inserted = await versions.insertOne({
+          blueprintId: blueprint._id,
+          name: null,
+          data: blueprint.data ?? null,
+          thumbnail: blueprint.thumbnail ?? null,
+          modVersion: null,
+          createdAt: blueprint.createdAt ?? new Date(),
+          deletedAt: null,
+        });
+        versionId = inserted.insertedId;
+      }
       await blueprints.updateOne(
         { _id: blueprint._id, currentVersionId: null },
-        { $set: { currentVersionId: version.insertedId } }
+        { $set: { currentVersionId: versionId } }
       );
     }
 
@@ -78,13 +87,11 @@ module.exports = {
     }
 
     // Indexes
+    // Backs listVersions/deleteVersion/restoreVersion: filter { blueprintId, deletedAt: null },
+    // sort/find-latest by createdAt desc — one compound index serves both.
     await versions.createIndex(
-      { blueprintId: 1, createdAt: -1 },
-      { name: 'blueprintId_1_createdAt_-1' }
-    );
-    await versions.createIndex(
-      { blueprintId: 1, deletedAt: 1 },
-      { name: 'blueprintId_1_deletedAt_1' }
+      { blueprintId: 1, deletedAt: 1, createdAt: -1 },
+      { name: 'blueprintId_1_deletedAt_1_createdAt_-1' }
     );
     // Index backing sort({ forkCount: -1, createdAt: -1 }) on the public feed
     await blueprints.createIndex(

--- a/migrations/20260707000000_blueprint-version-init.js
+++ b/migrations/20260707000000_blueprint-version-init.js
@@ -86,7 +86,11 @@ module.exports = {
       { blueprintId: 1, deletedAt: 1 },
       { name: 'blueprintId_1_deletedAt_1' }
     );
-    await blueprints.createIndex({ forkCount: -1 }, { name: 'forkCount_-1' });
+    // Index backing sort({ forkCount: -1, createdAt: -1 }) on the public feed
+    await blueprints.createIndex(
+      { deletedAt: 1, forkCount: -1, createdAt: -1 },
+      { name: 'deletedAt_1_forkCount_-1_createdAt_-1' }
+    );
   },
 
   async down(db) {
@@ -106,7 +110,7 @@ module.exports = {
 
     await blueprints.updateMany({}, { $unset: { currentVersionId: '', forkedFrom: '' } });
     try {
-      await blueprints.dropIndex('forkCount_-1');
+      await blueprints.dropIndex('deletedAt_1_forkCount_-1_createdAt_-1');
     } catch (err) {
       if (err.codeName !== 'IndexNotFound') throw err;
     }

--- a/migrations/20260707000000_blueprint-version-init.js
+++ b/migrations/20260707000000_blueprint-version-init.js
@@ -7,7 +7,11 @@
 //          place on Blueprint as a read cache during the transition (removed in a
 //          later, separate migration once all read paths go through currentVersionId).
 // Step 2b: for every Blueprint with isCopy:true and copyOf set (and no forkedFrom yet),
-//          set forkedFrom to the copyOf blueprint's initial version (created in 2a).
+//          set forkedFrom to the copyOf blueprint's initial version (created in 2a), and
+//          bump the parent's forkCount so legacy forks (predating the fork feature) are
+//          reflected in "most forked" sort/nbForks alongside forks made through the new
+//          fork endpoint. The forkCount bump is guarded on the forkedFrom update actually
+//          matching, so a re-run (forkedFrom already set) does not double-count.
 //          2a runs to completion for all documents before 2b starts, so every copyOf
 //          target already has currentVersionId by the time 2b reads it.
 //
@@ -56,7 +60,7 @@ module.exports = {
       );
       if (!parent || !parent.currentVersionId) continue;
 
-      await blueprints.updateOne(
+      const result = await blueprints.updateOne(
         { _id: blueprint._id, forkedFrom: null },
         {
           $set: {
@@ -68,6 +72,9 @@ module.exports = {
           },
         }
       );
+      if (result.modifiedCount > 0) {
+        await blueprints.updateOne({ _id: blueprint.copyOf }, { $inc: { forkCount: 1 } });
+      }
     }
 
     // Indexes
@@ -84,6 +91,19 @@ module.exports = {
 
   async down(db) {
     const blueprints = db.collection('blueprints');
+
+    const forkedCursor = blueprints.find(
+      { forkedFrom: { $ne: null } },
+      { projection: { 'forkedFrom.blueprintId': 1 } }
+    );
+    while (await forkedCursor.hasNext()) {
+      const blueprint = await forkedCursor.next();
+      await blueprints.updateOne(
+        { _id: blueprint.forkedFrom.blueprintId },
+        { $inc: { forkCount: -1 } }
+      );
+    }
+
     await blueprints.updateMany({}, { $unset: { currentVersionId: '', forkedFrom: '' } });
     try {
       await blueprints.dropIndex('forkCount_-1');


### PR DESCRIPTION
## Summary

Implements `spec/FORKS.md` — fork/remix and version history, the largest
remaining slice of the social roadmap (see `ROADMAP_DECISIONS.md` → "New
collections" → `BlueprintVersion` and Migration 2).

**Data model**
- New `BlueprintVersion` collection: `blueprintId`, `name`, `data`, `thumbnail`,
  `modVersion`, `createdAt`, `deletedAt`.
- `Blueprint` gains `currentVersionId`, `forkedFrom { blueprintId, versionId,
  forkedAt }`, `forkCount` (all additive). `data` stays on `Blueprint` as a
  read cache during the transition, kept in sync on every save.
- Migration `20260707000000_blueprint-version-init.js`: backfills an initial
  version per blueprint and migrates `isCopy`/`copyOf` → `forkedFrom`. Both
  `up`/`down` are idempotent (covered by backend tests running the migration
  directly against the test DB). **Not yet run against a prod dump** — that
  step needs prod read-only credentials this session didn't have; follow
  CLAUDE.md's migration pre-merge process before deploying.

**Backend endpoints** (`app/api/blueprint-version-controller.ts`)
- `POST /api/blueprints/:id/fork` — copies data into an independent new
  Blueprint + BlueprintVersion immediately; `forkedFrom` is provenance only.
- `GET /api/blueprints/:id/versions` — anonymous, light metadata list.
- `POST /api/blueprints/:id/versions` — owner-only named snapshot.
- `DELETE /api/blueprints/:id/versions/:versionId` — owner-only soft-delete,
  advances `currentVersionId`, 400 on the last remaining version.
- `POST /api/blueprints/:id/versions/:versionId/restore` — **added beyond the
  spec's section-4 table**, which only listed 4 endpoints even though section
  5 (frontend) assumed a restore action exists. Implements the simpler of the
  two semantics the spec floated: points `currentVersionId` back at a live
  version without creating a new one.
- Routes use `/api/blueprints/...` (plural) rather than the spec's literal
  `/api/blueprint/...`, to match the existing `/api/blueprints/:id` and
  `/api/blueprints/:id/comments` routes already in `app/routes.ts`.

**Issue #8** (browse duplicates too aggressive): resolved by deleting the
silent `isCopy` filter in `getBlueprints` — forks are now an explicit, visible
relationship via `forkCount`/`forkedFrom`, so there's nothing left to hide.
The now-dead "Show duplicate blueprints" checkbox and `getDuplicates` plumbing
was removed from the frontend (`dialog-browse`, `user-menu`,
`blueprint-service`) rather than carried forward as dead UI.

**Frontend**
- `BlueprintVersionService`, `ForkButtonComponent`, `VersionHistoryDialogComponent`.
- Fork button, fork count, and "forked from X" / "[original removed by
  author]" provenance link on the blueprint details page; fork count on
  browse cards.
- "Most forked" sort alongside "Most liked" on the browse page.

## Test plan

- [x] Backend: `npm run test` — 345 passing (Mocha/Chai), incl. new
      `__tests__/api/blueprint-forks.test.ts` covering fork, list/create/
      delete/restore versions, and migration idempotency.
- [x] Frontend: `npm test` — 590 passing (Vitest).
- [x] `npm run tsc` clean (backend + `lib`), frontend `tsc --noEmit` clean,
      `ng lint` clean, frontend production build clean.
- [ ] Migration not yet run against a prod dump — required before deploy per
      CLAUDE.md's pre-merge process.
- [ ] Follow-up migration to drop `isCopy`/`copyOf`/`Blueprint.data` — deferred
      until this has soaked one release in production, per spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)