### PR TITLE
feat(previews): durable Mongo storage for preview images + backfill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ and their `npm run generate*` / `seed` / `enhancedSeed` / `testCanvas` entries n
 Remaining batch utilities:
 - `npm run fixHtmlLabels` - Fix HTML formatting in labels.
 - `npm run derive-metadata` - Backfill `gameVersion` and `modded` on all blueprint documents from stored building IDs. Use `--dry-run` flag (`npm run derive-metadata:dry-run`) to preview counts without writing.
+- `npm run backfill-previews` - Render preview images for all non-deleted blueprints and store them durably in Mongo (`previewimages` collection). Skips blueprints whose durable rows are already fresh, so it's rerunnable/resumable. Use `--dry-run` (`npm run backfill-previews:dry-run`) to report the fresh/stale split without rendering or writing.
 
 ### Docker
 - `docker-compose up` - Full development environment with database

--- a/__tests__/api/preview.test.ts
+++ b/__tests__/api/preview.test.ts
@@ -13,7 +13,11 @@ process.env.NODE_ENV = 'test';
 import { TestSetup } from '../setup/testSetup';
 import { BlueprintModel } from '../../app/api/models/blueprint';
 import { BlueprintVersionModel } from '../../app/api/models/blueprint-version';
-import { PreviewImageService } from '../../app/api/services/preview-image-service';
+import { PreviewImageModel } from '../../app/api/models/preview-image';
+import {
+  PreviewImageService,
+  PREVIEW_VARIANTS,
+} from '../../app/api/services/preview-image-service';
 import { Types } from 'mongoose';
 
 // Waits for a fire-and-forget prerender to finish (or fail) by polling.
@@ -50,11 +54,8 @@ describe('Blueprint preview images', function () {
         (await TestSetup.request().get(`/api/blueprints/${blueprintId}/preview/nope.gif`)).status
       ).to.equal(404);
       expect(
-        (
-          await TestSetup.request().get(
-            `/api/blueprints/${new Types.ObjectId()}/preview/card.webp`
-          )
-        ).status
+        (await TestSetup.request().get(`/api/blueprints/${new Types.ObjectId()}/preview/card.webp`))
+          .status
       ).to.equal(404);
     });
 
@@ -105,7 +106,12 @@ describe('Blueprint preview images', function () {
       const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'preview-test-'));
       let renderCount = 0;
       const fakeMaster = await sharp({
-        create: { width: 64, height: 64, channels: 4, background: { r: 10, g: 200, b: 10, alpha: 1 } },
+        create: {
+          width: 64,
+          height: 64,
+          channels: 4,
+          background: { r: 10, g: 200, b: 10, alpha: 1 },
+        },
       })
         .png()
         .toBuffer();
@@ -247,12 +253,7 @@ describe('Blueprint preview images', function () {
       });
       const loadMdb = async () => ({ items: [] });
 
-      const first = service.getVariant(
-        new Types.ObjectId().toString(),
-        null,
-        'card.webp',
-        loadMdb
-      );
+      const first = service.getVariant(new Types.ObjectId().toString(), null, 'card.webp', loadMdb);
       await new Promise(resolve => setImmediate(resolve));
 
       // Queue holds one render (the active one); the next request is shed
