### PR TITLE
fix(previews): backfill loads its worklist upfront instead of a live cursor

### DIFF
--- a/app/api/batch/backfill-preview-images.ts
+++ b/app/api/batch/backfill-preview-images.ts
@@ -39,15 +39,19 @@ async function run(dryRun: boolean) {
   const service = PreviewImageService.instance;
   if (!dryRun) service.warmUp();
 
-  const total = await BlueprintModel.model.countDocuments({ deletedAt: null });
-  // Newest first: recent blueprints are the ones users actually browse, so an
-  // interrupted run still covers the highest-value slice of the corpus
-  // (index-backed by { deletedAt: 1, createdAt: -1 }).
-  const cursor = BlueprintModel.model
+  // The whole worklist upfront (id + modifiedAt, ~50 bytes/doc) instead of a
+  // server-side cursor: at ~2.5s per render, consuming one default-sized
+  // cursor batch takes ~40 minutes of server-side silence, and Mongo reaps
+  // cursors idle past 10 minutes (CursorNotFound, observed ~1,100 documents
+  // into a staging run). Newest first: recent blueprints are the ones users
+  // actually browse, so an interrupted run still covers the highest-value
+  // slice of the corpus (index-backed by { deletedAt: 1, createdAt: -1 }).
+  const docs = await BlueprintModel.model
     .find({ deletedAt: null })
     .select('modifiedAt')
     .sort({ createdAt: -1 })
-    .cursor();
+    .lean();
+  const total = docs.length;
 
   let processed = 0;
   let fresh = 0;
@@ -55,7 +59,7 @@ async function run(dryRun: boolean) {
   let failed = 0;
   const startedAt = Date.now();
 
-  for await (const doc of cursor) {
+  for (const doc of docs) {
     processed++;
     const blueprintId = doc._id as mongoose.Types.ObjectId;
     const modifiedAt = doc.modifiedAt ?? null;


### PR DESCRIPTION
## What

The staging backfill died ~1,100 blueprints in with `MongoServerError: cursor id … not found` (code 43, CursorNotFound).

**Why:** the script streamed blueprints through a server-side cursor while rendering ~2.5s per document. Mongo reaps cursors that go 10+ minutes between `getMore`s; consuming one default-sized batch (~1,000 docs) is ~40 minutes of server-side silence. The death landing right after document ~1,100 (initial batch 101 + one ~1,000-doc batch) confirms it.

**Fix:** the worklist is only `_id` + `modifiedAt` (~50 bytes/doc, ~250KB for the full corpus) — fetch it entirely before rendering starts, iterate in memory. No cursor lifetime, no `noCursorTimeout` hacks.

## Verification

- 412 backend tests pass, `tsc` clean
- Dry-run against the local prod dump (4,484 blueprints): worklist loads and iterates in ~2s, correct newest-first order, no cursor
- (`fresh=0` locally is expected — the previously stored local rows were lost in the 2026-07-09 disk-full Mongo crash; staging freshness skipping works, `fresh=54` in the live run)

Interrupted runs resume as before: rerun skips already-stored blueprints via the durable-row freshness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)