### PR TITLE
fix(editor): stop dialog-browse forcing 600px+ width on phone screens

### DIFF
--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.css
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.css
@@ -11,7 +11,8 @@
 
 .blueprint-line {
   display: flex;
-  width: 600px;
+  width: 100%;
+  box-sizing: border-box;
   margin-bottom: 10px;
   padding: 10px;
 
@@ -40,12 +41,29 @@
 
 .thumbnail {
   margin-right: 10px;
+  flex: 0 0 auto;
 }
 
-.thumbnail img {
+.thumbnail img,
+.thumbnail svg {
   width: 200px;
+  height: 200px;
 }
 
 .search {
   margin-top: 10px;
+}
+
+.float-input {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+@media (max-width: 500px) {
+  .thumbnail img,
+  .thumbnail svg {
+    width: 72px;
+    height: 72px;
+  }
 }

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.html
@@ -11,12 +11,13 @@
   [draggable]="false"
   [resizable]="false"
   [contentStyle]=""
+  [style]="{ width: '640px' }"
+  [breakpoints]="{ '700px': '92vw' }"
 >
   <div>
     <input
       class="float-input"
       type="text"
-      size="30"
       i18n-placeholder
       placeholder="Search"
       [(ngModel)]="filterName"


### PR DESCRIPTION
## Summary

Fifth step of mobile support (stacked on #139 / `feat/mobile-touch-tooltips`, itself stacked on #138 → #137 → #136). Found while sweeping remaining editor surfaces after the top-menu and auth pages both checked out clean (no PR needed for those - PrimeNG's menubar already auto-hamburgers correctly, and the auth pages already use relative `width:100%; max-width:420px`).

The editor's in-app blueprint browser (`Blueprint > Browse` in the top menu) was the worst overflow offender found in this entire pass:

- `.blueprint-line` had a **hard `width: 600px`** per row - not a max-width, every row was forced to exactly 600px regardless of viewport.
- Row thumbnails were a fixed 200x200px (both the real `<img>` and the placeholder `<svg>`).
- The search input had the same unstyled `size="30"` bug already fixed twice elsewhere in this stack (`dialog-share-url`, `version-history-dialog`) - an unstyled `size` attribute sets the input's intrinsic content-width, which nothing was overriding.
- The `p-dialog` itself had no `[style]` width at all, so nothing bounded it - it sized to fit whatever forced-wide content was largest.

## What shipped

- `.blueprint-line`: `width: 600px` → `width: 100%` (border-box) - fills whatever width the dialog actually has instead of forcing one.
- `.thumbnail img`/`svg`: capped to 72px under 500px viewports.
- Search input: `size="30"` removed, `.float-input` given explicit `width: 100%`.
- `p-dialog`: added `[style]` width `640px` (preserves current desktop sizing, which was previously accidental/content-driven) + `breakpoints` down to 92vw, matching the pattern established in #137/#139.

## Test plan

- [x] `npm run tsc` - clean
- [x] Full frontend suite: 725 passing, 2 pre-existing skips, 0 regressions
- [x] Manually verified with a scripted Playwright session driving the real menu path (hamburger → Blueprint → Browse) at 375px: zero horizontal document overflow, dialog and every row now fit within the viewport with margin - screenshot confirms the list renders cleanly with scaled-down thumbnails. Without this fix the dialog would have forced at least 600px onto a 375px screen.