### PR TITLE
fix(previews): derive worker RSS cap from container limit; backfill newest-first

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,7 +288,10 @@ Rules:
 
 ### Credential rules
 - Admin URI (`doadmin`) — DO app console env only. Never on local machine.
-- `doctl` — not installed. Removed to eliminate a path to admin credentials.
+- `doctl` — installed; use it freely for reads (app logs, specs, deployments). The API
+  token is normally **read-only**; writes (`doctl apps update` etc.) fail by design. For
+  rare write tasks Kevin temporarily swaps in a full-access token and removes it after —
+  if a write fails on permissions, ask, don't work around it.
 - Read-only URI — `/.env.migration` (gitignored). Safe to store; cannot write to DB.
 - `/.env` — local dev only. Never put prod or staging credentials here.
 - `/prod-dump/` — gitignored. Real prod data; never commit.

--- a/app/api/batch/backfill-preview-images.ts
+++ b/app/api/batch/backfill-preview-images.ts
@@ -40,10 +40,13 @@ async function run(dryRun: boolean) {
   if (!dryRun) service.warmUp();
 
   const total = await BlueprintModel.model.countDocuments({ deletedAt: null });
+  // Newest first: recent blueprints are the ones users actually browse, so an
+  // interrupted run still covers the highest-value slice of the corpus
+  // (index-backed by { deletedAt: 1, createdAt: -1 }).
   const cursor = BlueprintModel.model
     .find({ deletedAt: null })
     .select('modifiedAt')
-    .sort({ createdAt: 1 })
+    .sort({ createdAt: -1 })
     .cursor();
 
   let processed = 0;

--- a/app/api/services/preview-image-service.ts
+++ b/app/api/services/preview-image-service.ts
@@ -440,7 +440,8 @@ export class PreviewImageService {
       `preview render ${blueprintId}: loadMdb=${loadMdbMs}ms queueWait=${queueWaitMs}ms` +
         ` master=${masterMs}ms${cold ? ' (cold)' : ''}` +
         ` derivatives=${mongoStart - derivativesStart}ms` +
-        ` mongo=${Date.now() - mongoStart}ms total=${Date.now() - totalStart}ms`
+        ` mongo=${Date.now() - mongoStart}ms total=${Date.now() - totalStart}ms` +
+        ` parentRss=${Math.round(process.memoryUsage().rss / (1024 * 1024))}MB`
     );
   }
 

--- a/app/api/services/preview-render-worker.ts
+++ b/app/api/services/preview-render-worker.ts
@@ -82,6 +82,53 @@ function logRss(label: string) {
   console.log(`preview-render-worker: ${label} rss=${rssMb}MB`);
 }
 
+// Container memory limit in MB from the cgroup (v2, then v1). Null when
+// unlimited or not in a container (dev machines, CI).
+function readCgroupMemoryLimitMb(): number | null {
+  const candidates = [
+    '/sys/fs/cgroup/memory.max',
+    '/sys/fs/cgroup/memory/memory.limit_in_bytes',
+  ];
+  for (const candidate of candidates) {
+    try {
+      const raw = fs.readFileSync(candidate, 'utf8').trim();
+      if (raw === 'max') return null;
+      const bytes = Number(raw);
+      // cgroup v1 reports "unlimited" as a huge number (~2^63); anything past
+      // 1TB is not a real app-container limit.
+      if (Number.isFinite(bytes) && bytes > 0 && bytes < 2 ** 40) {
+        return bytes / (1024 * 1024);
+      }
+    } catch {
+      // File absent — try the next cgroup layout.
+    }
+  }
+  return null;
+}
+
+// The recycle cap must leave room for the parent API process (~200MB Express +
+// sharp) plus render overshoot inside the same cgroup — the check runs between
+// renders, and a single render can add ~60MB before it fires. A flat 384MB
+// default OOM-killed 512MB containers (the worker never reached the cap before
+// the cgroup killed everything), so the default is derived from the container
+// limit; PREVIEW_WORKER_MAX_RSS_MB overrides it.
+const PARENT_HEADROOM_MB = 320;
+function resolveMaxRssMb(): number {
+  const fromEnv = Number(process.env.PREVIEW_WORKER_MAX_RSS_MB ?? NaN);
+  if (Number.isFinite(fromEnv) && fromEnv > 0) return fromEnv;
+  if (process.env.PREVIEW_WORKER_MAX_RSS_MB != null)
+    console.warn(
+      `preview-render-worker: invalid PREVIEW_WORKER_MAX_RSS_MB "${process.env.PREVIEW_WORKER_MAX_RSS_MB}", deriving from container limit`
+    );
+  const limitMb = readCgroupMemoryLimitMb();
+  if (limitMb == null) return 384;
+  const derived = Math.min(Math.max(limitMb - PARENT_HEADROOM_MB, 128), 384);
+  console.log(
+    `preview-render-worker: container limit ${Math.round(limitMb)}MB, rss cap ${Math.round(derived)}MB`
+  );
+  return derived;
+}
+
 // Every image id a render of this blueprint can request. Static walk of the
 // texture consumers (DrawPart.prepareSprite, SpriteInfo.getTexture,
 // drawPixiUtility) so only these files are decoded — preloading the full
