### PR TITLE
fix(previews): rss cap falls back to os.totalmem — cgroup is unlimited on DO gVisor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,8 @@ and their `npm run generate*` / `seed` / `enhancedSeed` / `testCanvas` entries n
 Remaining batch utilities:
 - `npm run fixHtmlLabels` - Fix HTML formatting in labels.
 - `npm run derive-metadata` - Backfill `gameVersion` and `modded` on all blueprint documents from stored building IDs. Use `--dry-run` flag (`npm run derive-metadata:dry-run`) to preview counts without writing.
-- `npm run backfill-previews` - Render preview images for all non-deleted blueprints and store them durably in Mongo (`previewimages` collection). Skips blueprints whose durable rows are already fresh, so it's rerunnable/resumable. Use `--dry-run` (`npm run backfill-previews:dry-run`) to report the fresh/stale split without rendering or writing.
+- `npm run backfill-previews` - Render preview images for all non-deleted blueprints (newest first) and store them durably in Mongo (`previewimages` collection). Skips blueprints whose durable rows are already fresh, so it's rerunnable/resumable. Use `--dry-run` (`npm run backfill-previews:dry-run`) to report the fresh/stale split without rendering or writing.
+- The `ts-node` batch scripts only work in a dev checkout. The deploy image has no devDependencies or TS sources — in a DO console run the compiled output instead: `cd /bpni/build && node app/api/batch/backfill-preview-images.js [--dry-run]` (same for `derive-blueprint-metadata.js`).
 
 ### Docker
 - `docker-compose up` - Full development environment with database

--- a/__tests__/api/render-memory.test.ts
+++ b/__tests__/api/render-memory.test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  readCgroupMemoryLimitMb,
+  resolveMaxRssMb,
+  PARENT_HEADROOM_MB,
+  MIN_RSS_CAP_MB,
+  MAX_RSS_CAP_MB,
+} from '../../app/api/services/render-memory';
+
+describe('resolveMaxRssMb', () => {
+  it('uses a valid PREVIEW_WORKER_MAX_RSS_MB verbatim', () => {
+    const { maxRssMb, detail } = resolveMaxRssMb({ env: '250', cgroupLimitMb: 512, totalMemMb: 512 });
+    expect(maxRssMb).to.equal(250);
+    expect(detail).to.contain('PREVIEW_WORKER_MAX_RSS_MB');
+  });
+
+  it('ignores an invalid env value and derives instead', () => {
+    const { maxRssMb, detail } = resolveMaxRssMb({ env: 'lots', cgroupLimitMb: 512, totalMemMb: 512 });
+    expect(maxRssMb).to.equal(512 - PARENT_HEADROOM_MB);
+    expect(detail).to.contain('ignored invalid');
+  });
+
+  it('derives 192MB on a 512MB container (cgroup signal)', () => {
+    const { maxRssMb, detail } = resolveMaxRssMb({ cgroupLimitMb: 512, totalMemMb: 32768 });
+    expect(maxRssMb).to.equal(192);
+    expect(detail).to.contain('via cgroup');
+  });
+
+  it('falls back to os.totalmem when the cgroup reports no limit (DO gVisor)', () => {
+    const { maxRssMb, detail } = resolveMaxRssMb({ cgroupLimitMb: null, totalMemMb: 512 });
+    expect(maxRssMb).to.equal(192);
+    expect(detail).to.contain('via os.totalmem');
+  });
+
+  it('takes the smaller of the two signals', () => {
+    expect(resolveMaxRssMb({ cgroupLimitMb: 512, totalMemMb: 1024 }).maxRssMb).to.equal(192);
+    expect(resolveMaxRssMb({ cgroupLimitMb: 1024, totalMemMb: 512 }).maxRssMb).to.equal(192);
+  });
+
+  it('caps at the 384MB ceiling on large hosts', () => {
+    const { maxRssMb } = resolveMaxRssMb({ cgroupLimitMb: null, totalMemMb: 32768 });
+    expect(maxRssMb).to.equal(MAX_RSS_CAP_MB);
+  });
+
+  it('never drops below the floor on tiny containers', () => {
+    const { maxRssMb } = resolveMaxRssMb({ cgroupLimitMb: 256, totalMemMb: 256 });
+    expect(maxRssMb).to.equal(MIN_RSS_CAP_MB);
+  });
+});
+
+describe('readCgroupMemoryLimitMb', () => {
+  const tempFile = (contents: string): string => {
+    const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'cgroup-test-')), 'memory.max');
+    fs.writeFileSync(file, contents);
+    return file;
+  };
+
+  it('reads a real limit in MB', () => {
+    expect(readCgroupMemoryLimitMb([tempFile('536870912\n')])).to.equal(512);
+  });
+
+  it('returns null for the v2 "max" sentinel', () => {
+    expect(readCgroupMemoryLimitMb([tempFile('max\n')])).to.equal(null);
+  });
+
+  it('returns null for the unlimited numeric sentinel (gVisor / cgroup v1)', () => {
+    expect(readCgroupMemoryLimitMb([tempFile('9223372036854771712\n')])).to.equal(null);
+  });
+
+  it('returns null when no candidate file exists', () => {
+    expect(readCgroupMemoryLimitMb(['/nonexistent/memory.max'])).to.equal(null);
+  });
+
+  it('falls through unreadable candidates to a later one', () => {
+    expect(readCgroupMemoryLimitMb(['/nonexistent/memory.max', tempFile('1073741824')])).to.equal(
+      1024
+    );
+  });
+});