@@ -369,7 +370,11 @@ describe('Blueprint preview images', function () {
       const response = await TestSetup.request()
         .post('/api/uploadblueprint')
         .set('Authorization', `Bearer ${token}`)
-        .send({ name: 'Prerendered Blueprint', blueprint: data, thumbnail: 'data:image/png;base64,x' });
+        .send({
+          name: 'Prerendered Blueprint',
+          blueprint: data,
+          thumbnail: 'data:image/png;base64,x',
+        });
       expect(response.status).to.equal(200);
       const savedId = response.body.id;
 
@@ -436,6 +441,137 @@ describe('Blueprint preview images', function () {
       expect(response.status).to.equal(200);
       expect(renderCount).to.equal(1);
       expect(renderedMdbs[0]).to.deep.equal(versionData);
+    });
+  });
+
+  // ─── Durable Mongo storage (spec/social/preview-images-perf-2.md Phase 3) ───
+
+  describe('durable Mongo storage', function () {
+    let cacheDir: string;
+    let renderCount: number;
+
+    // Seeds the three durable rows the way a previous deploy's render would
+    // have (disk cache empty — the redeploy scenario).
+    async function seedMongoRows(sourceModifiedAt: Date | null) {
+      const renderedAt = new Date();
+      await PreviewImageModel.model.create(
+        PREVIEW_VARIANTS.map(variant => ({
+          blueprintId,
+          variant,
+          bytes: Buffer.from(`stored-${variant}`),
+          contentType: variant.endsWith('.png') ? 'image/png' : 'image/webp',
+          renderedAt,
+          sourceModifiedAt,
+        }))
+      );
+    }
+
+    function makeService(overrides?: { disabled?: boolean }) {
+      return new PreviewImageService({
+        cacheDir,
+        disabled: overrides?.disabled ?? false,
+        renderMasterFn: async () => {
+          renderCount++;
+          return await sharp({
+            create: {
+              width: 8,
+              height: 8,
+              channels: 4,
+              background: { r: 0, g: 0, b: 0, alpha: 1 },
+            },
+          })
+            .png()
+            .toBuffer();
+        },
+      });
+    }
+
+    beforeEach(function () {
+      cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'preview-mongo-'));
+      renderCount = 0;
+    });
+
+    afterEach(function () {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+    });
+
+    it('renders write durable rows alongside the disk cache', async function () {
+      const service = makeService();
+      const modifiedAt = new Date(Date.now() - 60_000);
+      await service.renderAndStore(blueprintId, modifiedAt, async () => ({ items: [] }));
+      expect(renderCount).to.equal(1);
+
+      const rows = await PreviewImageModel.model.find({ blueprintId }).lean();
+      expect(rows.map(row => row.variant).sort()).to.deep.equal([...PREVIEW_VARIANTS].sort());
+      for (const row of rows) {
+        expect(row.contentType).to.equal(row.variant === 'og.png' ? 'image/png' : 'image/webp');
+        // lean() surfaces the bytes as a driver Binary, not a Buffer.
+        const bytes: any = row.bytes;
+        const buffer = Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes.buffer);
+        expect(buffer.length).to.be.greaterThan(0);
+        expect(new Date(row.sourceModifiedAt!).getTime()).to.equal(modifiedAt.getTime());
+      }
+    });
+
+    it('serves a fresh durable row on a disk miss without rendering, and hydrates the disk', async function () {
+      const modifiedAt = new Date(Date.now() - 60_000);
+      await seedMongoRows(modifiedAt);
+      const service = makeService();
+
+      const result = await service.getVariant(blueprintId, modifiedAt, 'card.webp', async () => ({
+        items: [],
+      }));
+      expect(result).to.not.equal(null);
+      expect(result!.buffer.toString()).to.equal('stored-card.webp');
+      expect(result!.contentType).to.equal('image/webp');
+      expect(renderCount).to.equal(0);
+
+      // Hydrated: the next read is a disk (L1) hit.
+      expect(fs.existsSync(path.join(cacheDir, blueprintId, 'card.webp'))).to.equal(true);
+    });
+
+    it('re-renders when the durable rows are stale', async function () {
+      const staleSource = new Date(Date.now() - 120_000);
+      await seedMongoRows(staleSource);
+      const modifiedAt = new Date(Date.now() - 60_000); // blueprint modified after render
+      const service = makeService();
+
+      const result = await service.getVariant(blueprintId, modifiedAt, 'card.webp', async () => ({
+        items: [],
+      }));
+      expect(result).to.not.equal(null);
+      expect(renderCount).to.equal(1);
+
+      // The stale rows were replaced, not duplicated (unique index).
+      const rows = await PreviewImageModel.model.find({ blueprintId }).lean();
+      expect(rows.length).to.equal(PREVIEW_VARIANTS.length);
+      for (const row of rows) {
+        expect(new Date(row.sourceModifiedAt!).getTime()).to.equal(modifiedAt.getTime());
+      }
+    });
+
+    it('serves durable rows even when rendering is disabled (redeploy acceptance)', async function () {
+      const modifiedAt = new Date(Date.now() - 60_000);
+      await seedMongoRows(modifiedAt);
+      PreviewImageService.setInstance(makeService({ disabled: true }));
+
+      const response = await TestSetup.request().get(
+        `/api/blueprints/${blueprintId}/preview/hero.webp`
+      );
+      expect(response.status).to.equal(200);
+      expect(response.headers['content-type']).to.match(/image\/webp/);
+      expect(response.body.toString()).to.equal('stored-hero.webp');
+      expect(renderCount).to.equal(0);
+    });
+
+    it('prerender skips rendering when durable rows are fresh', async function () {
+      const modifiedAt = new Date(Date.now() - 60_000);
+      await seedMongoRows(modifiedAt);
+      const service = makeService();
+
+      service.prerender(blueprintId, modifiedAt, async () => ({ items: [] }));
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(renderCount).to.equal(0);
     });
   });
 });

