### PR TITLE
feat(previews): render on write for save, fork and version-restore

### DIFF
--- a/__tests__/api/preview.test.ts
+++ b/__tests__/api/preview.test.ts
@@ -12,8 +12,18 @@ process.env.NODE_ENV = 'test';
 
 import { TestSetup } from '../setup/testSetup';
 import { BlueprintModel } from '../../app/api/models/blueprint';
+import { BlueprintVersionModel } from '../../app/api/models/blueprint-version';
 import { PreviewImageService } from '../../app/api/services/preview-image-service';
 import { Types } from 'mongoose';
+
+// Waits for a fire-and-forget prerender to finish (or fail) by polling.
+async function waitFor(condition: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() > deadline) throw new Error('waitFor timed out');
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+}
 
 describe('Blueprint preview images', function () {
   let testData: any;
@@ -279,6 +289,153 @@ describe('Blueprint preview images', function () {
       expect(response.headers['content-type']).to.match(/image\/png/);
 
       fs.rmSync(cacheDir, { recursive: true, force: true });
+    });
+  });
+
+  // ─── Render on write (spec/social/preview-images-perf-2.md Phase 2) ─────────
+
+  describe('render on write', function () {
+    let cacheDir: string;
+    let renderCount: number;
+    let renderedMdbs: unknown[];
+
+    beforeEach(async function () {
+      cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'preview-prerender-'));
+      renderCount = 0;
+      renderedMdbs = [];
+      const fakeMaster = await sharp({
+        create: { width: 8, height: 8, channels: 4, background: { r: 0, g: 0, b: 0, alpha: 1 } },
+      })
+        .png()
+        .toBuffer();
+      PreviewImageService.setInstance(
+        new PreviewImageService({
+          cacheDir,
+          disabled: false,
+          renderMasterFn: async mdb => {
+            renderCount++;
+            renderedMdbs.push(mdb);
+            return fakeMaster;
+          },
+        })
+      );
+    });
+
+    afterEach(function () {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+    });
+
+    it('prerender writes every variant, then reads serve from cache without rendering', async function () {
+      const service = PreviewImageService.instance;
+      service.prerender(blueprintId, new Date(), async () => ({ items: [] }));
+      await waitFor(() => fs.existsSync(path.join(cacheDir, blueprintId, 'og.png')));
+      expect(renderCount).to.equal(1);
+      expect(fs.existsSync(path.join(cacheDir, blueprintId, 'card.webp'))).to.equal(true);
+      expect(fs.existsSync(path.join(cacheDir, blueprintId, 'hero.webp'))).to.equal(true);
+
+      // A read against the pre-rendered cache never touches the renderer.
+      const result = await service.getVariant(
+        blueprintId,
+        new Date(Date.now() - 60_000),
+        'card.webp',
+        async () => ({ items: [] })
+      );
+      expect(result).to.not.equal(null);
+      expect(renderCount).to.equal(1);
+
+      // A repeated prerender against a fresh cache is a no-op.
+      service.prerender(blueprintId, new Date(Date.now() - 60_000), async () => ({ items: [] }));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(renderCount).to.equal(1);
+    });
+
+    it('prerender swallows render failures (the lazy read path retries later)', async function () {
+      const service = new PreviewImageService({
+        cacheDir,
+        disabled: false,
+        renderMasterFn: async () => {
+          throw new Error('worker exploded');
+        },
+      });
+      service.prerender(blueprintId, new Date(), async () => ({ items: [] }));
+      // Nothing to await — just verify no unhandled rejection escapes.
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(fs.existsSync(path.join(cacheDir, blueprintId))).to.equal(false);
+    });
+
+    it('saving a blueprint pre-renders its previews with the saved data', async function () {
+      const token = testData.users.user1.generateJwt();
+      const data = { blueprintItems: [{ id: 'Generator' }] };
+      const response = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'Prerendered Blueprint', blueprint: data, thumbnail: 'data:image/png;base64,x' });
+      expect(response.status).to.equal(200);
+      const savedId = response.body.id;
+
+      await waitFor(() => fs.existsSync(path.join(cacheDir, savedId, 'og.png')));
+      expect(renderCount).to.equal(1);
+      expect(renderedMdbs[0]).to.deep.equal(data);
+    });
+
+    it('forking pre-renders the fork with the source version data', async function () {
+      const token = testData.users.user2.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/fork`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(response.status).to.equal(200);
+      const forkId = response.body.id;
+
+      await waitFor(() => fs.existsSync(path.join(cacheDir, forkId, 'og.png')));
+      expect(renderCount).to.equal(1);
+      expect(renderedMdbs[0]).to.deep.equal(testData.blueprints.popularBlueprint.data);
+    });
+
+    it('restoring a version bumps modifiedAt and pre-renders the restored data', async function () {
+      const restoredData = { blueprintItems: [{ id: 'RestoredBuilding' }] };
+      const version = new BlueprintVersionModel.model({
+        blueprintId,
+        data: restoredData,
+        createdAt: new Date(),
+      });
+      await version.save();
+
+      const before = (await BlueprintModel.model.findById(blueprintId))!.modifiedAt;
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/versions/${version.id}/restore`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(response.status).to.equal(200);
+
+      const after = (await BlueprintModel.model.findById(blueprintId))!.modifiedAt;
+      expect(after.getTime()).to.be.greaterThan(before.getTime());
+
+      await waitFor(() => fs.existsSync(path.join(cacheDir, blueprintId, 'og.png')));
+      expect(renderCount).to.equal(1);
+      expect(renderedMdbs[0]).to.deep.equal(restoredData);
+    });
+
+    it('the preview endpoint renders the current version data, not the stale blueprint cache', async function () {
+      // A restore points currentVersionId at an older version without
+      // rewriting Blueprint.data — the render must follow the version.
+      const versionData = { blueprintItems: [{ id: 'VersionBuilding' }] };
+      const version = new BlueprintVersionModel.model({
+        blueprintId,
+        data: versionData,
+        createdAt: new Date(),
+      });
+      await version.save();
+      await BlueprintModel.model.updateOne(
+        { _id: blueprintId },
+        { currentVersionId: version._id, modifiedAt: new Date(Date.now() - 60_000) }
+      );
+
+      const response = await TestSetup.request().get(
+        `/api/blueprints/${blueprintId}/preview/card.webp`
+      );
+      expect(response.status).to.equal(200);
+      expect(renderCount).to.equal(1);
+      expect(renderedMdbs[0]).to.deep.equal(versionData);
     });
   });
 });

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -25,6 +25,7 @@ import { apiError } from './utils/apiError';
 import { parseOlderThan } from './utils/pagination';
 import { optionalViewer } from './utils/optionalViewer';
 import { resolveCurrentData, syncCurrentVersion } from './services/blueprint-version-service';
