### PR TITLE
feat(editor): support touch input on the editor canvas

### DIFF
--- a/frontend/src/app/module-blueprint/components/component-canvas/component-canvas.component.css
+++ b/frontend/src/app/module-blueprint/components/component-canvas/component-canvas.component.css
@@ -2,4 +2,8 @@
   background-color: black;
   position: absolute;
   z-index: -1;
+  /* Interaction is handled entirely by our own pointer-event pipeline
+     (pan, pinch-zoom, tool drags) - stop the browser from intercepting
+     touch gestures as native scroll/pinch-zoom before they reach it. */
+  touch-action: none;
 }

--- a/frontend/src/app/module-blueprint/components/component-canvas/component-canvas.component.html
+++ b/frontend/src/app/module-blueprint/components/component-canvas/component-canvas.component.html
@@ -11,6 +11,7 @@
   (myMouseUp)="mouseUp($event)"
   (myMouseDown)="mouseDown($event)"
   (myMouseOut)="mouseOut($event)"
+  (myMultiTouchGesture)="multiTouchGesture($event)"
   appMouseWheel
   (mouseWheel)="mouseWheel($event)"
   appKeyEvents

--- a/frontend/src/app/module-blueprint/components/component-canvas/component-canvas.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-canvas/component-canvas.component.ts
@@ -335,6 +335,26 @@ export class ComponentCanvasComponent
     this.toolService.dragStop();
   }
 
+  // Two-finger touch gesture: pans and zooms the camera together, mirroring
+  // desktop's right-drag-to-pan + wheel-to-zoom since touch has no
+  // equivalent buttons/wheel. Single-finger touch drives the active tool
+  // exactly like a left-button mouse drag (see mouseDrag/mouseDown above).
+  multiTouchGesture(event: any) {
+    this.cameraService.cameraOffset.x +=
+      event.panX / this.cameraService.currentZoom;
+    this.cameraService.cameraOffset.y +=
+      event.panY / this.cameraService.currentZoom;
+
+    if (event.zoomDelta) {
+      let rect = this.canvasRef.nativeElement.getBoundingClientRect();
+      let centerPos = new Vector2(
+        event.centerClientX - rect.left,
+        event.centerClientY - rect.top
+      );
+      this.cameraService.changeZoom(event.zoomDelta, centerPos);
+    }
+  }
+
   // previousMouse is used by the keyboard zoom
   previousMouse: Vector2 = new Vector2();
   previousTileUnderMouse: Vector2 | null = null;

--- a/frontend/src/app/module-blueprint/directives/draganddrop.directive.spec.ts
+++ b/frontend/src/app/module-blueprint/directives/draganddrop.directive.spec.ts
@@ -1,23 +1,37 @@
+import { ElementRef } from "@angular/core";
 import { DragAndDropDirective } from "./draganddrop.directive";
 
