### PR TITLE
Social Tier 2: chip links, forks list, comment deep-links, follow lists, liked tab, share button, notifications

### DIFF
--- a/__tests__/api/blueprint-metadata.test.ts
+++ b/__tests__/api/blueprint-metadata.test.ts
@@ -338,7 +338,7 @@ describe('Blueprint metadata API', function () {
   });
 
   describe('GET /api/getblueprints — likedBy filter', function () {
-    it('returns only blueprints liked by the given user', async function () {
+    it('returns only blueprints liked by the given user, for that user themselves', async function () {
       const otherToken = testData.users.user2.generateJwt();
 
       const liked = await TestSetup.request()
@@ -355,8 +355,10 @@ describe('Blueprint metadata API', function () {
         .set('Authorization', `Bearer ${authToken}`)
         .send({ ...BASE_BODY, name: 'Not Liked By User2' });
 
+      // likedBy is private — only user2 themselves can list what user2 has liked
       const response = await TestSetup.request()
-        .get('/api/getblueprints')
+        .get('/api/getblueprintsSecure')
+        .set('Authorization', `Bearer ${otherToken}`)
         .query({ olderthan: Date.now(), likedBy: testData.users.user2._id.toString() });
 
       expect(response.status).to.equal(200);
@@ -371,6 +373,23 @@ describe('Blueprint metadata API', function () {
         .query({ olderthan: Date.now(), likedBy: 'not-an-id' });
 
       expect(response.status).to.equal(400);
+    });
+
+    it('returns 403 for an anonymous request', async function () {
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), likedBy: testData.users.user2._id.toString() });
+
+      expect(response.status).to.equal(403);
+    });
+
+    it("returns 403 when a logged-in user requests another user's liked blueprints", async function () {
+      const response = await TestSetup.request()
+        .get('/api/getblueprintsSecure')
+        .set('Authorization', `Bearer ${authToken}`) // user1
+        .query({ olderthan: Date.now(), likedBy: testData.users.user2._id.toString() });
+
+      expect(response.status).to.equal(403);
     });
   });
 });

--- a/__tests__/api/blueprint-metadata.test.ts
+++ b/__tests__/api/blueprint-metadata.test.ts
@@ -297,4 +297,42 @@ describe('Blueprint metadata API', function () {
       expect(response.status).to.equal(400);
     });
   });
+
+  describe('GET /api/getblueprints — forkedFrom filter', function () {
+    it('returns only forks of the given blueprint', async function () {
+      const source = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ ...BASE_BODY, name: 'Fork Source' });
+      const sourceId = source.body.id;
+
+      const forkResponse = await TestSetup.request()
+        .post(`/api/blueprints/${sourceId}/fork`)
+        .set('Authorization', `Bearer ${authToken}`);
+      expect(forkResponse.status).to.equal(200);
+
+      await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ ...BASE_BODY, name: 'Unrelated Blueprint' });
+
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), forkedFrom: sourceId });
+
+      expect(response.status).to.equal(200);
+      const names = response.body.blueprints.map((bp: any) => bp.name);
+      expect(names).to.include('Fork Source fork');
+      expect(names).to.not.include('Fork Source');
+      expect(names).to.not.include('Unrelated Blueprint');
+    });
+
+    it('returns 400 for a malformed forkedFrom id', async function () {
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), forkedFrom: 'not-an-id' });
+
+      expect(response.status).to.equal(400);
+    });
+  });
 });

--- a/__tests__/api/blueprint-metadata.test.ts
+++ b/__tests__/api/blueprint-metadata.test.ts
@@ -250,5 +250,51 @@ describe('Blueprint metadata API', function () {
       const names = response.body.blueprints.map((bp: any) => bp.name);
       expect(names).to.not.include('Untagged Blueprint');
     });
+
+    it('filters by modded=true', async function () {
+      await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ ...BASE_BODY, name: 'Modded Blueprint', modded: true });
+
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), modded: 'true' });
+
+      expect(response.status).to.equal(200);
+      const names = response.body.blueprints.map((bp: any) => bp.name);
+      expect(names).to.include('Modded Blueprint');
+      expect(names).to.not.include('Power Blueprint');
+      expect(names).to.not.include('Oxygen Blueprint');
+    });
+
+    it('filters by modded=false, excluding both modded=true and untagged (null) blueprints', async function () {
+      await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ ...BASE_BODY, name: 'Modded Blueprint', modded: true });
+      await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ ...BASE_BODY, name: 'Explicitly Unmodded Blueprint', modded: false });
+
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), modded: 'false' });
+
+      expect(response.status).to.equal(200);
+      const names = response.body.blueprints.map((bp: any) => bp.name);
+      expect(names).to.include('Explicitly Unmodded Blueprint');
+      expect(names).to.not.include('Modded Blueprint');
+      expect(names).to.not.include('Power Blueprint'); // modded left null, not false
+    });
+
+    it('returns 400 for an invalid modded value', async function () {
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), modded: 'yes' });
+
+      expect(response.status).to.equal(400);
+    });
   });
 });

--- a/__tests__/api/blueprint-metadata.test.ts
+++ b/__tests__/api/blueprint-metadata.test.ts
@@ -20,10 +20,11 @@ const BASE_BODY = {
 
 describe('Blueprint metadata API', function () {
   let authToken: string;
+  let testData: any;
 
   beforeEach(async function () {
     this.timeout(15000);
-    const testData = await TestSetup.beforeEach();
+    testData = await TestSetup.beforeEach();
     authToken = testData.users.user1.generateJwt();
   });
 
@@ -331,6 +332,43 @@ describe('Blueprint metadata API', function () {
       const response = await TestSetup.request()
         .get('/api/getblueprints')
         .query({ olderthan: Date.now(), forkedFrom: 'not-an-id' });
+
+      expect(response.status).to.equal(400);
+    });
+  });
+
+  describe('GET /api/getblueprints — likedBy filter', function () {
+    it('returns only blueprints liked by the given user', async function () {
+      const otherToken = testData.users.user2.generateJwt();
+
+      const liked = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ ...BASE_BODY, name: 'Liked By User2' });
+      await TestSetup.request()
+        .post('/api/likeblueprint')
+        .set('Authorization', `Bearer ${otherToken}`)
+        .send({ blueprintId: liked.body.id, like: true });
+
+      await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ ...BASE_BODY, name: 'Not Liked By User2' });
+
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), likedBy: testData.users.user2._id.toString() });
+
+      expect(response.status).to.equal(200);
+      const names = response.body.blueprints.map((bp: any) => bp.name);
+      expect(names).to.include('Liked By User2');
+      expect(names).to.not.include('Not Liked By User2');
+    });
+
+    it('returns 400 for a malformed likedBy id', async function () {
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), likedBy: 'not-an-id' });
 
       expect(response.status).to.equal(400);
     });

--- a/__tests__/api/notifications.test.ts
+++ b/__tests__/api/notifications.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load test environment first
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup } from '../setup/testSetup';
+import { NotificationModel } from '../../app/api/models/notification';
+
+describe('Notifications API', function () {
+  let testData: any;
+  let popularId: string;
+
+  beforeEach(async function () {
+    this.timeout(5000);
+    testData = await TestSetup.beforeEach();
+    popularId = testData.blueprints.popularBlueprint._id.toString();
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    await TestSetup.afterEach();
+  });
+
+  // ─── Triggers ─────────────────────────────────────────────────────────────
+
+  describe('comment/reply triggers', function () {
+    it('notifies the blueprint owner on a top-level comment', async function () {
+      const token = testData.users.user2.generateJwt(); // popularBlueprint is owned by user1
+      await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/comments`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ body: 'nice build' });
+
+      const notifications = await NotificationModel.model.find({ recipientId: testData.users.user1._id });
+      expect(notifications).to.have.lengthOf(1);
+      expect(notifications[0].type).to.equal('comment');
+      expect(notifications[0].actorId.toString()).to.equal(testData.users.user2._id.toString());
+      expect(notifications[0].blueprintId!.toString()).to.equal(popularId);
+    });
+
+    it('does not notify the owner when they comment on their own blueprint', async function () {
+      const token = testData.users.user1.generateJwt(); // owner of popularBlueprint
+      await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/comments`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ body: 'note to self' });
+
+      const notifications = await NotificationModel.model.find({ recipientId: testData.users.user1._id });
+      expect(notifications).to.have.lengthOf(0);
+    });
+
+    it('notifies the parent comment author (not just the blueprint owner) on a reply', async function () {
+      const user2Token = testData.users.user2.generateJwt();
+      const topLevel = await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/comments`)
+        .set('Authorization', `Bearer ${user2Token}`)
+        .send({ body: 'top level comment' });
+      const parentId = topLevel.body.comment.id;
+
+      // user1 (blueprint owner) already got a 'comment' notification for the top-level; clear it
+      // so we can isolate the reply notification.
+      await NotificationModel.model.deleteMany({});
+
+      const user3Token = testData.users.user3.generateJwt();
+      await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/comments`)
+        .set('Authorization', `Bearer ${user3Token}`)
+        .send({ body: 'a reply', parentId });
+
+      const notifications = await NotificationModel.model.find({});
+      expect(notifications).to.have.lengthOf(1);
+      expect(notifications[0].type).to.equal('reply');
+      expect(notifications[0].recipientId.toString()).to.equal(testData.users.user2._id.toString());
+      expect(notifications[0].actorId.toString()).to.equal(testData.users.user3._id.toString());
+    });
+  });
+
+  describe('like trigger', function () {
+    it('notifies the blueprint owner when someone else likes it', async function () {
+      // recentBlueprint is owned by user2 and not yet liked by user3 (popularBlueprint
+      // is pre-liked by both user2 and user3 in the seed, which would make a re-like a no-op)
+      const recentId = testData.blueprints.recentBlueprint._id.toString();
+      const token = testData.users.user3.generateJwt();
+      await TestSetup.request()
+        .post('/api/likeblueprint')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ blueprintId: recentId, like: true });
+
+      const notifications = await NotificationModel.model.find({ recipientId: testData.users.user2._id });
+      expect(notifications).to.have.lengthOf(1);
+      expect(notifications[0].type).to.equal('like');
+      expect(notifications[0].actorId.toString()).to.equal(testData.users.user3._id.toString());
+    });
+
+    it('does not notify on unlike', async function () {
+      // user2 and user3 already like popularBlueprint (seeded)
+      const token = testData.users.user2.generateJwt();
+      await TestSetup.request()
+        .post('/api/likeblueprint')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ blueprintId: popularId, like: false });
+
+      const notifications = await NotificationModel.model.find({});
+      expect(notifications).to.have.lengthOf(0);
+    });
+  });
+
+  describe('fork trigger', function () {
+    it('notifies the source blueprint owner, pointing at the new fork', async function () {
+      const token = testData.users.user2.generateJwt();
+      const fork = await TestSetup.request()
+        .post(`/api/blueprints/${popularId}/fork`)
+        .set('Authorization', `Bearer ${token}`);
+
+      const notifications = await NotificationModel.model.find({ recipientId: testData.users.user1._id });
+      expect(notifications).to.have.lengthOf(1);
+      expect(notifications[0].type).to.equal('fork');
+      expect(notifications[0].blueprintId!.toString()).to.equal(fork.body.id);
+    });
+  });
+
+  describe('follow trigger', function () {
+    it('notifies the followee on a new follow', async function () {
+      const token = testData.users.user2.generateJwt();
+      await TestSetup.request()
+        .post('/api/follow')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ followeeId: testData.users.user1._id.toString(), follow: true });
+
+      const notifications = await NotificationModel.model.find({ recipientId: testData.users.user1._id });
+      expect(notifications).to.have.lengthOf(1);
+      expect(notifications[0].type).to.equal('follow');
+    });
+
+    it('does not create a duplicate notification for an idempotent repeat follow', async function () {
+      const token = testData.users.user2.generateJwt();
+      const body = { followeeId: testData.users.user1._id.toString(), follow: true };
+      await TestSetup.request().post('/api/follow').set('Authorization', `Bearer ${token}`).send(body);
+      await TestSetup.request().post('/api/follow').set('Authorization', `Bearer ${token}`).send(body);
+
+      const notifications = await NotificationModel.model.find({ recipientId: testData.users.user1._id });
+      expect(notifications).to.have.lengthOf(1);
+    });
+
+    it('does not notify on unfollow', async function () {
+      const token = testData.users.user2.generateJwt();
+      const followeeId = testData.users.user1._id.toString();
+      await TestSetup.request()
+        .post('/api/follow')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ followeeId, follow: true });
+      await NotificationModel.model.deleteMany({});
+
+      await TestSetup.request()
+        .post('/api/follow')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ followeeId, follow: false });
+
+      const notifications = await NotificationModel.model.find({});
+      expect(notifications).to.have.lengthOf(0);
+    });
+  });
+
+  // ─── GET /api/notifications ───────────────────────────────────────────────
+
+  describe('GET /api/notifications', function () {
+    it('returns 401 without a token', async function () {
+      const response = await TestSetup.request().get('/api/notifications').query({ olderthan: Date.now() });
+      expect(response.status).to.equal(401);
+    });
+
+    it('lists notifications newest first with actor username and unreadCount', async function () {
+      await NotificationModel.model.create({
+        recipientId: testData.users.user1._id,
+        actorId: testData.users.user2._id,
+        type: 'like',
+        blueprintId: popularId,
+        createdAt: new Date(Date.now() - 60 * 1000),
+      });
+      await NotificationModel.model.create({
+        recipientId: testData.users.user1._id,
+        actorId: testData.users.user3._id,
+        type: 'follow',
+        createdAt: new Date(),
+      });
+
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .get('/api/notifications')
+        .query({ olderthan: Date.now() })
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).to.equal(200);
+      expect(response.body.unreadCount).to.equal(2);
+      expect(response.body.notifications).to.have.lengthOf(2);
+      expect(response.body.notifications[0].type).to.equal('follow');
+      expect(response.body.notifications[0].actorUsername).to.equal(testData.users.user3.username);
+      expect(response.body.notifications[1].type).to.equal('like');
+      expect(response.body.notifications[1].blueprintName).to.equal('Super Coal Generator Setup');
+    });
+
+    it("only returns the requesting user's own notifications", async function () {
+      await NotificationModel.model.create({
+        recipientId: testData.users.user2._id,
+        actorId: testData.users.user1._id,
+        type: 'follow',
+      });
+
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .get('/api/notifications')
+        .query({ olderthan: Date.now() })
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.body.notifications).to.have.lengthOf(0);
+      expect(response.body.unreadCount).to.equal(0);
+    });
+  });
+
+  // ─── POST /api/notifications/mark-read ───────────────────────────────────
+
+  describe('POST /api/notifications/mark-read', function () {
+    it('returns 401 without a token', async function () {
+      const response = await TestSetup.request().post('/api/notifications/mark-read');
+      expect(response.status).to.equal(401);
+    });
+
+    it('marks all of the caller\'s unread notifications as read', async function () {
+      await NotificationModel.model.create({
+        recipientId: testData.users.user1._id,
+        actorId: testData.users.user2._id,
+        type: 'follow',
+      });
+      await NotificationModel.model.create({
+        recipientId: testData.users.user1._id,
+        actorId: testData.users.user3._id,
+        type: 'follow',
+      });
+
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .post('/api/notifications/mark-read')
+        .set('Authorization', `Bearer ${token}`);
+      expect(response.status).to.equal(200);
+
+      const stillUnread = await NotificationModel.model.countDocuments({
+        recipientId: testData.users.user1._id,
+        read: false,
+      });
+      expect(stillUnread).to.equal(0);
+    });
+
+    it("does not mark another user's notifications as read", async function () {
+      await NotificationModel.model.create({
+        recipientId: testData.users.user2._id,
+        actorId: testData.users.user1._id,
+        type: 'follow',
+      });
+
+      const token = testData.users.user1.generateJwt();
+      await TestSetup.request().post('/api/notifications/mark-read').set('Authorization', `Bearer ${token}`);
+
+      const stillUnread = await NotificationModel.model.countDocuments({
+        recipientId: testData.users.user2._id,
+        read: false,
+      });
+      expect(stillUnread).to.equal(1);
+    });
+  });
+});

