### PR TITLE
ci: replace GHA docker cache with Blacksmith sticky-disk builder

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,11 +42,16 @@ jobs:
           echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
           echo "GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # Blacksmith sticky-disk layer cache instead of cache-from/to type=gha:
+      # on Blacksmith runners the GHA cache is a cross-provider transfer, and
+      # mode=max's ~400MB node_modules blobs kept the repo cache pinned at the
+      # 10GB cap — evictions made every build re-download blobs at <1MB/s
+      # (30+ min builds). The Blacksmith builder caches layers on local NVMe.
+      - name: Set up Docker builder
+        uses: useblacksmith/setup-docker-builder@v1
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: deploy.Dockerfile
@@ -56,8 +61,6 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             GIT_COMMIT=${{ env.GIT_COMMIT }}
             GIT_BRANCH=${{ env.GIT_BRANCH }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
         
       - name: Smoke test preview renderer
         # Renders a fixture blueprint inside the deploy image under a


### PR DESCRIPTION
## Problem

The 2026-07-09 deploy (run 29025795952) sat in the docker build step for 30+ minutes versus the usual ~4. Root cause: `cache-to: type=gha,mode=max` exports the ~400MB `npm ci` node_modules layers of every build stage, which pinned the repo's Actions cache at **9.98GB of the 10GB cap** (120 entries). GitHub then LRU-evicts entries, so each build re-uploads what it lost and re-downloads the giant blobs — and on Blacksmith runners that GHA cache traffic is a cross-provider transfer that was crawling at <1MB/s (~430MB blobs × 15–20 min each).

## Fix

Swap to Blacksmith's Docker layer caching, which is the intended setup for their runners:

- `docker/setup-buildx-action@v3` → `useblacksmith/setup-docker-builder@v1`
- `docker/build-push-action@v6` → `useblacksmith/build-push-action@v2` (a fork of the upstream action, so `load`/`build-args`/`file`/`tags` are unchanged)
- `cache-from`/`cache-to` removed — the Blacksmith builder keeps the layer cache on local NVMe sticky disks, no external cache config needed

The GHA cache was cleared with `gh cache delete --all` before this change, so the backend/frontend test workflows' npm caches will rebuild cleanly on their next runs.

## Verification

- YAML validated locally.
- `publish.yml` only runs on push to master, so the real proof is the first deploy after merge: expect the first build to be a cold ~10 min (populating the sticky disk), and subsequent builds back at or under the previous ~4 min with warm layer cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)