### PR TITLE
feat(forks): attribute editor copy-saves as forks

### DIFF
--- a/__tests__/api/blueprint-forks.test.ts
+++ b/__tests__/api/blueprint-forks.test.ts
@@ -529,7 +529,7 @@ describe('Fork + BlueprintVersion API', function () {
       const token = testData.users.user2.generateJwt();
       const response = await upload(token, {
         name: 'Copy Of Hidden Draft',
-        sourceBlueprintId: draft._id.toString(),
+        sourceBlueprintId: String(draft._id),
       });
       expect(response.status).to.equal(200);
       await settle();

--- a/__tests__/api/blueprint-forks.test.ts
+++ b/__tests__/api/blueprint-forks.test.ts
@@ -8,9 +8,19 @@ dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
 process.env.NODE_ENV = 'test';
 
 import mongoose, { Types } from 'mongoose';
-import { TestSetup } from '../setup/testSetup';
+import { TestSetup, TestDbHelper } from '../setup/testSetup';
 import { BlueprintModel } from '../../app/api/models/blueprint';
 import { BlueprintVersionModel } from '../../app/api/models/blueprint-version';
+import { NotificationModel } from '../../app/api/models/notification';
+
+const SAMPLE_BLUEPRINT_DATA = {
+  version: '1.0',
+  buildings: [{ id: 'Generator', x: 0, y: 0, element: 'Coal' }],
+  info: { name: 'Test', description: 'Test blueprint' },
+};
+
+const TINY_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const versionInitMigration = require('../../migrations/20260707000000_blueprint-version-init.js');
@@ -420,6 +430,140 @@ describe('Fork + BlueprintVersion API', function () {
 
       const versionCount = await BlueprintVersionModel.model.countDocuments({});
       expect(versionCount).to.equal(0);
+    });
+  });
+
+  // ─── Copy-as-fork: POST /api/uploadblueprint with sourceBlueprintId ──────────
+  // The editor's old "copy" flow (non-owner saves someone else's blueprint)
+  // now carries fork attribution.
+
+  describe('copy-as-fork via POST /api/uploadblueprint', function () {
+    // Fork bookkeeping (forkCount inc + notification) is fire-and-forget
+    // after res.json — give the writes a beat to land before asserting
+    const settle = () => new Promise(resolve => setTimeout(resolve, 50));
+
+    function upload(token: string, body: Record<string, unknown>) {
+      return TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          blueprint: SAMPLE_BLUEPRINT_DATA,
+          thumbnail: TINY_PNG,
+          overwrite: false,
+          ...body,
+        });
+    }
+
+    it('non-owner save records forkedFrom, increments forkCount, and notifies the source owner', async function () {
+      const token = testData.users.user2.generateJwt();
+      const response = await upload(token, {
+        name: 'My Copied Setup',
+        sourceBlueprintId: popularId,
+      });
+      expect(response.status).to.equal(200);
+      await settle();
+
+      const copy = await BlueprintModel.model.findById(response.body.id);
+      expect(copy!.owner.toString()).to.equal(testData.users.user2._id.toString());
+      // The user's chosen name is kept — no " fork" suffix on the copy path
+      expect(copy!.name).to.equal('My Copied Setup');
+      expect(copy!.forkedFrom!.blueprintId.toString()).to.equal(popularId);
+
+      const source = await BlueprintModel.model.findById(popularId);
+      expect(source!.forkCount).to.equal(1);
+      expect(copy!.forkedFrom!.versionId.toString()).to.equal(source!.currentVersionId!.toString());
+
+      const notifications = await NotificationModel.model.find({
+        recipientId: testData.users.user1._id,
+        type: 'fork',
+      });
+      expect(notifications).to.have.length(1);
+      expect(notifications[0].actorId.toString()).to.equal(testData.users.user2._id.toString());
+      expect(notifications[0].blueprintId!.toString()).to.equal(response.body.id);
+    });
+
+    it('owner saving their own blueprint under a new name gets no fork attribution', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await upload(token, {
+        name: 'Renamed Own Copy',
+        sourceBlueprintId: popularId,
+      });
+      expect(response.status).to.equal(200);
+      await settle();
+
+      const copy = await BlueprintModel.model.findById(response.body.id);
+      expect(copy!.forkedFrom ?? null).to.equal(null);
+
+      const source = await BlueprintModel.model.findById(popularId);
+      expect(source!.forkCount ?? 0).to.equal(0);
+    });
+
+    it('unknown or malformed sourceBlueprintId still saves, without attribution', async function () {
+      const token = testData.users.user2.generateJwt();
+
+      const unknown = await upload(token, {
+        name: 'Copy Of Nothing',
+        sourceBlueprintId: new Types.ObjectId().toString(),
+      });
+      expect(unknown.status).to.equal(200);
+      expect(
+        (await BlueprintModel.model.findById(unknown.body.id))!.forkedFrom ?? null
+      ).to.equal(null);
+
+      const malformed = await upload(token, {
+        name: 'Copy Of Garbage',
+        sourceBlueprintId: 'not-an-id',
+      });
+      expect(malformed.status).to.equal(200);
+      expect(
+        (await BlueprintModel.model.findById(malformed.body.id))!.forkedFrom ?? null
+      ).to.equal(null);
+    });
+
+    it("someone else's draft as source gets no attribution (not viewable)", async function () {
+      const draft = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Hidden Draft Source',
+        isPublished: false,
+      });
+
+      const token = testData.users.user2.generateJwt();
+      const response = await upload(token, {
+        name: 'Copy Of Hidden Draft',
+        sourceBlueprintId: draft._id.toString(),
+      });
+      expect(response.status).to.equal(200);
+      await settle();
+
+      const copy = await BlueprintModel.model.findById(response.body.id);
+      expect(copy!.forkedFrom ?? null).to.equal(null);
+      const source = await BlueprintModel.model.findById(draft._id);
+      expect(source!.forkCount ?? 0).to.equal(0);
+    });
+
+    it('overwrite saves of the copy keep forkedFrom and do not re-increment forkCount', async function () {
+      const token = testData.users.user2.generateJwt();
+      const first = await upload(token, {
+        name: 'My Copied Setup',
+        sourceBlueprintId: popularId,
+      });
+      expect(first.status).to.equal(200);
+      await settle();
+
+      // Second save from the same editor session: the frontend now sends the
+      // copy's own id as the source
+      const second = await upload(token, {
+        name: 'My Copied Setup',
+        overwrite: true,
+        sourceBlueprintId: first.body.id,
+      });
+      expect(second.status).to.equal(200);
+      expect(second.body.id).to.equal(first.body.id);
+      await settle();
+
+      const copy = await BlueprintModel.model.findById(first.body.id);
+      expect(copy!.forkedFrom!.blueprintId.toString()).to.equal(popularId);
+      const source = await BlueprintModel.model.findById(popularId);
+      expect(source!.forkCount).to.equal(1);
     });
   });
 });

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -27,7 +27,11 @@ import { optionalViewer } from './utils/optionalViewer';
 import { canViewBlueprint } from './utils/blueprint-visibility';
 import { BlueprintEventService } from './services/blueprint-event-service';
 import { BlueprintCounterService, CounterKind } from './services/blueprint-counter-service';