--- a/app/api/services/preview-render-worker.ts
+++ b/app/api/services/preview-render-worker.ts
@@ -40,6 +40,7 @@ import {
   Display,
 } from '../../../lib';
 import { PixiNodeUtil } from '../pixi-node-util';
+import { resolveMaxRssMb } from './render-memory';
 
 const REPO_ROOT = path.resolve(__dirname, '../../..');
 
@@ -80,53 +81,6 @@ function initSharedLib() {
 function logRss(label: string) {
   const rssMb = Math.round(process.memoryUsage().rss / (1024 * 1024));
   console.log(`preview-render-worker: ${label} rss=${rssMb}MB`);
-}
-
-// Container memory limit in MB from the cgroup (v2, then v1). Null when
-// unlimited or not in a container (dev machines, CI).
-function readCgroupMemoryLimitMb(): number | null {
-  const candidates = [
-    '/sys/fs/cgroup/memory.max',
-    '/sys/fs/cgroup/memory/memory.limit_in_bytes',
-  ];
-  for (const candidate of candidates) {
-    try {
-      const raw = fs.readFileSync(candidate, 'utf8').trim();
-      if (raw === 'max') return null;
-      const bytes = Number(raw);
-      // cgroup v1 reports "unlimited" as a huge number (~2^63); anything past
-      // 1TB is not a real app-container limit.
-      if (Number.isFinite(bytes) && bytes > 0 && bytes < 2 ** 40) {
-        return bytes / (1024 * 1024);
-      }
-    } catch {
-      // File absent — try the next cgroup layout.
-    }
-  }
-  return null;
-}
-
-// The recycle cap must leave room for the parent API process (~200MB Express +
-// sharp) plus render overshoot inside the same cgroup — the check runs between
-// renders, and a single render can add ~60MB before it fires. A flat 384MB
-// default OOM-killed 512MB containers (the worker never reached the cap before
-// the cgroup killed everything), so the default is derived from the container
-// limit; PREVIEW_WORKER_MAX_RSS_MB overrides it.
-const PARENT_HEADROOM_MB = 320;
-function resolveMaxRssMb(): number {
-  const fromEnv = Number(process.env.PREVIEW_WORKER_MAX_RSS_MB ?? NaN);
-  if (Number.isFinite(fromEnv) && fromEnv > 0) return fromEnv;
-  if (process.env.PREVIEW_WORKER_MAX_RSS_MB != null)
-    console.warn(
-      `preview-render-worker: invalid PREVIEW_WORKER_MAX_RSS_MB "${process.env.PREVIEW_WORKER_MAX_RSS_MB}", deriving from container limit`
-    );
-  const limitMb = readCgroupMemoryLimitMb();
-  if (limitMb == null) return 384;
-  const derived = Math.min(Math.max(limitMb - PARENT_HEADROOM_MB, 128), 384);
-  console.log(
-    `preview-render-worker: container limit ${Math.round(limitMb)}MB, rss cap ${Math.round(derived)}MB`
-  );
-  return derived;
 }
 
 // Every image id a render of this blueprint can request. Static walk of the
@@ -308,6 +262,11 @@ async function main() {
   if (!smoke && !process.send)
     throw new Error('preview-render-worker must be forked with an IPC channel');
 
+  // Resolved (and logged) up front — including under --smoke, so the deploy
+  // image check in CI shows the cap the production container will run with.
+  const { maxRssMb, detail } = resolveMaxRssMb();
+  console.log(`preview-render-worker: ${detail}`);
+
   initSharedLib();
   const pixi = new PixiNodeUtil({ forceCanvas: true, preserveDrawingBuffer: true });
   const assetBaseDir = resolveAssetBaseDir();
@@ -330,7 +289,6 @@ async function main() {
   // toward the full-preload footprint. Once RSS crosses the cap, exit between
   // renders: the parent re-forks on the next request (~1s cold start) and the
   // container never approaches the cgroup memory limit.
-  const maxRssMb = resolveMaxRssMb();
   let rendersInFlight = 0;
 
   process.on('message', async (message: any) => {

--- a/app/api/services/render-memory.ts
+++ b/app/api/services/render-memory.ts
@@ -1,0 +1,83 @@
+// Memory sizing for the preview render worker (see preview-render-worker.ts).
+//
+// The worker self-recycles when its RSS crosses a cap. That cap must leave
+// room inside the container for the parent API process (~200MB Express +
+// sharp) plus render overshoot — the recycle check runs between renders, and
+// a single render can add ~60MB before it fires. A flat 384MB default
+// OOM-killed 512MiB DO instances (the cgroup killed the whole container
+// before the worker ever reached the cap), so the default derives from the
+// smallest believable container memory limit.
+//
+// Detection is two-signal because no single source works everywhere:
+//   - cgroup limit files: authoritative under Docker/Kubernetes, but DO App
+//     Platform runs gVisor, which mounts a cgroupfs that reports the
+//     "unlimited" sentinel (~2^63) — useless there.
+//   - os.totalmem(): gVisor scopes it to the sandbox (512MB on basic-xxs),
+//     verified in a DO console 2026-07-09. Under plain Docker it reports the
+//     host's RAM, so it cannot replace the cgroup signal.
+// The effective limit is the smaller of the two; a dev machine or CI runner
+// with plenty of RAM lands on the 384MB ceiling either way.
+import * as fs from 'fs';
+import * as os from 'os';
+
+export const PARENT_HEADROOM_MB = 320;
+export const MIN_RSS_CAP_MB = 128;
+export const MAX_RSS_CAP_MB = 384;
+
+const CGROUP_LIMIT_PATHS = [
+  '/sys/fs/cgroup/memory.max', // v2
+  '/sys/fs/cgroup/memory/memory.limit_in_bytes', // v1
+];
+
+// Container memory limit in MB from the cgroup. Null when absent, "max", or
+// an implausible (unlimited-sentinel) value — gVisor reports ~2^63, cgroup v1
+// unlimited is similar; anything past 1TB is not a real app-container limit.
+export function readCgroupMemoryLimitMb(paths: string[] = CGROUP_LIMIT_PATHS): number | null {
+  for (const path of paths) {
+    try {
+      const raw = fs.readFileSync(path, 'utf8').trim();
+      if (raw === 'max') return null;
+      const bytes = Number(raw);
+      if (Number.isFinite(bytes) && bytes > 0 && bytes < 2 ** 40) {
+        return bytes / (1024 * 1024);
+      }
+    } catch {
+      // File absent — try the next cgroup layout.
+    }
+  }
+  return null;
+}
+
+export interface ResolvedRssCap {
+  maxRssMb: number;
+  /** Human-readable derivation, logged once at worker startup. */
+  detail: string;
+}
+
+export function resolveMaxRssMb(opts?: {
+  env?: string;
+  cgroupLimitMb?: number | null;
+  totalMemMb?: number;
+}): ResolvedRssCap {
+  const env = opts && 'env' in opts ? opts.env : process.env.PREVIEW_WORKER_MAX_RSS_MB;
+  let invalidEnvNote = '';
+  if (env != null) {
+    const fromEnv = Number(env);
+    if (Number.isFinite(fromEnv) && fromEnv > 0) {
+      return { maxRssMb: fromEnv, detail: `rss cap ${fromEnv}MB (PREVIEW_WORKER_MAX_RSS_MB)` };
+    }
+    invalidEnvNote = `; ignored invalid PREVIEW_WORKER_MAX_RSS_MB "${env}"`;
+  }
+  const cgroupLimitMb =
+    opts && 'cgroupLimitMb' in opts ? opts.cgroupLimitMb : readCgroupMemoryLimitMb();
+  const totalMemMb = opts?.totalMemMb ?? os.totalmem() / (1024 * 1024);
+  const limitMb = Math.min(cgroupLimitMb ?? Infinity, totalMemMb);
+  const maxRssMb = Math.min(Math.max(limitMb - PARENT_HEADROOM_MB, MIN_RSS_CAP_MB), MAX_RSS_CAP_MB);
+  const source = cgroupLimitMb != null && cgroupLimitMb <= totalMemMb ? 'cgroup' : 'os.totalmem';
+  return {
+    maxRssMb,
+    detail:
+      `rss cap ${Math.round(maxRssMb)}MB` +
+      ` (memory limit ${Math.round(limitMb)}MB via ${source}${invalidEnvNote})`,
+  };
+}


### PR DESCRIPTION
## What

Follow-up to #124 — the cgroup-derived worker RSS cap **silently never engaged on DO App Platform**, leaving 512MiB instances back at the flat 384MB default (the original OOM configuration).

**Why:** DO runs apps under gVisor, which mounts a cgroupfs whose memory limit reads as the unlimited sentinel (~2^63). Verified empirically on staging after removing the env override: worker crossed 257MB with no recycle. Console diagnostics on the instance showed:
- `/sys/fs/cgroup` exists (v1 layout) but the limit is the unlimited sentinel (`process.constrainedMemory()` → 2^63)
- `os.totalmem()` → **512MB** — gVisor scopes it to the sandbox

**Fix:** effective container limit = `min(cgroup limit, os.totalmem())`.
- DO basic-xxs → 192MB cap (via totalmem)
- `docker --memory=512m` → 192MB (via cgroup; Docker's totalmem is the host's, cgroup wins)
- dev/CI on big hosts → 384MB ceiling, unchanged behavior
- `PREVIEW_WORKER_MAX_RSS_MB` still overrides everything

Logic extracted to `render-memory.ts` (pure, unit-tested). The worker now logs the resolved cap and its derivation at startup, including under `--smoke` — so the `--memory=512m` deploy-image check in publish.yml prints the cap production will actually run with.

Also carries over a CLAUDE.md note that missed the #124 merge: batch scripts in the deploy image run via compiled JS (`cd /bpni/build && node app/api/batch/backfill-preview-images.js`), not ts-node.

## Verification

- 412 backend tests pass (12 new for cap resolution + cgroup parsing), `tsc` clean
- Worker `--smoke` locally: `rss cap 384MB (memory limit 16384MB via os.totalmem)` + render ok
- After deploy, staging boot log should read `rss cap 192MB (memory limit 512MB via os.totalmem)` — and a burst of uncached preview requests should show recycle lines again

🤖 Generated with [Claude Code](https://claude.com/claude-code)