### PR TITLE
fix(editor): stop editor chrome overflow, add safe-area/tap-target polish

### DIFF
--- a/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.css
+++ b/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.css
@@ -1,13 +1,17 @@
 .side-panel {
   position: absolute;
   width: 310px;
+  max-width: calc(100vw - 20px);
   padding: 10px;
+  box-sizing: border-box;
 }
 
 .side-panel-right {
   position: absolute;
   right: 0;
+  max-width: calc(100vw - 20px);
   padding: 10px;
+  box-sizing: border-box;
 }
 .outer {
   display: flex;
@@ -17,9 +21,12 @@
 .tool-toolbar {
   position: fixed;
   right: 16px;
-  bottom: 16px;
+  bottom: calc(16px + env(safe-area-inset-bottom));
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  max-width: calc(100vw - 32px);
   gap: 8px;
   z-index: 10;
 }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -4,7 +4,10 @@
     <meta charset="utf-8" />
     <title>Blueprintnotincluded</title>
     <base href="/" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
     <link
       rel="apple-touch-icon"
       sizes="180x180"

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -54,9 +54,13 @@ body {
   float: right;
   cursor: pointer;
   transition: color 0.2s;
+  /* Icon glyph is ~14px; pad the tap target out without shifting layout. */
+  padding: 12px;
+  margin: -12px;
 }
 
-.ui-close-button:hover {
+.ui-close-button:hover,
+.ui-close-button:active {
   color: var(--p-text-color);
 }
 


### PR DESCRIPTION
## Summary

Third step of mobile support (stacked on #137 / `feat/mobile-discover-responsive`, which is itself stacked on #136). The editor canvas got touch input in #136 and Discover got overflow fixes in #137 - this pass covers the editor's surrounding UI chrome (side panels, bottom toolbar), which had never been tested at phone widths either.

## What shipped

- **`.side-panel`** (build tool / select tool panel): fixed `width: 310px` in `content-box` sizing + `10px` padding each side = 330px total footprint - wider than a 320px viewport (iPhone SE class) with almost no margin on a 375px one. Capped with `max-width: calc(100vw - 20px)` and switched to `border-box` so the cap is exact.
- **`.side-panel-right`** (temperature scale / element report panels): had no width constraint at all - same `max-width` cap added.
- **`.tool-toolbar`** (bottom-right Select/Scissors buttons): pinned to a raw `bottom: 16px` with no safe-area awareness, so on a notched phone it can sit under the iOS home-indicator/gesture bar. Added `env(safe-area-inset-bottom)` (now takes effect since `index.html`'s viewport meta also gained `viewport-fit=cover`), plus defensive `flex-wrap`/`max-width` since this toolbar is expected to grow further (per the commit that added the Select button).
- **`.ui-close-button`**: no explicit hit area beyond the ~14px glyph itself. Padded the tap target out via `padding` + negative `margin` (no layout shift) and added an `:active` state, since `:hover` alone gives zero feedback on touch.

## Deferred to a follow-up

PrimeNG `pTooltip` labels on icon-only buttons across the build menu and side panels (build-tool, buildable-element-picker, item-collection-info, selection-tool, element-report-tool, plus a few dialogs) are hover-only and thus invisible on touch - `pTooltip`'s default `tooltipEvent` is `'hover'`. Not fixed in this PR since it touches ~10 files and is a UX call (tap-to-show vs tap-to-toggle vs leaning on `aria-label` alone), not a one-line CSS bug like the fixes above. Queuing as the next branch.

## Test plan

- [x] `npm run tsc` - clean
- [x] Full frontend suite: 725 passing, 2 pre-existing skips, 0 regressions (pure CSS/viewport-meta change)
- [x] Manually verified with a scripted Playwright session at 320px (iPhone SE class, the tightest realistic target): zero horizontal document overflow with the editor loaded, and with the Build Tool panel (the widest side panel in the app) open - screenshot confirms it now fits with margin on both sides instead of overflowing