### PR TITLE
fix(discover): stop overflow/padding breakage on phone-width screens

### DIFF
--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.css
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.css
@@ -35,8 +35,9 @@
 
 .card-social {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 14px;
+  gap: 8px 14px;
   margin-top: 2px;
 }
 

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.css
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.css
@@ -17,6 +17,16 @@
     padding: 20px 14px 28px;
     border-radius: 8px;
   }
+
+  .browse-header h1 {
+    font-size: 24px;
+    white-space: normal;
+    flex: 1 1 100%;
+  }
+
+  .create-cta {
+    margin-left: 0;
+  }
 }
 
 .browse-header {

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-about/dialog-about.component.css
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-about/dialog-about.component.css
@@ -40,6 +40,14 @@
   margin-left: 20px;
 }
 
+@media (max-width: 500px) {
+  .image-float-right {
+    float: none;
+    display: block;
+    margin: 0 auto 12px;
+  }
+}
+
 .content {
   text-align: justify;
 }

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-about/dialog-about.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-about/dialog-about.component.html
@@ -4,6 +4,7 @@
   [(visible)]="visible"
   [modal]="true"
   [style]="{ width: '640px', maxHeight: '80vh' }"
+  [breakpoints]="{ '700px': '92vw' }"
   [draggable]="false"
 >
   <div class="scrollable">

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-follow-list/dialog-follow-list.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-follow-list/dialog-follow-list.component.html
@@ -7,6 +7,7 @@
   [draggable]="false"
   [resizable]="false"
   [style]="{ width: '420px', maxHeight: '80vh' }"
+  [breakpoints]="{ '480px': '92vw' }"
 >
   <div #scrollable class="follow-list-scrollable" (scroll)="onScroll()">
     <div

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-share-url/dialog-share-url.component.css
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-share-url/dialog-share-url.component.css
@@ -1,3 +1,10 @@
 .copy-button {
   margin-left: 5px;
 }
+
+.float-input {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 8px;
+}

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-share-url/dialog-share-url.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-share-url/dialog-share-url.component.html
@@ -10,13 +10,14 @@
   [maximizable]="false"
   [draggable]="false"
   [resizable]="false"
+  [style]="{ width: '480px' }"
+  [breakpoints]="{ '560px': '92vw' }"
 >
   <div i18n>Use the following url to share this blueprint :</div>
   <input
     #urlInput
     class="float-input"
     type="text"
-    size="60"
     [ngModel]="url"
     pInputText
     [disabled]="url === ''"

--- a/frontend/src/app/module-blueprint/components/dialogs/feedback-dialog/feedback-dialog.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/feedback-dialog/feedback-dialog.component.html
@@ -3,6 +3,7 @@
   [(visible)]="visible"
   [modal]="true"
   [style]="{ width: '480px' }"
+  [breakpoints]="{ '560px': '92vw' }"
   [draggable]="false"
 >
   <ng-container *ngIf="state !== 'success'">