-import { resolveCurrentData, syncCurrentVersion } from './services/blueprint-version-service';
+import {
+  ensureCurrentVersion,
+  resolveCurrentData,
+  syncCurrentVersion,
+} from './services/blueprint-version-service';
 import { PreviewImageService } from './services/preview-image-service';
 import mongoose from 'mongoose';
 
@@ -107,9 +111,20 @@ export class BlueprintController {
 
       const metadata = { gameVersion, category, subcategory, description, researchTier, modded };
 
+      // Copy-as-fork: when the editor saves a blueprint it loaded from
+      // someone else's document, the client passes the source id so the new
+      // copy is attributed as a fork. Malformed ids are treated as absent —
+      // attribution is best-effort and must never fail the save.
+      const rawSourceBlueprintId = req.body.sourceBlueprintId;
+      const sourceBlueprintId =
+        typeof rawSourceBlueprintId === 'string' &&
+        mongoose.Types.ObjectId.isValid(rawSourceBlueprintId)
+          ? rawSourceBlueprintId
+          : null;
+
       BlueprintModel.model
         .find({ owner: ownerId, name: name })
-        .then(blueprints => {
+        .then(async blueprints => {
           if (blueprints.length > 0) {
             if (overwrite || blueprints[0].deletedAt != null)
               BlueprintController.saveBlueprint(
@@ -130,6 +145,10 @@ export class BlueprintController {
             // Every blueprint starts with the author's like (GitHub-star semantics)
             blueprint.likes = [ownerId];
             blueprint.likeCount = 1;
+            const forkSource = await BlueprintController.resolveForkSource(
+              sourceBlueprintId,
+              user
+            );
             BlueprintController.saveBlueprint(
               req,
               res,
@@ -140,7 +159,8 @@ export class BlueprintController {
               thumbnail,
               true,
               metadata,
-              publish
+              publish,
+              forkSource
             );
           }
         })
@@ -899,6 +919,31 @@ export class BlueprintController {
     }
   }
 
+  // Copy-as-fork: a non-owner saving from the editor creates a new blueprint;
+  // when the client names the source, attribute it as a fork. Any problem with
+  // the source (missing, deleted, not viewable, requester's own document) just
+  // skips attribution — the save itself must never fail because of it.
+  private static async resolveForkSource(
+    sourceBlueprintId: string | null,
+    user: UserJwt
+  ): Promise<{ source: Blueprint; versionId: mongoose.Types.ObjectId } | null> {
+    if (sourceBlueprintId == null) return null;
+    try {
+      const source = await BlueprintModel.model.findOne({
+        _id: sourceBlueprintId,
+        deletedAt: null,
+      });
+      if (!source || !canViewBlueprint(source, user)) return null;
+      if (source.owner.toString() === user._id.toString()) return null;
+      const sourceVersion = await ensureCurrentVersion(source);
+      return { source, versionId: sourceVersion._id as mongoose.Types.ObjectId };
+    } catch (err) {
+      console.log('fork source lookup error');
+      console.log(err);
+      return null;
+    }
+  }
+
   private static async saveBlueprint(
     _req: Request,
     res: Response,
@@ -916,7 +961,8 @@ export class BlueprintController {
       researchTier: string | null;
       modded: boolean | null;
     },
-    publish?: boolean | null
+    publish?: boolean | null,
+    forkSource?: { source: Blueprint; versionId: mongoose.Types.ObjectId } | null
   ): Promise<void> {
     // New blueprints start as drafts (set explicitly — see the schema comment
     // on isPublished for why there is no schema default). Resurrect-via-
@@ -925,6 +971,16 @@ export class BlueprintController {
     if (blueprint.isNew) blueprint.isPublished = false;
     const wasPublished = blueprint.isPublished !== false;
     if (publish === true && !wasPublished) blueprint.isPublished = true;
+
+    // Copy-as-fork attribution (create path only — an overwrite of the
+    // requester's own document keeps its history)
+    if (blueprint.isNew && forkSource != null) {
+      blueprint.forkedFrom = {
+        blueprintId: forkSource.source._id as mongoose.Types.ObjectId,
+        versionId: forkSource.versionId,
+        forkedAt: new Date(),
+      };
+    }
 
     blueprint.owner = ownerId;
     blueprint.name = name;
@@ -970,6 +1026,22 @@ export class BlueprintController {
     });
     if (publish === true && !wasPublished) {
       BlueprintEventService.log({ blueprintId: newBlueprint.id, actorId: ownerId, type: 'published' });
+    }
+
+    // Copy-as-fork bookkeeping — mirrors POST /api/blueprints/:id/fork
+    if (blueprint.forkedFrom != null && forkSource != null) {
+      BlueprintModel.model
+        .updateOne({ _id: forkSource.source._id }, { $inc: { forkCount: 1 } })
+        .catch(err => {
+          console.log('fork count increment error');
+          console.log(err);
+        });
+      NotificationController.notify({
+        recipientId: forkSource.source.owner,
+        actorId: ownerId,
+        type: 'fork',
+        blueprintId: newBlueprint._id as mongoose.Types.ObjectId,
+      });
     }
 
     // Render-on-write: warm the preview cache so the first browse view of

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -1041,6 +1041,9 @@ export class BlueprintController {
         actorId: ownerId,
         type: 'fork',
         blueprintId: newBlueprint._id as mongoose.Types.ObjectId,
+      }).catch(err => {
+        console.log('fork notification error');
+        console.log(err);
       });
     }
 

--- a/frontend/src/app/module-blueprint/services/blueprint-service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.spec.ts
@@ -471,6 +471,22 @@ describe("BlueprintService", () => {
       const body = mockHttp.post.mock.calls[0][1];
       expect(body.overwrite).toBe(true);
     });
+
+    it("sends sourceBlueprintId when the editor started from an existing blueprint", () => {
+      service.id = "source-bp-id";
+      mockHttp.post.mockReturnValue(of({ id: "copy-id" }));
+      service.saveBlueprint(false).subscribe(() => {});
+      const body = mockHttp.post.mock.calls[0][1];
+      expect(body.sourceBlueprintId).toBe("source-bp-id");
+    });
+
+    it("omits sourceBlueprintId for a brand-new blueprint", () => {
+      service.id = null;
+      mockHttp.post.mockReturnValue(of({}));
+      service.saveBlueprint(false).subscribe(() => {});
+      const body = mockHttp.post.mock.calls[0][1];
+      expect(body.sourceBlueprintId).toBeUndefined();
+    });
   });
 
   describe("likeBlueprint()", () => {

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -448,6 +448,10 @@ export class BlueprintService implements IObsBlueprintChange {
     // publish: true publishes in the same save; null/undefined keeps the
     // current state (new blueprints start as drafts server-side)
     if (publish != null) body.publish = publish;
+    // Copy-as-fork attribution: when the editor started from an existing
+    // blueprint, name it as the source — the server records forkedFrom when
+    // the save creates a copy because the requester isn't the owner
+    if (this.id != null) body.sourceBlueprintId = this.id;
     Object.assign(body, this.metadata);
     const request = this.http
       .post("/api/uploadblueprint", body, {
@@ -535,6 +539,9 @@ export class SaveBlueprintMessage {
   thumbnail!: string;
   // true = publish with this save; omitted = keep current publish state
   publish?: boolean;
+  // id of the blueprint the editor was opened from; the server records
+  // forkedFrom when the save creates a copy (requester isn't the owner)
+  sourceBlueprintId?: string;
   gameVersion?: string | null;
   category?: string | null;
   subcategory?: string | null;


### PR DESCRIPTION
## What ships

The editor's old "copy" flow — a non-owner opens someone else's blueprint and saves it — used to silently create a detached copy with no link to the original. That copy is now attributed as a fork, using the same top-level fork concept as the fork button:

- **Frontend** (`blueprint-service.ts`): `saveBlueprint` includes `sourceBlueprintId` (the id the editor was opened from) in the upload payload whenever one exists. The server decides whether it matters.
- **Backend** (`blueprint-controller.ts`): on the create path of `POST /api/uploadblueprint`, if the requester can view the source and doesn't own it, the new document gets `forkedFrom` (source id + current version id, via `ensureCurrentVersion`), the source's `forkCount` is incremented, and its owner receives the existing `fork` notification — mirroring `POST /api/blueprints/:id/fork`.

## Design decisions

- **Best-effort attribution, never a save failure**: a malformed id is treated as absent; a missing/deleted/unviewable/self-owned source just skips attribution. The old copy behavior is fully preserved — same results, better attribution.
- **Create path only**: overwriting your own document (including the resurrect-soft-deleted path) never gains attribution; a copy's later overwrite saves keep their original `forkedFrom` and don't re-increment `forkCount`.
- **Name is kept**: unlike the fork button, no " fork" suffix — the user typed the name in the save dialog.
- **No self-forks**: owner saving their own blueprint under a new name stays an unattributed copy, per the feature's scope (non-owner saves).

## Verification

- Backend: full Mocha suite 447 passing (incl. 5 new copy-as-fork tests covering attribution, owner/self skip, unknown/malformed source, draft source, overwrite idempotence). One pre-existing comments-API timeout flaked in the full run and passes in isolation.
- Frontend: 679 passing (2 new specs for `sourceBlueprintId` presence/absence in the save payload).
- `npm run tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)