### PR TITLE
fix(editor,discover): show tooltips on focus so touch isn't left guessing

### DIFF
--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.html
@@ -109,6 +109,7 @@
               (click)="deleteBlueprint(item)"
               i18n-pTooltip
               pTooltip="Delete this blueprint"
+              tooltipEvent="both"
             ></button>
             <!--
             <app-like-widget

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-share-url/dialog-share-url.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-share-url/dialog-share-url.component.html
@@ -30,6 +30,7 @@
     (click)="copyToClipboard(urlInput)"
     i18n-pTooltip
     pTooltip="Copy url to clipboard"
+    tooltipEvent="both"
     [disabled]="url === ''"
   ></button>
   <button
@@ -40,6 +41,7 @@
     (click)="newTab()"
     i18n-pTooltip
     pTooltip="Open in new tab"
+    tooltipEvent="both"
     [disabled]="url === ''"
   ></button>
   <button
@@ -50,6 +52,7 @@
     (click)="shareToReddit()"
     i18n-pTooltip
     pTooltip="Share to Reddit"
+    tooltipEvent="both"
     [disabled]="url === ''"
   ></button>
 </p-dialog>

--- a/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/version-history-dialog/version-history-dialog.component.html
@@ -60,6 +60,7 @@
           icon="pi pi-history"
           i18n-pTooltip
           pTooltip="Restore this version"
+          tooltipEvent="both"
           i18n-aria-label
           aria-label="Restore this version"
           [disabled]="busyVersionId === version.id"
@@ -72,6 +73,7 @@
           icon="pi pi-trash"
           i18n-pTooltip
           pTooltip="Delete this version"
+          tooltipEvent="both"
           i18n-aria-label
           aria-label="Delete this version"
           [disabled]="busyVersionId === version.id"

--- a/frontend/src/app/module-blueprint/components/side-bar/build-tool/build-tool.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/build-tool/build-tool.component.html
@@ -123,6 +123,7 @@
           (click)="chooseItem(item)"
           [pTooltip]="item.name"
           tooltipPosition="bottom"
+          tooltipEvent="both"
           life="5000"
         >
           <img src="{{ item.iconUrl }}" height="40px" />
@@ -140,6 +141,7 @@
       i18n-pTooltip
       pTooltip="Add info tip"
       tooltipPosition="bottom"
+      tooltipEvent="both"
       life="5000"
     >
       <img
@@ -153,6 +155,7 @@
       i18n-pTooltip
       pTooltip="Paint Element"
       tooltipPosition="bottom"
+      tooltipEvent="both"
       life="5000"
     >
       <img src="assets/images/ui/manual/liquid_icon.png" height="40px" />
@@ -168,6 +171,7 @@
         (click)="showItems($event, buildMenuCategory, indexCategory)"
         [pTooltip]="buildMenuCategory.categoryShowName"
         tooltipPosition="bottom"
+        tooltipEvent="both"
         life="5000"
       >
         <img src="{{ buildMenuCategory.categoryIconUrl }}" height="40px" />

--- a/frontend/src/app/module-blueprint/components/side-bar/buildable-element-picker/buildable-element-picker.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/buildable-element-picker/buildable-element-picker.component.html
@@ -50,6 +50,7 @@
                 (click)="chooseElement(buildableElement, indexElement)"
                 [pTooltip]="buildableElement.name"
                 tooltipPosition="bottom"
+                tooltipEvent="both"
                 life="5000"
               >
                 <app-element-icon

--- a/frontend/src/app/module-blueprint/components/side-bar/element-report-tool/element-report-tool.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/element-report-tool/element-report-tool.component.html
@@ -35,6 +35,7 @@
           dataItem.buildableElement.name
         }}"
         tooltipPosition="left"
+        tooltipEvent="both"
       ></button>
     </div>
     <!--TODO this is super ugly, the line should be its own component-->
@@ -67,6 +68,7 @@
           dataItem.buildableElement.name
         }}"
         tooltipPosition="left"
+        tooltipEvent="both"
       ></button>
     </div>
     <div class="element-card-header" i18n>Gases :</div>
@@ -95,6 +97,7 @@
           dataItem.buildableElement.name
         }}"
         tooltipPosition="left"
+        tooltipEvent="both"
       ></button>
     </div>
   </div>