--- a/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.css
+++ b/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.css
@@ -8,12 +8,14 @@
 
 .new-version-row {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 14px;
 }
 
 .new-version-row input {
   flex: 1;
+  min-width: 0;
 }
 
 .version-status {
@@ -31,6 +33,7 @@
 
 .version-row {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 12px;
   padding: 9px 10px;

--- a/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.html
@@ -10,11 +10,12 @@
   [maximizable]="false"
   [draggable]="false"
   [resizable]="false"
+  [style]="{ width: '480px' }"
+  [breakpoints]="{ '560px': '92vw' }"
 >
   <div *ngIf="isOwner" class="new-version-row">
     <input
       type="text"
-      size="30"
       i18n-placeholder
       placeholder="Name this snapshot (optional)"
       [(ngModel)]="newVersionName"

--- a/frontend/src/app/module-blueprint/components/notification-bell/notification-bell.component.css
+++ b/frontend/src/app/module-blueprint/components/notification-bell/notification-bell.component.css
@@ -28,7 +28,7 @@
 }
 
 .notification-panel {
-  width: 320px;
+  width: min(320px, calc(100vw - 24px));
   max-height: 60vh;
   overflow-y: auto;
   display: flex;

--- a/frontend/src/app/module-blueprint/components/site-nav/site-nav.component.css
+++ b/frontend/src/app/module-blueprint/components/site-nav/site-nav.component.css
@@ -7,3 +7,10 @@
   border-width: 0 0 2px;
   box-shadow: 0 2px 0 rgba(0, 0, 0, 0.25);
 }
+
+@media (max-width: 640px) {
+  :host ::ng-deep .p-menubar {
+    padding: 8px 10px;
+    gap: 6px;
+  }
+}

--- a/frontend/src/bni-skin.css
+++ b/frontend/src/bni-skin.css
@@ -628,6 +628,8 @@ a.bni-chip:hover {
 /* ---- segmented control (Discover | From creators you follow) ---- */
 .bni-seg {
   display: inline-flex;
+  flex-wrap: wrap;
+  max-width: 100%;
   border: 1px solid var(--bni-line2);
   border-radius: 5px;
   overflow: hidden;


### PR DESCRIPTION
## Summary

Second step of mobile support (stacked on #136 / `feat/mobile-editor-touch-v2`, since that branch isn't merged yet). Discover and its dialogs were tolerable but never actually tested at phone widths — several elements used fixed intrinsic sizing that silently forced the page or a dialog wider than the viewport. `body` has `overflow-x: auto` rather than `hidden`, so every one of these manifested as horizontal page scroll rather than visible clipping — the concrete, testable symptom used to find and verify each fix.

## What shipped

- **`browse-page`**: the `<h1>Browse Blueprints</h1>` had `white-space: nowrap` with no override below the existing 640px breakpoint, so it couldn't shrink below its full unwrapped width. It now drops to its own row with a smaller font size under 640px.
- **`bni-skin.css` `.bni-seg`** (the Discover / "From creators you follow" segmented control): had no `flex-wrap`, so the two buttons were permanently side-by-side regardless of available width.
- **`site-nav`**: fixed 22px side padding on the menubar, tightened to 10px under 640px.
- **`notification-bell` panel**: fixed 320px width, now clamped to the viewport via `min(320px, calc(100vw - 24px))`.
- **Fixed-width dialogs** (`dialog-about` 640px, `feedback-dialog` 480px, `dialog-follow-list` 420px) now use PrimeNG's `breakpoints` input to shrink to ~92vw below their respective breakpoints, instead of forcing the viewport wider than the screen.
- **`dialog-share-url`** and **`version-history-dialog`** had no dialog width set at all *and* an `<input size="N">` forcing an intrinsic content width — the input's `size` attribute overrode its own flex/`100%` CSS sizing. Removed the `size` attribute, gave both dialogs an explicit width + `breakpoints`.
- Defensive `flex-wrap` added to `blueprint-card`'s social-icons row and the version-history row — both tight-but-not-yet-broken at 375-430px, now safe if content grows (e.g. localization to a longer language).

## Test plan

- [x] `npm run tsc` — clean
- [x] Full frontend suite: 725 passing, 2 pre-existing skips, 0 regressions (this is a pure CSS/HTML change, consistent with this repo's practice of verifying style-only diffs visually rather than growing the unit suite for them)
- [x] Manually verified with a scripted Playwright session at 375px and 320px viewports: `document.documentElement.scrollWidth` never exceeds `clientWidth` (no horizontal overflow) on the Discover grid, with the About dialog open, and with the Feedback dialog open — screenshots confirm the About dialog's floated image now stacks above the text and the Feedback dialog's textarea/buttons fit fully within the viewport
- [ ] Login-gated surfaces (view-mode segmented control, notification panel contents, version-history dialog, share-url dialog) were fixed with the same proven pattern (`breakpoints` input, `min-width: 0`, `flex-wrap`) but not re-verified live under an authenticated session in this pass — worth a spot-check