### PR TITLE
fix(rendering): stop PixelPack/Portrait render order flipping after overlay switch

### DIFF
--- a/__tests__/asset-processing/game-structure-contract.test.ts
+++ b/__tests__/asset-processing/game-structure-contract.test.ts
@@ -2,10 +2,12 @@ import { expect } from 'chai';
 import * as fs from 'fs';
 import * as path from 'path';
 import {
+  BlueprintItem,
   BuildableElement,
   BuildLocationRule,
   BuildMenuCategory,
   BuildMenuItem,
+  CameraService,
   ConnectionType,
   SpriteInfo,
   SpriteModifier,
@@ -207,6 +209,44 @@ describe('Game structure contract (representative buildings)', () => {
       for (const b of database.buildings)
         for (const dlcId of b.dlcIds ?? []) if (!knownDlcIds.has(dlcId)) unknown.add(dlcId);
       expect([...unknown], `unknown DLC ids: ${[...unknown].join(', ')}`).to.be.empty;
+    });
+  });
+
+  // PixelPack (a wall-plane decal, ObjectLayer.Backwall) and the Portrait Canvas
+  // (ObjectLayer.Building) both sit at the InteriorWall scene layer, so at rest
+  // they tie on sceneLayer alone. PixelPack is architecturally "behind the wall"
+  // (like drywall) and must never exactly tie with - let alone render in front
+  // of - a portrait mounted on it. Before the objectLayerBackwall depth offset,
+  // both got the exact same computed `depth` in Base, and PIXI's
+  // Container.sortChildren() breaks such ties using an index it re-stamps from
+  // current array position on every call - so a real, temporary depth
+  // divergence (this pair diverges under the Automation overlay, since
+  // PixelPack has an automation viewMode) permanently reordered them even after
+  // returning to Base, where they tie again.
+  describe('render depth ordering (BlueprintItem.cameraChanged)', () => {
+    it('PixelPack (Backwall) never ties with Canvas (Building) at rest, and reverts deterministically', () => {
+      const pixelPack = new BlueprintItem('PixelPack');
+      const canvas = new BlueprintItem('Canvas');
+      const camera = new CameraService({});
+
+      // Base (both before and after the Automation round-trip): both are
+      // "primary" at the InteriorWall tier - PixelPack must lose the tie,
+      // and must do so identically each time (no hysteresis from the switch).
+      for (const _ of [0, 1]) {
+        camera.overlay = Overlay.Base;
+        pixelPack.cameraChanged(camera);
+        canvas.cameraChanged(camera);
+        expect(pixelPack.depth, 'PixelPack.depth in Base').to.be.lessThan(canvas.depth);
+
+        // Automation: PixelPack has a wire connection and is meant to highlight
+        // forward (like wires popping above tiles in the Power overlay) while
+        // the unrelated Canvas dims to alpha 0.3 - intentional, not the bug.
+        camera.overlay = Overlay.Automation;
+        pixelPack.cameraChanged(camera);
+        canvas.cameraChanged(camera);
+        expect(pixelPack.depth, 'PixelPack.depth in Automation').to.be.greaterThan(canvas.depth);
+        expect(canvas.isOpaque, 'Canvas.isOpaque in Automation').to.equal(false);
+      }
     });
   });
 

--- a/__tests__/asset-processing/game-structure-contract.test.ts
+++ b/__tests__/asset-processing/game-structure-contract.test.ts
@@ -212,41 +212,50 @@ describe('Game structure contract (representative buildings)', () => {
     });
   });
 
