### PR TITLE
perf(previews): raw-pixel IPC, pre-warmed worker, phase timings

### DIFF
--- a/__tests__/api/preview.test.ts
+++ b/__tests__/api/preview.test.ts
@@ -140,6 +140,47 @@ describe('Blueprint preview images', function () {
       fs.rmSync(cacheDir, { recursive: true, force: true });
     });
 
+    it('derives variants from a raw-pixel master (the render worker format)', async function () {
+      this.timeout(10000);
+      const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'preview-raw-'));
+      // 64x64 opaque green RGBA — what the worker ships instead of a PNG.
+      const raw = Buffer.alloc(64 * 64 * 4);
+      for (let i = 0; i < raw.length; i += 4) {
+        raw[i + 1] = 200;
+        raw[i + 3] = 255;
+      }
+      PreviewImageService.setInstance(
+        new PreviewImageService({
+          cacheDir,
+          disabled: false,
+          renderMasterFn: async () => ({ raw, width: 64, height: 64 }),
+        })
+      );
+
+      const card = await TestSetup.request().get(
+        `/api/blueprints/${blueprintId}/preview/card.webp`
+      );
+      expect(card.status).to.equal(200);
+      expect(card.headers['content-type']).to.match(/image\/webp/);
+      const cardMeta = await sharp(card.body).metadata();
+      expect(cardMeta.width).to.equal(480);
+
+      const og = await TestSetup.request().get(`/api/blueprints/${blueprintId}/preview/og.png`);
+      expect(og.status).to.equal(200);
+      const ogMeta = await sharp(og.body).metadata();
+      expect(ogMeta.width).to.equal(1200);
+      expect(ogMeta.height).to.equal(630);
+      // Center pixel keeps the green channel — guards against channel swaps.
+      const center = await sharp(og.body)
+        .extract({ left: 600, top: 315, width: 1, height: 1 })
+        .raw()
+        .toBuffer();
+      expect(center[1]).to.be.greaterThan(center[0]);
+      expect(center[1]).to.be.greaterThan(center[2]);
+
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+    });
+
     it('renders one master at a time even when requests arrive together', async function () {
       this.timeout(10000);
       const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'preview-queue-'));

--- a/app/api/services/preview-image-service.ts
+++ b/app/api/services/preview-image-service.ts
@@ -34,10 +34,20 @@ export interface PreviewRenderResult {
   contentType: string;
 }
 
-type RenderMasterFn = (mdb: unknown) => Promise<Buffer>;
+/** Raw RGBA pixels as produced by the render worker (sharp raw input). */
+export interface RawMaster {
+  raw: Buffer;
+  width: number;
+  height: number;
+}
+
+/** A master render: raw pixels from the worker, or an encoded image (tests). */
+export type MasterImage = Buffer | RawMaster;
+
+type RenderMasterFn = (mdb: unknown) => Promise<MasterImage>;
 
 interface PendingRequest {
-  resolve: (pngBase64: string) => void;
+  resolve: (master: RawMaster) => void;
   reject: (err: Error) => void;
   timer: NodeJS.Timeout;
 }
