### PR TITLE
fix(previews): address review findings in server-render path

### DIFF
--- a/app/api/preview-controller.ts
+++ b/app/api/preview-controller.ts
@@ -35,7 +35,10 @@ export class PreviewController {
       const modifiedAt = blueprint.modifiedAt ?? null;
 
       const etag = `"${id}-${modifiedAt ? new Date(modifiedAt).getTime() : 0}-${variant}"`;
-      if (req.headers['if-none-match'] === etag) return res.status(304).send();
+      if (req.headers['if-none-match'] === etag) {
+        res.set({ ETag: etag });
+        return res.status(304).end();
+      }
 
       const result = await PreviewImageService.instance.getVariant(id, modifiedAt, variant, () =>
         BlueprintModel.model

--- a/app/api/services/preview-image-service.ts
+++ b/app/api/services/preview-image-service.ts
@@ -259,10 +259,13 @@ export class PreviewImageService {
         this.pending.clear();
         this.worker = null;
         this.workerReady = null;
+        reject(new Error('preview render worker exited'));
       });
 
       worker.on('error', err => {
         clearTimeout(startTimer);
+        this.worker = null;
+        this.workerReady = null;
         reject(err);
       });
     });

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
@@ -3,7 +3,7 @@ import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { By } from "@angular/platform-browser";
 import { Location } from "@angular/common";
 import { ActivatedRoute, convertToParamMap } from "@angular/router";
-import { of, throwError } from "rxjs";
+import { of, throwError, Subject } from "rxjs";
 
 import { BlueprintDetailsPageComponent } from "./blueprint-details-page.component";
 import { BlueprintService } from "../../services/blueprint-service";
@@ -113,6 +113,38 @@ describe("BlueprintDetailsPageComponent", () => {
     img.triggerEventHandler("error", {});
     fixture.detectChanges();
     expect(img.properties["src"]).toBe("data:image/png;base64,xyz");
+  });
+
+  it("clears a previous preview failure when switching to a different blueprint", () => {
+    const route = TestBed.inject(ActivatedRoute) as any;
+    const paramMap$ = new Subject<ReturnType<typeof convertToParamMap>>();
+    route.paramMap = paramMap$;
+
+    fixture = TestBed.createComponent(BlueprintDetailsPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    paramMap$.next(convertToParamMap({ id: "bp1" }));
+    fixture.detectChanges();
+
+    let img = fixture.debugElement.query(By.css(".details-thumbnail img"));
+    img.triggerEventHandler("error", {});
+    fixture.detectChanges();
+    expect(component.previewFailed).toBe(true);
+
+    blueprintService.getBlueprintDetails.mockReturnValue(
+      of(makeDetails({ id: "bp2", name: "Other Setup" }))
+    );
+    paramMap$.next(convertToParamMap({ id: "bp2" }));
+    fixture.detectChanges();
+
+    expect(component.previewFailed).toBe(false);
+    img = fixture.debugElement.query(By.css(".details-thumbnail img"));
+    expect(img.properties["src"]).toBe(
+      `/api/blueprints/bp2/preview/hero.webp?v=${new Date(
+        "2026-07-01"
+      ).getTime()}`
+    );
   });
 
   it("renders the details and passes the blueprint id to the comment section", () => {

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
@@ -102,6 +102,7 @@ export class BlueprintDetailsPageComponent implements OnInit {
     this.blueprintId = null;
     this.notFound = false;
     this.loadError = false;
+    this.previewFailed = false;
 
     if (id == null) {
       this.loading = false;

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.ts
@@ -172,6 +172,7 @@ export class DialogBrowseComponent implements OnInit {
     this.filterUserId = null as any;
     this.filterUserName = null as any;
     this.filterName = null as any;
+    this.previewFailed.clear();
 
     this.removeAll();
   }


### PR DESCRIPTION
- 304 responses now carry the ETag header and end without a body
- worker error/exit handlers reset cached worker state so ensureWorker() can spawn a fresh child instead of reusing a rejected/dead one, and reject a pending startup promise if the worker dies before ready
- clear stale previewFailed tracking on dialog reopen and blueprint navigation so a past render failure doesn't permanently suppress retries for that id/page