-  // PixelPack (a wall-plane decal, ObjectLayer.Backwall) and the Portrait Canvas
-  // (ObjectLayer.Building) both sit at the InteriorWall scene layer, so at rest
-  // they tie on sceneLayer alone. PixelPack is architecturally "behind the wall"
-  // (like drywall) and must never exactly tie with - let alone render in front
-  // of - a portrait mounted on it. Before the objectLayerBackwall depth offset,
-  // both got the exact same computed `depth` in Base, and PIXI's
-  // Container.sortChildren() breaks such ties using an index it re-stamps from
-  // current array position on every call - so a real, temporary depth
-  // divergence (this pair diverges under the Automation overlay, since
-  // PixelPack has an automation viewMode) permanently reordered them even after
-  // returning to Base, where they tie again.
+  // PixelPack is a wall-plane decal (ObjectLayer.Backwall) that sits flush in the
+  // wall - like drywall - behind whatever building is placed against it. Since the
+  // game forbids buildings from overlapping each other, the only render-order
+  // comparison that is ever visually observed is "some buildable vs a decal on the
+  // same wall", never buildable-vs-buildable: so the decal must lose that
+  // comparison unconditionally, regardless of its own scene layer/overlay boost or
+  // the other building's. A relative per-tier offset (e.g. nudging just enough to
+  // beat buildings sharing PixelPack's own InteriorWall tier) is not enough - it
+  // silently fails against a building on any *higher* tier that also gets a
+  // boost, such as a Building-layer light fixture in the Base overlay (their tier
+  // gap alone already separates them; the boost widens it further in the wrong
+  // direction only for pairs living below PixelPack's own tier). This pins the
+  // absolute, tier-independent invariant instead of re-deriving it per pair.
   describe('render depth ordering (BlueprintItem.cameraChanged)', () => {
-    it('PixelPack (Backwall) never ties with Canvas (Building) at rest, and reverts deterministically', () => {
-      const pixelPack = new BlueprintItem('PixelPack');
-      const canvas = new BlueprintItem('Canvas');
+    const expectAlwaysBehind = (packId: string, buildingId: string) => {
+      const pack = new BlueprintItem(packId);
+      const building = new BlueprintItem(buildingId);
       const camera = new CameraService({});
 
-      // Base (both before and after the Automation round-trip): both are
-      // "primary" at the InteriorWall tier - PixelPack must lose the tie,
-      // and must do so identically each time (no hysteresis from the switch).
-      for (const _ of [0, 1]) {
-        camera.overlay = Overlay.Base;
-        pixelPack.cameraChanged(camera);
-        canvas.cameraChanged(camera);
-        expect(pixelPack.depth, 'PixelPack.depth in Base').to.be.lessThan(canvas.depth);
-
-        // Automation: PixelPack has a wire connection and is meant to highlight
-        // forward (like wires popping above tiles in the Power overlay) while
-        // the unrelated Canvas dims to alpha 0.3 - intentional, not the bug.
-        camera.overlay = Overlay.Automation;
-        pixelPack.cameraChanged(camera);
-        canvas.cameraChanged(camera);
-        expect(pixelPack.depth, 'PixelPack.depth in Automation').to.be.greaterThan(canvas.depth);
-        expect(canvas.isOpaque, 'Canvas.isOpaque in Automation').to.equal(false);
+      for (const overlay of [Overlay.Base, Overlay.Automation, Overlay.Base]) {
+        camera.overlay = overlay;
+        pack.cameraChanged(camera);
+        building.cameraChanged(camera);
+        expect(
+          pack.depth,
+          `${packId}.depth vs ${buildingId}.depth in ${Overlay[overlay]}`
+        ).to.be.lessThan(building.depth);
       }
+    };
+
+    it('PixelPack stays behind the Portrait Canvas (same InteriorWall scene layer)', () => {
+      expectAlwaysBehind('PixelPack', 'Canvas');
+    });
+
+    it('PixelPack stays behind a Mercury Ceiling Light (higher Building scene layer)', () => {
+      expectAlwaysBehind('PixelPack', 'MercuryCeilingLight');
+    });
+
+    it('PixelPack still highlights as opaque in the Automation overlay (alpha, not depth, signals relevance)', () => {
+      const pixelPack = new BlueprintItem('PixelPack');
+      const camera = new CameraService({});
+      camera.overlay = Overlay.Automation;
+      pixelPack.cameraChanged(camera);
+      expect(pixelPack.isOpaque).to.equal(true);
     });
   });
 

--- a/frontend/src/app/module-blueprint/drawing/draw-pixi.ts
+++ b/frontend/src/app/module-blueprint/drawing/draw-pixi.ts
@@ -6,6 +6,7 @@ import {
   Vector2,
   PixiUtil,
   ZIndex,
+  stableSortChildren,
 } from "../../../../../lib/index";
 import { ComponentMenuComponent } from "../components/component-menu/component-menu.component";
 
@@ -124,7 +125,7 @@ export class DrawPixi implements PixiUtil {
 
   public sortChildren() {
     //console.log('sortChildren')
-    this.blueprintContainer.sortChildren();
+    stableSortChildren(this.blueprintContainer);
   }
 
   animateAll() {

--- a/lib/src/blueprint/blueprint-item.d.ts
+++ b/lib/src/blueprint/blueprint-item.d.ts
@@ -14,6 +14,7 @@ export declare class BlueprintItem {
     static defaultRotation: number;
     static defaultScale: Vector2;
     static defaultTemperature: number;
+    static readonly backwallDepth = -1000;
     id: string;
     temperature: number;
     get temperatureCelcius(): number;

--- a/lib/src/blueprint/blueprint-item.ts
+++ b/lib/src/blueprint/blueprint-item.ts
@@ -23,6 +23,15 @@ export class BlueprintItem {
   static defaultScale = Vector2.One;
   static defaultTemperature = 30 + 273.15;
 
+  // Buildings never overlap each other (the game's placement rules forbid it), so the
+  // only render-order comparison that can ever be visually observed is "some buildable
+  // vs a wall-plane decal placed on the same wall" - never buildable-vs-buildable. Decals
+  // (PixelPack, ...) must always lose that comparison, unconditionally, regardless of
+  // their own scene layer or overlay boost. A fixed sentinel below every real depth
+  // (zIndex range ~-2..34, plus at most a +100 overlay boost) is simpler and more robust
+  // than trying to out-rank every other buildable's tier case by case.
+  static readonly backwallDepth = -1000;
+
   public id: string;
   public temperature: number = BlueprintItem.defaultTemperature;
   public get temperatureCelcius() {
@@ -515,10 +524,10 @@ export class BlueprintItem {
     else if (this.oniItem.isOverlaySecondary(camera.overlay)) this.depth = this.oniItem.zIndex + 50;
     else this.depth = this.oniItem.zIndex;
 
-    // Wall-plane props (PixelPack, ...) render flush in the wall, so they must
-    // always sit behind Building-layer items sharing the same tier (e.g. a
-    // portrait mounted on the wall) - never left to tie/insertion order.
-    if (this.oniItem.objectLayer == OniItem.objectLayerBackwall) this.depth -= 0.5;
+    // Wall-plane decals always render behind whatever they're placed against -
+    // see BlueprintItem.backwallDepth above.
+    if (this.oniItem.objectLayer == OniItem.objectLayerBackwall)
+      this.depth = BlueprintItem.backwallDepth;
 
     if (this.isBuildCandidate) this.depth = 199;
 

--- a/lib/src/blueprint/blueprint-item.ts
+++ b/lib/src/blueprint/blueprint-item.ts
@@ -16,7 +16,7 @@ import { Display } from '../enums/display';
 import { Visualization } from '../enums/visualization';
 import { ConnectionHelper } from '../utility-connection';
 import { SpriteInfo } from '../drawing/sprite-info';
-import { PixiUtil } from '../drawing/pixi-util';
+import { PixiUtil, stableSortChildren } from '../drawing/pixi-util';
 
 export class BlueprintItem {
   static defaultRotation = 0;
@@ -515,6 +515,11 @@ export class BlueprintItem {
     else if (this.oniItem.isOverlaySecondary(camera.overlay)) this.depth = this.oniItem.zIndex + 50;
     else this.depth = this.oniItem.zIndex;
 
+    // Wall-plane props (PixelPack, ...) render flush in the wall, so they must
+    // always sit behind Building-layer items sharing the same tier (e.g. a
+    // portrait mounted on the wall) - never left to tie/insertion order.
+    if (this.oniItem.objectLayer == OniItem.objectLayerBackwall) this.depth -= 0.5;
+
     if (this.isBuildCandidate) this.depth = 199;
 
     this.visualizationTint = -1;
@@ -801,7 +806,7 @@ export class BlueprintItem {
   */
 
   sortChildren() {
-    if (this.container != null) this.container.sortChildren();
+    if (this.container != null) stableSortChildren(this.container);
   }
 
   destroyed: boolean = false;

--- a/lib/src/drawing/pixi-util.d.ts
+++ b/lib/src/drawing/pixi-util.d.ts
@@ -12,4 +12,5 @@ export interface PixiUtil {
     getUtilityGraphicsBack(): any;
     getUtilityGraphicsFront(): any;
 }
+export declare function stableSortChildren(container: any): void;
 //# sourceMappingURL=pixi-util.d.ts.map

--- a/lib/src/drawing/pixi-util.ts
+++ b/lib/src/drawing/pixi-util.ts
@@ -12,3 +12,21 @@ export interface PixiUtil {
   getUtilityGraphicsBack(): any;
   getUtilityGraphicsFront(): any;
 }
+
+let nextStableSortOrder = 0;
+
+// PIXI's built-in Container.sortChildren() breaks zIndex ties using an index
+// it re-stamps from each child's *current* array position on every call. That
+// means a transient zIndex divergence (e.g. a building that only outranks a
+// sibling while a specific overlay is active) permanently reorders the two
+// once they tie again, instead of reverting - render order ends up depending
+// on overlay navigation history rather than current state. Stamp each child
+// once with a fixed key on first sight and tie-break on that instead.
+export function stableSortChildren(container: any): void {
+  for (const child of container.children) {
+    if (child._stableSortOrder === undefined) child._stableSortOrder = nextStableSortOrder++;
+  }
+  container.children.sort(
+    (a: any, b: any) => a.zIndex - b.zIndex || a._stableSortOrder - b._stableSortOrder
+  );
+}

--- a/lib/src/oni-item.d.ts
+++ b/lib/src/oni-item.d.ts
@@ -72,6 +72,7 @@ export declare class OniItem {
     static init(): void;
     static load(buildings: BBuilding[]): void;
     static readonly objectLayerBuilding = 1;
+    static readonly objectLayerBackwall = 2;
     isOverlayPrimary(overlay: Overlay): boolean;
     isOverlaySecondary(overlay: Overlay): boolean;
     getCategoryFromItem(): BuildMenuCategory;

--- a/lib/src/oni-item.ts
+++ b/lib/src/oni-item.ts
@@ -367,6 +367,14 @@ export class OniItem {
   // structures even when their sceneLayer is a wire/conduit render layer.
   static readonly objectLayerBuilding = 1;
 
+  // ObjectLayer.Backwall: wall-plane props (ExteriorWall, GlassExteriorWall,
+  // PropGravitasLabWall/Window, PixelPack, ...). These sit flush in the wall
+  // itself, so they must always render behind Building-layer items even when
+  // they share the same sceneLayer tier (e.g. PixelPack and the Portrait
+  // Canvas both sit at InteriorWall) - a wall mural is always behind whatever
+  // is mounted on the wall, regardless of build order.
+  static readonly objectLayerBackwall = 2;
+
   public isOverlayPrimary(overlay: Overlay): boolean {
     // U59 moved the Heavi-Watt joint plates to the WireBridges/WireBridgesFront
     // scene layers, but they occupy the Building object layer: solid in the Base


### PR DESCRIPTION
## Summary

Reported bug: after switching to the Automation overlay and back to Base, the Portrait Canvas renders behind the PixelPack decor — which is backwards, since PixelPack sits flush in the wall (like drywall) and should never render in front of anything mounted on it.

Two separate issues, both fixed:

- **PIXI's tie-break is stateful, not fixed.** `Container.sortChildren()` breaks zIndex ties using an index (`_lastSortedIndex`) it re-stamps from each child's *current* array position on every call, instead of a fixed insertion-order key. A real, temporary zIndex divergence between two items (e.g. one pops forward during a specific overlay) permanently reordered them in PIXI's child array — so once they tied again later, render order "remembered" the old state instead of reverting. Fixed with `stableSortChildren()` (`lib/src/drawing/pixi-util.ts`), used at both call sites that previously called PIXI's built-in `sortChildren()`.
- **Pack decals must render behind literally everything, unconditionally.** Buildings can never overlap each other, so the only render-order comparison that's ever visually observed is "some buildable vs. a decal (PixelPack) placed on the same wall" — never buildable-vs-buildable. That means the decal must lose that comparison no matter what: regardless of its own scene layer, regardless of any overlay-driven boost on either side. An earlier version of this fix used a small relative offset scoped to PixelPack's own tier, which broke as soon as it was checked against a building on a *different* tier that also gets an overlay boost (e.g. a Mercury Ceiling Light, `Building` layer/tier 19, still ended up hidden behind PixelPack once the Automation overlay's highlight boost pushed PixelPack above it). `BlueprintItem.cameraChanged` now assigns `ObjectLayer.Backwall` items (PixelPack, currently the only member with this problem) a fixed sentinel depth (`BlueprintItem.backwallDepth`) below any real building's depth range, unconditionally — no per-pair/per-tier reasoning required.

## Design decisions

- Pack decals still go opaque (`alpha = 1`) in the overlay where they're relevant (e.g. Automation, since PixelPack has a wire connection) — that's existing highlight behavior via `isOpaque`/alpha, unrelated to depth, and is untouched.
- Depth for packs is now unconditional, so they no longer pop forward in *any* overlay — only their opacity changes. That matches the invariant: packs render behind everything, full stop.

## Test plan

- [x] `__tests__/asset-processing/game-structure-contract.test.ts` — `render depth ordering (BlueprintItem.cameraChanged)`:
  - PixelPack stays behind Canvas (same scene layer as PixelPack)
  - PixelPack stays behind a Mercury Ceiling Light (different, higher scene layer) — this is the case that caught the first version's relative-offset gap
  - PixelPack still reports `isOpaque` in the Automation overlay (confirms the highlight is preserved)
  - Verified each assertion fails without its corresponding fix and passes with it (including deliberately reverting to the old relative-offset approach to confirm the Mercury Ceiling Light case catches its gap)
- [x] `npm run tsc` clean
- [x] Backend suite: 449 passing / 2 failing (both are the pre-existing `workos-provision` local-only flakes documented in CLAUDE.md, confirmed unrelated by running in isolation)
- [x] Frontend `build-tool.spec.ts` (49 tests, exercises `sortChildren`) passing against the rebuilt lib
- [ ] Not manually verified in the browser — recommend placing an overlapping Portrait + PixelPack (and separately a Ceiling Light + PixelPack), switching to Automation and back, and confirming the pack always stays behind before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)