-const mouseEvent = (
-  _type: string,
+let nextPointerId = 1;
+
+const pointerEvent = (
   button: number,
   clientX: number,
-  clientY: number
+  clientY: number,
+  opts: { pointerType?: string; pointerId?: number } = {}
 ) =>
   ({
     button,
     clientX,
     clientY,
+    pointerId: opts.pointerId ?? nextPointerId++,
+    pointerType: opts.pointerType ?? "mouse",
     preventDefault: vi.fn(),
   } as any);
+
+const fakeElementRef = () =>
+  ({
+    nativeElement: {
+      setPointerCapture: vi.fn(),
+      releasePointerCapture: vi.fn(),
+    },
+  } as unknown as ElementRef);
 
 describe("DragAndDropDirective", () => {
   let dir: DragAndDropDirective;
 
   beforeEach(() => {
-    dir = new DragAndDropDirective();
+    nextPointerId = 1;
+    dir = new DragAndDropDirective(fakeElementRef());
   });
 
   describe("initial state", () => {
@@ -28,42 +42,62 @@ describe("DragAndDropDirective", () => {
     });
   });
 
-  describe("onMouseDown", () => {
+  describe("onPointerDown", () => {
     it("sets isMouseDown[button] to true", () => {
-      dir.onMouseDown(mouseEvent("mousedown", 0, 10, 20));
+      dir.onPointerDown(pointerEvent(0, 10, 20));
       expect(dir.isMouseDown[0]).toBe(true);
     });
 
     it("emits myMouseDown", () => {
       const handler = vi.fn();
       dir.myMouseDown.subscribe(handler);
-      dir.onMouseDown(mouseEvent("mousedown", 0, 10, 20));
+      dir.onPointerDown(pointerEvent(0, 10, 20));
       expect(handler).toHaveBeenCalledTimes(1);
     });
 
     it("does not emit again if mouse is already down", () => {
       const handler = vi.fn();
       dir.myMouseDown.subscribe(handler);
-      dir.onMouseDown(mouseEvent("mousedown", 0, 10, 20));
-      dir.onMouseDown(mouseEvent("mousedown", 0, 10, 20)); // duplicate
+      const id = nextPointerId++;
+      dir.onPointerDown(pointerEvent(0, 10, 20, { pointerId: id }));
+      dir.onPointerDown(pointerEvent(0, 10, 20, { pointerId: id })); // duplicate
       expect(handler).toHaveBeenCalledTimes(1);
     });
 
-    it("tracks different buttons independently", () => {
-      dir.onMouseDown(mouseEvent("mousedown", 0, 10, 20));
-      dir.onMouseDown(mouseEvent("mousedown", 2, 10, 20));
+    it("tracks different buttons independently for a single physical mouse (one pointerId, multiple buttons)", () => {
+      const id = nextPointerId++;
+      dir.onPointerDown(pointerEvent(0, 10, 20, { pointerId: id }));
+      dir.onPointerDown(pointerEvent(2, 10, 20, { pointerId: id }));
       expect(dir.isMouseDown[0]).toBe(true);
       expect(dir.isMouseDown[2]).toBe(true);
     });
+
+    it("synthesizes a myMouseMove before myMouseDown for touch, to drive hover/preview state on tap", () => {
+      const calls: string[] = [];
+      dir.myMouseMove.subscribe(() => calls.push("move"));
+      dir.myMouseDown.subscribe(() => calls.push("down"));
+
+      dir.onPointerDown(pointerEvent(0, 10, 20, { pointerType: "touch" }));
+
+      expect(calls).toEqual(["move", "down"]);
+    });
+
+    it("does not synthesize myMouseMove for a real mouse press", () => {
+      const handler = vi.fn();
+      dir.myMouseMove.subscribe(handler);
+      dir.onPointerDown(pointerEvent(0, 10, 20, { pointerType: "mouse" }));
+      expect(handler).not.toHaveBeenCalled();
+    });
   });
 
-  describe("onMouseUp", () => {
+  describe("onPointerUp", () => {
     it("emits myMouseClick when position matches startDragPosition", () => {
       const clickHandler = vi.fn();
       dir.myMouseClick.subscribe(clickHandler);
 
-      dir.onMouseDown(mouseEvent("mousedown", 0, 50, 60));
-      dir.onMouseUp(mouseEvent("mouseup", 0, 50, 60)); // same position = click
+      const id = nextPointerId++;
+      dir.onPointerDown(pointerEvent(0, 50, 60, { pointerId: id }));
+      dir.onPointerUp(pointerEvent(0, 50, 60, { pointerId: id })); // same position = click
       expect(clickHandler).toHaveBeenCalledTimes(1);
     });
 
@@ -71,48 +105,75 @@ describe("DragAndDropDirective", () => {
       const clickHandler = vi.fn();
       dir.myMouseClick.subscribe(clickHandler);
 
-      dir.onMouseDown(mouseEvent("mousedown", 0, 50, 60));
-      dir.onMouseUp(mouseEvent("mouseup", 0, 80, 90)); // moved = no click
+      const id = nextPointerId++;
+      dir.onPointerDown(pointerEvent(0, 50, 60, { pointerId: id }));
+      dir.onPointerUp(pointerEvent(0, 80, 90, { pointerId: id })); // moved = no click
       expect(clickHandler).not.toHaveBeenCalled();
     });
 
     it("emits myMouseUp", () => {
       const handler = vi.fn();
       dir.myMouseUp.subscribe(handler);
-      dir.onMouseDown(mouseEvent("mousedown", 0, 0, 0));
-      dir.onMouseUp(mouseEvent("mouseup", 0, 0, 0));
+      const id = nextPointerId++;
+      dir.onPointerDown(pointerEvent(0, 0, 0, { pointerId: id }));
+      dir.onPointerUp(pointerEvent(0, 0, 0, { pointerId: id }));
       expect(handler).toHaveBeenCalledTimes(1);
     });
 
     it("sets isMouseDown[button] to false", () => {
-      dir.onMouseDown(mouseEvent("mousedown", 0, 0, 0));
-      dir.onMouseUp(mouseEvent("mouseup", 0, 0, 0));
+      const id = nextPointerId++;
+      dir.onPointerDown(pointerEvent(0, 0, 0, { pointerId: id }));
+      dir.onPointerUp(pointerEvent(0, 0, 0, { pointerId: id }));
       expect(dir.isMouseDown[0]).toBe(false);
     });
 
-    it("emits myMouseStopDrag on mouseup", () => {
+    it("emits myMouseStopDrag on pointer up", () => {
       const handler = vi.fn();
       dir.myMouseStopDrag.subscribe(handler);
-      dir.onMouseDown(mouseEvent("mousedown", 0, 0, 0));
-      dir.onMouseUp(mouseEvent("mouseup", 0, 5, 5));
+      const id = nextPointerId++;
+      dir.onPointerDown(pointerEvent(0, 0, 0, { pointerId: id }));
+      dir.onPointerUp(pointerEvent(0, 5, 5, { pointerId: id }));
       expect(handler).toHaveBeenCalled();
+    });
+
+    it("a tap (touch down+up at same tile) fires a click, matching the tap-to-place flow", () => {
+      const clickHandler = vi.fn();
+      dir.myMouseClick.subscribe(clickHandler);
+
+      const id = nextPointerId++;
+      dir.onPointerDown(
+        pointerEvent(0, 30, 40, { pointerId: id, pointerType: "touch" })
+      );
+      dir.onPointerUp(
+        pointerEvent(0, 30, 40, { pointerId: id, pointerType: "touch" })
+      );
+
+      expect(clickHandler).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe("onMouseLeave", () => {
-    it("emits myMouseOut", () => {
+  describe("onPointerLeave", () => {
+    it("emits myMouseOut for a real mouse", () => {
       const handler = vi.fn();
       dir.myMouseOut.subscribe(handler);
-      dir.onMouseLeave(mouseEvent("mouseout", 0, 0, 0));
+      dir.onPointerLeave(pointerEvent(0, 0, 0, { pointerType: "mouse" }));
       expect(handler).toHaveBeenCalledTimes(1);
     });
 
     it("clears all drag states on leave", () => {
-      dir.onMouseDown(mouseEvent("mousedown", 0, 10, 20));
-      dir.onMouseDown(mouseEvent("mousedown", 2, 10, 20));
-      dir.onMouseLeave(mouseEvent("mouseout", 0, 0, 0));
+      const id = nextPointerId++;
+      dir.onPointerDown(pointerEvent(0, 10, 20, { pointerId: id }));
+      dir.onPointerDown(pointerEvent(2, 10, 20, { pointerId: id }));
+      dir.onPointerLeave(pointerEvent(0, 0, 0, { pointerType: "mouse" }));
       expect(dir.isMouseDown[0]).toBe(false);
       expect(dir.isMouseDown[2]).toBe(false);
+    });
+
+    it("is ignored for touch, since a finger lifting is a pointerup/cancel, not a leave", () => {
+      const handler = vi.fn();
+      dir.myMouseOut.subscribe(handler);
+      dir.onPointerLeave(pointerEvent(0, 0, 0, { pointerType: "touch" }));
+      expect(handler).not.toHaveBeenCalled();
     });
   });
 
@@ -122,11 +183,11 @@ describe("DragAndDropDirective", () => {
     });
   });
 
-  describe("onMouseMove", () => {
+  describe("onPointerMove", () => {
     it("emits myMouseMove when not dragging", () => {
       const handler = vi.fn();
       dir.myMouseMove.subscribe(handler);
-      dir.onMouseMove({ clientX: 5, clientY: 5 } as any);
+      dir.onPointerMove(pointerEvent(0, 5, 5));
       expect(handler).toHaveBeenCalled();
     });
 
@@ -136,11 +197,98 @@ describe("DragAndDropDirective", () => {
       dir.myMouseMove.subscribe(moveHandler);
       dir.myMouseDrag.subscribe(dragHandler);
 
-      dir.onMouseDown(mouseEvent("mousedown", 0, 10, 20));
-      dir.onMouseMove({ clientX: 15, clientY: 25, button: 0 } as any);
+      const id = nextPointerId++;
+      dir.onPointerDown(pointerEvent(0, 10, 20, { pointerId: id }));
+      dir.onPointerMove(pointerEvent(0, 15, 25, { pointerId: id }));
 
       expect(dragHandler).toHaveBeenCalled();
       expect(moveHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("two-finger touch gesture", () => {
+    it("stops any single-finger drag (without a click) once a second finger touches down", () => {
+      const clickHandler = vi.fn();
+      const stopDragHandler = vi.fn();
+      dir.myMouseClick.subscribe(clickHandler);
+      dir.myMouseStopDrag.subscribe(stopDragHandler);
+
+      dir.onPointerDown(
+        pointerEvent(0, 10, 10, { pointerId: 1, pointerType: "touch" })
+      );
+      dir.onPointerDown(
+        pointerEvent(0, 50, 10, { pointerId: 2, pointerType: "touch" })
+      );
+
+      expect(stopDragHandler).toHaveBeenCalled();
+      expect(clickHandler).not.toHaveBeenCalled();
+      expect(dir.isMouseDown[0]).toBe(false);
+    });
+
+    it("emits myMultiTouchGesture with pan and zoom deltas as the two fingers move", () => {
+      const gestureHandler = vi.fn();
+      dir.myMultiTouchGesture.subscribe(gestureHandler);
+
+      dir.onPointerDown(
+        pointerEvent(0, 0, 0, { pointerId: 1, pointerType: "touch" })
+      );
+      dir.onPointerDown(
+        pointerEvent(0, 100, 0, { pointerId: 2, pointerType: "touch" })
+      );
+
+      // Fingers spread apart and both shift right -> pan right, zoom in.
+      dir.onPointerMove(
+        pointerEvent(0, 10, 0, { pointerId: 1, pointerType: "touch" })
+      );
+      dir.onPointerMove(
+        pointerEvent(0, 130, 0, { pointerId: 2, pointerType: "touch" })
+      );
+
+      expect(gestureHandler).toHaveBeenCalled();
+      const lastEvent = gestureHandler.mock.calls.at(-1)![0];
+      expect(lastEvent.panX).toBeGreaterThan(0);
+      expect(lastEvent.zoomDelta).toBeGreaterThan(0);
+    });
+
+    it("does not emit myMouseClick/myMouseUp for a finger lifted while gesturing", () => {
+      const clickHandler = vi.fn();
+      const upHandler = vi.fn();
+      dir.myMouseClick.subscribe(clickHandler);
+      dir.myMouseUp.subscribe(upHandler);
+
+      dir.onPointerDown(
+        pointerEvent(0, 0, 0, { pointerId: 1, pointerType: "touch" })
+      );
+      dir.onPointerDown(
+        pointerEvent(0, 100, 0, { pointerId: 2, pointerType: "touch" })
+      );
+      dir.onPointerUp(
+        pointerEvent(0, 0, 0, { pointerId: 1, pointerType: "touch" })
+      );
+
+      expect(clickHandler).not.toHaveBeenCalled();
+      expect(upHandler).not.toHaveBeenCalled();
+    });
+
+    it("lets the user keep dragging with the remaining finger after the pinch ends", () => {
+      dir.onPointerDown(
+        pointerEvent(0, 0, 0, { pointerId: 1, pointerType: "touch" })
+      );
+      dir.onPointerDown(
+        pointerEvent(0, 100, 0, { pointerId: 2, pointerType: "touch" })
+      );
+      dir.onPointerUp(
+        pointerEvent(0, 100, 0, { pointerId: 2, pointerType: "touch" })
+      );
+
+      expect(dir.isMouseDown[0]).toBe(true);
+
+      const dragHandler = vi.fn();
+      dir.myMouseDrag.subscribe(dragHandler);
+      dir.onPointerMove(
+        pointerEvent(0, 20, 0, { pointerId: 1, pointerType: "touch" })
+      );
+      expect(dragHandler).toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/app/module-blueprint/directives/draganddrop.directive.ts
+++ b/frontend/src/app/module-blueprint/directives/draganddrop.directive.ts
@@ -1,5 +1,15 @@
-import { Directive, Output, HostListener, EventEmitter } from "@angular/core";
+import {
+  Directive,
+  Output,
+  HostListener,
+  EventEmitter,
+  ElementRef,
+} from "@angular/core";
 import { Vector2 } from "../../../../../lib/index";
+
+// How much a two-finger pinch (in screen px of finger separation) changes
+// CameraService.currentZoom (in px/tile). Lower = less sensitive pinch.
+const PINCH_ZOOM_SENSITIVITY = 0.5;
 
 @Directive({
   selector: "[appDragAndDrop]",
@@ -13,12 +23,23 @@ export class DragAndDropDirective {
   @Output() myMouseStopDrag = new EventEmitter();
   @Output() myMouseMove = new EventEmitter();
   @Output() myMouseClick = new EventEmitter();
+  // Two-finger touch gesture: pans and zooms the camera at once.
+  @Output() myMultiTouchGesture = new EventEmitter();
 
   isMouseDown: boolean[];
   lastDragPosition: (Vector2 | null)[];
   startDragPosition: (Vector2 | null)[];
 
-  constructor() {
+  // Pointer Events let one code path drive mouse, touch and pen. A single
+  // active pointer is treated exactly like the old single mouse button
+  // (button index 0 for touch, since touch has no button concept). A second
+  // simultaneous pointer switches into a two-finger pan/zoom gesture instead.
+  private activePointers: Map<number, Vector2> = new Map();
+  private gestureActive: boolean = false;
+  private gestureLastDistance: number = 0;
+  private gestureLastMidpoint: Vector2 | null = null;
+
+  constructor(private el: ElementRef) {
     this.isMouseDown = [];
     this.lastDragPosition = [];
     this.startDragPosition = [];
@@ -28,8 +49,42 @@ export class DragAndDropDirective {
     }
   }
 
-  @HostListener("mousedown", ["$event"]) onMouseDown(event: any) {
-    var event = window.event || event; // old IE support
+  @HostListener("pointerdown", ["$event"]) onPointerDown(event: any) {
+    this.activePointers.set(
+      event.pointerId,
+      new Vector2(event.clientX, event.clientY)
+    );
+
+    if (event.pointerType) {
+      try {
+        this.el.nativeElement.setPointerCapture(event.pointerId);
+      } catch {
+        // Ignore - capture is a best-effort reliability improvement.
+      }
+    }
+
+    if (this.activePointers.size == 2) {
+      // A second finger just touched down: whatever single-pointer drag was
+      // in progress stops here (without registering as a click), and we
+      // switch to interpreting further movement as a pan/zoom gesture.
+      this.stopDrag(event, 0);
+      this.gestureActive = true;
+      this.primeGestureBaseline();
+      if (event.preventDefault) event.preventDefault();
+      return;
+    }
+
+    if (this.activePointers.size > 2) {
+      if (event.preventDefault) event.preventDefault();
+      return;
+    }
+
+    // Touch has no hover state distinct from touching, so synthesize one
+    // hover event at touch-down. This drives the build tool's placement
+    // preview/validity check before the matching touch-up fires the tap.
+    if (event.pointerType === "touch") {
+      this.myMouseMove.emit(event);
+    }
 
     let dragButton: number = event.button;
     if (!this.isMouseDown[dragButton]) {
@@ -50,12 +105,46 @@ export class DragAndDropDirective {
     }
   }
 
-  @HostListener("mouseup", ["$event"]) onMouseUp(event: any) {
-    var event = window.event || event; // old IE support
+  @HostListener("pointerup", ["$event"]) onPointerUp(event: any) {
+    this.onPointerEnd(event, true);
+  }
+
+  @HostListener("pointercancel", ["$event"]) onPointerCancel(event: any) {
+    this.onPointerEnd(event, false);
+  }
+
+  private onPointerEnd(event: any, allowClick: boolean) {
+    this.activePointers.delete(event.pointerId);
+
+    if (this.gestureActive) {
+      if (this.activePointers.size >= 2) {
+        this.primeGestureBaseline();
+        return;
+      }
+
+      this.gestureActive = false;
+      this.gestureLastMidpoint = null;
+
+      if (this.activePointers.size == 1) {
+        // One finger is still down after the pinch ends: let the user keep
+        // dragging with it, but re-baseline drag tracking to that finger's
+        // current position so it doesn't jump.
+        let remaining = this.activePointers.values().next().value as Vector2;
+        this.isMouseDown[0] = true;
+        this.startDragPosition[0] = new Vector2(remaining.x, remaining.y);
+        this.lastDragPosition[0] = new Vector2(remaining.x, remaining.y);
+      } else {
+        this.isMouseDown[0] = false;
+        this.startDragPosition[0] = null;
+        this.lastDragPosition[0] = null;
+      }
+      return;
+    }
 
     let dragButton: number = event.button;
 
     if (
+      allowClick &&
       this.startDragPosition[dragButton] != null &&
       new Vector2(event.clientX, event.clientY).equals(
         this.startDragPosition[dragButton]!
@@ -73,13 +162,23 @@ export class DragAndDropDirective {
     return false;
   }
 
-  @HostListener("mouseout", ["$event"]) onMouseLeave(event: any) {
+  @HostListener("pointerleave", ["$event"]) onPointerLeave(event: any) {
+    if (event.pointerType !== "mouse") return;
     for (let i = 0; i <= 2; i++) this.stopDrag(event, i);
     this.myMouseOut.emit(event);
   }
 
-  @HostListener("mousemove.out-zone", ["$event"]) onMouseMove(event: any) {
-    var event = window.event || event; // old IE support
+  @HostListener("pointermove.out-zone", ["$event"]) onPointerMove(event: any) {
+    if (this.activePointers.has(event.pointerId))
+      this.activePointers.set(
+        event.pointerId,
+        new Vector2(event.clientX, event.clientY)
+      );
+
+    if (this.gestureActive) {
+      this.handleGestureMove(event);
+      return;
+    }
 
     let isDragging = false;
     for (let i = 0; i <= 2; i++) if (this.isMouseDown[i]) isDragging = true;
@@ -98,6 +197,47 @@ export class DragAndDropDirective {
     } else {
       this.myMouseMove.emit(event);
     }
+  }
+
+  private static pointerDistance(a: Vector2, b: Vector2): number {
+    return Math.hypot(b.x - a.x, b.y - a.y);
+  }
+
+  private primeGestureBaseline() {
+    let points = Array.from(this.activePointers.values());
+    if (points.length < 2) return;
+
+    this.gestureLastDistance = DragAndDropDirective.pointerDistance(
+      points[0],
+      points[1]
+    );
+    this.gestureLastMidpoint = new Vector2(
+      (points[0].x + points[1].x) / 2,
+      (points[0].y + points[1].y) / 2
+    );
+  }
+
+  private handleGestureMove(event: any) {
+    let points = Array.from(this.activePointers.values());
+    if (points.length < 2 || this.gestureLastMidpoint == null) return;
+
+    let distance = DragAndDropDirective.pointerDistance(points[0], points[1]);
+    let midpoint = new Vector2(
+      (points[0].x + points[1].x) / 2,
+      (points[0].y + points[1].y) / 2
+    );
+
+    event.panX = midpoint.x - this.gestureLastMidpoint.x;
+    event.panY = midpoint.y - this.gestureLastMidpoint.y;
+    event.zoomDelta =
+      (distance - this.gestureLastDistance) * PINCH_ZOOM_SENSITIVITY;
+    event.centerClientX = midpoint.x;
+    event.centerClientY = midpoint.y;
+
+    this.gestureLastDistance = distance;
+    this.gestureLastMidpoint = midpoint;
+
+    this.myMultiTouchGesture.emit(event);
   }
 
   stopDrag(event: any, i: number) {


### PR DESCRIPTION
## Summary

First step of mobile support for the editor: the canvas's interaction pipeline was mouse-events-only, so tapping/dragging on a touchscreen never reliably reached the tools (root-caused via an exploration pass over the whole interaction stack before writing any code). This makes the canvas itself touch-usable; discover-page and toolbar/UI mobile polish are separate follow-ups.

## What shipped

- `draganddrop.directive.ts` now listens for **Pointer Events** instead of mouse events, so mouse, touch and pen share one code path. A single active pointer drives the active tool exactly like a left-button mouse drag did before (select-box, build-tool drag-placement, scissors-cut) — no changes needed in the tools themselves.
- **Two-finger gesture = pan + zoom together**, one-finger drag = active tool (matches Figma/Miro/Procreate convention). A second simultaneous pointer switches into gesture mode: further movement pans the camera by the two pointers' midpoint delta and zooms by the change in inter-finger distance. Lifting one finger after a pinch re-baselines drag tracking so the remaining finger can keep dragging without a jump.
- **Tap-to-place, matching existing click semantics**: touch has no hover state distinct from touching, so touch-down synthesizes a `hover` event before the down/click sequence — this keeps the build tool's ghost/validity preview working on a single tap, reusing the exact same `hover()` → `leftClick()` pipeline mouse already used.
- `touch-action: none` on the canvas stops the browser from intercepting these gestures as native scroll/pinch-zoom before the app ever sees them.

## Design decisions (confirmed with the requester up front)

- Pan/zoom gesture mapping: **two-finger pan+zoom, one-finger tool-drag** (no new toolbar mode button needed).
- Build-tool touch flow: **tap places immediately** (touchstart synthesizes hover/preview, touchend on the same tile places), not a two-step preview-then-confirm.

## Test plan

- [x] `npm run tsc` — clean
- [x] Full frontend suite (`npm test` in `frontend/`): 720 passing, 2 pre-existing skips, 0 regressions
- [x] `draganddrop.directive.spec.ts` rewritten for the new pointer-based API (23 tests), plus new coverage for: touch tap→hover synthesis, two-finger gesture entry/exit, pan/zoom event shape, and continuing a single-finger drag after a pinch ends
- [x] Manually verified end-to-end in a real (headless) Chromium browser via a scripted Playwright session dispatching synthetic `PointerEvent`s at the canvas: single-finger touch drag correctly drew the select-tool's grid-snapped selection box; two-finger gesture visibly panned and zoomed the background grid; zero console/page errors throughout