@@ -283,14 +330,7 @@ async function main() {
   // toward the full-preload footprint. Once RSS crosses the cap, exit between
   // renders: the parent re-forks on the next request (~1s cold start) and the
   // container never approaches the cgroup memory limit.
-  const maxRssMbRaw = Number(process.env.PREVIEW_WORKER_MAX_RSS_MB ?? 384);
-  // An invalid value (NaN, zero, negative) would make the rssMb comparison
-  // below always false and silently disable recycling — fall back instead.
-  const maxRssMb = Number.isFinite(maxRssMbRaw) && maxRssMbRaw > 0 ? maxRssMbRaw : 384;
-  if (maxRssMb !== maxRssMbRaw)
-    console.warn(
-      `preview-render-worker: invalid PREVIEW_WORKER_MAX_RSS_MB "${process.env.PREVIEW_WORKER_MAX_RSS_MB}", using ${maxRssMb}`
-    );
+  const maxRssMb = resolveMaxRssMb();
   let rendersInFlight = 0;
 
   process.on('message', async (message: any) => {


### PR DESCRIPTION
## What

Fixes the staging/prod container OOM (503s, `exited with code: 128`) triggered by bursts of uncached preview requests.

**Root cause:** both DO apps run `basic-xxs` (512MiB). The preview worker's RSS recycle cap defaulted to a flat 384MB, but the parent API process needs ~200MB of the same cgroup — the container was OOM-killed (worker at ~310MB after 9 distinct-blueprint renders) before the recycle ever fired. Same failure signature as the PR #118 incident; the 384 default never actually fit a 512MiB box.

- **Worker cap now derives from the cgroup memory limit** (v2 `memory.max`, v1 fallback): `clamp(limit − 320MB headroom, 128, 384)` → 192MB on 512MiB instances, scaling back to 384 automatically if an instance is bumped to 1GB+. `PREVIEW_WORKER_MAX_RSS_MB` still overrides; no cgroup (dev/CI) keeps the old 384.
- **Backfill walks newest-first** (`createdAt: -1`, index-backed): an interrupted/partial run now covers the blueprints users actually browse first.
- Parent render log line gains `parentRss=` so the full memory envelope is visible in prod logs.

## Verification

- 400 backend tests pass, `tsc` clean
- Worker `--smoke` render passes locally
- cgroup read path verified inside `docker run --memory=512m`: `memory.max` → 536870912 → derived cap 192MB

## Ops notes

- Merge auto-deploys both apps (shared `latest` image, `deploy_on_push`) — no env changes required.
- Temporary staging bump for backlog processing: raise instance size, run `npm run backfill-previews` in the console (renders newest-first, resumable), size back down. The cap follows the container size automatically as long as `PREVIEW_WORKER_MAX_RSS_MB` stays unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)