### PR TITLE
fix(previews): ship canvas native binding in prod image

### DIFF
--- a/deploy.Dockerfile
+++ b/deploy.Dockerfile
@@ -34,10 +34,16 @@ COPY ./frontend ./
 RUN npm run build -- --output-path=../build/app/public/
 RUN npm run build:admin -- --output-path=../build/app/public/admin/
 
-FROM --platform=amd64 node:20-alpine as serve-prod
+# Debian (glibc) base: node-canvas ships no musl prebuilds, and building it from
+# source on alpine needs the full cairo toolchain. The glibc prebuild is static.
+FROM --platform=amd64 node:20-slim as serve-prod
 WORKDIR /bpni
 COPY package*.json ./
 RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
+# --ignore-scripts skips canvas's install script (prebuild-install), which is what
+# fetches build/Release/canvas.node. Rebuild only canvas, then fail the build early
+# if the binding still can't load.
+RUN npm rebuild canvas && node -e "require('canvas')"
 COPY --from=build-backend /bpni/build /bpni/build
 COPY --from=build-frontend /bpni/build/app/public /bpni/build/app/public
 


### PR DESCRIPTION
## What

Prod preview rendering crashed on every request:

```
Error: Cannot find module '../build/Release/canvas.node'
```

The `serve-prod` stage of `deploy.Dockerfile` runs `npm ci --ignore-scripts`, which skips canvas's install script — the step (`prebuild-install`) that downloads the native binding. The new preview render worker (#115) is the first prod code path to load canvas, so the binding's absence only surfaced now.

A second, compounding problem: the runtime image was `node:20-alpine` (musl), and node-canvas 3.x publishes **glibc-only** prebuilds (verified against the v3.2.3 release assets — no `linux-musl` tarballs). Enabling scripts on alpine would have fallen back to a full cairo source build.

## Fix

- Runtime stage moves `node:20-alpine` → `node:20-slim` (glibc). Canvas's glibc prebuild is statically linked, so no system libraries are added; the render path is sprite-only (no text), so no fonts/fontconfig needed either.
- `--ignore-scripts` stays for everything else; `npm rebuild canvas` runs only canvas's install script.
- `node -e "require('canvas')"` after the rebuild fails the **image build** early instead of crashing at runtime in prod.
- Build stages stay alpine (tsc/Angular don't need the binding). `sharp` is unaffected — its prebuilds ship as regular npm packages, immune to `--ignore-scripts`.

## Verification

Ran the exact runtime-stage install sequence in a `linux/amd64 node:20-slim` container: `npm ci --omit=dev --ignore-scripts` → `npm rebuild canvas` → `require('canvas')`, then drew and encoded a PNG successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)