--- a/frontend/src/app/module-blueprint/components/side-bar/item-collection-info/item-collection-info.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/item-collection-info/item-collection-info.component.html
@@ -76,6 +76,7 @@
   (click)="buildingsCopy()"
   i18n-pTooltip
   pTooltip="Build this type of building"
+  tooltipEvent="both"
 ></button>
 <button
   *ngIf="!itemCollection.oniItem.isInfo || itemCollection.items.length === 1"
@@ -86,6 +87,7 @@
   (click)="selectEvery()"
   i18n-pTooltip
   pTooltip="Select every {{ itemCollection.oniItem.name }}"
+  tooltipEvent="both"
 ></button>
 <button
   *ngIf="!itemCollection.oniItem.isInfo || itemCollection.items.length === 1"
@@ -96,4 +98,5 @@
   (click)="buildingsDestroy()"
   i18n-pTooltip
   pTooltip="Destroy these buildings (Delete key)"
+  tooltipEvent="both"
 ></button>

--- a/frontend/src/app/module-blueprint/components/side-bar/selection-tool/selection-tool.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/selection-tool/selection-tool.component.html
@@ -9,6 +9,7 @@
       (click)="itemGroupeNext()"
       i18n-pTooltip
       pTooltip="Select next item group"
+      tooltipEvent="both"
     ></button>
     <button
       pButton
@@ -18,6 +19,7 @@
       (click)="itemGroupePrevious()"
       i18n-pTooltip
       pTooltip="Select previous item group"
+      tooltipEvent="both"
     ></button>
     <button
       pButton
@@ -27,6 +29,7 @@
       (click)="destroyAll()"
       i18n-pTooltip
       pTooltip="Destroy every item group"
+      tooltipEvent="both"
     ></button>
   </div>
   <div class="scrollable">

--- a/frontend/src/app/module-blueprint/components/toolbar-button/toolbar-button.component.html
+++ b/frontend/src/app/module-blueprint/components/toolbar-button/toolbar-button.component.html
@@ -5,6 +5,7 @@
   [disabled]="disabled"
   [pTooltip]="label"
   tooltipPosition="left"
+  tooltipEvent="both"
   (click)="buttonClick.emit()"
 >
   <img


### PR DESCRIPTION
## Summary

Fourth step of mobile support (stacked on #138 / `feat/mobile-editor-toolbar-touch`, itself stacked on #137 → #136). This is the follow-up flagged explicitly in #138's description.

Every icon-only button in the build menu, select-tool side panel, and a few dialogs relies entirely on a `pTooltip` label to convey what it does. PrimeNG's `pTooltip` defaults to `tooltipEvent="hover"`, which never fires on touch (a finger has no hover state). On a phone these were unlabeled icons with zero affordance - a trash can, a chevron, a magnifying glass - with no way to learn what tapping them does before doing it.

## What shipped

Added `tooltipEvent="both"` (hover **or** focus) to every icon-only `pTooltip` usage across:
- `toolbar-button` (the editor's Select/Scissors buttons)
- `build-tool` (building picker, "Add info tip", "Paint Element", category buttons)
- `buildable-element-picker` (element-variant icons)
- `item-collection-info` (Copy/Select-every/Destroy icons)
- `selection-tool` (chevron-up/down, trash)
- `element-report-tool` ("Select every building made of X")
- `dialog-share-url`, `dialog-browse`, `version-history-dialog`

Native `<button>` elements receive focus on tap in all modern mobile browsers, so this also makes every one of these tooltips show up for keyboard/focus navigation, which they did not before - a genuine accessibility fix independent of touch.

## Deliberately not touched

`fork-button`, `like-widget`, and the profile follow button. Their `pTooltip` only carries content in the *disabled* state (explaining why the action is unavailable) - the enabled state already has a visible text label, so these aren't the "mystery icon" bug the rest of this change fixes, and a disabled element can't receive focus anyway.

## Test plan

- [x] `npm run tsc` - clean
- [x] Full frontend suite: 725 passing, 2 pre-existing skips, 0 regressions (template compiles cleanly, confirming `tooltipEvent` is a valid PrimeNG Tooltip input)
- [x] Scripted Playwright check: programmatically focusing the editor's Select toolbar button (the same focus event a tap produces) now shows its "Select" tooltip - previously required a mouse hover