### PR TITLE
fix(previews): stop simultaneous preview requests from failing together

### DIFF
--- a/__tests__/api/preview.test.ts
+++ b/__tests__/api/preview.test.ts
@@ -140,6 +140,85 @@ describe('Blueprint preview images', function () {
       fs.rmSync(cacheDir, { recursive: true, force: true });
     });
 
+    it('renders one master at a time even when requests arrive together', async function () {
+      this.timeout(10000);
+      const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'preview-queue-'));
+      const fakeMaster = await sharp({
+        create: { width: 8, height: 8, channels: 4, background: { r: 0, g: 0, b: 0, alpha: 1 } },
+      })
+        .png()
+        .toBuffer();
+      let active = 0;
+      let maxActive = 0;
+      const service = new PreviewImageService({
+        cacheDir,
+        disabled: false,
+        renderMasterFn: async () => {
+          active++;
+          maxActive = Math.max(maxActive, active);
+          await new Promise(resolve => setTimeout(resolve, 20));
+          active--;
+          return fakeMaster;
+        },
+      });
+
+      const ids = [new Types.ObjectId(), new Types.ObjectId(), new Types.ObjectId()];
+      const results = await Promise.all(
+        ids.map(id =>
+          service.getVariant(id.toString(), null, 'card.webp', async () => ({ items: [] }))
+        )
+      );
+
+      results.forEach(result => expect(result).to.not.be.null);
+      expect(maxActive).to.equal(1);
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+    });
+
+    it('fails fast (fallback, not hang) when the render queue is full', async function () {
+      const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'preview-queue-'));
+      const fakeMaster = await sharp({
+        create: { width: 8, height: 8, channels: 4, background: { r: 0, g: 0, b: 0, alpha: 1 } },
+      })
+        .png()
+        .toBuffer();
+      let releaseFirst!: () => void;
+      const firstStarted = new Promise<void>(resolve => {
+        releaseFirst = resolve;
+      });
+      const service = new PreviewImageService({
+        cacheDir,
+        disabled: false,
+        renderQueueMax: 1,
+        renderMasterFn: async () => {
+          await firstStarted;
+          return fakeMaster;
+        },
+      });
+      const loadMdb = async () => ({ items: [] });
+
+      const first = service.getVariant(
+        new Types.ObjectId().toString(),
+        null,
+        'card.webp',
+        loadMdb
+      );
+      await new Promise(resolve => setImmediate(resolve));
+
+      // Queue holds one render (the active one); the next request is shed
+      // immediately so the controller serves the legacy thumbnail.
+      const second = await service.getVariant(
+        new Types.ObjectId().toString(),
+        null,
+        'card.webp',
+        loadMdb
+      );
+      expect(second).to.be.null;
+
+      releaseFirst();
+      expect(await first).to.not.be.null;
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+    });
+
     it('falls back to the legacy thumbnail when the renderer fails', async function () {
       const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'preview-test-'));
       PreviewImageService.setInstance(

--- a/app/api/services/preview-image-service.ts
+++ b/app/api/services/preview-image-service.ts
@@ -59,16 +59,20 @@ export class PreviewImageService {
   private pending = new Map<number, PendingRequest>();
   private idleTimer: NodeJS.Timeout | null = null;
   private inFlight = new Map<string, Promise<void>>();
+  private renderQueueTail: Promise<unknown> = Promise.resolve();
+  private renderQueueDepth = 0;
 
   private readonly cacheDir: string;
   private readonly idleShutdownMs: number;
   private readonly renderMasterFn: RenderMasterFn;
+  private readonly renderQueueMax: number;
   private readonly disabled: boolean;
 
   constructor(options?: {
     cacheDir?: string;
     renderMasterFn?: RenderMasterFn;
     idleShutdownMs?: number;
+    renderQueueMax?: number;
     disabled?: boolean;
   }) {
     this.cacheDir =
@@ -78,6 +82,9 @@ export class PreviewImageService {
     this.idleShutdownMs =
       options?.idleShutdownMs ?? Number(process.env.PREVIEW_WORKER_IDLE_MS ?? 120_000);
     this.renderMasterFn = options?.renderMasterFn ?? (mdb => this.renderMasterInWorker(mdb));
+    const queueMaxRaw =
+      options?.renderQueueMax ?? Number(process.env.PREVIEW_RENDER_QUEUE_MAX ?? 8);
+    this.renderQueueMax = Number.isFinite(queueMaxRaw) && queueMaxRaw > 0 ? queueMaxRaw : 8;
     // Default off in tests (no canvas/PIXI in CI) and behind an env kill switch.
     this.disabled =
       options?.disabled ??
@@ -145,11 +152,31 @@ export class PreviewImageService {
     }
   }
 
+  /**
+   * Serialize master renders: the worker rasterizes one blueprint at a time,
+   * so dispatching concurrently only made every caller share one wall-clock
+   * timeout budget — a page of card requests would queue on the worker and
+   * then all time out together. The render timeout now covers only the
+   * active render. Depth is capped so a pile-up fails fast (callers serve the
+   * legacy thumbnail) instead of holding requests for minutes.
+   */
+  private enqueueMasterRender(mdb: unknown): Promise<Buffer> {
+    if (this.renderQueueDepth >= this.renderQueueMax) {
+      return Promise.reject(
+        new Error(`preview render queue full (${this.renderQueueDepth} waiting)`)
+      );
+    }
+    this.renderQueueDepth++;
+    const render = this.renderQueueTail.then(() => this.renderMasterFn(mdb));
+    this.renderQueueTail = render.catch(() => undefined);
+    return render.finally(() => this.renderQueueDepth--);
+  }
+
   private async renderAllVariants(blueprintId: string, loadMdb: () => Promise<unknown | null>) {
     const mdb = await loadMdb();
     if (mdb == null) throw new Error('blueprint has no data');
 
-    const masterPng = await this.renderMasterFn(mdb);
+    const masterPng = await this.enqueueMasterRender(mdb);
 
     const dir = path.join(this.cacheDir, blueprintId);
     await fs.promises.mkdir(dir, { recursive: true });
@@ -202,6 +229,10 @@ export class PreviewImageService {
           const requestId = this.nextRequestId++;
           const timer = setTimeout(() => {
             this.pending.delete(requestId);
+            // Renders are serialized, so a timeout means the worker is wedged
+            // on this render; recycle it so the next render forks fresh
+            // instead of waiting behind the stuck one.
+            this.stopWorker();
             reject(new Error('preview render timed out'));
           }, RENDER_TIMEOUT_MS);
           this.pending.set(requestId, {

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.html
@@ -8,10 +8,9 @@
     [state]="linkState"
   >
     <img
-      [src]="previewFailed ? item.thumbnail : cardPreviewUrl()"
-      (error)="previewFailed = true"
+      [appQueuedPreview]="cardPreviewUrl()"
+      [previewFallback]="item.thumbnail"
       [alt]="item.name"
-      loading="lazy"
       width="480"
       height="480"
     />

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.spec.ts
@@ -3,6 +3,7 @@ import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { By } from "@angular/platform-browser";
 
 import { BlueprintCardComponent } from "./blueprint-card.component";
+import { QueuedPreviewDirective } from "../../directives/queued-preview.directive";
 
 function makeItem(overrides: any = {}) {
   return {
@@ -32,6 +33,7 @@ describe("BlueprintCardComponent", () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [BlueprintCardComponent],
+      imports: [QueuedPreviewDirective],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
@@ -63,10 +65,9 @@ describe("BlueprintCardComponent", () => {
     fixture.detectChanges();
 
     const img = fixture.debugElement.query(By.css(".bni-card__thumb img"));
-    expect(img.properties["src"]).toBe(
+    expect(img.nativeElement.getAttribute("src")).toBe(
       "/api/blueprints/bp-1/preview/card.webp?v=1700000000000"
     );
-    expect(img.attributes["loading"]).toBe("lazy");
   });
 
   it("falls back to the inline thumbnail when the server preview errors", () => {
@@ -77,7 +78,9 @@ describe("BlueprintCardComponent", () => {
     img.triggerEventHandler("error", {});
     fixture.detectChanges();
 
-    expect(img.properties["src"]).toBe("data:image/png;base64,xyz");
+    expect(img.nativeElement.getAttribute("src")).toBe(
+      "data:image/png;base64,xyz"
+    );
   });
 
   it("shows the Untagged chip when there is no category, and the category chip when there is", () => {

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.ts
@@ -23,9 +23,6 @@ export class BlueprintCardComponent {
   readonly gameVersionTooltip = gameVersionTooltip;
   readonly moddedTooltip = moddedTooltip;
 
-  /** Falls back to the legacy inline thumbnail when the server render 404s/errors. */
-  previewFailed = false;
-
   isReal(thumbnail: string): boolean {
     return thumbnail !== "svg" && thumbnail !== "svg_nothing";
   }

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.html
@@ -41,13 +41,8 @@
       <div class="thumbnail">
         <img
           *ngIf="isReal(item.thumbnail)"
-          [src]="
-            item.id && !previewFailed.has(item.id)
-              ? previewUrl(item)
-              : item.thumbnail
-          "
-          (error)="onPreviewError(item)"
-          loading="lazy"
+          [appQueuedPreview]="previewUrl(item)"
+          [previewFallback]="item.thumbnail"
         />
         <svg
           *ngIf="item.thumbnail === 'svg'"

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.ts
@@ -91,16 +91,9 @@ export class DialogBrowseComponent implements OnInit {
     return thumbnail != "svg" && thumbnail != "svg_nothing";
   }
 
-  /** Ids whose server-rendered preview failed; those fall back to the inline thumbnail. */
-  previewFailed = new Set<string>();
-
   previewUrl(item: BlueprintListItem): string {
     const version = item.modifiedAt ? new Date(item.modifiedAt).getTime() : 0;
     return `/api/blueprints/${item.id}/preview/card.webp?v=${version}`;
-  }
-
-  onPreviewError(item: BlueprintListItem) {
-    if (item.id) this.previewFailed.add(item.id);
   }
 
   ngOnInit() {
@@ -172,7 +165,6 @@ export class DialogBrowseComponent implements OnInit {
     this.filterUserId = null as any;
     this.filterUserName = null as any;
     this.filterName = null as any;
-    this.previewFailed.clear();
 
     this.removeAll();
   }

--- a/frontend/src/app/module-blueprint/directives/queued-preview.directive.spec.ts
+++ b/frontend/src/app/module-blueprint/directives/queued-preview.directive.spec.ts
@@ -1,0 +1,83 @@
+import { Component } from "@angular/core";
+import { NgIf } from "@angular/common";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+
+import { QueuedPreviewDirective } from "./queued-preview.directive";
+
+@Component({
+  template: `
+    <img
+      id="a"
+      *ngIf="showA"
+      [appQueuedPreview]="urlA"
+      [previewFallback]="fallbackA"
+    />
+    <img id="b" *ngIf="showB" [appQueuedPreview]="urlB" />
+  `,
+  standalone: true,
+  imports: [NgIf, QueuedPreviewDirective],
+})
+class HostComponent {
+  showA = true;
+  showB = true;
+  urlA = "/api/blueprints/a/preview/card.webp?v=1";
+  urlB = "/api/blueprints/b/preview/card.webp?v=1";
+  fallbackA = "data:image/png;base64,aaa";
+}
+
+describe("QueuedPreviewDirective", () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  const img = (id: string) =>
+    fixture.debugElement.query(By.css(`#${id}`)).nativeElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+  });
+
+  it("loads one preview at a time", () => {
+    expect(img("a").getAttribute("src")).toBe(
+      "/api/blueprints/a/preview/card.webp?v=1"
+    );
+    expect(img("b").getAttribute("src")).toBeNull();
+
+    img("a").dispatchEvent(new Event("load"));
+
+    expect(img("b").getAttribute("src")).toBe(
+      "/api/blueprints/b/preview/card.webp?v=1"
+    );
+  });
+
+  it("swaps to the fallback on error and frees the slot", () => {
+    img("a").dispatchEvent(new Event("error"));
+
+    expect(img("a").getAttribute("src")).toBe("data:image/png;base64,aaa");
+    expect(img("b").getAttribute("src")).toBe(
+      "/api/blueprints/b/preview/card.webp?v=1"
+    );
+  });
+
+  it("does not loop when the fallback itself errors", () => {
+    img("a").dispatchEvent(new Event("error"));
+    img("a").dispatchEvent(new Event("error"));
+
+    expect(img("a").getAttribute("src")).toBe("data:image/png;base64,aaa");
+  });
+
+  it("frees the slot when the active image is destroyed", () => {
+    // b is waiting behind a; destroying a mid-load must not strand it.
+    expect(img("b").getAttribute("src")).toBeNull();
+    fixture.componentInstance.showA = false;
+    fixture.detectChanges();
+
+    expect(img("b").getAttribute("src")).toBe(
+      "/api/blueprints/b/preview/card.webp?v=1"
+    );
+  });
+});

--- a/frontend/src/app/module-blueprint/directives/queued-preview.directive.ts
+++ b/frontend/src/app/module-blueprint/directives/queued-preview.directive.ts
@@ -1,0 +1,85 @@
+import {
+  Directive,
+  ElementRef,
+  HostListener,
+  Input,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges,
+} from "@angular/core";
+import {
+  PreviewQueueService,
+  PreviewQueueTicket,
+} from "../services/preview-queue.service";
+
+/**
+ * If neither load nor error ever fires (stalled connection, tab throttling),
+ * free the slot anyway so one bad request cannot wedge the whole queue.
+ */
+const LOAD_SAFETY_TIMEOUT_MS = 30_000;
+
+/**
+ * Loads a server-rendered preview through PreviewQueueService: the img gets
+ * its src only when no earlier preview is still loading, and swaps to the
+ * legacy inline thumbnail if the preview request errors. Do not combine with
+ * loading="lazy" — a deferred offscreen fetch never fires load and would
+ * stall the queue.
+ */
+@Directive({
+  selector: "img[appQueuedPreview]",
+  standalone: true,
+})
+export class QueuedPreviewDirective implements OnChanges, OnDestroy {
+  @Input("appQueuedPreview") previewUrl!: string;
+  /** Legacy inline thumbnail (data url) used when the preview request errors. */
+  @Input() previewFallback: string | null = null;
+
+  private ticket: PreviewQueueTicket | null = null;
+  private safetyTimer: ReturnType<typeof setTimeout> | null = null;
+  private fallbackApplied = false;
+
+  constructor(
+    private element: ElementRef<HTMLImageElement>,
+    private queue: PreviewQueueService
+  ) {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (!changes["previewUrl"]) return;
+    this.releaseSlot();
+    this.fallbackApplied = false;
+    this.ticket = this.queue.enqueue(() => {
+      this.element.nativeElement.src = this.previewUrl;
+      this.safetyTimer = setTimeout(
+        () => this.releaseSlot(),
+        LOAD_SAFETY_TIMEOUT_MS
+      );
+    });
+  }
+
+  @HostListener("load")
+  onLoad() {
+    this.releaseSlot();
+  }
+
+  @HostListener("error")
+  onError() {
+    if (this.previewFallback && !this.fallbackApplied) {
+      this.fallbackApplied = true;
+      this.element.nativeElement.src = this.previewFallback;
+    }
+    this.releaseSlot();
+  }
+
+  ngOnDestroy() {
+    this.releaseSlot();
+  }
+
+  private releaseSlot() {
+    if (this.safetyTimer) {
+      clearTimeout(this.safetyTimer);
+      this.safetyTimer = null;
+    }
+    this.ticket?.done();
+    this.ticket = null;
+  }
+}

--- a/frontend/src/app/module-blueprint/module-blueprint.module.ts
+++ b/frontend/src/app/module-blueprint/module-blueprint.module.ts
@@ -57,6 +57,7 @@ import { ItemCollectionInfoComponent } from "./components/side-bar/item-collecti
 import { DialogBrowseComponent } from "./components/dialogs/dialog-browse/dialog-browse.component";
 import { DialogExportImagesComponent } from "./components/dialogs/dialog-export-images/dialog-export-images.component";
 import { BlueprintNameValidationDirective } from "./directives/blueprint-name-validation.directive";
+import { QueuedPreviewDirective } from "./directives/queued-preview.directive";
 import { LikeWidgetComponent } from "./components/like-widget/like-widget.component";
 import { ForkButtonComponent } from "./components/fork-button/fork-button.component";
 import { BlueprintCardComponent } from "./components/blueprint-card/blueprint-card.component";
@@ -159,6 +160,7 @@ import { NotificationBellComponent } from "./components/notification-bell/notifi
   exports: [ComponentBlueprintParentComponent],
   imports: [
     CommonModule,
+    QueuedPreviewDirective,
     RouterModule,
     FormsModule,
     ReactiveFormsModule,

--- a/frontend/src/app/module-blueprint/services/preview-queue.service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/preview-queue.service.spec.ts
@@ -1,0 +1,49 @@
+import { PreviewQueueService } from "./preview-queue.service";
+
+describe("PreviewQueueService", () => {
+  let service: PreviewQueueService;
+
+  beforeEach(() => {
+    service = new PreviewQueueService();
+  });
+
+  it("starts the first task immediately and holds later ones", () => {
+    const started: string[] = [];
+    service.enqueue(() => started.push("a"));
+    service.enqueue(() => started.push("b"));
+    service.enqueue(() => started.push("c"));
+
+    expect(started).toEqual(["a"]);
+  });
+
+  it("starts the next task when the active one finishes", () => {
+    const started: string[] = [];
+    const first = service.enqueue(() => started.push("a"));
+    service.enqueue(() => started.push("b"));
+
+    first.done();
+    expect(started).toEqual(["a", "b"]);
+  });
+
+  it("removes a waiting task without starting it", () => {
+    const started: string[] = [];
+    const first = service.enqueue(() => started.push("a"));
+    const second = service.enqueue(() => started.push("b"));
+    service.enqueue(() => started.push("c"));
+
+    second.done();
+    first.done();
+    expect(started).toEqual(["a", "c"]);
+  });
+
+  it("ignores repeated done() calls", () => {
+    const started: string[] = [];
+    const first = service.enqueue(() => started.push("a"));
+    service.enqueue(() => started.push("b"));
+    service.enqueue(() => started.push("c"));
+
+    first.done();
+    first.done();
+    expect(started).toEqual(["a", "b"]);
+  });
+});

--- a/frontend/src/app/module-blueprint/services/preview-queue.service.ts
+++ b/frontend/src/app/module-blueprint/services/preview-queue.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from "@angular/core";
+
+export interface PreviewQueueTicket {
+  /**
+   * Idempotent: removes a still-waiting task from the queue, or frees the
+   * active slot so the next waiting task starts.
+   */
+  done(): void;
+}
+
+/**
+ * Serializes server-rendered preview loads so each client has at most one
+ * preview request in flight. The backend renders previews one at a time; a
+ * page of cards firing 20+ simultaneous requests just queued on the render
+ * worker until they all timed out together.
+ */
+@Injectable({ providedIn: "root" })
+export class PreviewQueueService {
+  private queue: Array<() => void> = [];
+  private activeCount = 0;
+  private readonly maxConcurrent = 1;
+
+  /** Queues `start`; it runs (synchronously if the slot is free) once no earlier task is active. */
+  enqueue(start: () => void): PreviewQueueTicket {
+    let state: "waiting" | "active" | "done" = "waiting";
+    const run = () => {
+      state = "active";
+      this.activeCount++;
+      start();
+    };
+    this.queue.push(run);
+    this.pump();
+    return {
+      done: () => {
+        if (state === "done") return;
+        const wasActive = state === "active";
+        state = "done";
+        if (wasActive) {
+          this.activeCount--;
+          this.pump();
+        } else {
+          this.queue = this.queue.filter((task) => task !== run);
+        }
+      },
+    };
+  }
+
+  private pump() {
+    while (this.activeCount < this.maxConcurrent && this.queue.length > 0) {
+      this.queue.shift()!();
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Loading the discover page or editor browse dialog fires 20+ simultaneous `card.webp` requests. The render worker rasterizes one blueprint at a time, but the parent dispatched every render immediately with a 30s timeout measured **from dispatch** — so the whole burst queued on the worker and then timed out together in one mass failure.

## What shipped

**Backend — serialize renders, shed overload** (`preview-image-service.ts`)
- Master renders now run one at a time through a promise-chain queue; the 30s timeout covers only the *active* render.
- A timed-out worker is recycled so the next render forks fresh instead of waiting behind a wedged one.
- Queue depth is capped (`PREVIEW_RENDER_QUEUE_MAX`, default 8). When full, the request fails fast and the controller serves the legacy stored thumbnail instead of hanging.

**Frontend — one preview request in flight per client**
- New `PreviewQueueService` (concurrency 1) + `QueuedPreviewDirective` (`img[appQueuedPreview]`): the img only gets its `src` once no earlier preview is still loading; `load`/`error`/destroy free the slot, with a 30s safety timer so a stalled request can't wedge the queue.
- On error the directive swaps to the legacy inline thumbnail (replaces the per-component `previewFailed` tracking in the card component and browse dialog).
- Applied to blueprint cards (discover + profile pages) and the editor browse dialog. The details-page hero is a single request and stays as-is.
- `loading="lazy"` dropped on queued imgs: a deferred offscreen fetch never fires `load` and would stall the queue.

## Deviations / notes
- This is the short-term fix from the session request; the longer-term "more powerful, faster, more proactive" preview pipeline (e.g. render-on-save, pre-warming) is deferred.
- Offscreen cards now do fetch their previews (sequentially) since lazy-loading was removed — deliberate trade-off to keep the queue simple and warm the server cache.

## Verification
- Backend: 9/9 preview tests passing, including two new ones (renders serialized under concurrent requests; queue-full sheds to fallback instead of hanging). `npm run tsc` clean.
- Frontend: full suite 657 passing, including new specs for `PreviewQueueService` (4) and `QueuedPreviewDirective` (4: serialization, error fallback, no fallback loop, destroyed-image slot release).
- Pre-existing flake: `workos-provision.test.ts` times out intermittently on a loaded machine (fails on clean master too; unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)