--- a/__tests__/api/notifications.test.ts
+++ b/__tests__/api/notifications.test.ts
@@ -191,7 +191,8 @@ describe('Notifications API', function () {
       const token = testData.users.user1.generateJwt();
       const response = await TestSetup.request()
         .get('/api/notifications')
-        .query({ olderthan: Date.now() })
+        // Small future buffer so this can't race the second notification's createdAt: new Date()
+        .query({ olderthan: Date.now() + 1000 })
         .set('Authorization', `Bearer ${token}`);
 
       expect(response.status).to.equal(200);

--- a/__tests__/api/social.test.ts
+++ b/__tests__/api/social.test.ts
@@ -179,6 +179,101 @@ describe('Profile, Follow, Feed API', function () {
     });
   });
 
+  // ─── GET /api/users/:username/followers, /following ──────────────────────────
+
+  describe('GET /api/users/:username/followers', function () {
+    it('returns 404 for an unknown username', async function () {
+      const response = await TestSetup.request()
+        .get('/api/users/no-such-user/followers')
+        .query({ olderthan: Date.now() });
+      expect(response.status).to.equal(404);
+    });
+
+    it('returns an empty list when nobody follows the user', async function () {
+      const response = await TestSetup.request()
+        .get(`/api/users/${testData.users.user1.username}/followers`)
+        .query({ olderthan: Date.now() });
+      expect(response.status).to.equal(200);
+      expect(response.body.users).to.deep.equal([]);
+      expect(response.body.remaining).to.equal(0);
+    });
+
+    it('lists followers newest first, with followedByMe reflecting the viewer', async function () {
+      // user2 and user3 both follow user1; the viewer (user2) also follows user3 back
+      await FollowModel.model.create({
+        followerId: testData.users.user2._id,
+        followeeId: testData.users.user1._id,
+        createdAt: new Date(Date.now() - 60 * 60 * 1000),
+      });
+      await FollowModel.model.create({
+        followerId: testData.users.user3._id,
+        followeeId: testData.users.user1._id,
+        createdAt: new Date(),
+      });
+      await FollowModel.model.create({
+        followerId: testData.users.user2._id,
+        followeeId: testData.users.user3._id,
+      });
+
+      const token = testData.users.user2.generateJwt();
+      const response = await TestSetup.request()
+        .get(`/api/users/${testData.users.user1.username}/followers`)
+        .query({ olderthan: Date.now() })
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).to.equal(200);
+      const usernames = response.body.users.map((u: any) => u.username);
+      expect(usernames).to.deep.equal([
+        testData.users.user3.username,
+        testData.users.user2.username,
+      ]);
+
+      const user3Row = response.body.users.find((u: any) => u.username === testData.users.user3.username);
+      expect(user3Row.followedByMe).to.equal(true); // viewer (user2) follows user3 back
+
+      const user2Row = response.body.users.find((u: any) => u.username === testData.users.user2.username);
+      expect(user2Row.followedByMe).to.equal(false); // viewer does not follow themselves
+    });
+
+    it('returns followedByMe false for an anonymous viewer', async function () {
+      await FollowModel.model.create({
+        followerId: testData.users.user2._id,
+        followeeId: testData.users.user1._id,
+      });
+
+      const response = await TestSetup.request()
+        .get(`/api/users/${testData.users.user1.username}/followers`)
+        .query({ olderthan: Date.now() });
+
+      expect(response.status).to.equal(200);
+      expect(response.body.users[0].followedByMe).to.equal(false);
+    });
+  });
+
+  describe('GET /api/users/:username/following', function () {
+    it('returns 404 for an unknown username', async function () {
+      const response = await TestSetup.request()
+        .get('/api/users/no-such-user/following')
+        .query({ olderthan: Date.now() });
+      expect(response.status).to.equal(404);
+    });
+
+    it('lists who the user follows', async function () {
+      await FollowModel.model.create({
+        followerId: testData.users.user1._id,
+        followeeId: testData.users.user2._id,
+      });
+
+      const response = await TestSetup.request()
+        .get(`/api/users/${testData.users.user1.username}/following`)
+        .query({ olderthan: Date.now() });
+
+      expect(response.status).to.equal(200);
+      const usernames = response.body.users.map((u: any) => u.username);
+      expect(usernames).to.deep.equal([testData.users.user2.username]);
+    });
+  });
+
   // ─── PATCH /api/users/me ─────────────────────────────────────────────────────
 
   describe('PATCH /api/users/me', function () {

--- a/__tests__/api/social.test.ts
+++ b/__tests__/api/social.test.ts
@@ -218,7 +218,8 @@ describe('Profile, Follow, Feed API', function () {
       const token = testData.users.user2.generateJwt();
       const response = await TestSetup.request()
         .get(`/api/users/${testData.users.user1.username}/followers`)
-        .query({ olderthan: Date.now() })
+        // Small future buffer so this can't race the createdAt: new Date() follow just above
+        .query({ olderthan: Date.now() + 1000 })
         .set('Authorization', `Bearer ${token}`);
 
       expect(response.status).to.equal(200);
@@ -243,7 +244,8 @@ describe('Profile, Follow, Feed API', function () {
 
       const response = await TestSetup.request()
         .get(`/api/users/${testData.users.user1.username}/followers`)
-        .query({ olderthan: Date.now() });
+        // Small future buffer so this can't race the Follow's default createdAt: Date.now()
+        .query({ olderthan: Date.now() + 1000 });
 
       expect(response.status).to.equal(200);
       expect(response.body.users[0].followedByMe).to.equal(false);

--- a/__tests__/api/social.test.ts
+++ b/__tests__/api/social.test.ts
@@ -268,7 +268,8 @@ describe('Profile, Follow, Feed API', function () {
 
       const response = await TestSetup.request()
         .get(`/api/users/${testData.users.user1.username}/following`)
-        .query({ olderthan: Date.now() });
+        // Small future buffer so this can't race the Follow's default createdAt: Date.now()
+        .query({ olderthan: Date.now() + 1000 });
 
       expect(response.status).to.equal(200);
       const usernames = response.body.users.map((u: any) => u.username);

--- a/__tests__/helpers/testDb.ts
+++ b/__tests__/helpers/testDb.ts
@@ -4,6 +4,7 @@ import { BlueprintVersionModel } from '../../app/api/models/blueprint-version';
 import { FeedbackModel } from '../../app/api/models/feedback';
 import { FollowModel } from '../../app/api/models/follow';
 import { CommentModel } from '../../app/api/models/comment';
+import { NotificationModel } from '../../app/api/models/notification';
 import { TestDataFactory, TestUser, TestBlueprint } from '../factories/testData';
 import { Types } from 'mongoose';
 
@@ -125,6 +126,7 @@ export class TestDbHelper {
       await FeedbackModel.model.deleteMany({});
       await FollowModel.model.deleteMany({});
       await CommentModel.model.deleteMany({});
+      await NotificationModel.model.deleteMany({});
       TestDataFactory.reset();
     } catch (error) {
       console.error('Error cleaning database:', error);

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -352,6 +352,7 @@ export class BlueprintController {
       let filterCategory: string | null = null;
       let filterSubcategory: string | null = null;
       let filterModded: boolean | null = null;
+      let filterForkedFrom: string | null = null;
       let sort: 'recent' | 'popular' | 'mostForked';
       let skip = 0;
 
@@ -394,6 +395,13 @@ export class BlueprintController {
         }
         filterModded = rawModded != null ? rawModded === 'true' : null;
 
+        const rawForkedFrom = req.query.forkedFrom as string | undefined;
+        if (rawForkedFrom != null && !mongoose.Types.ObjectId.isValid(rawForkedFrom)) {
+          res.status(400).json(apiError(400, 'Invalid forkedFrom: must be a valid blueprint id'));
+          return;
+        }
+        filterForkedFrom = rawForkedFrom ?? null;
+
         const rawSort = req.query.sort as string | undefined;
         if (rawSort != null && rawSort !== 'recent' && rawSort !== 'popular' && rawSort !== 'mostForked') {
           res.status(400).json(apiError(400, "Invalid sort: must be one of recent, popular, mostForked"));
@@ -430,6 +438,7 @@ export class BlueprintController {
       if (filterCategory != null) filter.$and.push({ category: filterCategory });
       if (filterSubcategory != null) filter.$and.push({ subcategory: filterSubcategory });
       if (filterModded != null) filter.$and.push({ modded: filterModded });
+      if (filterForkedFrom != null) filter.$and.push({ 'forkedFrom.blueprintId': filterForkedFrom });
 
       let sortSpec: Record<string, 1 | -1> = { createdAt: -1 };
       if (sort === 'popular') sortSpec = { likeCount: -1, createdAt: -1 };

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -423,6 +423,12 @@ export class BlueprintController {
           res.status(400).json(apiError(400, 'Invalid likedBy: must be a valid user id'));
           return;
         }
+        // Liked blueprints are private — only the owner can list their own likes (matches
+        // the profile page's "Liked" tab, which is only ever rendered on your own profile).
+        if (rawLikedBy != null && rawLikedBy !== userId) {
+          res.status(403).json(apiError(403, 'Cannot view another user\'s liked blueprints'));
+          return;
+        }
         filterLikedBy = rawLikedBy ?? null;
 
         const rawSort = req.query.sort as string | undefined;

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -351,6 +351,7 @@ export class BlueprintController {
       let filterGameVersion: string | null = null;
       let filterCategory: string | null = null;
       let filterSubcategory: string | null = null;
+      let filterModded: boolean | null = null;
       let sort: 'recent' | 'popular' | 'mostForked';
       let skip = 0;
 
@@ -385,6 +386,13 @@ export class BlueprintController {
         filterCategory = rawCategory ?? null;
 
         filterSubcategory = req.query.subcategory as string ?? null;
+
+        const rawModded = req.query.modded as string | undefined;
+        if (rawModded != null && rawModded !== 'true' && rawModded !== 'false') {
+          res.status(400).json(apiError(400, "Invalid modded: must be 'true' or 'false'"));
+          return;
+        }
+        filterModded = rawModded != null ? rawModded === 'true' : null;
 
         const rawSort = req.query.sort as string | undefined;
         if (rawSort != null && rawSort !== 'recent' && rawSort !== 'popular' && rawSort !== 'mostForked') {
@@ -421,6 +429,7 @@ export class BlueprintController {
       if (filterGameVersion != null) filter.$and.push({ gameVersion: filterGameVersion });
       if (filterCategory != null) filter.$and.push({ category: filterCategory });
       if (filterSubcategory != null) filter.$and.push({ subcategory: filterSubcategory });
+      if (filterModded != null) filter.$and.push({ modded: filterModded });
 
       let sortSpec: Record<string, 1 | -1> = { createdAt: -1 };
       if (sort === 'popular') sortSpec = { likeCount: -1, createdAt: -1 };

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -353,6 +353,7 @@ export class BlueprintController {
       let filterSubcategory: string | null = null;
       let filterModded: boolean | null = null;
       let filterForkedFrom: string | null = null;
+      let filterLikedBy: string | null = null;
       let sort: 'recent' | 'popular' | 'mostForked';
       let skip = 0;
 
@@ -402,6 +403,13 @@ export class BlueprintController {
         }
         filterForkedFrom = rawForkedFrom ?? null;
 
+        const rawLikedBy = req.query.likedBy as string | undefined;
+        if (rawLikedBy != null && !mongoose.Types.ObjectId.isValid(rawLikedBy)) {
+          res.status(400).json(apiError(400, 'Invalid likedBy: must be a valid user id'));
+          return;
+        }
+        filterLikedBy = rawLikedBy ?? null;
+
         const rawSort = req.query.sort as string | undefined;
         if (rawSort != null && rawSort !== 'recent' && rawSort !== 'popular' && rawSort !== 'mostForked') {
           res.status(400).json(apiError(400, "Invalid sort: must be one of recent, popular, mostForked"));
@@ -439,6 +447,7 @@ export class BlueprintController {
       if (filterSubcategory != null) filter.$and.push({ subcategory: filterSubcategory });
       if (filterModded != null) filter.$and.push({ modded: filterModded });
       if (filterForkedFrom != null) filter.$and.push({ 'forkedFrom.blueprintId': filterForkedFrom });
+      if (filterLikedBy != null) filter.$and.push({ likes: filterLikedBy });
 
       let sortSpec: Record<string, 1 | -1> = { createdAt: -1 };
       if (sort === 'popular') sortSpec = { likeCount: -1, createdAt: -1 };

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -19,6 +19,7 @@ import {
 import { Blueprint as sharedBlueprint, BlueprintDetailsResponse } from '../../lib/index';
 import { UserModel, UserJwt } from './models/user';
 import { CommentModel } from './models/comment';
+import { NotificationController } from './notification-controller';
 import { BatchUtils } from './batch/batch-utils';
 import { apiError } from './utils/apiError';
 import { parseOlderThan } from './utils/pagination';
@@ -213,12 +214,26 @@ export class BlueprintController {
 
         update
           .then(async result => {
-            if (
-              result.matchedCount > 0 ||
-              (await BlueprintModel.model.exists({ _id: blueprintLike.blueprintId })) != null
-            ) {
-              res.json({ likeBlueprint: 'OK' });
-            } else res.status(404).json(apiError(404, 'Blueprint not found'));
+            if (result.matchedCount === 0) {
+              if ((await BlueprintModel.model.exists({ _id: blueprintLike.blueprintId })) != null) {
+                res.json({ likeBlueprint: 'OK' });
+              } else res.status(404).json(apiError(404, 'Blueprint not found'));
+              return;
+            }
+
+            if (blueprintLike.like) {
+              const liked = await BlueprintModel.model.findById(blueprintLike.blueprintId).select('owner').lean();
+              if (liked != null) {
+                await NotificationController.notify({
+                  recipientId: liked.owner,
+                  actorId: userId,
+                  type: 'like',
+                  blueprintId: blueprintLike.blueprintId,
+                });
+              }
+            }
+
+            res.json({ likeBlueprint: 'OK' });
           })
           .catch(err => {
             console.log('likeBlueprint error');

--- a/app/api/blueprint-version-controller.ts
+++ b/app/api/blueprint-version-controller.ts
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 import { BlueprintModel } from './models/blueprint';
 import { BlueprintVersionModel, BlueprintVersion } from './models/blueprint-version';
 import { UserJwt } from './models/user';
+import { NotificationController } from './notification-controller';
 import { apiError } from './utils/apiError';
 import {
   ensureCurrentVersion,
@@ -102,6 +103,13 @@ export class BlueprintVersionController {
       await forked.save();
 
       await BlueprintModel.model.updateOne({ _id: source._id }, { $inc: { forkCount: 1 } });
+
+      await NotificationController.notify({
+        recipientId: source.owner,
+        actorId: user._id,
+        type: 'fork',
+        blueprintId: forked._id as mongoose.Types.ObjectId,
+      });
 
       const response: ForkBlueprintResponse = { id: forked.id };
       res.json(response);

--- a/app/api/comment-controller.ts
+++ b/app/api/comment-controller.ts
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 import { CommentModel, Comment } from './models/comment';
 import { BlueprintModel } from './models/blueprint';
 import { UserModel, UserJwt } from './models/user';
+import { NotificationController } from './notification-controller';
 import { apiError } from './utils/apiError';
 import { optionalViewer } from './utils/optionalViewer';
 import {
@@ -258,6 +259,21 @@ export class CommentController {
       if (parent != null) {
         // Active threads surface first in the feed
         await CommentModel.model.updateOne({ _id: parent._id }, { $max: { lastActivityAt: now } });
+        await NotificationController.notify({
+          recipientId: parent.authorId,
+          actorId: user._id,
+          type: 'reply',
+          blueprintId,
+          commentId: comment._id as mongoose.Types.ObjectId,
+        });
+      } else {
+        await NotificationController.notify({
+          recipientId: blueprint.owner,
+          actorId: user._id,
+          type: 'comment',
+          blueprintId,
+          commentId: comment._id as mongoose.Types.ObjectId,
+        });
       }
 
       const context = await buildRenderContext([comment], blueprint.owner.toString(), user);

--- a/app/api/db.ts
+++ b/app/api/db.ts
@@ -5,6 +5,7 @@ import { BlueprintVersionModel } from './models/blueprint-version';
 import { FeedbackModel } from './models/feedback';
 import { FollowModel } from './models/follow';
 import { CommentModel } from './models/comment';
+import { NotificationModel } from './models/notification';
 
 export class Database {
   constructor() {
@@ -26,6 +27,7 @@ export class Database {
       FeedbackModel.init();
       FollowModel.init();
       CommentModel.init();
+      NotificationModel.init();
     });
     mongoose.connection.on('error', err => {
       if (process.env.NODE_ENV !== 'test') {

--- a/app/api/models/notification.ts
+++ b/app/api/models/notification.ts
@@ -1,0 +1,40 @@
+import mongoose, { Schema, Document, Model } from 'mongoose';
+
+export type NotificationType = 'comment' | 'reply' | 'like' | 'fork' | 'follow';
+
+export interface Notification extends Document {
+  recipientId: mongoose.Types.ObjectId;
+  actorId: mongoose.Types.ObjectId;
+  type: NotificationType;
+  // Set for comment/reply/like/fork; null for follow
+  blueprintId: mongoose.Types.ObjectId | null;
+  // Set for comment/reply only
+  commentId: mongoose.Types.ObjectId | null;
+  read: boolean;
+  createdAt: Date;
+}
+
+export class NotificationModel {
+  static model: Model<Notification>;
+
+  public static init() {
+    const notificationSchema = new mongoose.Schema({
+      recipientId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+      actorId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+      type: { type: String, enum: ['comment', 'reply', 'like', 'fork', 'follow'], required: true },
+      blueprintId: { type: Schema.Types.ObjectId, ref: 'Blueprint', default: null },
+      commentId: { type: Schema.Types.ObjectId, ref: 'Comment', default: null },
+      read: { type: Boolean, default: false },
+      createdAt: { type: Date, default: Date.now },
+    });
+
+    // List, newest first
+    notificationSchema.index({ recipientId: 1, createdAt: -1 });
+    // Unread count
+    notificationSchema.index({ recipientId: 1, read: 1 });
+
+    NotificationModel.model =
+      (mongoose.models['Notification'] as Model<Notification>) ??
+      mongoose.model<Notification>('Notification', notificationSchema);
+  }
+}

--- a/app/api/notification-controller.ts
+++ b/app/api/notification-controller.ts
@@ -1,0 +1,126 @@
+import { Request, Response } from 'express';
+import mongoose from 'mongoose';
+import { NotificationModel, NotificationType } from './models/notification';
+import { UserJwt } from './models/user';
+import { BlueprintController } from './blueprint-controller';
+import { NotificationListResponse } from '../../lib/index';
+import { apiError } from './utils/apiError';
+import { parseOlderThan } from './utils/pagination';
+
+export interface NotifyParams {
+  recipientId: mongoose.Types.ObjectId | string;
+  actorId: mongoose.Types.ObjectId | string;
+  type: NotificationType;
+  blueprintId?: mongoose.Types.ObjectId | string | null;
+  commentId?: mongoose.Types.ObjectId | string | null;
+}
+
+export class NotificationController {
+  constructor() {
+    this.list = this.list.bind(this);
+    this.markAllRead = this.markAllRead.bind(this);
+  }
+
+  // Fire-and-forget: called from other controllers after their primary action
+  // succeeds. Never let a notification failure fail the caller's request.
+  public static async notify(params: NotifyParams): Promise<void> {
+    if (params.recipientId.toString() === params.actorId.toString()) return;
+    try {
+      await NotificationModel.model.create({
+        recipientId: params.recipientId,
+        actorId: params.actorId,
+        type: params.type,
+        blueprintId: params.blueprintId ?? null,
+        commentId: params.commentId ?? null,
+      });
+    } catch (err) {
+      console.log('notification create error');
+      console.log(err);
+    }
+  }
+
+  public async list(req: Request, res: Response): Promise<void> {
+    const user = req.user as UserJwt;
+
+    const dateFilter = parseOlderThan(req, res);
+    if (dateFilter == null) return;
+
+    try {
+      const browseIncrement = parseInt(process.env.BROWSE_INCREMENT as string);
+      const [rows, unreadCount] = await Promise.all([
+        NotificationModel.model
+          .find({ recipientId: user._id, createdAt: { $lt: dateFilter } })
+          .sort({ createdAt: -1 })
+          .limit(browseIncrement * 2)
+          .populate('actorId', 'username')
+          .lean(),
+        NotificationModel.model.countDocuments({ recipientId: user._id, read: false }),
+      ]);
+
+      const response: NotificationListResponse = {
+        notifications: [],
+        unreadCount,
+        oldest: new Date().toISOString(),
+        remaining: 0,
+      };
+
+      if (rows.length > 0) {
+        response.remaining = Math.max(0, rows.length - browseIncrement);
+        const page = rows.slice(0, Math.min(browseIncrement, rows.length));
+
+        let oldest = new Date();
+        const blueprintIds: mongoose.Types.ObjectId[] = [];
+        for (const row of page) {
+          const createdAt = row.createdAt as Date;
+          if (createdAt < oldest) oldest = createdAt;
+          if (row.blueprintId != null) blueprintIds.push(row.blueprintId as mongoose.Types.ObjectId);
+        }
+        response.oldest = oldest.toISOString();
+
+        let blueprintNames = new Map<string, string | null>();
+        try {
+          blueprintNames = await BlueprintController.getForkedFromNames(blueprintIds);
+        } catch (err) {
+          // Decoration on the list — never fail it for this
+          console.log('notification blueprint name lookup error');
+          console.log(err);
+        }
+
+        for (const row of page) {
+          const actor = row.actorId as unknown as { _id: mongoose.Types.ObjectId; username: string } | null;
+          if (actor == null) continue; // actor account deleted
+
+          const blueprintId = row.blueprintId != null ? (row.blueprintId as mongoose.Types.ObjectId).toString() : null;
+          response.notifications.push({
+            id: (row._id as mongoose.Types.ObjectId).toString(),
+            type: row.type as NotificationType,
+            actorUsername: actor.username,
+            blueprintId,
+            blueprintName: blueprintId != null ? blueprintNames.get(blueprintId) ?? null : null,
+            commentId: row.commentId != null ? (row.commentId as mongoose.Types.ObjectId).toString() : null,
+            createdAt: (row.createdAt as Date).toISOString(),
+            read: row.read as boolean,
+          });
+        }
+      }
+
+      res.json(response);
+    } catch (err) {
+      console.log('notification list error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to retrieve notifications'));
+    }
+  }
+
+  public async markAllRead(req: Request, res: Response): Promise<void> {
+    const user = req.user as UserJwt;
+    try {
+      await NotificationModel.model.updateMany({ recipientId: user._id, read: false }, { read: true });
+      res.json({ markRead: 'OK' });
+    } catch (err) {
+      console.log('markAllRead error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to mark notifications read'));
+    }
+  }
+}

--- a/app/api/user-controller.ts
+++ b/app/api/user-controller.ts
@@ -5,6 +5,7 @@ import { FollowModel } from './models/follow';
 import { BlueprintModel } from './models/blueprint';
 import { BlueprintController } from './blueprint-controller';
 import { ProfileResponse, FollowRequest, UpdateBioRequest, FollowListResponse } from '../../lib/index';
+import { NotificationController } from './notification-controller';
 import { apiError } from './utils/apiError';
 import { parseOlderThan } from './utils/pagination';
 import { optionalViewer } from './utils/optionalViewer';
@@ -96,7 +97,14 @@ export class UserController {
         if (follow) {
           FollowModel.model
             .create({ followerId: user._id, followeeId })
-            .then(() => res.json({ follow: 'OK' }))
+            .then(async () => {
+              await NotificationController.notify({
+                recipientId: followeeId,
+                actorId: user._id,
+                type: 'follow',
+              });
+              res.json({ follow: 'OK' });
+            })
             .catch(err => {
               // Duplicate-key on the unique pair index just means "already following" — idempotent success
               if (err?.code === 11000) {

--- a/app/api/user-controller.ts
+++ b/app/api/user-controller.ts
@@ -4,9 +4,10 @@ import { UserModel, UserJwt } from './models/user';
 import { FollowModel } from './models/follow';
 import { BlueprintModel } from './models/blueprint';
 import { BlueprintController } from './blueprint-controller';
-import { ProfileResponse, FollowRequest, UpdateBioRequest } from '../../lib/index';
+import { ProfileResponse, FollowRequest, UpdateBioRequest, FollowListResponse } from '../../lib/index';
 import { apiError } from './utils/apiError';
 import { parseOlderThan } from './utils/pagination';
+import { optionalViewer } from './utils/optionalViewer';
 
 // Caps the $in list on the feed's blueprint query so an account following an
 // unusually large number of users can't force an unbounded lookup
@@ -18,6 +19,8 @@ export class UserController {
     this.follow = this.follow.bind(this);
     this.updateBio = this.updateBio.bind(this);
     this.getFeed = this.getFeed.bind(this);
+    this.getFollowers = this.getFollowers.bind(this);
+    this.getFollowing = this.getFollowing.bind(this);
   }
 
   public getProfile(req: Request, res: Response): void {
@@ -187,5 +190,86 @@ export class UserController {
         console.log(err);
         res.status(500).json(apiError(500, 'Failed to retrieve feed'));
       });
+  }
+
+  public getFollowers(req: Request, res: Response): void {
+    this.getConnections(req, res, 'followers').catch(err => {
+      console.log('getFollowers error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to retrieve followers'));
+    });
+  }
+
+  public getFollowing(req: Request, res: Response): void {
+    this.getConnections(req, res, 'following').catch(err => {
+      console.log('getFollowing error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to retrieve following'));
+    });
+  }
+
+  // Shared implementation for the followers/following lists: same shape, only the
+  // side of the Follow relation being matched/populated differs.
+  private async getConnections(req: Request, res: Response, mode: 'followers' | 'following'): Promise<void> {
+    const username = req.params.username;
+    const viewer = optionalViewer(req);
+
+    const dateFilter = parseOlderThan(req, res);
+    if (dateFilter == null) return;
+
+    const targetUser = await UserModel.model.findOne({ username });
+    if (!targetUser) {
+      res.status(404).json(apiError(404, 'User not found'));
+      return;
+    }
+
+    const matchField = mode === 'followers' ? 'followeeId' : 'followerId';
+    const populateField = mode === 'followers' ? 'followerId' : 'followeeId';
+
+    const browseIncrement = parseInt(process.env.BROWSE_INCREMENT as string);
+    const rows = await FollowModel.model
+      .find({ [matchField]: targetUser._id, createdAt: { $lt: dateFilter } })
+      .sort({ createdAt: -1 })
+      .limit(browseIncrement * 2)
+      .populate(populateField, 'username')
+      .lean();
+
+    const response: FollowListResponse = { users: [], oldest: new Date().toISOString(), remaining: 0 };
+
+    if (rows.length > 0) {
+      response.remaining = Math.max(0, rows.length - browseIncrement);
+      const page = rows.slice(0, Math.min(browseIncrement, rows.length));
+
+      let oldest = new Date();
+      const rowUserIds: mongoose.Types.ObjectId[] = [];
+      for (const row of page) {
+        const createdAt = row.createdAt as Date;
+        if (createdAt < oldest) oldest = createdAt;
+        const populated = row[populateField] as unknown as { _id: mongoose.Types.ObjectId; username: string } | null;
+        if (populated != null) rowUserIds.push(populated._id);
+      }
+      response.oldest = oldest.toISOString();
+
+      let followedByMeIds = new Set<string>();
+      if (viewer != null && rowUserIds.length > 0) {
+        const myFollows = await FollowModel.model
+          .find({ followerId: viewer._id, followeeId: { $in: rowUserIds } })
+          .select('followeeId')
+          .lean();
+        followedByMeIds = new Set(myFollows.map(f => (f.followeeId as mongoose.Types.ObjectId).toString()));
+      }
+
+      for (const row of page) {
+        const populated = row[populateField] as unknown as { _id: mongoose.Types.ObjectId; username: string } | null;
+        if (populated == null) continue; // referenced user was deleted
+        response.users.push({
+          id: populated._id.toString(),
+          username: populated.username,
+          followedByMe: followedByMeIds.has(populated._id.toString()),
+        });
+      }
+    }
+
+    res.json(response);
   }
 }

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -15,6 +15,7 @@ import { FeedbackController } from './api/feedback-controller';
 import { AlphaController } from './api/alpha-controller';
 import { UserController } from './api/user-controller';
 import { CommentController } from './api/comment-controller';
+import { NotificationController } from './api/notification-controller';
 export class Routes {
   public staticController = new StaticController();
   public uploadBlueprintController = new BlueprintController();
@@ -27,6 +28,7 @@ export class Routes {
   public alphaController = new AlphaController();
   public userController = new UserController();
   public commentController = new CommentController();
+  public notificationController = new NotificationController();
 
   public routes(app: Application): void {
     // Admin-only middleware: requires role === 'admin' in the JWT (set from WorkOS platform org membership)
@@ -98,6 +100,8 @@ export class Routes {
     app.route('/api/comments/:id').patch(auth, this.commentController.edit);
     app.route('/api/comments/:id').delete(auth, this.commentController.remove);
     app.route('/api/blueprints/:id/fork').post(auth, this.blueprintVersionController.fork);
+    app.route('/api/notifications').get(auth, this.notificationController.list);
+    app.route('/api/notifications/mark-read').post(auth, this.notificationController.markAllRead);
     app.route('/api/blueprints/:id/versions').post(auth, this.blueprintVersionController.createVersion);
     app
       .route('/api/blueprints/:id/versions/:versionId')

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -78,6 +78,8 @@ export class Routes {
     app.route('/api/version').get(this.versionController.getVersion);
     app.route('/api/health').get(this.healthController.getHealth);
     app.route('/api/users/:username/profile').get(this.userController.getProfile);
+    app.route('/api/users/:username/followers').get(this.userController.getFollowers);
+    app.route('/api/users/:username/following').get(this.userController.getFollowing);
     app.route('/api/blueprints/:id').get(this.uploadBlueprintController.getBlueprintDetails);
     app.route('/api/blueprints/:id/comments').get(this.commentController.list);
     app.route('/api/blueprints/:id/versions').get(this.blueprintVersionController.listVersions);

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.html
@@ -27,17 +27,33 @@
       <span class="card-date">{{ item.createdAt | date : "yyyy-MM-dd" }}</span>
     </div>
     <div class="card-badges">
-      <span *ngIf="item.category" class="bni-chip bni-chip--cat">{{
-        item.category
-      }}</span>
+      <a
+        *ngIf="item.category"
+        class="bni-chip bni-chip--cat"
+        [routerLink]="['/discover']"
+        [queryParams]="{ category: item.category }"
+        [title]="categoryTooltip(item.category)"
+        >{{ item.category }}</a
+      >
       <span *ngIf="!item.category" class="bni-chip bni-chip--untagged" i18n
         >Untagged</span
       >
-      <span *ngIf="item.gameVersion" class="bni-chip">{{
-        item.gameVersion
-      }}</span>
-      <span *ngIf="item.modded" class="bni-chip bni-chip--modded" i18n
-        >Modded</span
+      <a
+        *ngIf="item.gameVersion"
+        class="bni-chip"
+        [routerLink]="['/discover']"
+        [queryParams]="{ gameVersion: item.gameVersion }"
+        [title]="gameVersionTooltip(item.gameVersion)"
+        >{{ item.gameVersion }}</a
+      >
+      <a
+        *ngIf="item.modded"
+        class="bni-chip bni-chip--modded"
+        [routerLink]="['/discover']"
+        [queryParams]="{ modded: 'true' }"
+        [title]="moddedTooltip()"
+        i18n
+        >Modded</a
       >
     </div>
     <div class="card-social">

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.html
@@ -67,6 +67,7 @@
       <a
         class="card-comments bni-icon-link"
         [routerLink]="['/blueprint', item.id]"
+        fragment="comments"
         [state]="linkState"
         i18n-title
         title="View comments"

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.spec.ts
@@ -75,6 +75,32 @@ describe("BlueprintCardComponent", () => {
     expect(fixture.nativeElement.textContent).toContain("Modded");
   });
 
+  it("links the category, gameVersion, and modded chips to filtered discover pages", () => {
+    component.item = makeItem({
+      category: "power",
+      gameVersion: "spacedOut",
+      modded: true,
+    });
+    fixture.detectChanges();
+
+    const category = fixture.debugElement.query(By.css(".bni-chip--cat"));
+    expect(category.properties["routerLink"]).toEqual(["/discover"]);
+    expect(category.properties["queryParams"]).toEqual({ category: "power" });
+    expect(category.properties["title"]).toContain("power");
+
+    const gameVersion = fixture.debugElement.query(
+      By.css("a.bni-chip:not(.bni-chip--cat):not(.bni-chip--modded)")
+    );
+    expect(gameVersion.properties["routerLink"]).toEqual(["/discover"]);
+    expect(gameVersion.properties["queryParams"]).toEqual({
+      gameVersion: "spacedOut",
+    });
+
+    const modded = fixture.debugElement.query(By.css(".bni-chip--modded"));
+    expect(modded.properties["routerLink"]).toEqual(["/discover"]);
+    expect(modded.properties["queryParams"]).toEqual({ modded: "true" });
+  });
+
   it("passes like state through to the like widget", () => {
     component.item = makeItem({ nbLikes: 7, likedByMe: true });
     component.loggedIn = false;

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.ts
@@ -1,5 +1,10 @@
 import { Component, Input } from "@angular/core";
 import { BlueprintListItem } from "../../../../../../lib/index";
+import {
+  categoryTooltip,
+  gameVersionTooltip,
+  moddedTooltip,
+} from "../../utils/chip-tooltip";
 
 @Component({
   selector: "app-blueprint-card",
@@ -13,6 +18,10 @@ export class BlueprintCardComponent {
   @Input() showOwner = true;
   /** Router navigation state attached to the details link, e.g. to enable a history-aware back-link. */
   @Input() linkState: Record<string, unknown> | undefined = undefined;
+
+  readonly categoryTooltip = categoryTooltip;
+  readonly gameVersionTooltip = gameVersionTooltip;
+  readonly moddedTooltip = moddedTooltip;
 
   isReal(thumbnail: string): boolean {
     return thumbnail !== "svg" && thumbnail !== "svg_nothing";

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.css
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.css
@@ -144,4 +144,9 @@
 .details-fork-count {
   font-size: 13px;
   color: var(--bni-muted);
+  text-decoration: none;
+}
+
+.details-fork-count:hover {
+  text-decoration: underline;
 }

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
@@ -158,6 +158,15 @@
               label="Version History"
               (click)="openVersionHistory()"
             ></button>
+            <button
+              pButton
+              type="button"
+              class="p-button-text"
+              icon="pi pi-share-alt"
+              i18n-label
+              label="Share"
+              (click)="shareDialog.showDialog()"
+            ></button>
           </div>
         </div>
       </div>
@@ -169,6 +178,11 @@
       <app-version-history-dialog
         #versionHistoryDialog
       ></app-version-history-dialog>
+      <app-dialog-share-url
+        #shareDialog
+        [blueprintId]="details.id"
+        [blueprintName]="details.name"
+      ></app-dialog-share-url>
     </ng-container>
   </div>
 </div>

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
@@ -141,8 +141,13 @@
               [blueprintId]="details.id"
               [disabled]="!loggedIn"
             ></app-fork-button>
-            <span class="details-fork-count"
-              >{{ details.nbForks }}&nbsp;{{ nbForksString }}</span
+            <a
+              class="details-fork-count"
+              [routerLink]="['/discover']"
+              [queryParams]="{ forkedFrom: details.id }"
+              i18n-title
+              title="See forks of this blueprint"
+              >{{ details.nbForks }}&nbsp;{{ nbForksString }}</a
             >
             <button
               pButton

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
@@ -162,7 +162,10 @@
         </div>
       </div>
 
-      <app-comment-section [blueprintId]="blueprintId"></app-comment-section>
+      <app-comment-section
+        [blueprintId]="blueprintId"
+        (commentsLoaded)="scrollToFragment()"
+      ></app-comment-section>
       <app-version-history-dialog
         #versionHistoryDialog
       ></app-version-history-dialog>

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
@@ -79,17 +79,41 @@
           </div>
 
           <div class="details-badges">
-            <span *ngIf="details.category" class="bni-chip bni-chip--cat">{{
-              details.category
-            }}</span>
-            <span *ngIf="details.subcategory" class="bni-chip bni-chip--cat">{{
-              details.subcategory
-            }}</span>
-            <span *ngIf="details.gameVersion" class="bni-chip">{{
-              details.gameVersion
-            }}</span>
-            <span *ngIf="details.modded" class="bni-chip bni-chip--modded" i18n
-              >Modded</span
+            <a
+              *ngIf="details.category"
+              class="bni-chip bni-chip--cat"
+              [routerLink]="['/discover']"
+              [queryParams]="{ category: details.category }"
+              [title]="categoryTooltip(details.category)"
+              >{{ details.category }}</a
+            >
+            <a
+              *ngIf="details.subcategory"
+              class="bni-chip bni-chip--cat"
+              [routerLink]="['/discover']"
+              [queryParams]="{
+                category: details.category,
+                subcategory: details.subcategory
+              }"
+              [title]="subcategoryTooltip(details.subcategory)"
+              >{{ details.subcategory }}</a
+            >
+            <a
+              *ngIf="details.gameVersion"
+              class="bni-chip"
+              [routerLink]="['/discover']"
+              [queryParams]="{ gameVersion: details.gameVersion }"
+              [title]="gameVersionTooltip(details.gameVersion)"
+              >{{ details.gameVersion }}</a
+            >
+            <a
+              *ngIf="details.modded"
+              class="bni-chip bni-chip--modded"
+              [routerLink]="['/discover']"
+              [queryParams]="{ modded: 'true' }"
+              [title]="moddedTooltip()"
+              i18n
+              >Modded</a
             >
           </div>
 

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
@@ -230,6 +230,17 @@ describe("BlueprintDetailsPageComponent", () => {
     );
   });
 
+  it("passes the blueprint id and name to the share dialog", () => {
+    fixture.detectChanges();
+    const shareDialog = fixture.debugElement.query(
+      By.css("app-dialog-share-url")
+    );
+    expect(shareDialog.properties["blueprintId"]).toBe("bp1");
+    expect(shareDialog.properties["blueprintName"]).toBe(
+      "Super Coal Generator Setup"
+    );
+  });
+
   describe("back-link", () => {
     it("defaults to Discover when there is no navigation state", () => {
       fixture.detectChanges();

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
@@ -54,7 +54,10 @@ describe("BlueprintDetailsPageComponent", () => {
         { provide: AuthenticationService, useValue: authService },
         {
           provide: ActivatedRoute,
-          useValue: { paramMap: of(convertToParamMap({ id: "bp1" })) },
+          useValue: {
+            paramMap: of(convertToParamMap({ id: "bp1" })),
+            fragment: of(null),
+          },
         },
       ],
     }).compileComponents();
@@ -180,6 +183,39 @@ describe("BlueprintDetailsPageComponent", () => {
     expect(forkCount.properties["routerLink"]).toEqual(["/discover"]);
     expect(forkCount.properties["queryParams"]).toEqual({ forkedFrom: "bp1" });
     expect(forkCount.nativeElement.textContent).toContain("5");
+  });
+
+  describe("scrollToFragment", () => {
+    it("scrolls to the fragment element once and clears the pending fragment", () => {
+      const route = TestBed.inject(ActivatedRoute) as any;
+      route.fragment = of("comments");
+
+      // re-create so ngOnInit subscribes to the updated fragment observable
+      fixture = TestBed.createComponent(BlueprintDetailsPageComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      const target = document.createElement("div");
+      target.id = "comments";
+      // jsdom does not implement scrollIntoView
+      const scrollSpy = vi.fn();
+      (target as any).scrollIntoView = scrollSpy;
+      document.body.appendChild(target);
+
+      component.scrollToFragment();
+      expect(scrollSpy).toHaveBeenCalled();
+
+      scrollSpy.mockClear();
+      component.scrollToFragment();
+      expect(scrollSpy).not.toHaveBeenCalled();
+
+      document.body.removeChild(target);
+    });
+
+    it("does nothing when there is no fragment", () => {
+      fixture.detectChanges();
+      expect(() => component.scrollToFragment()).not.toThrow();
+    });
   });
 
   it("opens the version history dialog with ownership passed through", () => {

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
@@ -170,6 +170,18 @@ describe("BlueprintDetailsPageComponent", () => {
     expect(modded.properties["queryParams"]).toEqual({ modded: "true" });
   });
 
+  it("links the fork count to a discover page filtered by forkedFrom", () => {
+    blueprintService.getBlueprintDetails.mockReturnValue(
+      of(makeDetails({ nbForks: 5 }))
+    );
+    fixture.detectChanges();
+
+    const forkCount = fixture.debugElement.query(By.css(".details-fork-count"));
+    expect(forkCount.properties["routerLink"]).toEqual(["/discover"]);
+    expect(forkCount.properties["queryParams"]).toEqual({ forkedFrom: "bp1" });
+    expect(forkCount.nativeElement.textContent).toContain("5");
+  });
+
   it("opens the version history dialog with ownership passed through", () => {
     fixture.detectChanges();
     component.versionHistoryDialog = { showDialog: vi.fn() } as any;

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { By } from "@angular/platform-browser";
 import { Location } from "@angular/common";
 import { ActivatedRoute, convertToParamMap } from "@angular/router";
 import { of, throwError } from "rxjs";
@@ -137,6 +138,36 @@ describe("BlueprintDetailsPageComponent", () => {
     const el: HTMLElement = fixture.nativeElement;
 
     expect(el.textContent).toContain("[original removed by author]");
+  });
+
+  it("links the category, subcategory, gameVersion, and modded chips to filtered discover pages", () => {
+    blueprintService.getBlueprintDetails.mockReturnValue(
+      of(makeDetails({ subcategory: "generator", modded: true }))
+    );
+    fixture.detectChanges();
+
+    const category = fixture.debugElement.query(By.css(".bni-chip--cat"));
+    expect(category.properties["routerLink"]).toEqual(["/discover"]);
+    expect(category.properties["queryParams"]).toEqual({ category: "power" });
+
+    const subcategory = fixture.debugElement.queryAll(
+      By.css(".bni-chip--cat")
+    )[1];
+    expect(subcategory.properties["routerLink"]).toEqual(["/discover"]);
+    expect(subcategory.properties["queryParams"]).toEqual({
+      category: "power",
+      subcategory: "generator",
+    });
+
+    const gameVersion = fixture.debugElement.query(
+      By.css("a.bni-chip:not(.bni-chip--cat):not(.bni-chip--modded)")
+    );
+    expect(gameVersion.properties["queryParams"]).toEqual({
+      gameVersion: "spacedOut",
+    });
+
+    const modded = fixture.debugElement.query(By.css(".bni-chip--modded"));
+    expect(modded.properties["queryParams"]).toEqual({ modded: "true" });
   });
 
   it("opens the version history dialog with ownership passed through", () => {

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
@@ -8,6 +8,12 @@ import { BlueprintService } from "../../services/blueprint-service";
 import { AuthenticationService } from "../../services/authentification-service";
 import { VersionHistoryDialogComponent } from "../dialogs/version-history-dialog/version-history-dialog.component";
 import { BrowseData } from "../user-menu/user-menu.component";
+import {
+  categoryTooltip,
+  subcategoryTooltip,
+  gameVersionTooltip,
+  moddedTooltip,
+} from "../../utils/chip-tooltip";
 
 const BACK_TO_DISCOVER = $localize`:blueprintDetails.backToDiscover:Back to Discover`;
 const BACK_TO_PROFILE = $localize`:blueprintDetails.backToProfile:Back to Profile`;
@@ -30,6 +36,11 @@ export class BlueprintDetailsPageComponent implements OnInit {
 
   backLink: any[] = ["/discover"];
   backLabel = BACK_TO_DISCOVER;
+
+  readonly categoryTooltip = categoryTooltip;
+  readonly subcategoryTooltip = subcategoryTooltip;
+  readonly gameVersionTooltip = gameVersionTooltip;
+  readonly moddedTooltip = moddedTooltip;
 
   constructor(
     private route: ActivatedRoute,

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
@@ -42,6 +42,8 @@ export class BlueprintDetailsPageComponent implements OnInit {
   readonly gameVersionTooltip = gameVersionTooltip;
   readonly moddedTooltip = moddedTooltip;
 
+  private pendingFragment: string | null = null;
+
   constructor(
     private route: ActivatedRoute,
     private router: Router,
@@ -71,6 +73,17 @@ export class BlueprintDetailsPageComponent implements OnInit {
         this.blueprintId = details.id;
         this.loading = false;
       });
+
+    this.route.fragment.subscribe((fragment) => {
+      this.pendingFragment = fragment;
+    });
+  }
+
+  scrollToFragment() {
+    if (this.pendingFragment == null) return;
+    const target = document.getElementById(this.pendingFragment);
+    if (target != null) target.scrollIntoView({ block: "center" });
+    this.pendingFragment = null;
   }
 
   private updateBackLink() {

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.css
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.css
@@ -90,6 +90,15 @@
   color: var(--bni-danger);
 }
 
+.filter-context-banner {
+  margin: 0 0 16px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  background: var(--bni-panel2);
+  color: var(--bni-muted);
+  font-size: 0.9rem;
+}
+
 .blueprint-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
@@ -108,7 +108,8 @@
           filterCategory ||
           filterSubcategory ||
           filterName ||
-          filterModded !== null
+          filterModded !== null ||
+          filterForkedFrom
         "
         type="button"
         class="clear-filters"
@@ -135,6 +136,10 @@
       <span *ngIf="!filterModded" i18n
         >Showing base-game (unmodded) blueprints only.</span
       >
+    </div>
+
+    <div *ngIf="filterForkedFrom" class="filter-context-banner" i18n>
+      Showing forks of this blueprint.
     </div>
 
     <div *ngIf="loadError" class="browse-error" role="alert">

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
@@ -104,7 +104,11 @@
       ></p-select>
       <button
         *ngIf="
-          filterGameVersion || filterCategory || filterSubcategory || filterName
+          filterGameVersion ||
+          filterCategory ||
+          filterSubcategory ||
+          filterName ||
+          filterModded !== null
         "
         type="button"
         class="clear-filters"
@@ -124,6 +128,13 @@
         </svg>
         <ng-container i18n>Clear filters</ng-container>
       </button>
+    </div>
+
+    <div *ngIf="filterModded !== null" class="filter-context-banner">
+      <span *ngIf="filterModded" i18n>Showing modded blueprints only.</span>
+      <span *ngIf="!filterModded" i18n
+        >Showing base-game (unmodded) blueprints only.</span
+      >
     </div>
 
     <div *ngIf="loadError" class="browse-error" role="alert">

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
@@ -133,6 +133,7 @@ describe("BrowsePageComponent", () => {
         null,
         "recent",
         undefined,
+        null,
         null
       );
     });
@@ -152,6 +153,7 @@ describe("BrowsePageComponent", () => {
         null,
         "recent",
         undefined,
+        null,
         null
       );
     });
@@ -169,6 +171,7 @@ describe("BrowsePageComponent", () => {
         null,
         "recent",
         undefined,
+        null,
         null
       );
     });
@@ -187,6 +190,7 @@ describe("BrowsePageComponent", () => {
         "generator",
         "recent",
         undefined,
+        null,
         null
       );
     });
@@ -204,22 +208,43 @@ describe("BrowsePageComponent", () => {
         null,
         "recent",
         undefined,
-        true
+        true,
+        null
       );
     });
 
-    it("clearFilters resets all facets (including modded) and refetches", () => {
+    it("passes forkedFrom filter to getBlueprints", () => {
+      component.filterForkedFrom = "parent-1";
+      component.getBlueprints();
+
+      expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
+        expect.any(Date),
+        null,
+        null,
+        null,
+        null,
+        null,
+        "recent",
+        undefined,
+        null,
+        "parent-1"
+      );
+    });
+
+    it("clearFilters resets all facets (including modded and forkedFrom) and refetches", () => {
       component.filterGameVersion = "base";
       component.filterCategory = "cooling";
       component.filterSubcategory = "fan";
       component.filterName = "test";
       component.filterModded = true;
+      component.filterForkedFrom = "parent-1";
       component.clearFilters();
 
       expect(component.filterGameVersion).toBeNull();
       expect(component.filterCategory).toBeNull();
       expect(component.filterSubcategory).toBeNull();
       expect(component.filterModded).toBeNull();
+      expect(component.filterForkedFrom).toBeNull();
       expect(component.filterName).toBe("");
       expect(blueprintService.getBlueprints).toHaveBeenCalled();
     });
@@ -231,6 +256,15 @@ describe("BrowsePageComponent", () => {
       };
       component.ngOnInit();
       expect(component.filterModded).toBe(true);
+    });
+
+    it("initializes forkedFrom from the URL query param", () => {
+      const route = TestBed.inject(ActivatedRoute) as any;
+      route.snapshot = {
+        queryParamMap: convertToParamMap({ forkedFrom: "parent-1" }),
+      };
+      component.ngOnInit();
+      expect(component.filterForkedFrom).toBe("parent-1");
     });
 
     it("onFacetChange resets subcategory before refetching", () => {

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
@@ -132,7 +132,8 @@ describe("BrowsePageComponent", () => {
         null,
         null,
         "recent",
-        undefined
+        undefined,
+        null
       );
     });
   });
@@ -150,7 +151,8 @@ describe("BrowsePageComponent", () => {
         null,
         null,
         "recent",
-        undefined
+        undefined,
+        null
       );
     });
 
@@ -166,7 +168,8 @@ describe("BrowsePageComponent", () => {
         "power",
         null,
         "recent",
-        undefined
+        undefined,
+        null
       );
     });
 
@@ -183,22 +186,51 @@ describe("BrowsePageComponent", () => {
         "power",
         "generator",
         "recent",
-        undefined
+        undefined,
+        null
       );
     });
 
-    it("clearFilters resets all facets and refetches", () => {
+    it("passes modded filter to getBlueprints", () => {
+      component.filterModded = true;
+      component.getBlueprints();
+
+      expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
+        expect.any(Date),
+        null,
+        null,
+        null,
+        null,
+        null,
+        "recent",
+        undefined,
+        true
+      );
+    });
+
+    it("clearFilters resets all facets (including modded) and refetches", () => {
       component.filterGameVersion = "base";
       component.filterCategory = "cooling";
       component.filterSubcategory = "fan";
       component.filterName = "test";
+      component.filterModded = true;
       component.clearFilters();
 
       expect(component.filterGameVersion).toBeNull();
       expect(component.filterCategory).toBeNull();
       expect(component.filterSubcategory).toBeNull();
+      expect(component.filterModded).toBeNull();
       expect(component.filterName).toBe("");
       expect(blueprintService.getBlueprints).toHaveBeenCalled();
+    });
+
+    it("initializes modded from the URL query param", () => {
+      const route = TestBed.inject(ActivatedRoute) as any;
+      route.snapshot = {
+        queryParamMap: convertToParamMap({ modded: "true" }),
+      };
+      component.ngOnInit();
+      expect(component.filterModded).toBe(true);
     });
 
     it("onFacetChange resets subcategory before refetching", () => {

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
@@ -46,6 +46,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   filterCategory: string | null = null;
   filterSubcategory: string | null = null;
   filterModded: boolean | null = null;
+  filterForkedFrom: string | null = null;
   remaining = 0;
   sort: "recent" | "popular" | "mostForked" = "recent";
   skipCount = 0;
@@ -148,6 +149,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     const rawModded = params.get("modded");
     this.filterModded =
       rawModded === "true" ? true : rawModded === "false" ? false : null;
+    this.filterForkedFrom = params.get("forkedFrom");
     const rawSort = params.get("sort");
     this.sort =
       rawSort === "popular" || rawSort === "mostForked" ? rawSort : "recent";
@@ -208,6 +210,8 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
       queryParams["subcategory"] = this.filterSubcategory;
     if (this.filterModded != null)
       queryParams["modded"] = String(this.filterModded);
+    if (this.filterForkedFrom)
+      queryParams["forkedFrom"] = this.filterForkedFrom;
     if (this.sort !== "recent") queryParams["sort"] = this.sort;
     this.router.navigate([], { queryParams, replaceUrl: true });
   }
@@ -218,6 +222,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     this.filterCategory = null;
     this.filterSubcategory = null;
     this.filterModded = null;
+    this.filterForkedFrom = null;
     this.applyFiltersToUrl();
     this.reset();
     this.getBlueprints();
@@ -252,7 +257,8 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
             this.filterSubcategory,
             this.sort,
             this.sort !== "recent" ? this.skipCount : undefined,
-            this.filterModded
+            this.filterModded,
+            this.filterForkedFrom
           );
 
     request$.subscribe({

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
@@ -45,6 +45,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   filterGameVersion: string | null = null;
   filterCategory: string | null = null;
   filterSubcategory: string | null = null;
+  filterModded: boolean | null = null;
   remaining = 0;
   sort: "recent" | "popular" | "mostForked" = "recent";
   skipCount = 0;
@@ -144,6 +145,9 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     this.filterGameVersion = params.get("gameVersion");
     this.filterCategory = params.get("category");
     this.filterSubcategory = params.get("subcategory");
+    const rawModded = params.get("modded");
+    this.filterModded =
+      rawModded === "true" ? true : rawModded === "false" ? false : null;
     const rawSort = params.get("sort");
     this.sort =
       rawSort === "popular" || rawSort === "mostForked" ? rawSort : "recent";
@@ -202,6 +206,8 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     if (this.filterCategory) queryParams["category"] = this.filterCategory;
     if (this.filterSubcategory)
       queryParams["subcategory"] = this.filterSubcategory;
+    if (this.filterModded != null)
+      queryParams["modded"] = String(this.filterModded);
     if (this.sort !== "recent") queryParams["sort"] = this.sort;
     this.router.navigate([], { queryParams, replaceUrl: true });
   }
@@ -211,6 +217,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     this.filterGameVersion = null;
     this.filterCategory = null;
     this.filterSubcategory = null;
+    this.filterModded = null;
     this.applyFiltersToUrl();
     this.reset();
     this.getBlueprints();
@@ -244,7 +251,8 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
             this.filterCategory,
             this.filterSubcategory,
             this.sort,
-            this.sort !== "recent" ? this.skipCount : undefined
+            this.sort !== "recent" ? this.skipCount : undefined,
+            this.filterModded
           );
 
     request$.subscribe({

--- a/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.html
+++ b/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.html
@@ -1,4 +1,4 @@
-<section class="comment-section">
+<section class="comment-section" id="comments">
   <h2 class="comments-heading">
     <ng-container i18n>Comments</ng-container>
     <span class="comments-count" *ngIf="!loading && !loadError"
@@ -98,7 +98,11 @@
 </section>
 
 <ng-template #commentTpl let-comment="comment" let-isReply="isReply">
-  <div class="comment" [class.comment-reply]="isReply">
+  <div
+    class="comment"
+    [class.comment-reply]="isReply"
+    [id]="'comment-' + comment.id"
+  >
     <div class="comment-meta">
       <ng-container *ngIf="!comment.deleted">
         <a

--- a/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.spec.ts
@@ -73,6 +73,18 @@ describe("CommentSectionComponent", () => {
       expect(component.loading).toBe(false);
     });
 
+    it("gives each comment a stable anchor id and emits commentsLoaded", () => {
+      const emitSpy = vi.fn();
+      component.commentsLoaded.subscribe(emitSpy);
+
+      bindBlueprint("bp1");
+      fixture.detectChanges();
+
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.querySelector("#comment-c1")).toBeTruthy();
+      expect(emitSpy).toHaveBeenCalled();
+    });
+
     it("does nothing without a blueprint id", () => {
       bindBlueprint(null);
       expect(commentService.getComments).not.toHaveBeenCalled();

--- a/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.ts
+++ b/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.ts
@@ -1,4 +1,10 @@
-import { Component, Input, OnChanges } from "@angular/core";
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+} from "@angular/core";
 import {
   CommentDto,
   CommentThread,
@@ -15,6 +21,7 @@ import { AuthenticationService } from "../../services/authentification-service";
 })
 export class CommentSectionComponent implements OnChanges {
   @Input() blueprintId: string | null = null;
+  @Output() commentsLoaded = new EventEmitter<void>();
 
   loading = false;
   loadError = false;
@@ -57,6 +64,7 @@ export class CommentSectionComponent implements OnChanges {
         this.threads = response.threads;
         this.total = response.total;
         this.loading = false;
+        this.commentsLoaded.emit();
       },
       error: () => {
         this.loading = false;

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-follow-list/dialog-follow-list.component.css
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-follow-list/dialog-follow-list.component.css
@@ -1,0 +1,52 @@
+.follow-list-scrollable {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.follow-list-empty,
+.follow-list-error,
+.follow-list-loading {
+  padding: 12px 4px;
+  color: var(--bni-muted);
+  text-align: center;
+}
+
+.follow-list-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 4px;
+  text-decoration: none;
+  color: inherit;
+  border-bottom: 1px solid var(--bni-line);
+}
+
+.follow-list-row:hover {
+  background: var(--bni-panel2);
+}
+
+.follow-list-avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--bni-panel2);
+  color: var(--bni-ink);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.follow-list-username {
+  flex: 1;
+  font-weight: 600;
+  color: var(--bni-ink);
+}
+
+.follow-list-mutual {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--bni-muted);
+}

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-follow-list/dialog-follow-list.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-follow-list/dialog-follow-list.component.html
@@ -1,0 +1,41 @@
+<p-dialog
+  [header]="title"
+  [(visible)]="visible"
+  [modal]="true"
+  [dismissableMask]="true"
+  [closable]="true"
+  [draggable]="false"
+  [resizable]="false"
+  [style]="{ width: '420px', maxHeight: '80vh' }"
+>
+  <div #scrollable class="follow-list-scrollable" (scroll)="onScroll()">
+    <div
+      *ngIf="entries.length === 0 && !working && !loadError"
+      class="follow-list-empty"
+      i18n
+    >
+      Nobody here yet.
+    </div>
+
+    <div *ngIf="loadError" class="follow-list-error" i18n>
+      Couldn't load this list. Scroll to try again.
+    </div>
+
+    <a
+      *ngFor="let entry of entries"
+      class="follow-list-row"
+      [routerLink]="['/profile', entry.username]"
+      (click)="hideDialog()"
+    >
+      <span class="follow-list-avatar">{{
+        entry.username.charAt(0).toUpperCase()
+      }}</span>
+      <span class="follow-list-username">{{ entry.username }}</span>
+      <span *ngIf="entry.followedByMe" class="follow-list-mutual" i18n
+        >Following</span
+      >
+    </a>
+
+    <div *ngIf="working" class="follow-list-loading" i18n>Loading…</div>
+  </div>
+</p-dialog>

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-follow-list/dialog-follow-list.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-follow-list/dialog-follow-list.component.spec.ts
@@ -1,0 +1,131 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { By } from "@angular/platform-browser";
+import { RouterTestingModule } from "@angular/router/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { DialogModule } from "primeng/dialog";
+import { of, throwError } from "rxjs";
+
+import { DialogFollowListComponent } from "./dialog-follow-list.component";
+import { UserService } from "src/app/module-blueprint/services/user-service";
+
+function makeResponse(
+  users: { id: string; username: string; followedByMe: boolean }[] = [],
+  remaining = 0
+) {
+  return { users, oldest: new Date("2026-01-01").toISOString(), remaining };
+}
+
+describe("DialogFollowListComponent", () => {
+  let component: DialogFollowListComponent;
+  let fixture: ComponentFixture<DialogFollowListComponent>;
+  let userService: any;
+
+  beforeEach(async () => {
+    userService = {
+      getFollowers: vi.fn().mockReturnValue(of(makeResponse())),
+      getFollowing: vi.fn().mockReturnValue(of(makeResponse())),
+    };
+
+    await TestBed.configureTestingModule({
+      declarations: [DialogFollowListComponent],
+      imports: [
+        RouterTestingModule.withRoutes([]),
+        DialogModule,
+        NoopAnimationsModule,
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [{ provide: UserService, useValue: userService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DialogFollowListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("creates", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("loads followers and shows the dialog", () => {
+    userService.getFollowers.mockReturnValue(
+      of(
+        makeResponse([
+          { id: "u1", username: "alice", followedByMe: true },
+          { id: "u2", username: "bob", followedByMe: false },
+        ])
+      )
+    );
+
+    component.showDialog("carol", "followers");
+
+    expect(userService.getFollowers).toHaveBeenCalledWith(
+      "carol",
+      expect.any(Date)
+    );
+    expect(component.visible).toBe(true);
+    expect(component.entries).toHaveLength(2);
+    expect(component.title).toContain("Followers");
+  });
+
+  it("loads following instead when mode is 'following'", () => {
+    component.showDialog("carol", "following");
+    expect(userService.getFollowing).toHaveBeenCalledWith(
+      "carol",
+      expect.any(Date)
+    );
+    expect(component.title).toContain("Following");
+  });
+
+  it("renders a mutual-follow tag only for rows the viewer already follows", () => {
+    userService.getFollowers.mockReturnValue(
+      of(
+        makeResponse([
+          { id: "u1", username: "alice", followedByMe: true },
+          { id: "u2", username: "bob", followedByMe: false },
+        ])
+      )
+    );
+    component.showDialog("carol", "followers");
+    fixture.detectChanges();
+
+    const rows = fixture.debugElement.queryAll(By.css(".follow-list-row"));
+    expect(rows).toHaveLength(2);
+    expect(rows[0].query(By.css(".follow-list-mutual"))).toBeTruthy();
+    expect(rows[1].query(By.css(".follow-list-mutual"))).toBeNull();
+  });
+
+  it("paginates on scroll and stops once remaining is 0", () => {
+    userService.getFollowers
+      .mockReturnValueOnce(
+        of(
+          makeResponse(
+            [{ id: "u1", username: "alice", followedByMe: false }],
+            1
+          )
+        )
+      )
+      .mockReturnValueOnce(
+        of(
+          makeResponse([{ id: "u2", username: "bob", followedByMe: false }], 0)
+        )
+      );
+
+    component.showDialog("carol", "followers");
+    expect(component.entries).toHaveLength(1);
+    expect(component.noMore).toBe(false);
+
+    component.loadMore();
+    expect(component.entries).toHaveLength(2);
+    expect(component.noMore).toBe(true);
+  });
+
+  it("flags loadError on failure", () => {
+    userService.getFollowers.mockReturnValue(
+      throwError(() => new Error("network"))
+    );
+    component.showDialog("carol", "followers");
+    expect(component.loadError).toBe(true);
+    expect(component.working).toBe(false);
+  });
+});

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-follow-list/dialog-follow-list.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-follow-list/dialog-follow-list.component.ts
@@ -1,0 +1,76 @@
+import { Component, ElementRef, ViewChild } from "@angular/core";
+import {
+  FollowListEntry,
+  FollowListResponse,
+} from "../../../../../../../lib/index";
+import { UserService } from "src/app/module-blueprint/services/user-service";
+
+const FOLLOWERS_TITLE = $localize`:followList.followersTitle:Followers`;
+const FOLLOWING_TITLE = $localize`:followList.followingTitle:Following`;
+
+@Component({
+  selector: "app-dialog-follow-list",
+  templateUrl: "./dialog-follow-list.component.html",
+  styleUrls: ["./dialog-follow-list.component.css"],
+  standalone: false,
+})
+export class DialogFollowListComponent {
+  @ViewChild("scrollable", { static: true }) scrollable!: ElementRef;
+
+  visible = false;
+  title = "";
+  entries: FollowListEntry[] = [];
+  working = false;
+  noMore = false;
+  loadError = false;
+
+  private username = "";
+  private mode: "followers" | "following" = "followers";
+  private oldestDate = new Date();
+
+  constructor(private userService: UserService) {}
+
+  showDialog(username: string, mode: "followers" | "following") {
+    this.username = username;
+    this.mode = mode;
+    this.title = mode === "followers" ? FOLLOWERS_TITLE : FOLLOWING_TITLE;
+    this.entries = [];
+    this.oldestDate = new Date();
+    this.noMore = false;
+    this.loadError = false;
+    this.visible = true;
+    this.loadMore();
+  }
+
+  hideDialog() {
+    this.visible = false;
+  }
+
+  onScroll() {
+    const el = this.scrollable.nativeElement;
+    const atBottom = el.scrollTop + el.clientHeight > el.scrollHeight - 40;
+    if (atBottom && !this.working && !this.noMore) this.loadMore();
+  }
+
+  loadMore() {
+    this.working = true;
+    this.loadError = false;
+    const request$ =
+      this.mode === "followers"
+        ? this.userService.getFollowers(this.username, this.oldestDate)
+        : this.userService.getFollowing(this.username, this.oldestDate);
+
+    request$.subscribe({
+      next: (response: FollowListResponse) => {
+        this.working = false;
+        this.oldestDate = new Date(response.oldest);
+        this.entries = this.entries.concat(response.users);
+        if (response.remaining === 0) this.noMore = true;
+      },
+      error: () => {
+        this.working = false;
+        this.loadError = true;
+      },
+    });
+  }
+}

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-share-url/dialog-share-url.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-share-url/dialog-share-url.component.html
@@ -19,7 +19,7 @@
     size="60"
     [ngModel]="url"
     pInputText
-    [disabled]="blueprintService.id === null"
+    [disabled]="url === ''"
   />
   <button
     pButton
@@ -29,7 +29,7 @@
     (click)="copyToClipboard(urlInput)"
     i18n-pTooltip
     pTooltip="Copy url to clipboard"
-    [disabled]="blueprintService.id === null"
+    [disabled]="url === ''"
   ></button>
   <button
     pButton
@@ -39,6 +39,16 @@
     (click)="newTab()"
     i18n-pTooltip
     pTooltip="Open in new tab"
-    [disabled]="blueprintService.id === null"
+    [disabled]="url === ''"
+  ></button>
+  <button
+    pButton
+    type="button"
+    class="ui-button copy-button"
+    icon="fab fa-reddit"
+    (click)="shareToReddit()"
+    i18n-pTooltip
+    pTooltip="Share to Reddit"
+    [disabled]="url === ''"
   ></button>
 </p-dialog>

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-share-url/dialog-share-url.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-share-url/dialog-share-url.component.spec.ts
@@ -36,4 +36,39 @@ describe("DialogShareUrlComponent", () => {
   it("should create", () => {
     expect(component).toBeTruthy();
   });
+
+  describe("url", () => {
+    it("is empty when neither blueprintId input nor blueprintService.id is set", () => {
+      expect(component.url).toBe("");
+    });
+
+    it("falls back to blueprintService.id when the input is not set", () => {
+      component.blueprintService.id = "editor-id";
+      expect(component.url).toContain("/b/editor-id");
+    });
+
+    it("prefers the blueprintId input over blueprintService.id", () => {
+      component.blueprintService.id = "editor-id";
+      component.blueprintId = "details-id";
+      expect(component.url).toContain("/b/details-id");
+      expect(component.url).not.toContain("editor-id");
+    });
+  });
+
+  describe("redditShareUrl", () => {
+    it("includes the url and a generic title when blueprintName is unset", () => {
+      component.blueprintId = "bp1";
+      const url = new URL(component.redditShareUrl);
+      expect(url.origin + url.pathname).toBe("https://www.reddit.com/submit");
+      expect(url.searchParams.get("url")).toContain("/b/bp1");
+      expect(url.searchParams.get("title")).toBeTruthy();
+    });
+
+    it("uses blueprintName as the title when set", () => {
+      component.blueprintId = "bp1";
+      component.blueprintName = "My Coal Generator";
+      const url = new URL(component.redditShareUrl);
+      expect(url.searchParams.get("title")).toBe("My Coal Generator");
+    });
+  });
 });

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-share-url/dialog-share-url.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-share-url/dialog-share-url.component.ts
@@ -1,4 +1,4 @@
-import { Component } from "@angular/core";
+import { Component, Input } from "@angular/core";
 import { BlueprintService } from "../../../services/blueprint-service";
 import { MessageService } from "primeng/api";
 
@@ -9,6 +9,11 @@ import { MessageService } from "primeng/api";
   standalone: false,
 })
 export class DialogShareUrlComponent {
+  /** When set (e.g. from the details page), used instead of the editor-scoped BlueprintService.id. */
+  @Input() blueprintId?: string;
+  /** Used to prefill the Reddit share title; falls back to a generic title when unset. */
+  @Input() blueprintName?: string;
+
   visible: boolean = false;
 
   constructor(
@@ -16,10 +21,12 @@ export class DialogShareUrlComponent {
     private messageService: MessageService
   ) {}
 
+  private get id(): string | null {
+    return this.blueprintId ?? this.blueprintService.id;
+  }
+
   get url() {
-    return this.blueprintService.id != null
-      ? BlueprintService.baseUrl + "/b/" + this.blueprintService.id
-      : "";
+    return this.id != null ? BlueprintService.baseUrl + "/b/" + this.id : "";
   }
 
   showDialog() {
@@ -43,5 +50,17 @@ export class DialogShareUrlComponent {
 
   newTab() {
     window.open(this.url, Math.random().toString(36));
+  }
+
+  get redditShareUrl(): string {
+    const title =
+      this.blueprintName ??
+      $localize`Check out my Oxygen Not Included blueprint`;
+    const params = new URLSearchParams({ url: this.url, title });
+    return "https://www.reddit.com/submit?" + params.toString();
+  }
+
+  shareToReddit() {
+    window.open(this.redditShareUrl, Math.random().toString(36));
   }
 }

--- a/frontend/src/app/module-blueprint/components/notification-bell/notification-bell.component.css
+++ b/frontend/src/app/module-blueprint/components/notification-bell/notification-bell.component.css
@@ -1,0 +1,75 @@
+.notification-bell-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--bni-ink);
+  font-size: 1.1rem;
+  cursor: pointer;
+  padding: 6px;
+}
+
+.notification-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 3px;
+  border-radius: 8px;
+  background: var(--bni-accent2, #d95f4c);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 16px;
+  text-align: center;
+}
+
+.notification-panel {
+  width: 320px;
+  max-height: 60vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.notification-panel-header {
+  font-weight: 600;
+  padding: 4px 4px 10px;
+  color: var(--bni-ink);
+}
+
+.notification-empty,
+.notification-loading {
+  padding: 12px 4px;
+  color: var(--bni-muted);
+  text-align: center;
+}
+
+.notification-row {
+  display: block;
+  padding: 8px 4px;
+  text-decoration: none;
+  color: var(--bni-ink);
+  border-bottom: 1px solid var(--bni-line);
+  font-size: 13px;
+}
+
+.notification-row:hover {
+  background: var(--bni-panel2);
+}
+
+.notification-unread {
+  font-weight: 600;
+}
+
+.notification-load-more {
+  background: none;
+  border: none;
+  padding: 10px 4px;
+  color: var(--bni-accent);
+  cursor: pointer;
+  text-align: center;
+}

--- a/frontend/src/app/module-blueprint/components/notification-bell/notification-bell.component.html
+++ b/frontend/src/app/module-blueprint/components/notification-bell/notification-bell.component.html
@@ -1,0 +1,54 @@
+<button
+  type="button"
+  class="notification-bell-button"
+  (click)="toggle($event)"
+  i18n-aria-label
+  aria-label="Notifications"
+>
+  <i class="pi pi-bell"></i>
+  <span *ngIf="unreadCount > 0" class="notification-badge">{{
+    unreadCount > 9 ? "9+" : unreadCount
+  }}</span>
+</button>
+
+<p-popover #notifPanel [appendTo]="'body'" (onShow)="onShow()">
+  <div class="notification-panel">
+    <div class="notification-panel-header" i18n>Notifications</div>
+
+    <div
+      *ngIf="!working && !loadError && notifications.length === 0"
+      class="notification-empty"
+      i18n
+    >
+      Nothing yet — activity on your blueprints will show up here.
+    </div>
+
+    <div *ngIf="loadError" class="notification-empty" i18n>
+      Couldn't load notifications.
+    </div>
+
+    <a
+      *ngFor="let n of notifications"
+      class="notification-row"
+      [class.notification-unread]="!n.read"
+      [routerLink]="link(n)"
+      [fragment]="fragment(n)"
+      (click)="hidePanel()"
+    >
+      {{ message(n) }}
+    </a>
+
+    <button
+      *ngIf="remaining > 0"
+      type="button"
+      class="notification-load-more"
+      (click)="loadMore()"
+      [disabled]="working"
+      i18n
+    >
+      Load more
+    </button>
+
+    <div *ngIf="working" class="notification-loading" i18n>Loading…</div>
+  </div>
+</p-popover>

--- a/frontend/src/app/module-blueprint/components/notification-bell/notification-bell.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/notification-bell/notification-bell.component.spec.ts
@@ -1,0 +1,251 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { By } from "@angular/platform-browser";
+import { RouterTestingModule } from "@angular/router/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { PopoverModule } from "primeng/popover";
+import { of, throwError } from "rxjs";
+
+import { NotificationBellComponent } from "./notification-bell.component";
+import { NotificationService } from "src/app/module-blueprint/services/notification.service";
+import { AuthenticationService } from "src/app/module-blueprint/services/authentification-service";
+
+function makeResponse(
+  notifications: any[] = [],
+  unreadCount = 0,
+  remaining = 0
+) {
+  return {
+    notifications,
+    unreadCount,
+    oldest: new Date("2026-01-01").toISOString(),
+    remaining,
+  };
+}
+
+describe("NotificationBellComponent", () => {
+  let component: NotificationBellComponent;
+  let fixture: ComponentFixture<NotificationBellComponent>;
+  let notificationService: any;
+  let authService: any;
+
+  beforeEach(async () => {
+    notificationService = {
+      list: vi.fn().mockReturnValue(of(makeResponse())),
+      markAllRead: vi.fn().mockReturnValue(of({ markRead: "OK" })),
+    };
+    authService = { isLoggedIn: vi.fn().mockReturnValue(true) };
+
+    await TestBed.configureTestingModule({
+      declarations: [NotificationBellComponent],
+      imports: [
+        RouterTestingModule.withRoutes([]),
+        PopoverModule,
+        NoopAnimationsModule,
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        { provide: NotificationService, useValue: notificationService },
+        { provide: AuthenticationService, useValue: authService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NotificationBellComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("creates", () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it("polls unread count on init when logged in", () => {
+    notificationService.list.mockReturnValue(of(makeResponse([], 3)));
+    fixture.detectChanges();
+    expect(notificationService.list).toHaveBeenCalled();
+    expect(component.unreadCount).toBe(3);
+  });
+
+  it("does not poll when logged out", () => {
+    authService.isLoggedIn.mockReturnValue(false);
+    fixture.detectChanges();
+    expect(notificationService.list).not.toHaveBeenCalled();
+  });
+
+  it("shows a 9+ badge once unread count exceeds 9", () => {
+    notificationService.list.mockReturnValue(of(makeResponse([], 15)));
+    fixture.detectChanges();
+    const badge = fixture.debugElement.query(By.css(".notification-badge"));
+    expect(badge.nativeElement.textContent.trim()).toBe("9+");
+  });
+
+  it("hides the badge when unreadCount is 0", () => {
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.query(By.css(".notification-badge"))
+    ).toBeNull();
+  });
+
+  describe("onShow", () => {
+    it("loads notifications, zeroes the badge, and marks all read", () => {
+      fixture.detectChanges();
+      notificationService.list.mockReturnValue(
+        of(
+          makeResponse(
+            [
+              {
+                id: "n1",
+                type: "like",
+                actorUsername: "alice",
+                blueprintId: "bp1",
+                blueprintName: "Coal Setup",
+                commentId: null,
+                createdAt: new Date().toISOString(),
+                read: false,
+              },
+            ],
+            1
+          )
+        )
+      );
+      component.onShow();
+
+      expect(component.notifications).toHaveLength(1);
+      expect(component.unreadCount).toBe(0);
+      expect(notificationService.markAllRead).toHaveBeenCalled();
+    });
+
+    it("flags loadError on failure", () => {
+      fixture.detectChanges();
+      notificationService.list.mockReturnValue(
+        throwError(() => new Error("network"))
+      );
+      component.onShow();
+      expect(component.loadError).toBe(true);
+      expect(component.working).toBe(false);
+    });
+  });
+
+  describe("message", () => {
+    const base = {
+      id: "n1",
+      actorUsername: "alice",
+      blueprintId: "bp1",
+      blueprintName: null,
+      commentId: null,
+      createdAt: new Date().toISOString(),
+      read: false,
+    };
+
+    it("composes a message per notification type", () => {
+      expect(component.message({ ...base, type: "comment" } as any)).toContain(
+        "commented on your blueprint"
+      );
+      expect(component.message({ ...base, type: "reply" } as any)).toContain(
+        "replied to your comment"
+      );
+      expect(component.message({ ...base, type: "like" } as any)).toContain(
+        "liked your blueprint"
+      );
+      expect(component.message({ ...base, type: "fork" } as any)).toContain(
+        "forked your blueprint"
+      );
+      expect(component.message({ ...base, type: "follow" } as any)).toContain(
+        "started following you"
+      );
+    });
+  });
+
+  describe("link/fragment", () => {
+    const base = {
+      id: "n1",
+      actorUsername: "alice",
+      createdAt: new Date().toISOString(),
+      read: false,
+    };
+
+    it("links a follow notification to the actor's profile", () => {
+      const n = {
+        ...base,
+        type: "follow",
+        blueprintId: null,
+        commentId: null,
+      } as any;
+      expect(component.link(n)).toEqual(["/profile", "alice"]);
+      expect(component.fragment(n)).toBeUndefined();
+    });
+
+    it("links a comment notification to the blueprint with a comment fragment", () => {
+      const n = {
+        ...base,
+        type: "comment",
+        blueprintId: "bp1",
+        commentId: "c1",
+      } as any;
+      expect(component.link(n)).toEqual(["/blueprint", "bp1"]);
+      expect(component.fragment(n)).toBe("comment-c1");
+    });
+
+    it("links a like/fork notification to the blueprint with no fragment", () => {
+      const n = {
+        ...base,
+        type: "like",
+        blueprintId: "bp1",
+        commentId: null,
+      } as any;
+      expect(component.link(n)).toEqual(["/blueprint", "bp1"]);
+      expect(component.fragment(n)).toBeUndefined();
+    });
+  });
+
+  it("loadMore appends the next page and advances the cursor", () => {
+    fixture.detectChanges();
+    notificationService.list.mockReturnValue(
+      of(
+        makeResponse(
+          [
+            {
+              id: "n1",
+              type: "like",
+              actorUsername: "alice",
+              blueprintId: "bp1",
+              blueprintName: null,
+              commentId: null,
+              createdAt: new Date().toISOString(),
+              read: false,
+            },
+          ],
+          0,
+          1
+        )
+      )
+    );
+    component.onShow();
+    expect(component.notifications).toHaveLength(1);
+    expect(component.remaining).toBe(1);
+
+    notificationService.list.mockReturnValue(
+      of(
+        makeResponse(
+          [
+            {
+              id: "n2",
+              type: "follow",
+              actorUsername: "bob",
+              blueprintId: null,
+              blueprintName: null,
+              commentId: null,
+              createdAt: new Date().toISOString(),
+              read: false,
+            },
+          ],
+          0,
+          0
+        )
+      )
+    );
+    component.loadMore();
+    expect(component.notifications).toHaveLength(2);
+    expect(component.remaining).toBe(0);
+  });
+});

--- a/frontend/src/app/module-blueprint/components/notification-bell/notification-bell.component.ts
+++ b/frontend/src/app/module-blueprint/components/notification-bell/notification-bell.component.ts
@@ -1,0 +1,122 @@
+import { Component, OnDestroy, OnInit, ViewChild } from "@angular/core";
+import { Popover } from "primeng/popover";
+import { Subscription, interval } from "rxjs";
+import { switchMap, startWith } from "rxjs/operators";
+import { NotificationDto } from "../../../../../../lib/index";
+import { NotificationService } from "../../services/notification.service";
+import { AuthenticationService } from "../../services/authentification-service";
+
+const POLL_INTERVAL_MS = 45000;
+
+@Component({
+  selector: "app-notification-bell",
+  templateUrl: "./notification-bell.component.html",
+  styleUrls: ["./notification-bell.component.css"],
+  standalone: false,
+})
+export class NotificationBellComponent implements OnInit, OnDestroy {
+  @ViewChild("notifPanel") notifPanel!: Popover;
+
+  unreadCount = 0;
+  notifications: NotificationDto[] = [];
+  working = false;
+  loadError = false;
+  remaining = 0;
+  private oldestDate = new Date();
+  private pollSub?: Subscription;
+
+  constructor(
+    private notificationService: NotificationService,
+    public authService: AuthenticationService
+  ) {}
+
+  ngOnInit() {
+    if (!this.authService.isLoggedIn()) return;
+    this.pollSub = interval(POLL_INTERVAL_MS)
+      .pipe(
+        startWith(0),
+        switchMap(() => this.notificationService.list(new Date()))
+      )
+      .subscribe({
+        next: (response) => {
+          this.unreadCount = response.unreadCount;
+        },
+        error: () => {},
+      });
+  }
+
+  ngOnDestroy() {
+    this.pollSub?.unsubscribe();
+  }
+
+  toggle(event: Event) {
+    this.notifPanel.toggle(event);
+  }
+
+  hidePanel() {
+    this.notifPanel.hide();
+  }
+
+  onShow() {
+    this.working = true;
+    this.loadError = false;
+    this.oldestDate = new Date();
+    this.notificationService.list(this.oldestDate).subscribe({
+      next: (response) => {
+        this.working = false;
+        this.notifications = response.notifications;
+        this.remaining = response.remaining;
+        this.oldestDate = new Date(response.oldest);
+        this.unreadCount = 0;
+        this.notificationService.markAllRead().subscribe({ error: () => {} });
+      },
+      error: () => {
+        this.working = false;
+        this.loadError = true;
+      },
+    });
+  }
+
+  loadMore() {
+    this.working = true;
+    this.notificationService.list(this.oldestDate).subscribe({
+      next: (response) => {
+        this.working = false;
+        this.notifications = this.notifications.concat(response.notifications);
+        this.remaining = response.remaining;
+        this.oldestDate = new Date(response.oldest);
+      },
+      error: () => {
+        this.working = false;
+      },
+    });
+  }
+
+  message(n: NotificationDto): string {
+    switch (n.type) {
+      case "comment":
+        return $localize`${n.actorUsername} commented on your blueprint`;
+      case "reply":
+        return $localize`${n.actorUsername} replied to your comment`;
+      case "like":
+        return $localize`${n.actorUsername} liked your blueprint`;
+      case "fork":
+        return $localize`${n.actorUsername} forked your blueprint`;
+      case "follow":
+        return $localize`${n.actorUsername} started following you`;
+    }
+  }
+
+  link(n: NotificationDto): any[] {
+    if (n.type === "follow") return ["/profile", n.actorUsername];
+    if (n.blueprintId == null) return [];
+    return ["/blueprint", n.blueprintId];
+  }
+
+  fragment(n: NotificationDto): string | undefined {
+    if ((n.type === "comment" || n.type === "reply") && n.commentId != null) {
+      return "comment-" + n.commentId;
+    }
+    return undefined;
+  }
+}

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.css
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.css
@@ -121,6 +121,10 @@
   z-index: 4;
 }
 
+.view-mode-tabs {
+  margin: 20px 0 14px;
+}
+
 .blueprint-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.css
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.css
@@ -100,6 +100,21 @@
   font-variant-numeric: tabular-nums;
 }
 
+.profile-meta-link {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.profile-meta-link:hover {
+  text-decoration: underline;
+}
+
 .profile-actions {
   flex: none;
   position: relative;

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.html
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.html
@@ -134,6 +134,27 @@
         </div>
       </div>
 
+      <div class="view-mode-tabs bni-seg" *ngIf="isOwnProfile">
+        <button
+          type="button"
+          [class.active]="activeTab === 'blueprints'"
+          [attr.aria-pressed]="activeTab === 'blueprints'"
+          (click)="setTab('blueprints')"
+          i18n
+        >
+          Blueprints
+        </button>
+        <button
+          type="button"
+          [class.active]="activeTab === 'liked'"
+          [attr.aria-pressed]="activeTab === 'liked'"
+          (click)="setTab('liked')"
+          i18n
+        >
+          Liked
+        </button>
+      </div>
+
       <div class="blueprint-grid">
         <app-blueprint-card
           *ngFor="let item of blueprintListItems"

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.html
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.html
@@ -7,6 +7,7 @@
 
   <app-dialog-about #aboutDialog></app-dialog-about>
   <app-feedback-dialog #feedbackDialog></app-feedback-dialog>
+  <app-dialog-follow-list #followListDialog></app-dialog-follow-list>
 
   <div class="profile-page">
     <a class="bni-back" routerLink="/discover">
@@ -98,14 +99,22 @@
               ><b>{{ profile.blueprintCount }}</b
               >&nbsp;<ng-container i18n>blueprints</ng-container></span
             >
-            <span
-              ><b>{{ profile.followerCount }}</b
-              >&nbsp;<ng-container i18n>followers</ng-container></span
+            <button
+              type="button"
+              class="profile-meta-link"
+              (click)="followListDialog.showDialog(username, 'followers')"
             >
-            <span
-              ><b>{{ profile.followingCount }}</b
-              >&nbsp;<ng-container i18n>following</ng-container></span
+              <b>{{ profile.followerCount }}</b
+              >&nbsp;<ng-container i18n>followers</ng-container>
+            </button>
+            <button
+              type="button"
+              class="profile-meta-link"
+              (click)="followListDialog.showDialog(username, 'following')"
             >
+              <b>{{ profile.followingCount }}</b
+              >&nbsp;<ng-container i18n>following</ng-container>
+            </button>
           </div>
         </div>
 

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { By } from "@angular/platform-browser";
 import { DatePipe } from "@angular/common";
 import { ActivatedRoute, convertToParamMap } from "@angular/router";
 import { of, throwError } from "rxjs";
@@ -94,6 +95,14 @@ describe("ProfilePageComponent", () => {
     fixture.detectChanges();
     expect(component.notFound).toBe(true);
     expect(component.loadingProfile).toBe(false);
+  });
+
+  it("makes the follower and following counts clickable buttons", () => {
+    fixture.detectChanges();
+    const buttons = fixture.debugElement.queryAll(By.css(".profile-meta-link"));
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0].nativeElement.textContent).toContain("followers");
+    expect(buttons[1].nativeElement.textContent).toContain("following");
   });
 
   describe("isOwnProfile", () => {

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.spec.ts
@@ -97,6 +97,67 @@ describe("ProfilePageComponent", () => {
     expect(component.loadingProfile).toBe(false);
   });
 
+  describe("Liked tab", () => {
+    it("is only rendered on the viewer's own profile", () => {
+      authService.getUserDetails.mockReturnValue({ username: "bob" });
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css(".view-mode-tabs"))).toBeNull();
+
+      authService.getUserDetails.mockReturnValue({ username: "alice" });
+      fixture.detectChanges();
+      expect(
+        fixture.debugElement.query(By.css(".view-mode-tabs"))
+      ).toBeTruthy();
+    });
+
+    it("switching to Liked resets the list and requests likedBy blueprints", () => {
+      fixture.detectChanges();
+      component.blueprintListItems = [{ name: "stale" } as any];
+      blueprintService.getBlueprints.mockClear();
+
+      component.setTab("liked");
+
+      expect(component.activeTab).toBe("liked");
+      expect(
+        component.blueprintListItems.some((i: any) => i.name === "stale")
+      ).toBe(false);
+      expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
+        expect.any(Date),
+        null,
+        null,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "owner-1"
+      );
+    });
+
+    it("switching back to Blueprints requests owner-filtered blueprints", () => {
+      fixture.detectChanges();
+      component.setTab("liked");
+      blueprintService.getBlueprints.mockClear();
+
+      component.setTab("blueprints");
+
+      expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
+        expect.any(Date),
+        "owner-1",
+        null
+      );
+    });
+
+    it("is a no-op when already on the requested tab", () => {
+      fixture.detectChanges();
+      blueprintService.getBlueprints.mockClear();
+      component.setTab("blueprints");
+      expect(blueprintService.getBlueprints).not.toHaveBeenCalled();
+    });
+  });
+
   it("makes the follower and following counts clickable buttons", () => {
     fixture.detectChanges();
     const buttons = fixture.debugElement.queryAll(By.css(".profile-meta-link"));

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.ts
@@ -38,6 +38,7 @@ export class ProfilePageComponent implements OnInit {
   noMoreBlueprints = false;
   oldestDate = new Date();
   remaining = 0;
+  activeTab: "blueprints" | "liked" = "blueprints";
 
   loadingBlueprintItem: BlueprintListItem;
   nothingBlueprintItem: BlueprintListItem;
@@ -112,6 +113,7 @@ export class ProfilePageComponent implements OnInit {
     this.noMoreBlueprints = false;
     this.oldestDate = new Date();
     this.remaining = 0;
+    this.activeTab = "blueprints";
   }
 
   get isOwnProfile(): boolean {
@@ -205,16 +207,47 @@ export class ProfilePageComponent implements OnInit {
     }
   }
 
+  setTab(tab: "blueprints" | "liked") {
+    if (this.activeTab === tab) return;
+    this.activeTab = tab;
+    this.blueprintListItems = [];
+    this.working = true;
+    this.noMoreBlueprints = false;
+    this.oldestDate = new Date();
+    this.remaining = 0;
+    this.appendLoading();
+    this.loadBlueprints();
+  }
+
   loadBlueprints() {
     if (!this.profile) return;
-    this.blueprintService
-      .getBlueprints(this.oldestDate, this.profile.id, null)
-      .subscribe({
-        next: (r: any) => this.handleGetBlueprints(r),
-        error: () => {
-          this.working = false;
-        },
-      });
+    const request$ =
+      this.activeTab === "liked"
+        ? this.blueprintService.getBlueprints(
+            this.oldestDate,
+            null,
+            null,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            this.profile.id
+          )
+        : this.blueprintService.getBlueprints(
+            this.oldestDate,
+            this.profile.id,
+            null
+          );
+
+    request$.subscribe({
+      next: (r: any) => this.handleGetBlueprints(r),
+      error: () => {
+        this.working = false;
+      },
+    });
   }
 
   handleGetBlueprints(response: BlueprintListResponse) {

--- a/frontend/src/app/module-blueprint/components/site-nav/site-nav.component.html
+++ b/frontend/src/app/module-blueprint/components/site-nav/site-nav.component.html
@@ -29,6 +29,9 @@
     </ng-container>
   </ng-template>
   <ng-template pTemplate="end">
+    <app-notification-bell
+      *ngIf="authService.isLoggedIn()"
+    ></app-notification-bell>
     <app-user-menu
       (sendFeedback)="sendFeedback.emit()"
       (myBlueprintsRequested)="myBlueprintsRequested.emit($event)"

--- a/frontend/src/app/module-blueprint/module-blueprint.module.ts
+++ b/frontend/src/app/module-blueprint/module-blueprint.module.ts
@@ -96,6 +96,7 @@ import { CommentService } from "./services/comment.service";
 import { BlueprintVersionService } from "./services/blueprint-version.service";
 import { BrowsePageComponent } from "./components/browse-page/browse-page.component";
 import { ProfilePageComponent } from "./components/profile-page/profile-page.component";
+import { DialogFollowListComponent } from "./components/dialogs/dialog-follow-list/dialog-follow-list.component";
 
 @NgModule({
   declarations: [
@@ -151,6 +152,7 @@ import { ProfilePageComponent } from "./components/profile-page/profile-page.com
     BlueprintDetailsPageComponent,
     BrowsePageComponent,
     ProfilePageComponent,
+    DialogFollowListComponent,
   ],
   exports: [ComponentBlueprintParentComponent],
   imports: [

--- a/frontend/src/app/module-blueprint/module-blueprint.module.ts
+++ b/frontend/src/app/module-blueprint/module-blueprint.module.ts
@@ -97,6 +97,7 @@ import { BlueprintVersionService } from "./services/blueprint-version.service";
 import { BrowsePageComponent } from "./components/browse-page/browse-page.component";
 import { ProfilePageComponent } from "./components/profile-page/profile-page.component";
 import { DialogFollowListComponent } from "./components/dialogs/dialog-follow-list/dialog-follow-list.component";
+import { NotificationBellComponent } from "./components/notification-bell/notification-bell.component";
 
 @NgModule({
   declarations: [
@@ -153,6 +154,7 @@ import { DialogFollowListComponent } from "./components/dialogs/dialog-follow-li
     BrowsePageComponent,
     ProfilePageComponent,
     DialogFollowListComponent,
+    NotificationBellComponent,
   ],
   exports: [ComponentBlueprintParentComponent],
   imports: [

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -324,7 +324,8 @@ export class BlueprintService implements IObsBlueprintChange {
     sort?: "recent" | "popular" | "mostForked",
     skip?: number,
     filterModded?: boolean | null,
-    filterForkedFrom?: string | null
+    filterForkedFrom?: string | null,
+    filterLikedBy?: string | null
   ) {
     let parameterOlderThan = "olderthan=" + olderThan.getTime().toString();
 
@@ -360,6 +361,9 @@ export class BlueprintService implements IObsBlueprintChange {
     if (filterForkedFrom != null)
       parameterForkedFrom = "&forkedFrom=" + filterForkedFrom;
 
+    let parameterLikedBy = "";
+    if (filterLikedBy != null) parameterLikedBy = "&likedBy=" + filterLikedBy;
+
     let parameters =
       parameterOlderThan +
       parameterFilterUserId +
@@ -369,7 +373,8 @@ export class BlueprintService implements IObsBlueprintChange {
       parameterSubcategory +
       parameterSort +
       parameterModded +
-      parameterForkedFrom;
+      parameterForkedFrom +
+      parameterLikedBy;
 
     let request = this.authService.isLoggedIn()
       ? this.http.get("/api/getblueprintsSecure?" + parameters, {

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -322,7 +322,8 @@ export class BlueprintService implements IObsBlueprintChange {
     filterCategory?: string | null,
     filterSubcategory?: string | null,
     sort?: "recent" | "popular" | "mostForked",
-    skip?: number
+    skip?: number,
+    filterModded?: boolean | null
   ) {
     let parameterOlderThan = "olderthan=" + olderThan.getTime().toString();
 
@@ -351,6 +352,9 @@ export class BlueprintService implements IObsBlueprintChange {
       if (skip != null) parameterSort += "&skip=" + skip;
     }
 
+    let parameterModded = "";
+    if (filterModded != null) parameterModded = "&modded=" + filterModded;
+
     let parameters =
       parameterOlderThan +
       parameterFilterUserId +
@@ -358,7 +362,8 @@ export class BlueprintService implements IObsBlueprintChange {
       parameterGameVersion +
       parameterCategory +
       parameterSubcategory +
-      parameterSort;
+      parameterSort +
+      parameterModded;
 
     let request = this.authService.isLoggedIn()
       ? this.http.get("/api/getblueprintsSecure?" + parameters, {

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -323,7 +323,8 @@ export class BlueprintService implements IObsBlueprintChange {
     filterSubcategory?: string | null,
     sort?: "recent" | "popular" | "mostForked",
     skip?: number,
-    filterModded?: boolean | null
+    filterModded?: boolean | null,
+    filterForkedFrom?: string | null
   ) {
     let parameterOlderThan = "olderthan=" + olderThan.getTime().toString();
 
@@ -355,6 +356,10 @@ export class BlueprintService implements IObsBlueprintChange {
     let parameterModded = "";
     if (filterModded != null) parameterModded = "&modded=" + filterModded;
 
+    let parameterForkedFrom = "";
+    if (filterForkedFrom != null)
+      parameterForkedFrom = "&forkedFrom=" + filterForkedFrom;
+
     let parameters =
       parameterOlderThan +
       parameterFilterUserId +
@@ -363,7 +368,8 @@ export class BlueprintService implements IObsBlueprintChange {
       parameterCategory +
       parameterSubcategory +
       parameterSort +
-      parameterModded;
+      parameterModded +
+      parameterForkedFrom;
 
     let request = this.authService.isLoggedIn()
       ? this.http.get("/api/getblueprintsSecure?" + parameters, {

--- a/frontend/src/app/module-blueprint/services/notification.service.ts
+++ b/frontend/src/app/module-blueprint/services/notification.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from "@angular/core";
+import { HttpClient, HttpParams } from "@angular/common/http";
+import { Observable } from "rxjs";
+import { AuthenticationService } from "./authentification-service";
+import { NotificationListResponse } from "../../../../../lib/index";
+
+@Injectable({ providedIn: "root" })
+export class NotificationService {
+  constructor(
+    private http: HttpClient,
+    private authService: AuthenticationService
+  ) {}
+
+  private authHeaders() {
+    return { Authorization: `Bearer ${this.authService.getToken()}` };
+  }
+
+  list(olderThan: Date): Observable<NotificationListResponse> {
+    const params = new HttpParams().set(
+      "olderthan",
+      olderThan.getTime().toString()
+    );
+    return this.http.get<NotificationListResponse>("/api/notifications", {
+      params,
+      headers: this.authHeaders(),
+    });
+  }
+
+  markAllRead(): Observable<{ markRead: string }> {
+    return this.http.post<{ markRead: string }>(
+      "/api/notifications/mark-read",
+      {},
+      { headers: this.authHeaders() }
+    );
+  }
+}

--- a/frontend/src/app/module-blueprint/services/user-service.ts
+++ b/frontend/src/app/module-blueprint/services/user-service.ts
@@ -7,6 +7,7 @@ import {
   FollowRequest,
   UpdateBioRequest,
   BlueprintListResponse,
+  FollowListResponse,
 } from "../../../../../lib/index";
 
 @Injectable({ providedIn: "root" })
@@ -46,6 +47,37 @@ export class UserService {
     return this.http.patch<{ bio: string }>("/api/users/me", body, {
       headers: { Authorization: `Bearer ${this.authService.getToken()}` },
     });
+  }
+
+  private getConnections(
+    username: string,
+    mode: "followers" | "following",
+    olderThan: Date
+  ): Observable<FollowListResponse> {
+    const params = new HttpParams().set(
+      "olderthan",
+      olderThan.getTime().toString()
+    );
+    return this.http.get<FollowListResponse>(`/api/users/${username}/${mode}`, {
+      params,
+      headers: this.authService.isLoggedIn()
+        ? { Authorization: `Bearer ${this.authService.getToken()}` }
+        : {},
+    });
+  }
+
+  getFollowers(
+    username: string,
+    olderThan: Date
+  ): Observable<FollowListResponse> {
+    return this.getConnections(username, "followers", olderThan);
+  }
+
+  getFollowing(
+    username: string,
+    olderThan: Date
+  ): Observable<FollowListResponse> {
+    return this.getConnections(username, "following", olderThan);
   }
 
   getFeed(olderThan: Date): Observable<BlueprintListResponse> {

--- a/frontend/src/app/module-blueprint/utils/chip-tooltip.ts
+++ b/frontend/src/app/module-blueprint/utils/chip-tooltip.ts
@@ -1,0 +1,22 @@
+const GAME_VERSION_TOOLTIPS: Record<string, string> = {
+  base: $localize`:chipTooltip.base:Base game — no DLC required`,
+  spacedOut: $localize`:chipTooltip.spacedOut:Spaced Out — requires the Spaced Out! DLC`,
+  frostyPlanet: $localize`:chipTooltip.frostyPlanet:Frosty Planet — requires the Frosty Planet DLC`,
+  bionicBooster: $localize`:chipTooltip.bionicBooster:Bionic Booster — requires the Bionic Booster DLC`,
+};
+
+export function gameVersionTooltip(gameVersion: string): string {
+  return GAME_VERSION_TOOLTIPS[gameVersion] ?? gameVersion;
+}
+
+export function categoryTooltip(category: string): string {
+  return $localize`Browse ${category} blueprints`;
+}
+
+export function subcategoryTooltip(subcategory: string): string {
+  return $localize`Browse ${subcategory} blueprints`;
+}
+
+export function moddedTooltip(): string {
+  return $localize`:chipTooltip.modded:Uses mods not included in the base game`;
+}

--- a/frontend/src/bni-skin.css
+++ b/frontend/src/bni-skin.css
@@ -263,6 +263,11 @@
   background: transparent;
   color: var(--bni-muted);
   border: 1px solid var(--bni-line);
+  text-decoration: none;
+}
+
+a.bni-chip:hover {
+  border-color: var(--bni-muted);
 }
 
 .bni-chip--cat {

--- a/lib/src/coms/social.d.ts
+++ b/lib/src/coms/social.d.ts
@@ -15,4 +15,14 @@ export interface FollowRequest {
 export interface UpdateBioRequest {
     bio: string;
 }
+export interface FollowListEntry {
+    id: string;
+    username: string;
+    followedByMe: boolean;
+}
+export interface FollowListResponse {
+    users: FollowListEntry[];
+    oldest: string;
+    remaining: number;
+}
 //# sourceMappingURL=social.d.ts.map

--- a/lib/src/coms/social.d.ts
+++ b/lib/src/coms/social.d.ts
@@ -25,4 +25,21 @@ export interface FollowListResponse {
     oldest: string;
     remaining: number;
 }
+export type NotificationType = 'comment' | 'reply' | 'like' | 'fork' | 'follow';
+export interface NotificationDto {
+    id: string;
+    type: NotificationType;
+    actorUsername: string;
+    blueprintId?: string | null;
+    blueprintName?: string | null;
+    commentId?: string | null;
+    createdAt: string;
+    read: boolean;
+}
+export interface NotificationListResponse {
+    notifications: NotificationDto[];
+    unreadCount: number;
+    oldest: string;
+    remaining: number;
+}
 //# sourceMappingURL=social.d.ts.map

--- a/lib/src/coms/social.ts
+++ b/lib/src/coms/social.ts
@@ -17,3 +17,15 @@ export interface FollowRequest {
 export interface UpdateBioRequest {
   bio: string;
 }
+
+export interface FollowListEntry {
+  id: string;
+  username: string;
+  followedByMe: boolean;
+}
+
+export interface FollowListResponse {
+  users: FollowListEntry[];
+  oldest: string;
+  remaining: number;
+}

--- a/lib/src/coms/social.ts
+++ b/lib/src/coms/social.ts
@@ -29,3 +29,23 @@ export interface FollowListResponse {
   oldest: string;
   remaining: number;
 }
+
+export type NotificationType = 'comment' | 'reply' | 'like' | 'fork' | 'follow';
+
+export interface NotificationDto {
+  id: string;
+  type: NotificationType;
+  actorUsername: string;
+  blueprintId?: string | null;
+  blueprintName?: string | null;
+  commentId?: string | null;
+  createdAt: string;
+  read: boolean;
+}
+
+export interface NotificationListResponse {
+  notifications: NotificationDto[];
+  unreadCount: number;
+  oldest: string;
+  remaining: number;
+}


### PR DESCRIPTION
## Summary

Ships all seven Tier 2 items from `spec/social/ROADMAP.md` ("Obvious gaps — certain
value, small-to-medium effort"), one commit per item:

- **#6 Chip links** — category/subcategory/gameVersion/modded chips on cards and the
  details page now link to `/discover?...` with a tooltip explaining each value. Also
  adds the backend `modded` filter, which turned out not to exist at all (the roadmap
  assumed only the frontend hydration was missing).
- **#9 Forks list** — the fork count on the details page links to
  `/discover?forkedFrom=:id`; adds the backend `forkedFrom` filter.
- **#8 Comment deep-links** — the comment icon on cards links to
  `/blueprint/:id#comments`; every comment gets a stable `#comment-:id` anchor and the
  details page scrolls to it once comments finish loading (they fetch async, so the
  router's built-in anchor scrolling can't find the target in time).
- **#7 Follower/following lists** — `GET /api/users/:username/followers` and
  `/following` (cursor-paginated, personalized like `getProfile` already is), opened
  from a dialog on the profile page; rows show a "Following" tag for mutuals.
- **#10 Liked tab** — a Blueprints/Liked toggle on your own profile, backed by a new
  `likedBy` filter on the blueprint list endpoint.
- **#12 Share button** — the details page gets a share button reusing (refactored)
  `dialog-share-url`, plus a Reddit share link.
- **#11 Notifications** — the biggest item. A new `Notification` collection with
  fire-and-forget triggers on comment/reply/like/fork/follow (skipping self-actions),
  `GET /api/notifications` + `POST /api/notifications/mark-read`, and a polling bell
  next to the user menu. No push infra exists in this app, so it's poll-based (45s).

## Test plan

- [x] `npm run tsc` and `npm run build` clean
- [x] Backend: `npm run test` — 377 passing (Mocha/Chai), including new suites for
      every new filter, endpoint, and notification trigger
- [x] Frontend: `cd frontend && npm test` — 645 passing (Vitest), 2 pre-existing skips
- [x] Live-verified new endpoints against the running dev backend with `curl`
      (modded/forkedFrom filters, followers/following lists) against real seeded data
- [ ] Manual click-through in a browser wasn't done this session (Playwright's browser
      profile was locked by another process) — worth a spot-check at localhost:4200
      logged in as `dev_you` before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)