@@ -79,8 +89,11 @@ export class PreviewImageService {
       options?.cacheDir ??
       process.env.PREVIEW_CACHE_DIR ??
       path.resolve(__dirname, '../../../preview-cache');
+    // 0 disables idle shutdown (the default): the server idles most of the
+    // time and a resident warm worker (~200-380MB) is what keeps renders off
+    // the cold-start path. The RSS recycle remains the memory backstop.
     this.idleShutdownMs =
-      options?.idleShutdownMs ?? Number(process.env.PREVIEW_WORKER_IDLE_MS ?? 120_000);
+      options?.idleShutdownMs ?? Number(process.env.PREVIEW_WORKER_IDLE_MS ?? 0);
     this.renderMasterFn = options?.renderMasterFn ?? (mdb => this.renderMasterInWorker(mdb));
     const queueMaxRaw =
       options?.renderQueueMax ?? Number(process.env.PREVIEW_RENDER_QUEUE_MAX ?? 8);
@@ -160,28 +173,43 @@ export class PreviewImageService {
    * active render. Depth is capped so a pile-up fails fast (callers serve the
    * legacy thumbnail) instead of holding requests for minutes.
    */
-  private enqueueMasterRender(mdb: unknown): Promise<Buffer> {
+  private enqueueMasterRender(
+    mdb: unknown
+  ): Promise<{ master: MasterImage; queueWaitMs: number; masterMs: number; cold: boolean }> {
     if (this.renderQueueDepth >= this.renderQueueMax) {
       return Promise.reject(
         new Error(`preview render queue full (${this.renderQueueDepth} waiting)`)
       );
     }
     this.renderQueueDepth++;
-    const render = this.renderQueueTail.then(() => this.renderMasterFn(mdb));
+    const enqueuedAt = Date.now();
+    const render = this.renderQueueTail.then(async () => {
+      const startedAt = Date.now();
+      const cold = this.worker == null;
+      const master = await this.renderMasterFn(mdb);
+      return { master, queueWaitMs: startedAt - enqueuedAt, masterMs: Date.now() - startedAt, cold };
+    });
     this.renderQueueTail = render.catch(() => undefined);
     return render.finally(() => this.renderQueueDepth--);
   }
 
   private async renderAllVariants(blueprintId: string, loadMdb: () => Promise<unknown | null>) {
+    const totalStart = Date.now();
     const mdb = await loadMdb();
     if (mdb == null) throw new Error('blueprint has no data');
+    const loadMdbMs = Date.now() - totalStart;
 
-    const masterPng = await this.enqueueMasterRender(mdb);
+    const { master: masterImage, queueWaitMs, masterMs, cold } = await this.enqueueMasterRender(mdb);
+    const derivativesStart = Date.now();
 
     const dir = path.join(this.cacheDir, blueprintId);
     await fs.promises.mkdir(dir, { recursive: true });
 
-    const master = sharp(masterPng);
+    const master = Buffer.isBuffer(masterImage)
+      ? sharp(masterImage)
+      : sharp(masterImage.raw, {
+          raw: { width: masterImage.width, height: masterImage.height, channels: 4 },
+        });
     const card = master
       .clone()
       .resize(CARD_SIZE, CARD_SIZE, { fit: 'contain', background: { r: 0, g: 0, b: 0, alpha: 0 } })
@@ -193,9 +221,12 @@ export class PreviewImageService {
     const og = master
       .clone()
       .trim({ background: { r: 0, g: 0, b: 0, alpha: 0 }, threshold: 1 })
-      .toBuffer()
-      .then(trimmed =>
-        sharp(trimmed)
+      .raw()
+      .toBuffer({ resolveWithObject: true })
+      .then(({ data, info }) =>
+        sharp(data, {
+          raw: { width: info.width, height: info.height, channels: info.channels as 4 },
+        })
           .resize(OG_WIDTH - OG_MARGIN * 2, OG_HEIGHT - OG_MARGIN * 2, {
             fit: 'contain',
             background: { r: 255, g: 255, b: 255, alpha: 1 },
@@ -218,14 +249,22 @@ export class PreviewImageService {
       fs.promises.writeFile(path.join(dir, 'hero.webp'), heroBuf),
       fs.promises.writeFile(path.join(dir, 'og.png'), ogBuf),
     ]);
+
+    // Phase timings (spec/social/preview-images-perf.md Phase 0). The worker
+    // logs its own sub-phases (import/textures/rasterize/encode) per request.
+    console.log(
+      `preview render ${blueprintId}: loadMdb=${loadMdbMs}ms queueWait=${queueWaitMs}ms` +
+        ` master=${masterMs}ms${cold ? ' (cold)' : ''}` +
+        ` derivatives=${Date.now() - derivativesStart}ms total=${Date.now() - totalStart}ms`
+    );
   }
 
   // --- worker process management ---
 
-  private renderMasterInWorker(mdb: unknown): Promise<Buffer> {
+  private renderMasterInWorker(mdb: unknown): Promise<RawMaster> {
     return this.ensureWorker().then(
       () =>
-        new Promise<Buffer>((resolve, reject) => {
+        new Promise<RawMaster>((resolve, reject) => {
           const requestId = this.nextRequestId++;
           const timer = setTimeout(() => {
             this.pending.delete(requestId);
@@ -235,11 +274,7 @@ export class PreviewImageService {
             this.stopWorker();
             reject(new Error('preview render timed out'));
           }, RENDER_TIMEOUT_MS);
-          this.pending.set(requestId, {
-            resolve: pngBase64 => resolve(Buffer.from(pngBase64, 'base64')),
-            reject,
-            timer,
-          });
+          this.pending.set(requestId, { resolve, reject, timer });
           this.worker!.send({ type: 'render', requestId, mdb, size: MASTER_SIZE });
           this.scheduleIdleShutdown();
         })
@@ -255,6 +290,9 @@ export class PreviewImageService {
       execArgv: isTs ? ['-r', 'ts-node/register/transpile-only'] : [],
       env: { ...process.env, TS_NODE_TRANSPILE_ONLY: '1' },
       stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+      // Structured clone instead of JSON: the rendered master crosses the
+      // channel as a Buffer, not a base64 string inside a JSON megastring.
+      serialization: 'advanced',
     });
     this.worker = worker;
 
@@ -276,8 +314,13 @@ export class PreviewImageService {
           if (!pendingRequest) return;
           this.pending.delete(message.requestId);
           clearTimeout(pendingRequest.timer);
-          if (message.type === 'rendered') pendingRequest.resolve(message.pngBase64);
-          else pendingRequest.reject(new Error(message.message));
+          if (message.type === 'rendered') {
+            pendingRequest.resolve({
+              raw: Buffer.isBuffer(message.raw) ? message.raw : Buffer.from(message.raw),
+              width: message.width,
+              height: message.height,
+            });
+          } else pendingRequest.reject(new Error(message.message));
         }
       });
 
@@ -297,6 +340,10 @@ export class PreviewImageService {
         this.worker = null;
         this.workerReady = null;
         reject(new Error(reason));
+        // A clean self-exit is the RSS recycle (the worker only does it
+        // between renders). Re-fork right away so the next render stays warm.
+        // Crashes (code>0) and signals stay lazy — no re-fork loop.
+        if (code === 0 && signal == null) setImmediate(() => this.warmUp());
       });
 
       worker.on('error', err => {
@@ -310,7 +357,18 @@ export class PreviewImageService {
     return this.workerReady;
   }
 
+  /**
+   * Fork the render worker ahead of the first request (server boot, or after
+   * an RSS recycle) so no request pays the ~10s cold start. No-op when
+   * rendering is disabled or a worker is already up.
+   */
+  public warmUp() {
+    if (this.disabled || this.worker) return;
+    this.ensureWorker().catch(e => console.log('preview render worker warm-up failed:', e));
+  }
+
   private scheduleIdleShutdown() {
+    if (this.idleShutdownMs <= 0) return;
     if (this.idleTimer) clearTimeout(this.idleTimer);
     this.idleTimer = setTimeout(() => {
       if (this.pending.size === 0) this.stopWorker();

--- a/app/api/services/preview-render-worker.ts
+++ b/app/api/services/preview-render-worker.ts
@@ -6,10 +6,13 @@
 // OOM-killed the whole container on small prod instances. Spawned lazily by
 // PreviewImageService and killed again after an idle period.
 //
-// IPC protocol (all messages JSON over process.send):
+// IPC protocol (advanced serialization — the parent forks with
+// serialization: 'advanced' so Buffers cross the channel natively, no base64).
+// The master crosses as raw RGBA pixels: no PNG encode here, no PNG decode in
+// the parent — sharp ingests the raw buffer directly.
 //   parent -> worker: { type: 'render', requestId, mdb, size }
 //   worker -> parent: { type: 'ready' }
-//                     { type: 'rendered', requestId, pngBase64 }
+//                     { type: 'rendered', requestId, raw: Buffer, width, height, timings }
 //                     { type: 'error', requestId, message }
 //
 // CLI: `node preview-render-worker.js --smoke` renders a built-in fixture and
@@ -131,6 +134,21 @@ async function ensureTextures(
   return missing;
 }
 
+interface RenderTimings {
+  importMs: number;
+  texturesMs: number;
+  rasterizeMs: number;
+  extractMs: number;
+}
+
+interface MasterPixels {
+  /** Non-premultiplied RGBA, size*size*4 bytes — sharp raw input format. */
+  raw: Buffer;
+  width: number;
+  height: number;
+  timings: RenderTimings;
+}
+
 // Deterministic fit-to-content framing — same camera rules as the historic
 // thumbnail path (~1.5 tiles padding, content centered on a square canvas)
 // but without the integer zoom flooring so framing is resolution-independent.
@@ -139,13 +157,16 @@ async function renderMaster(
   assetBaseDir: string,
   mdb: MdbBlueprint,
   size: number
-): Promise<string> {
+): Promise<MasterPixels> {
+  const importStart = Date.now();
   const blueprint = new SharedBlueprint();
   blueprint.importFromMdb(mdb);
   if (blueprint.blueprintItems.length === 0) throw new Error('empty blueprint');
 
+  const texturesStart = Date.now();
   await ensureTextures(pixi, assetBaseDir, collectImageIds(blueprint));
 
+  const rasterizeStart = Date.now();
   const [topLeft, bottomRight] = blueprint.getBoundingBox();
   const totalTileSize = new Vector2(
     bottomRight.x - topLeft.x + 3,
@@ -173,17 +194,31 @@ async function renderMaster(
   const baseRenderTexture = pixi.getNewBaseRenderTexture({ width: size, height: size });
   const renderTexture = pixi.getNewRenderTexture(baseRenderTexture);
   pixi.pixiApp.renderer.render(exportCamera.container, renderTexture, false);
-  const base64: string = pixi.pixiApp.renderer.plugins.extract
-    .canvas(renderTexture)
-    .toDataURL()
-    .replace(/^data:image\/png;base64,/, '');
+
+  // Raw RGBA straight out of getImageData (non-premultiplied): no PNG encode.
+  // The old toDataURL path (full zlib encode + base64 + JSON IPC + re-decode
+  // in the parent) was pure overhead — the master is consumed once and thrown
+  // away.
+  const extractStart = Date.now();
+  const pixels: Uint8ClampedArray = pixi.pixiApp.renderer.plugins.extract.pixels(renderTexture);
+  const raw = Buffer.from(pixels.buffer, pixels.byteOffset, pixels.byteLength);
 
   exportCamera.container.destroy({ children: true });
   baseRenderTexture.destroy();
   renderTexture.destroy();
   global.gc && global.gc();
 
-  return base64;
+  return {
+    raw,
+    width: size,
+    height: size,
+    timings: {
+      importMs: texturesStart - importStart,
+      texturesMs: rasterizeStart - texturesStart,
+      rasterizeMs: extractStart - rasterizeStart,
+      extractMs: Date.now() - extractStart,
+    },
+  };
 }
 
 // Minimal blueprint exercising every texture path: a flat-icon building
@@ -210,12 +245,15 @@ async function runSmokeTest(pixi: PixiNodeUtil, assetBaseDir: string) {
   const missing = await ensureTextures(pixi, assetBaseDir, collectImageIds(blueprint));
   if (missing > 0) throw new Error(`smoke: ${missing} fixture textures missing from asset root`);
 
-  const pngBase64 = await renderMaster(pixi, assetBaseDir, SMOKE_FIXTURE, 1200);
-  const pngBytes = Buffer.from(pngBase64, 'base64').length;
-  // A 1200px render of the fixture is far larger than this; placeholder-only
-  // output (near-empty PNG) is the failure this guards against.
-  if (pngBytes < 10_000) throw new Error(`smoke: render suspiciously small (${pngBytes} bytes)`);
-  logRss(`smoke render ok (${pngBytes} png bytes)`);
+  const { raw, width, height } = await renderMaster(pixi, assetBaseDir, SMOKE_FIXTURE, 1200);
+  // The fixture covers a meaningful share of the frame; an all-placeholder
+  // render (blank/transparent output) is the failure this guards against.
+  let opaque = 0;
+  for (let i = 3; i < raw.length; i += 4) if (raw[i] > 0) opaque++;
+  const coverage = opaque / (width * height);
+  if (coverage < 0.05)
+    throw new Error(`smoke: render suspiciously empty (${(coverage * 100).toFixed(2)}% coverage)`);
+  logRss(`smoke render ok (${(coverage * 100).toFixed(1)}% pixel coverage)`);
 }
 
 async function main() {
@@ -261,16 +299,20 @@ async function main() {
     rendersInFlight++;
     try {
       let reply: object;
+      let phases = '';
       try {
-        const pngBase64 = await renderMaster(pixi, assetBaseDir, mdb, size);
-        reply = { type: 'rendered', requestId, pngBase64 };
+        const { raw, width, height, timings } = await renderMaster(pixi, assetBaseDir, mdb, size);
+        reply = { type: 'rendered', requestId, raw, width, height, timings };
+        phases =
+          ` import=${timings.importMs}ms textures=${timings.texturesMs}ms` +
+          ` rasterize=${timings.rasterizeMs}ms extract=${timings.extractMs}ms`;
       } catch (e) {
         reply = { type: 'error', requestId, message: e instanceof Error ? e.message : String(e) };
       }
       // Wait for the IPC channel to flush the reply: process.exit in the
       // recycle check below would otherwise drop a still-queued message.
       await new Promise<void>(resolve => process.send!(reply, () => resolve()));
-      logRss(`handled request ${requestId}`);
+      logRss(`handled request ${requestId}${phases}`);
     } finally {
       rendersInFlight--;
     }

--- a/app/server.ts
+++ b/app/server.ts
@@ -5,9 +5,15 @@ dotenv.config();
 console.log(process.env.ENV_NAME);
 
 import app from './app';
+import { PreviewImageService } from './api/services/preview-image-service';
 
 const PORT = 3000;
-const server = app.listen(PORT, () => console.log(`Example app listening on port ${PORT}!`));
+const server = app.listen(PORT, () => {
+  console.log(`Example app listening on port ${PORT}!`);
+  // Pre-warm the preview render worker so the first preview request after a
+  // deploy doesn't pay the ~10s cold start (no-op when rendering is disabled).
+  PreviewImageService.instance.warmUp();
+});
 server.on('error', (err: NodeJS.ErrnoException) => {
   if (err.code === 'EADDRINUSE') {
     console.error(`Error: port ${PORT} is already in use. Is another server or Docker container running?`);


### PR DESCRIPTION
Phases 0 + 1 of the preview performance/durability plan (local spec `spec/social/preview-images-perf.md`). Goal: kill the cold start and the encode overhead behind the ~5s prod renders, and get real numbers on where time goes.

## Phase 0 — instrumentation + measurement

Per-phase timing logs on both sides of the IPC boundary:
- worker: `import=…ms textures=…ms rasterize=…ms extract=…ms` per request
- parent: `loadMdb=…ms queueWait=…ms master=…ms (cold) derivatives=…ms total=…ms` per render

Measured against the 5,131-blueprint prod dump (size-percentile sample, cold+warm each):
- **Cold start 2.6–5.2s locally (~10s prod)** — previously paid on the first request after every 120s idle window
- **p10–p75 render warm in ~0.4–0.5s**; tail: p95 ~2.4s, p99.9 8–12s — tail cost is `importFromMdb` (up to 7.3s) + rasterize in the shared lib, not encode. Recorded in the spec for a later phase.
- sharp derivatives 0.5–1.2s in the parent; texture decode negligible once warm

## Phase 1 — render-path speed

- **Raw-pixel IPC**: worker ships the master as raw RGBA (`CanvasExtract.pixels()`) over an `serialization: 'advanced'` fork channel; parent feeds sharp via raw input; og trim stays raw end-to-end. Replaces toDataURL (full zlib PNG) → base64 (+33%) → JSON IPC → sharp PNG re-decode, all of which was thrown away after one use. Extraction now 9–300ms.
- **Pre-warmed, always-on worker**: `warmUp()` at server boot; idle shutdown default off (`PREVIEW_WORKER_IDLE_MS` re-enables); immediate re-fork after a clean RSS-recycle exit so the next render stays warm. Crashes do not re-fork (no crash loop); the lazy path still recovers.
- Smoke test asserts pixel coverage (≥5%) instead of PNG byte size (there is no PNG anymore).

## Deviations from plan
- `extract.canvas().toBuffer()` was the original sketch — doesn't exist (shim canvas isn't node-canvas); `pixels()` is better anyway (skips a full canvas copy + putImageData).
- Worker pool of 2: skipped deliberately — RAM headroom unconfirmed and the measured tail is per-render lib CPU, which a pool doesn't help.

## Verification
- 10/10 backend preview tests, including a new raw-master test that also guards channel order (R/B swap) through the og pipeline
- `--smoke` passes; visual parity check on a p50 prod blueprint (colors correct)
- `npm run tsc` clean; full suite 386 passing, 2 failing = known pre-existing `workos-provision` flake (fails on clean master, network-timing dependent)
- Frontend untouched

## Next (per spec)
Phase 2: render on save/fork/restore. Phase 3: Mongo-backed variant storage + corpus backfill (kills the redeploy cache wipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)