+import { PreviewImageService } from './services/preview-image-service';
 import mongoose from 'mongoose';
 
 const MAX_SKIP = 10000;
@@ -759,6 +760,10 @@ export class BlueprintController {
     }
 
     res.json({ id: newBlueprint.id });
+
+    // Render-on-write: warm the preview cache so the first browse view of
+    // this save doesn't pay the render (preview-images-perf-2.md Phase 2).
+    PreviewImageService.instance.prerender(newBlueprint.id, newBlueprint.modifiedAt, async () => data);
 
     try {
       BatchUtils.UpdatePositionCorrection(newBlueprint);

--- a/app/api/blueprint-version-controller.ts
+++ b/app/api/blueprint-version-controller.ts
@@ -10,6 +10,7 @@ import {
   resolveCurrentData,
   getCurrentVersion,
 } from './services/blueprint-version-service';
+import { PreviewImageService } from './services/preview-image-service';
 import {
   BlueprintVersionDto,
   ListBlueprintVersionsResponse,
@@ -103,6 +104,9 @@ export class BlueprintVersionController {
       await forked.save();
 
       await BlueprintModel.model.updateOne({ _id: source._id }, { $inc: { forkCount: 1 } });
+
+      // Render-on-write: warm the fork's preview cache (Phase 2).
+      PreviewImageService.instance.prerender(forked.id, now, async () => forkedVersion.data);
 
       await NotificationController.notify({
         recipientId: source.owner,
@@ -288,7 +292,13 @@ export class BlueprintVersionController {
       }
 
       blueprint.currentVersionId = version._id as mongoose.Types.ObjectId;
+      // The rendered content changed: bumping modifiedAt invalidates both the
+      // disk preview cache and the frontend's versioned (?v=) preview urls.
+      blueprint.modifiedAt = new Date();
       await blueprint.save();
+
+      // Render-on-write: warm the preview cache with the restored data (Phase 2).
+      PreviewImageService.instance.prerender(blueprint.id, blueprint.modifiedAt, async () => version.data);
 
       const response: CreateBlueprintVersionResponse = { version: toVersionDto(version) };
       res.json(response);

--- a/app/api/preview-controller.ts
+++ b/app/api/preview-controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import mongoose from 'mongoose';
 import { BlueprintModel } from './models/blueprint';
+import { BlueprintVersionModel } from './models/blueprint-version';
 import {
   PreviewImageService,
   PreviewVariant,
@@ -41,11 +42,7 @@ export class PreviewController {
       }
 
       const result = await PreviewImageService.instance.getVariant(id, modifiedAt, variant, () =>
-        BlueprintModel.model
-          .findById(id)
-          .select('data')
-          .lean()
-          .then(doc => doc?.data ?? null)
+        PreviewController.loadRenderData(id)
       );
 
       // Versioned urls (?v=<modifiedAt millis>) are immutable; bare urls
@@ -72,5 +69,22 @@ export class PreviewController {
       console.log(err);
       return res.status(500).send();
     }
+  }
+
+  // What the blueprint currently renders as: the current version's data when
+  // one is set (a restore points currentVersionId at an older version without
+  // rewriting the Blueprint's cached `data`), else the cached `data` for
+  // documents predating versioning — the lean twin of resolveCurrentData.
+  private static async loadRenderData(id: string): Promise<unknown | null> {
+    const doc = await BlueprintModel.model.findById(id).select('data currentVersionId').lean();
+    if (doc == null) return null;
+    if (doc.currentVersionId != null) {
+      const version = await BlueprintVersionModel.model
+        .findById(doc.currentVersionId)
+        .select('data')
+        .lean();
+      if (version?.data != null) return version.data;
+    }
+    return doc.data ?? null;
   }
 }

--- a/app/api/services/preview-image-service.ts
+++ b/app/api/services/preview-image-service.ts
@@ -156,13 +156,50 @@ export class PreviewImageService {
   }
 
   private readIfFresh(filePath: string, modifiedAt: Date | null | undefined): Buffer | null {
+    if (!this.isFresh(filePath, modifiedAt)) return null;
     try {
-      const stat = fs.statSync(filePath);
-      if (modifiedAt != null && stat.mtimeMs <= modifiedAt.getTime()) return null;
       return fs.readFileSync(filePath);
     } catch {
       return null;
     }
+  }
+
+  private isFresh(filePath: string, modifiedAt: Date | null | undefined): boolean {
+    try {
+      const stat = fs.statSync(filePath);
+      return modifiedAt == null || stat.mtimeMs > modifiedAt.getTime();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Render-on-write (spec/social/preview-images-perf-2.md Phase 2):
+   * fire-and-forget render of every variant so the first browse view after a
+   * save/fork/restore serves from cache. Skips when the cache is already
+   * fresh; shares the single-flight map and queue cap with getVariant, so a
+   * shed or failed render just means the lazy read path picks it up later —
+   * never a user-visible failure.
+   */
+  public prerender(
+    blueprintId: string,
+    modifiedAt: Date | null | undefined,
+    loadMdb: () => Promise<unknown | null>
+  ): void {
+    if (this.disabled) return;
+    const allFresh = PREVIEW_VARIANTS.every(variant =>
+      this.isFresh(this.variantPath(blueprintId, variant), modifiedAt)
+    );
+    if (allFresh) return;
+
+    let render = this.inFlight.get(blueprintId);
+    if (!render) {
+      render = this.renderAllVariants(blueprintId, loadMdb).finally(() =>
+        this.inFlight.delete(blueprintId)
+      );
+      this.inFlight.set(blueprintId, render);
+    }
+    render.catch(e => console.log(`preview prerender failed for ${blueprintId}:`, e));
   }
 
   /**


### PR DESCRIPTION
## What shipped

Phase 2 of the preview render performance plan (follow-up to #115/#117/#118/#119 and the Phase 0+1 perf branch): blueprint **save, fork and version-restore now fire-and-forget a preview render**, so the first browse/discover view after a write serves from the disk cache instead of paying the lazy render.

- New `PreviewImageService.prerender(blueprintId, modifiedAt, loadMdb)` — skips when all three variants are already fresh, shares the single-flight map and render-queue cap with the lazy read path, and swallows failures. A shed or failed prerender is invisible: the existing render-on-request path picks it up later.
- `uploadBlueprint` prerenders with the just-saved data, `fork` with the source version's data, `restoreVersion` with the restored version's data.

## Latent restore bugs fixed along the way

1. **Restore never bumped `modifiedAt`.** Preview freshness (disk mtime vs `modifiedAt`) and the frontend's versioned `?v=<modifiedAt>` urls both key off it, so a restore kept serving the pre-restore image indefinitely. Restore now sets `modifiedAt = now`.
2. **The preview render path read `Blueprint.data` directly.** A restore points `currentVersionId` at an older version without rewriting the Blueprint's cached `data`, so a restored blueprint rendered the wrong content. The preview controller now resolves data through `currentVersionId` (lean twin of `resolveCurrentData`), falling back to `data` for pre-versioning documents.

## Verification

- 6 new backend tests (Mocha): prerender writes all variants once + subsequent reads skip the renderer, failure swallowing, and end-to-end save/fork/restore through the real HTTP endpoints with a stubbed render fn — including the `modifiedAt` bump and version-data resolution.
- Full suite: 383 passing. The 12 failing WorkOS provision/migration tests fail identically with this branch's changes stashed (local environmental timeouts, untouched by this PR).
- `npm run tsc` clean.

## Deferred

- Phase 3 (durable preview storage in Mongo + backfill) is next per `spec/social/preview-images-perf-2.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)