--- a/__tests__/helpers/testDb.ts
+++ b/__tests__/helpers/testDb.ts
@@ -5,6 +5,7 @@ import { FeedbackModel } from '../../app/api/models/feedback';
 import { FollowModel } from '../../app/api/models/follow';
 import { CommentModel } from '../../app/api/models/comment';
 import { NotificationModel } from '../../app/api/models/notification';
+import { PreviewImageModel } from '../../app/api/models/preview-image';
 import { TestDataFactory, TestUser, TestBlueprint } from '../factories/testData';
 import { Types } from 'mongoose';
 
@@ -127,6 +128,7 @@ export class TestDbHelper {
       await FollowModel.model.deleteMany({});
       await CommentModel.model.deleteMany({});
       await NotificationModel.model.deleteMany({});
+      await PreviewImageModel.model.deleteMany({});
       TestDataFactory.reset();
     } catch (error) {
       console.error('Error cleaning database:', error);

--- a/app/api/batch/backfill-preview-images.ts
+++ b/app/api/batch/backfill-preview-images.ts
@@ -19,25 +19,10 @@ import * as dotenv from 'dotenv';
 import { BlueprintModel } from '../models/blueprint';
 import { BlueprintVersionModel } from '../models/blueprint-version';
 import { PreviewImageModel } from '../models/preview-image';
-import { PreviewImageService, PREVIEW_VARIANTS } from '../services/preview-image-service';
+import { PreviewImageService } from '../services/preview-image-service';
 import { PreviewController } from '../preview-controller';
 
 dotenv.config();
-
-async function allRowsFresh(
-  blueprintId: mongoose.Types.ObjectId,
-  modifiedAt: Date | null | undefined
-): Promise<boolean> {
-  const rows = await PreviewImageModel.model
-    .find({ blueprintId })
-    .select('variant sourceModifiedAt')
-    .lean();
-  const byVariant = new Map(rows.map(row => [row.variant, row.sourceModifiedAt]));
-  return PREVIEW_VARIANTS.every(
-    variant =>
-      byVariant.has(variant) && PreviewImageService.isRowFresh(byVariant.get(variant), modifiedAt)
-  );
-}
 
 async function run(dryRun: boolean) {
   if (process.env.PREVIEW_RENDER_DISABLED === '1' || process.env.NODE_ENV === 'test') {
@@ -72,7 +57,9 @@ async function run(dryRun: boolean) {
     const blueprintId = doc._id as mongoose.Types.ObjectId;
     const modifiedAt = doc.modifiedAt ?? null;
 
-    if (await allRowsFresh(blueprintId, modifiedAt)) {
+    // Errors read as stale (the service catches them), so a transient Mongo
+    // hiccup costs a re-render instead of aborting the run.
+    if (await service.allFreshInMongo(blueprintId.toString(), modifiedAt)) {
       fresh++;
     } else if (dryRun) {
       rendered++; // counts what a real run would render

--- a/app/api/batch/backfill-preview-images.ts
+++ b/app/api/batch/backfill-preview-images.ts
@@ -1,0 +1,115 @@
+// Backfill script: render preview images for every non-deleted blueprint and
+// store them durably in Mongo (spec/social/preview-images-perf-2.md Phase 3).
+//
+// Usage:
+//   ts-node app/api/batch/backfill-preview-images.ts [--dry-run]
+//
+// Blueprints whose three durable rows are already fresh (sourceModifiedAt >=
+// the blueprint's modifiedAt) are skipped, so the run is rerunnable and
+// resumable — interrupt it anytime and start again. Renders go through the
+// same serialized worker queue as the live server (one at a time); failures
+// are logged and counted but never abort the run. --dry-run reports the
+// fresh/stale split without rendering or writing anything.
+//
+// This writes prod data: run it against a local bpni-prod dump first (the
+// migration pre-merge process in CLAUDE.md applies in spirit).
+
+import * as mongoose from 'mongoose';
+import * as dotenv from 'dotenv';
+import { BlueprintModel } from '../models/blueprint';
+import { BlueprintVersionModel } from '../models/blueprint-version';
+import { PreviewImageModel } from '../models/preview-image';
+import { PreviewImageService, PREVIEW_VARIANTS } from '../services/preview-image-service';
+import { PreviewController } from '../preview-controller';
+
+dotenv.config();
+
+async function allRowsFresh(
+  blueprintId: mongoose.Types.ObjectId,
+  modifiedAt: Date | null | undefined
+): Promise<boolean> {
+  const rows = await PreviewImageModel.model
+    .find({ blueprintId })
+    .select('variant sourceModifiedAt')
+    .lean();
+  const byVariant = new Map(rows.map(row => [row.variant, row.sourceModifiedAt]));
+  return PREVIEW_VARIANTS.every(
+    variant =>
+      byVariant.has(variant) && PreviewImageService.isRowFresh(byVariant.get(variant), modifiedAt)
+  );
+}
+
+async function run(dryRun: boolean) {
+  if (process.env.PREVIEW_RENDER_DISABLED === '1' || process.env.NODE_ENV === 'test') {
+    throw new Error('preview rendering is disabled in this environment');
+  }
+  const mongoUri = process.env.DB_URI;
+  if (!mongoUri) throw new Error('DB_URI not set in environment');
+
+  await mongoose.connect(mongoUri);
+  BlueprintModel.init();
+  BlueprintVersionModel.init();
+  PreviewImageModel.init();
+
+  const service = PreviewImageService.instance;
+  if (!dryRun) service.warmUp();
+
+  const total = await BlueprintModel.model.countDocuments({ deletedAt: null });
+  const cursor = BlueprintModel.model
+    .find({ deletedAt: null })
+    .select('modifiedAt')
+    .sort({ createdAt: 1 })
+    .cursor();
+
+  let processed = 0;
+  let fresh = 0;
+  let rendered = 0;
+  let failed = 0;
+  const startedAt = Date.now();
+
+  for await (const doc of cursor) {
+    processed++;
+    const blueprintId = doc._id as mongoose.Types.ObjectId;
+    const modifiedAt = doc.modifiedAt ?? null;
+
+    if (await allRowsFresh(blueprintId, modifiedAt)) {
+      fresh++;
+    } else if (dryRun) {
+      rendered++; // counts what a real run would render
+    } else {
+      try {
+        await service.renderAndStore(blueprintId.toString(), modifiedAt, () =>
+          PreviewController.loadRenderData(blueprintId.toString())
+        );
+        rendered++;
+      } catch (e) {
+        failed++;
+        console.log(`backfill render failed for ${blueprintId}:`, e);
+      }
+    }
+
+    if (processed % 25 === 0 || processed === total) {
+      const elapsedS = Math.round((Date.now() - startedAt) / 1000);
+      console.log(
+        `[${processed}/${total}] fresh=${fresh} ${dryRun ? 'stale' : 'rendered'}=${rendered}` +
+          ` failed=${failed} elapsed=${elapsedS}s`
+      );
+    }
+  }
+
+  console.log(
+    `Done. Processed: ${processed}, fresh (skipped): ${fresh}, ` +
+      `${dryRun ? 'would render' : 'rendered'}: ${rendered}, failed: ${failed}` +
+      `${dryRun ? ' (dry run — nothing written)' : ''}`
+  );
+
+  service.stopWorker();
+  await mongoose.disconnect();
+  if (failed > 0) process.exitCode = 1;
+}
+
+const dryRun = process.argv.includes('--dry-run');
+run(dryRun).catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/app/api/db.ts
+++ b/app/api/db.ts
@@ -6,6 +6,7 @@ import { FeedbackModel } from './models/feedback';
 import { FollowModel } from './models/follow';
 import { CommentModel } from './models/comment';
 import { NotificationModel } from './models/notification';
+import { PreviewImageModel } from './models/preview-image';
 
 export class Database {
   constructor() {
@@ -28,6 +29,7 @@ export class Database {
       FollowModel.init();
       CommentModel.init();
       NotificationModel.init();
+      PreviewImageModel.init();
     });
     mongoose.connection.on('error', err => {
       if (process.env.NODE_ENV !== 'test') {

--- a/app/api/models/preview-image.ts
+++ b/app/api/models/preview-image.ts
@@ -1,0 +1,40 @@
+import mongoose, { Schema, Document, Model } from 'mongoose';
+
+// Durable storage for server-rendered blueprint preview variants
+// (spec/social/preview-images-perf-2.md Phase 3). The local disk cache is
+// ephemeral (discarded on every redeploy); these rows are the L2 that
+// survives. ~200KB x 3 variants per blueprint, included in normal backups.
+// Rows for soft-deleted blueprints are left in place — invisible and
+// harmless; cleanup can piggyback on whatever purges deleted blueprints.
+export interface PreviewImage extends Document {
+  blueprintId: mongoose.Types.ObjectId;
+  variant: string; // 'card.webp' | 'hero.webp' | 'og.png'
+  bytes: Buffer;
+  contentType: string;
+  renderedAt: Date;
+  // The blueprint's modifiedAt at render time: the row is fresh while this
+  // is >= the blueprint's current modifiedAt (the Mongo twin of the disk
+  // cache's mtime rule). Null when the blueprint has no modifiedAt.
+  sourceModifiedAt?: Date | null;
+}
+
+export class PreviewImageModel {
+  static model: Model<PreviewImage>;
+
+  public static init() {
+    const previewImageSchema = new mongoose.Schema({
+      blueprintId: { type: Schema.Types.ObjectId, ref: 'Blueprint', required: true },
+      variant: { type: String, required: true },
+      bytes: { type: Buffer, required: true },
+      contentType: { type: String, required: true },
+      renderedAt: { type: Date, required: true },
+      sourceModifiedAt: { type: Date, default: null },
+    });
+
+    previewImageSchema.index({ blueprintId: 1, variant: 1 }, { unique: true });
+
+    PreviewImageModel.model =
+      (mongoose.models['PreviewImage'] as Model<PreviewImage>) ??
+      mongoose.model<PreviewImage>('PreviewImage', previewImageSchema);
+  }
+}

--- a/app/api/preview-controller.ts
+++ b/app/api/preview-controller.ts
@@ -75,7 +75,8 @@ export class PreviewController {
   // one is set (a restore points currentVersionId at an older version without
   // rewriting the Blueprint's cached `data`), else the cached `data` for
   // documents predating versioning — the lean twin of resolveCurrentData.
-  private static async loadRenderData(id: string): Promise<unknown | null> {
+  // Public: the preview backfill script feeds the render queue with it too.
+  public static async loadRenderData(id: string): Promise<unknown | null> {
     const doc = await BlueprintModel.model.findById(id).select('data currentVersionId').lean();
     if (doc == null) return null;
     if (doc.currentVersionId != null) {

--- a/app/api/services/preview-image-service.ts
+++ b/app/api/services/preview-image-service.ts
@@ -216,7 +216,12 @@ export class PreviewImageService {
     }
   }
 
-  private async allFreshInMongo(
+  /**
+   * True when every variant has a fresh durable row. Errors (and an
+   * unavailable Mongo) read as stale — callers just render. Public for the
+   * backfill script, which uses it to skip already-stored blueprints.
+   */
+  public async allFreshInMongo(
     blueprintId: string,
     modifiedAt: Date | null | undefined
   ): Promise<boolean> {

--- a/app/api/services/preview-image-service.ts
+++ b/app/api/services/preview-image-service.ts
@@ -6,15 +6,19 @@
 //   hero.webp  1200x1200 details page hero
 //   og.png     1200x630  Open Graph unfurl (letterboxed on white)
 //
-// Derivatives are cached on disk keyed by blueprint id; a cached file is
-// fresh while it is newer than the blueprint's modifiedAt, so restores,
-// forks and any future server-side edit invalidate naturally. The disk is
-// treated purely as a cache (prod containers are ephemeral) — misses are
-// re-rendered on demand.
+// Storage is two-tier (spec/social/preview-images-perf-2.md Phase 3):
+//   L1 = local disk, keyed by blueprint id; fresh while the file is newer
+//        than the blueprint's modifiedAt. Ephemeral — redeploys discard it.
+//   L2 = Mongo (previewimages collection); fresh while the row's
+//        sourceModifiedAt >= the blueprint's modifiedAt. Survives redeploys.
+// Reads go disk → Mongo (hydrating disk) → render; renders write both, so
+// restores, forks and any future server-side edit invalidate naturally.
 import { fork, ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import mongoose from 'mongoose';
 import sharp from 'sharp';
+import { PreviewImageModel } from '../models/preview-image';
 
 export type PreviewVariant = 'card.webp' | 'hero.webp' | 'og.png';
 
@@ -128,19 +132,24 @@ export class PreviewImageService {
     const cached = this.readIfFresh(filePath, modifiedAt);
     if (cached) return { buffer: cached, contentType: PreviewImageService.contentType(variant) };
 
-    if (this.disabled) return null;
-
-    // Single-flight per blueprint: one master render produces every variant.
-    let render = this.inFlight.get(blueprintId);
-    if (!render) {
-      render = this.renderAllVariants(blueprintId, loadMdb).finally(() =>
-        this.inFlight.delete(blueprintId)
-      );
-      this.inFlight.set(blueprintId, render);
+    // L2: a durable row survives redeploys; hydrate the disk cache so the
+    // next request for this variant is an L1 hit. Serving from Mongo is not
+    // rendering, so this path stays live even when rendering is disabled.
+    const stored = await this.readFromMongo(blueprintId, variant, modifiedAt);
+    if (stored) {
+      try {
+        await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+        await fs.promises.writeFile(filePath, stored.buffer);
+      } catch {
+        // Hydration is an optimization; serving the bytes is what matters.
+      }
+      return stored;
     }
 
+    if (this.disabled) return null;
+
     try {
-      await render;
+      await this.renderSingleFlight(blueprintId, modifiedAt, loadMdb);
     } catch (e) {
       // console.log: the test harness fails any test touching console.error
       console.log(`Preview render failed for ${blueprintId}:`, e);
@@ -173,6 +182,92 @@ export class PreviewImageService {
     }
   }
 
+  // --- Mongo (L2) storage ---
+
+  /** The Mongo twin of the disk mtime rule. */
+  public static isRowFresh(
+    sourceModifiedAt: Date | null | undefined,
+    modifiedAt: Date | null | undefined
+  ): boolean {
+    if (modifiedAt == null) return true;
+    return sourceModifiedAt != null && sourceModifiedAt.getTime() >= modifiedAt.getTime();
+  }
+
+  private static mongoAvailable(): boolean {
+    return PreviewImageModel.model != null && mongoose.connection.readyState === 1;
+  }
+
+  private async readFromMongo(
+    blueprintId: string,
+    variant: PreviewVariant,
+    modifiedAt: Date | null | undefined
+  ): Promise<PreviewRenderResult | null> {
+    if (!PreviewImageService.mongoAvailable()) return null;
+    try {
+      const row = await PreviewImageModel.model.findOne({ blueprintId, variant }).lean();
+      if (!row || !PreviewImageService.isRowFresh(row.sourceModifiedAt, modifiedAt)) return null;
+      // lean() may surface the bytes as a driver Binary instead of a Buffer.
+      const bytes: any = row.bytes;
+      const buffer = Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes.buffer);
+      return { buffer, contentType: row.contentType };
+    } catch (e) {
+      console.log(`preview Mongo read failed for ${blueprintId}/${variant}:`, e);
+      return null;
+    }
+  }
+
+  private async allFreshInMongo(
+    blueprintId: string,
+    modifiedAt: Date | null | undefined
+  ): Promise<boolean> {
+    if (!PreviewImageService.mongoAvailable()) return false;
+    try {
+      const rows = await PreviewImageModel.model
+        .find({ blueprintId })
+        .select('variant sourceModifiedAt')
+        .lean();
+      const byVariant = new Map(rows.map(row => [row.variant, row.sourceModifiedAt]));
+      return PREVIEW_VARIANTS.every(
+        variant =>
+          byVariant.has(variant) &&
+          PreviewImageService.isRowFresh(byVariant.get(variant), modifiedAt)
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  private async writeToMongo(
+    blueprintId: string,
+    modifiedAt: Date | null | undefined,
+    buffers: { variant: PreviewVariant; buffer: Buffer }[]
+  ): Promise<void> {
+    if (!PreviewImageService.mongoAvailable()) return;
+    try {
+      const renderedAt = new Date();
+      await PreviewImageModel.model.bulkWrite(
+        buffers.map(({ variant, buffer }) => ({
+          updateOne: {
+            filter: { blueprintId, variant },
+            update: {
+              $set: {
+                bytes: buffer,
+                contentType: PreviewImageService.contentType(variant),
+                renderedAt,
+                sourceModifiedAt: modifiedAt ?? null,
+              },
+            },
+            upsert: true,
+          },
+        }))
+      );
+    } catch (e) {
+      // Durability is best-effort per render: the disk copy still serves,
+      // and the backfill script / next render retries the Mongo write.
+      console.log(`preview Mongo write failed for ${blueprintId}:`, e);
+    }
+  }
+
   /**
    * Render-on-write (spec/social/preview-images-perf-2.md Phase 2):
    * fire-and-forget render of every variant so the first browse view after a
@@ -192,14 +287,40 @@ export class PreviewImageService {
     );
     if (allFresh) return;
 
+    (async () => {
+      // Fresh durable rows mean the read path serves (and hydrates disk)
+      // without rendering — nothing to do.
+      if (await this.allFreshInMongo(blueprintId, modifiedAt)) return;
+      await this.renderSingleFlight(blueprintId, modifiedAt, loadMdb);
+    })().catch(e => console.log(`preview prerender failed for ${blueprintId}:`, e));
+  }
+
+  /**
+   * Render every variant and write them to disk + Mongo, deduplicating
+   * concurrent requests per blueprint (one master render produces every
+   * variant). Used by the read path, prerender and the backfill script.
+   */
+  public renderAndStore(
+    blueprintId: string,
+    modifiedAt: Date | null | undefined,
+    loadMdb: () => Promise<unknown | null>
+  ): Promise<void> {
+    return this.renderSingleFlight(blueprintId, modifiedAt, loadMdb);
+  }
+
+  private renderSingleFlight(
+    blueprintId: string,
+    modifiedAt: Date | null | undefined,
+    loadMdb: () => Promise<unknown | null>
+  ): Promise<void> {
     let render = this.inFlight.get(blueprintId);
     if (!render) {
-      render = this.renderAllVariants(blueprintId, loadMdb).finally(() =>
+      render = this.renderAllVariants(blueprintId, modifiedAt, loadMdb).finally(() =>
         this.inFlight.delete(blueprintId)
       );
       this.inFlight.set(blueprintId, render);
     }
-    render.catch(e => console.log(`preview prerender failed for ${blueprintId}:`, e));
+    return render;
   }
 
   /**
@@ -224,19 +345,33 @@ export class PreviewImageService {
       const startedAt = Date.now();
       const cold = this.worker == null;
       const master = await this.renderMasterFn(mdb);
-      return { master, queueWaitMs: startedAt - enqueuedAt, masterMs: Date.now() - startedAt, cold };
+      return {
+        master,
+        queueWaitMs: startedAt - enqueuedAt,
+        masterMs: Date.now() - startedAt,
+        cold,
+      };
     });
     this.renderQueueTail = render.catch(() => undefined);
     return render.finally(() => this.renderQueueDepth--);
   }
 
-  private async renderAllVariants(blueprintId: string, loadMdb: () => Promise<unknown | null>) {
+  private async renderAllVariants(
+    blueprintId: string,
+    modifiedAt: Date | null | undefined,
+    loadMdb: () => Promise<unknown | null>
+  ) {
     const totalStart = Date.now();
     const mdb = await loadMdb();
     if (mdb == null) throw new Error('blueprint has no data');
     const loadMdbMs = Date.now() - totalStart;
 
-    const { master: masterImage, queueWaitMs, masterMs, cold } = await this.enqueueMasterRender(mdb);
+    const {
+      master: masterImage,
+      queueWaitMs,
+      masterMs,
+      cold,
+    } = await this.enqueueMasterRender(mdb);
     const derivativesStart = Date.now();
 
     const dir = path.join(this.cacheDir, blueprintId);
@@ -281,18 +416,26 @@ export class PreviewImageService {
       );
 
     const [cardBuf, heroBuf, ogBuf] = await Promise.all([card, hero, og]);
-    await Promise.all([
-      fs.promises.writeFile(path.join(dir, 'card.webp'), cardBuf),
-      fs.promises.writeFile(path.join(dir, 'hero.webp'), heroBuf),
-      fs.promises.writeFile(path.join(dir, 'og.png'), ogBuf),
-    ]);
+    const variantBuffers: { variant: PreviewVariant; buffer: Buffer }[] = [
+      { variant: 'card.webp', buffer: cardBuf },
+      { variant: 'hero.webp', buffer: heroBuf },
+      { variant: 'og.png', buffer: ogBuf },
+    ];
+    await Promise.all(
+      variantBuffers.map(({ variant, buffer }) =>
+        fs.promises.writeFile(path.join(dir, variant), buffer)
+      )
+    );
+    const mongoStart = Date.now();
+    await this.writeToMongo(blueprintId, modifiedAt, variantBuffers);
 
     // Phase timings (spec/social/preview-images-perf.md Phase 0). The worker
     // logs its own sub-phases (import/textures/rasterize/encode) per request.
     console.log(
       `preview render ${blueprintId}: loadMdb=${loadMdbMs}ms queueWait=${queueWaitMs}ms` +
         ` master=${masterMs}ms${cold ? ' (cold)' : ''}` +
-        ` derivatives=${Date.now() - derivativesStart}ms total=${Date.now() - totalStart}ms`
+        ` derivatives=${mongoStart - derivativesStart}ms` +
+        ` mongo=${Date.now() - mongoStart}ms total=${Date.now() - totalStart}ms`
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "fixHtmlLabels": "ts-node-dev --expose_gc --max_old_space_size=4096 --transpile-only ./app/api/batch/fix-html-labels.ts",
     "derive-metadata": "TS_NODE_TRANSPILE_ONLY=true ts-node app/api/batch/derive-blueprint-metadata.ts",
     "derive-metadata:dry-run": "TS_NODE_TRANSPILE_ONLY=true ts-node app/api/batch/derive-blueprint-metadata.ts --dry-run",
+    "backfill-previews": "TS_NODE_TRANSPILE_ONLY=true ts-node app/api/batch/backfill-preview-images.ts",
+    "backfill-previews:dry-run": "TS_NODE_TRANSPILE_ONLY=true ts-node app/api/batch/backfill-preview-images.ts --dry-run",
     "seed:dev-blueprints": "TS_NODE_TRANSPILE_ONLY=true ts-node app/api/batch/seed-dev-blueprints.ts",
     "seed:dev-user": "TS_NODE_TRANSPILE_ONLY=true ts-node app/api/batch/seed-dev-blueprints.ts --user-only",
     "convert:2024": "TS_NODE_TRANSPILE_ONLY=true ts-node app/api/batch/convert-export-2024.ts",


### PR DESCRIPTION
## What

Phase 3 of the preview render performance & durability plan: rendered preview images now survive redeploys.

- **New `previewimages` collection** (`PreviewImageModel`): `{ blueprintId, variant, bytes, contentType, renderedAt, sourceModifiedAt }`, unique index on `{ blueprintId, variant }`. ~200KB × 3 variants × ~4,500 blueprints ≈ 1GB, included in normal backups.
- **Two-tier read path** in `PreviewImageService`: disk (L1) → Mongo (L2, hydrates disk on hit) → render. Renders write both tiers. Mongo freshness mirrors the disk mtime rule: a row is fresh while `sourceModifiedAt >= blueprint.modifiedAt`, so saves/forks/restores invalidate naturally.
- **Serving from Mongo is not rendering** — the L2 path stays live even when rendering is disabled (kill switch / worker failure), so a redeployed container serves the whole corpus without re-rendering anything.
- `prerender` (render-on-write) now also skips when the durable rows are fresh, not just the disk cache.
- **Backfill script**: `npm run backfill-previews` (and `:dry-run`) iterates all non-deleted blueprints through the same serialized worker queue, skipping fresh rows — rerunnable/resumable, per-25 progress logging, non-zero exit if any renders failed.

## Design decisions

- Store all three variants (not master-only) per the spec's default — simpler, and halving storage wasn't worth re-running sharp on every L2 miss.
- Mongo read/write failures degrade gracefully (log + fall through to render / disk-only) — durability is best-effort per render; the backfill or next render retries.
- Soft-deleting a blueprint leaves its rows in place (invisible, harmless) — cleanup can piggyback on whatever purges soft-deleted blueprints later, per spec.
- `PreviewController.loadRenderData` made public so the backfill feeds the queue with the same currentVersionId-aware data resolution as the live read path.

## Verification

- `npm run tsc` clean; backend suite: 388 passing, 0 new failures (the 12 failing WorkOS suites fail identically on master locally — they time out without network access to WorkOS).
- 5 new tests: durable rows written on render, L2 hit serves without render + hydrates disk, stale rows re-render (upsert, no duplicates), disabled-rendering redeploy acceptance, prerender skip.
- Dry-run against the local bpni-prod dump: 4,484 blueprints, all reported stale, nothing written.
- Full backfill against the local bpni-prod dump is running now (~2–4s/blueprint through the real worker); will report the final fresh/rendered/failed counts in a comment before merge.

## Note for ops

- This grows prod dumps by ~1GB; `mongodump` remains fine.
- After deploy, run `npm run backfill-previews` once (DO app console) to populate the corpus; subsequent redeploys then serve every existing blueprint with zero re-renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)