### PR TITLE
feat(discover): related blueprints shelf + trending sort

### DIFF
--- a/__tests__/api/blueprint-discovery.test.ts
+++ b/__tests__/api/blueprint-discovery.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load test environment first
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup } from '../setup/testSetup';
+import { BlueprintModel } from '../../app/api/models/blueprint';
+import { CommentModel } from '../../app/api/models/comment';
+import { Types } from 'mongoose';
+
+const TINY_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+async function makeBlueprint(owner: Types.ObjectId, overrides: Record<string, any> = {}) {
+  return BlueprintModel.model.create({
+    owner,
+    name: `Discovery Test Blueprint ${new Types.ObjectId().toString()}`,
+    likes: [],
+    likeCount: 0,
+    forkCount: 0,
+    viewCount: 0,
+    downloadCount: 0,
+    createdAt: new Date(),
+    modifiedAt: new Date(),
+    thumbnail: TINY_PNG,
+    data: { version: '1.0', buildings: [] },
+    deletedAt: null,
+    isPublished: true,
+    ...overrides,
+  });
+}
+
+function daysAgo(n: number): Date {
+  return new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+}
+
+describe('Discovery: related blueprints + trending sort', function () {
+  let testData: any;
+
+  beforeEach(async function () {
+    this.timeout(5000);
+    testData = await TestSetup.beforeEach();
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    await TestSetup.afterEach();
+  });
+
+  describe('GET /api/blueprints/:id/related', function () {
+    it('returns 400 for a malformed id and 404 for an unknown or deleted blueprint', async function () {
+      expect((await TestSetup.request().get('/api/blueprints/not-an-id/related')).status).to.equal(400);
+      expect(
+        (await TestSetup.request().get(`/api/blueprints/${new Types.ObjectId()}/related`)).status
+      ).to.equal(404);
+    });
+
+    it('ranks same-category blueprints above unrelated ones', async function () {
+      const source = await makeBlueprint(testData.users.user1._id, {
+        name: 'Related Source Power',
+        category: 'power',
+      });
+      const sameCategory = await makeBlueprint(testData.users.user2._id, {
+        name: 'Related Same Category',
+        category: 'power',
+      });
+      const unrelated = await makeBlueprint(testData.users.user3._id, {
+        name: 'Related Unrelated Food',
+        category: 'food',
+      });
+
+      const response = await TestSetup.request().get(`/api/blueprints/${source._id}/related`);
+      expect(response.status).to.equal(200);
+      const names: string[] = response.body.blueprints.map((b: any) => b.name);
+
+      expect(names).to.include(sameCategory.name);
+      expect(names).to.include(unrelated.name);
+      expect(names.indexOf(sameCategory.name)).to.be.lessThan(names.indexOf(unrelated.name));
+    });
+
+    it('never includes the source blueprint itself', async function () {
+      const source = await makeBlueprint(testData.users.user1._id, {
+        name: 'Related Excludes Self',
+        category: 'power',
+      });
+
+      const response = await TestSetup.request().get(`/api/blueprints/${source._id}/related`);
+      const names: string[] = response.body.blueprints.map((b: any) => b.name);
+      expect(names).to.not.include(source.name);
+    });
+
+    it('excludes drafts and soft-deleted blueprints from the pool', async function () {
+      const source = await makeBlueprint(testData.users.user1._id, {
+        name: 'Related Source Draftcheck',
+        category: 'power',
+      });
+      const draft = await makeBlueprint(testData.users.user2._id, {
+        name: 'Related Draft Sibling',
+        category: 'power',
+        isPublished: false,
+      });
+      const deleted = await makeBlueprint(testData.users.user3._id, {
+        name: 'Related Deleted Sibling',
+        category: 'power',
+        deletedAt: new Date(),
+      });
+
+      const response = await TestSetup.request().get(`/api/blueprints/${source._id}/related`);
+      const names: string[] = response.body.blueprints.map((b: any) => b.name);
+      expect(names).to.not.include(draft.name);
+      expect(names).to.not.include(deleted.name);
+    });
+
+    it('ranks same-author blueprints above signal-free ones', async function () {
+      const owner = testData.users.user1._id;
+      const source = await makeBlueprint(owner, { name: 'Related Author Source' });
+      const sameAuthor = await makeBlueprint(owner, { name: 'Related Author Sibling' });
+
+      const response = await TestSetup.request().get(`/api/blueprints/${source._id}/related`);
+      const names: string[] = response.body.blueprints.map((b: any) => b.name);
+      expect(names).to.include(sameAuthor.name);
+    });
+
+    it('falls back to recent public blueprints when the source has no signals to match on', async function () {
+      const lonelyOwner = new Types.ObjectId();
+      const source = await makeBlueprint(lonelyOwner, { name: 'Related No Signal Source' });
+
+      const response = await TestSetup.request().get(`/api/blueprints/${source._id}/related`);
+      expect(response.status).to.equal(200);
+      expect(response.body.blueprints.length).to.be.greaterThan(0);
+    });
+  });
+
+  describe('GET /api/getblueprints?sort=trending', function () {
+    it('ranks recently engaged blueprints above older ones with the same raw engagement', async function () {
+      const hot = await makeBlueprint(testData.users.user1._id, {
+        name: 'Trending Hot Recent',
+        likeCount: 10,
+        forkCount: 2,
+        createdAt: new Date(),
+      });
+      const stale = await makeBlueprint(testData.users.user2._id, {
+        name: 'Trending Stale Old',
+        likeCount: 10,
+        forkCount: 2,
+        createdAt: daysAgo(60),
+      });
+
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), sort: 'trending' });
+
+      expect(response.status).to.equal(200);
+      const names: string[] = response.body.blueprints.map((b: any) => b.name);
+      expect(names.indexOf(hot.name)).to.be.lessThan(names.indexOf(stale.name));
+    });
+
+    it('reorders relative to the plain popular (most-liked) sort', async function () {
+      const oldButLiked = await makeBlueprint(testData.users.user1._id, {
+        name: 'Trending Old But Liked',
+        likeCount: 50,
+        createdAt: daysAgo(90),
+      });
+      const newSmall = await makeBlueprint(testData.users.user2._id, {
+        name: 'Trending New Small',
+        likeCount: 3,
+        createdAt: new Date(),
+      });
+
+      const popular = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), sort: 'popular' });
+      const popularNames: string[] = popular.body.blueprints.map((b: any) => b.name);
+      expect(popularNames.indexOf(oldButLiked.name)).to.be.lessThan(popularNames.indexOf(newSmall.name));
+
+      const trending = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), sort: 'trending' });
+      const trendingNames: string[] = trending.body.blueprints.map((b: any) => b.name);
+      expect(trendingNames.indexOf(newSmall.name)).to.be.lessThan(trendingNames.indexOf(oldButLiked.name));
+    });
+
+    it('factors live comment counts into the score', async function () {
+      const discussed = await makeBlueprint(testData.users.user1._id, {
+        name: 'Trending Discussed',
+        createdAt: new Date(),
+      });
+      const quiet = await makeBlueprint(testData.users.user2._id, {
+        name: 'Trending Quiet',
+        createdAt: new Date(),
+      });
+
+      await CommentModel.model.create([
+        { blueprintId: discussed._id, authorId: testData.users.user2._id, body: 'one' },
+        { blueprintId: discussed._id, authorId: testData.users.user3._id, body: 'two' },
+        {
+          blueprintId: discussed._id,
+          authorId: testData.users.user3._id,
+          body: 'removed',
+          deletedAt: new Date(),
+        },
+      ]);
+
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), sort: 'trending' });
+
+      const names: string[] = response.body.blueprints.map((b: any) => b.name);
+      expect(names.indexOf(discussed.name)).to.be.lessThan(names.indexOf(quiet.name));
+    });
+
+    it('rejects an unknown sort value', async function () {
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), sort: 'notASort' });
+      expect(response.status).to.equal(400);
+    });
+  });
+});

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -609,23 +609,30 @@ export class BlueprintController {
     skip: number,
     limit: number
   ): Promise<Blueprint[]> {
-    const rows: { _id: mongoose.Types.ObjectId }[] = await BlueprintModel.model.aggregate([
-      { $match: filter },
-      {
-        $lookup: {
-          from: CommentModel.model.collection.name,
-          let: { blueprintId: '$_id' },
-          pipeline: [
+    const commentLookupStage: mongoose.PipelineStage[] =
+      CommentModel.model == null
+        ? []
+        : [
             {
-              $match: {
-                $expr: { $and: [{ $eq: ['$blueprintId', '$$blueprintId'] }, { $eq: ['$deletedAt', null] }] },
+              $lookup: {
+                from: CommentModel.model.collection.name,
+                let: { blueprintId: '$_id' },
+                pipeline: [
+                  {
+                    $match: {
+                      $expr: { $and: [{ $eq: ['$blueprintId', '$$blueprintId'] }, { $eq: ['$deletedAt', null] }] },
+                    },
+                  },
+                  { $count: 'count' },
+                ],
+                as: 'commentAgg',
               },
             },
-            { $count: 'count' },
-          ],
-          as: 'commentAgg',
-        },
-      },
+          ];
+
+    const rows: { _id: mongoose.Types.ObjectId }[] = await BlueprintModel.model.aggregate([
+      { $match: filter },
+      ...commentLookupStage,
       {
         $addFields: {
           commentCount: { $ifNull: [{ $arrayElemAt: ['$commentAgg.count', 0] }, 0] },

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -3,8 +3,9 @@ import { BlueprintModel, Blueprint } from './models/blueprint';
 import {
   MdbBlueprint,
   BlueprintResponse,
-//   BlueprintListItem,
+  BlueprintListItem,
   BlueprintListResponse,
+  RelatedBlueprintsResponse,
   BlueprintLike,
 //   Vector2,
 //   CameraService,
@@ -24,7 +25,7 @@ import { BatchUtils } from './batch/batch-utils';
 import { apiError } from './utils/apiError';
 import { parseOlderThan } from './utils/pagination';
 import { optionalViewer } from './utils/optionalViewer';
-import { canViewBlueprint } from './utils/blueprint-visibility';
+import { canViewBlueprint, ownerIdOf } from './utils/blueprint-visibility';
 import { BlueprintEventService } from './services/blueprint-event-service';
 import { BlueprintCounterService, CounterKind } from './services/blueprint-counter-service';
 import {
@@ -37,8 +38,11 @@ import mongoose from 'mongoose';
 
 const MAX_SKIP = 10000;
 
-const SORTS = ['recent', 'popular', 'mostForked', 'mostViewed', 'mostDownloaded'] as const;
+const SORTS = ['recent', 'popular', 'mostForked', 'mostViewed', 'mostDownloaded', 'trending'] as const;
 type BlueprintSort = (typeof SORTS)[number];
+
+// How many "you might also like" cards the details page shows
+const RELATED_LIMIT = 6;
 
 export class BlueprintController {
   public uploadBlueprint(req: Request, res: Response) {
@@ -308,9 +312,7 @@ export class BlueprintController {
   ): void {
     if (blueprint.isPublished === false) return;
     const viewer = optionalViewer(req);
-    const ownerId = UserModel.isUser(blueprint.owner)
-      ? (blueprint.owner.id as string)
-      : blueprint.owner?.toString();
+    const ownerId = ownerIdOf(blueprint);
     if (viewer != null && viewer._id === ownerId) return;
     // Logged-in viewers dedupe by user id; anonymous ones by client IP
     const viewerKey = viewer != null ? viewer._id : `ip:${req.clientIp ?? 'unknown'}`;
@@ -574,14 +576,18 @@ export class BlueprintController {
       else if (sort === 'mostDownloaded') sortSpec = { downloadCount: -1, createdAt: -1 };
 
       let browseIncrement = parseInt(process.env.BROWSE_INCREMENT as string);
-      let query = BlueprintModel.model
-        .find(filter)
-        .sort(sortSpec)
-        .skip(usesOffsetPagination ? skip : 0)
-        .limit(browseIncrement * 2)
-        .populate('owner');
+      let skipAmount = usesOffsetPagination ? skip : 0;
+      let limit = browseIncrement * 2;
 
-      query
+      // Trending has no single indexed field to sort on — it's a computed,
+      // time-decayed score — so it goes through an aggregation instead of
+      // the plain find().sort() every other sort uses.
+      let blueprintsPromise: Promise<Blueprint[]> =
+        sort === 'trending'
+          ? BlueprintController.getTrendingBlueprints(filter, skipAmount, limit)
+          : BlueprintModel.model.find(filter).sort(sortSpec).skip(skipAmount).limit(limit).populate('owner');
+
+      blueprintsPromise
         .then(blueprints => {
           return BlueprintController.handleGetBlueprint(req, res, userId, blueprints);
         })
@@ -591,6 +597,72 @@ export class BlueprintController {
           res.status(500).json(apiError(500, 'Failed to retrieve blueprints'));
         });
     }
+  }
+
+  // Time-decayed engagement score (likes + weighted forks/comments/views,
+  // divided down by age) computed in an aggregation since it isn't a stored
+  // field. Only the ordered ids come out of the aggregation; the actual
+  // documents are then fetched + populated normally and put back in that
+  // order — cheaper than populating owner inside the pipeline via $lookup.
+  private static async getTrendingBlueprints(
+    filter: Record<string, unknown>,
+    skip: number,
+    limit: number
+  ): Promise<Blueprint[]> {
+    const rows: { _id: mongoose.Types.ObjectId }[] = await BlueprintModel.model.aggregate([
+      { $match: filter },
+      {
+        $lookup: {
+          from: CommentModel.model.collection.name,
+          let: { blueprintId: '$_id' },
+          pipeline: [
+            {
+              $match: {
+                $expr: { $and: [{ $eq: ['$blueprintId', '$$blueprintId'] }, { $eq: ['$deletedAt', null] }] },
+              },
+            },
+            { $count: 'count' },
+          ],
+          as: 'commentAgg',
+        },
+      },
+      {
+        $addFields: {
+          commentCount: { $ifNull: [{ $arrayElemAt: ['$commentAgg.count', 0] }, 0] },
+          ageInDays: { $divide: [{ $subtract: ['$$NOW', '$createdAt'] }, 1000 * 60 * 60 * 24] },
+        },
+      },
+      {
+        $addFields: {
+          trendingScore: {
+            $divide: [
+              {
+                $add: [
+                  { $ifNull: ['$likeCount', 0] },
+                  { $multiply: [{ $ifNull: ['$forkCount', 0] }, 3] },
+                  { $multiply: ['$commentCount', 2] },
+                  { $multiply: [{ $ifNull: ['$viewCount', 0] }, 0.05] },
+                ],
+              },
+              { $pow: [{ $add: ['$ageInDays', 2] }, 1.5] },
+            ],
+          },
+        },
+      },
+      { $sort: { trendingScore: -1, createdAt: -1 } },
+      { $skip: skip },
+      { $limit: limit },
+      { $project: { _id: 1 } },
+    ]);
+
+    const orderedIds = rows.map(row => row._id);
+    if (orderedIds.length === 0) return [];
+
+    const docs = await BlueprintModel.model.find({ _id: { $in: orderedIds } }).populate('owner');
+    const byId = new Map(docs.map(doc => [(doc._id as mongoose.Types.ObjectId).toString(), doc]));
+    return orderedIds
+      .map(id => byId.get(id.toString()))
+      .filter((doc): doc is NonNullable<typeof doc> => doc != null);
   }
 
   // Visible (non-deleted) comment counts for a page of blueprints, one aggregate.
@@ -673,56 +745,188 @@ export class BlueprintController {
 
       for (const blueprint of page) {
         if (blueprint.createdAt < returnValue.oldest) returnValue.oldest = blueprint.createdAt;
-
-        let ownerId = '';
-        let username: string = '';
-        if (UserModel.isUser(blueprint.owner)) {
-          username = blueprint.owner.username as string;
-          ownerId = blueprint.owner.id as string;
-        }
-
-        let likedByMe = false;
-        if (userId != null && blueprint.likes != null && blueprint.likes.indexOf(userId) != -1)
-          likedByMe = true;
-
-        let ownedByMe = false;
-        if (userId != null && ownerId == userId) ownedByMe = true;
-
-        let nbLikes = blueprint.likeCount ?? blueprint.likes?.length ?? 0;
-
-        returnValue.blueprints.push({
-          id: (blueprint._id as any).toString(),
-          name: blueprint.name,
-          ownerId: ownerId,
-          ownerName: username,
-          createdAt: blueprint.createdAt,
-          modifiedAt: blueprint.modifiedAt,
-          thumbnail: blueprint.thumbnail,
-          nbLikes: nbLikes,
-          likedByMe: likedByMe,
-          ownedByMe: ownedByMe,
-          commentCount: commentCounts.get((blueprint._id as any).toString()) ?? 0,
-          gameVersion: blueprint.gameVersion ?? null,
-          category: blueprint.category ?? null,
-          subcategory: blueprint.subcategory ?? null,
-          description: blueprint.description ?? null,
-          modded: blueprint.modded ?? null,
-          isPublished: blueprint.isPublished !== false,
-          nbForks: blueprint.forkCount ?? 0,
-          nbViews: blueprint.viewCount ?? 0,
-          nbDownloads: blueprint.downloadCount ?? 0,
-          forkedFrom:
-            blueprint.forkedFrom != null
-              ? {
-                  blueprintId: blueprint.forkedFrom.blueprintId.toString(),
-                  blueprintName: forkedFromNames.get(blueprint.forkedFrom.blueprintId.toString()) ?? null,
-                }
-              : null,
-        });
+        returnValue.blueprints.push(
+          BlueprintController.buildListItem(blueprint, userId, commentCounts, forkedFromNames)
+        );
       }
 
       res.json(returnValue);
     } else res.json(returnValue);
+  }
+
+  // Shared blueprint-document -> BlueprintListItem mapping, used by the browse
+  // list, and the details page's related-blueprints shelf.
+  private static buildListItem(
+    blueprint: Blueprint,
+    userId: string,
+    commentCounts: Map<string, number>,
+    forkedFromNames: Map<string, string | null>
+  ): BlueprintListItem {
+    const id = (blueprint._id as any).toString();
+
+    let ownerId = '';
+    let username = '';
+    if (UserModel.isUser(blueprint.owner)) {
+      username = blueprint.owner.username as string;
+      ownerId = blueprint.owner.id as string;
+    }
+
+    let likedByMe = false;
+    if (userId != null && blueprint.likes != null && blueprint.likes.indexOf(userId) != -1) likedByMe = true;
+
+    let ownedByMe = false;
+    if (userId != null && ownerId == userId) ownedByMe = true;
+
+    return {
+      id,
+      name: blueprint.name,
+      ownerId,
+      ownerName: username,
+      createdAt: blueprint.createdAt,
+      modifiedAt: blueprint.modifiedAt,
+      thumbnail: blueprint.thumbnail,
+      nbLikes: blueprint.likeCount ?? blueprint.likes?.length ?? 0,
+      likedByMe,
+      ownedByMe,
+      commentCount: commentCounts.get(id) ?? 0,
+      gameVersion: blueprint.gameVersion ?? null,
+      category: blueprint.category ?? null,
+      subcategory: blueprint.subcategory ?? null,
+      description: blueprint.description ?? null,
+      modded: blueprint.modded ?? null,
+      isPublished: blueprint.isPublished !== false,
+      nbForks: blueprint.forkCount ?? 0,
+      nbViews: blueprint.viewCount ?? 0,
+      nbDownloads: blueprint.downloadCount ?? 0,
+      forkedFrom:
+        blueprint.forkedFrom != null
+          ? {
+              blueprintId: blueprint.forkedFrom.blueprintId.toString(),
+              blueprintName: forkedFromNames.get(blueprint.forkedFrom.blueprintId.toString()) ?? null,
+            }
+          : null,
+    };
+  }
+
+  // "You might also like": same category/subcategory/gameVersion, or same
+  // author, scored simply and merged. Two cheap indexed queries + in-memory
+  // scoring — plenty at this catalog's size, and avoids an aggregation with
+  // no single field to sort on. Backfills with recent public blueprints so
+  // the shelf is never sparse for under-tagged or solo-author blueprints.
+  public async getRelatedBlueprints(req: Request, res: Response): Promise<void> {
+    if (BlueprintModel.model == null) {
+      res.status(503).send();
+      return;
+    }
+
+    const blueprintId = req.params.id;
+    if (!mongoose.Types.ObjectId.isValid(blueprintId)) {
+      res.status(400).json(apiError(400, 'Invalid blueprint id'));
+      return;
+    }
+
+    try {
+      const viewer = optionalViewer(req);
+      const source = await BlueprintModel.model
+        .findOne({ _id: blueprintId, deletedAt: null })
+        .select('owner category subcategory gameVersion isPublished')
+        .lean();
+      if (source == null || !canViewBlueprint(source, viewer)) {
+        res.status(404).json(apiError(404, 'Blueprint not found'));
+        return;
+      }
+
+      const userId = viewer?._id ?? '';
+      const sourceOwnerId = ownerIdOf(source);
+
+      const pools = await Promise.all([
+        source.category != null
+          ? BlueprintModel.model
+              .find({
+                deletedAt: null,
+                isPublished: { $ne: false },
+                category: source.category,
+                _id: { $ne: blueprintId },
+              })
+              .sort({ likeCount: -1, createdAt: -1 })
+              .limit(RELATED_LIMIT * 4)
+              .populate('owner')
+          : Promise.resolve([]),
+        BlueprintModel.model
+          .find({
+            deletedAt: null,
+            isPublished: { $ne: false },
+            owner: source.owner,
+            _id: { $ne: blueprintId },
+          })
+          .sort({ createdAt: -1 })
+          .limit(RELATED_LIMIT * 4)
+          .populate('owner'),
+      ]);
+
+      const candidates = new Map<string, Blueprint>();
+      for (const pool of pools) {
+        for (const candidate of pool) candidates.set((candidate._id as mongoose.Types.ObjectId).toString(), candidate);
+      }
+
+      if (candidates.size < RELATED_LIMIT) {
+        const fallback = await BlueprintModel.model
+          .find({ deletedAt: null, isPublished: { $ne: false }, _id: { $ne: blueprintId } })
+          .sort({ createdAt: -1 })
+          .limit(RELATED_LIMIT * 4)
+          .populate('owner');
+        for (const candidate of fallback) candidates.set((candidate._id as mongoose.Types.ObjectId).toString(), candidate);
+      }
+
+      const scored = Array.from(candidates.values()).map(candidate => {
+        let score = 0;
+        if (source.category != null && candidate.category === source.category) score += 3;
+        if (source.subcategory != null && candidate.subcategory === source.subcategory) score += 2;
+        if (source.gameVersion != null && candidate.gameVersion === source.gameVersion) score += 1;
+        if (sourceOwnerId != null && ownerIdOf(candidate) === sourceOwnerId) score += 2;
+        return { candidate, score };
+      });
+
+      scored.sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        const likeDiff = (b.candidate.likeCount ?? 0) - (a.candidate.likeCount ?? 0);
+        if (likeDiff !== 0) return likeDiff;
+        return b.candidate.createdAt.getTime() - a.candidate.createdAt.getTime();
+      });
+
+      const page = scored.slice(0, RELATED_LIMIT).map(s => s.candidate);
+
+      let commentCounts = new Map<string, number>();
+      try {
+        commentCounts = await BlueprintController.getCommentCounts(
+          page.map(blueprint => blueprint._id as mongoose.Types.ObjectId)
+        );
+      } catch (err) {
+        console.log('related comment count aggregate error');
+        console.log(err);
+      }
+
+      let forkedFromNames = new Map<string, string | null>();
+      try {
+        forkedFromNames = await BlueprintController.getForkedFromNames(
+          page.filter(blueprint => blueprint.forkedFrom != null).map(blueprint => blueprint.forkedFrom!.blueprintId)
+        );
+      } catch (err) {
+        console.log('related forkedFrom name lookup error');
+        console.log(err);
+      }
+
+      const response: RelatedBlueprintsResponse = {
+        blueprints: page.map(blueprint =>
+          BlueprintController.buildListItem(blueprint, userId, commentCounts, forkedFromNames)
+        ),
+      };
+      res.json(response);
+    } catch (err) {
+      console.log('getRelatedBlueprints error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to retrieve related blueprints'));
+    }
   }
 
   public publishBlueprint(req: Request, res: Response) {

--- a/app/api/utils/blueprint-visibility.ts
+++ b/app/api/utils/blueprint-visibility.ts
@@ -2,7 +2,7 @@ import { UserJwt } from '../models/user';
 
 // Owner may be a raw ObjectId/string or a populated User document depending on
 // which query produced the blueprint — normalize to the id string either way.
-function ownerIdOf(blueprint: { owner: any }): string | null {
+export function ownerIdOf(blueprint: { owner: any }): string | null {
   const owner = blueprint.owner;
   if (owner == null) return null;
   return (owner._id ?? owner).toString();

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -83,6 +83,7 @@ export class Routes {
     app.route('/api/users/:username/followers').get(this.userController.getFollowers);
     app.route('/api/users/:username/following').get(this.userController.getFollowing);
     app.route('/api/blueprints/:id').get(this.uploadBlueprintController.getBlueprintDetails);
+    app.route('/api/blueprints/:id/related').get(this.uploadBlueprintController.getRelatedBlueprints);
     app.route('/api/blueprints/:id/preview/:variant').get(this.previewController.getPreview);
     app.route('/api/blueprints/:id/comments').get(this.commentController.list);
     app.route('/api/blueprints/:id/versions').get(this.blueprintVersionController.listVersions);

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.css
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.css
@@ -159,6 +159,7 @@
 
 .details-related {
   margin-top: 36px;
+  margin-bottom: 36px;
 }
 
 .details-related h2 {
@@ -170,6 +171,10 @@
 
 .related-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-auto-flow: column;
+  grid-auto-columns: 220px;
   gap: 16px;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  padding-bottom: 6px;
 }

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.css
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.css
@@ -156,3 +156,20 @@
 .details-fork-count:hover {
   text-decoration: underline;
 }
+
+.details-related {
+  margin-top: 36px;
+}
+
+.details-related h2 {
+  font-size: 18px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  margin: 0 0 14px;
+}
+
+.related-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 16px;
+}

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
@@ -214,6 +214,17 @@
         </div>
       </div>
 
+      <div *ngIf="relatedBlueprints.length" class="details-related">
+        <h2 i18n>You might also like</h2>
+        <div class="related-grid">
+          <app-blueprint-card
+            *ngFor="let item of relatedBlueprints"
+            [item]="item"
+            [loggedIn]="loggedIn"
+          ></app-blueprint-card>
+        </div>
+      </div>
+
       <app-comment-section
         [blueprintId]="blueprintId"
         (commentsLoaded)="scrollToFragment()"

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
@@ -49,6 +49,7 @@ describe("BlueprintDetailsPageComponent", () => {
   beforeEach(async () => {
     blueprintService = {
       getBlueprintDetails: vi.fn().mockReturnValue(of(makeDetails())),
+      getRelatedBlueprints: vi.fn().mockReturnValue(of({ blueprints: [] })),
       setPublished: vi.fn().mockReturnValue(of({ isPublished: true })),
     };
     authService = { isLoggedIn: vi.fn().mockReturnValue(true) };
@@ -154,6 +155,56 @@ describe("BlueprintDetailsPageComponent", () => {
         "2026-07-01"
       ).getTime()}`
     );
+  });
+
+  describe("related blueprints", () => {
+    const relatedItem = {
+      id: "bp2",
+      name: "Related Setup",
+      ownerId: "owner-2",
+      ownerName: "bob",
+      createdAt: new Date("2026-06-01").toISOString(),
+      modifiedAt: new Date("2026-06-01").toISOString(),
+      thumbnail: "data:image/png;base64,xyz",
+      nbLikes: 0,
+      likedByMe: false,
+      ownedByMe: false,
+      commentCount: 0,
+      isPublished: true,
+      nbForks: 0,
+      nbViews: 0,
+      nbDownloads: 0,
+    };
+
+    it("fetches and renders related blueprints once details load", () => {
+      blueprintService.getRelatedBlueprints.mockReturnValue(
+        of({ blueprints: [relatedItem] })
+      );
+      fixture.detectChanges();
+
+      expect(blueprintService.getRelatedBlueprints).toHaveBeenCalledWith("bp1");
+      expect(component.relatedBlueprints).toEqual([relatedItem]);
+      const cards = fixture.debugElement.queryAll(
+        By.css(".details-related app-blueprint-card")
+      );
+      expect(cards.length).toBe(1);
+    });
+
+    it("hides the section when there are no related blueprints", () => {
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css(".details-related"))).toBeNull();
+    });
+
+    it("does not blow up the page when the related fetch fails", () => {
+      blueprintService.getRelatedBlueprints.mockReturnValue(
+        throwError(() => new Error("boom"))
+      );
+
+      expect(() => fixture.detectChanges()).not.toThrow();
+      expect(component.relatedBlueprints).toEqual([]);
+      expect(component.details?.name).toBe("Super Coal Generator Setup");
+    });
   });
 
   it("renders the details and passes the blueprint id to the comment section", () => {

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
@@ -149,7 +149,7 @@ export class BlueprintDetailsPageComponent implements OnInit {
   private loadRelatedBlueprints(id: string) {
     this.blueprintService.getRelatedBlueprints(id).subscribe({
       next: (response) => (this.relatedBlueprints = response.blueprints),
-      error: () => {},
+      error: (err) => console.warn("Failed to load related blueprints", err),
     });
   }
 

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
@@ -3,7 +3,10 @@ import { Location } from "@angular/common";
 import { ActivatedRoute, Router } from "@angular/router";
 import { EMPTY, Observable } from "rxjs";
 import { catchError, finalize, switchMap, tap } from "rxjs/operators";
-import { BlueprintDetailsResponse } from "../../../../../../lib/index";
+import {
+  BlueprintDetailsResponse,
+  BlueprintListItem,
+} from "../../../../../../lib/index";
 import { MessageService } from "primeng/api";
 import { BlueprintService } from "../../services/blueprint-service";
 import { AuthenticationService } from "../../services/authentification-service";
@@ -34,6 +37,7 @@ export class BlueprintDetailsPageComponent implements OnInit {
   loading = true;
   notFound = false;
   loadError = false;
+  relatedBlueprints: BlueprintListItem[] = [];
 
   backLink: any[] = ["/discover"];
   backLabel = BACK_TO_DISCOVER;
@@ -89,6 +93,7 @@ export class BlueprintDetailsPageComponent implements OnInit {
         this.details = details;
         this.blueprintId = details.id;
         this.loading = false;
+        this.loadRelatedBlueprints(details.id);
       });
 
     this.route.fragment.subscribe((fragment) => {
@@ -121,6 +126,7 @@ export class BlueprintDetailsPageComponent implements OnInit {
     this.loadError = false;
     this.previewFailed = false;
     this.publishWorking = false;
+    this.relatedBlueprints = [];
 
     if (id == null) {
       this.loading = false;
@@ -136,6 +142,15 @@ export class BlueprintDetailsPageComponent implements OnInit {
         return EMPTY;
       })
     );
+  }
+
+  // Decoration on the page — a failure here must never surface an error to
+  // the user, the shelf just stays empty.
+  private loadRelatedBlueprints(id: string) {
+    this.blueprintService.getRelatedBlueprints(id).subscribe({
+      next: (response) => (this.relatedBlueprints = response.blueprints),
+      error: () => {},
+    });
   }
 
   get loggedIn() {

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
@@ -60,6 +60,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
 
   readonly sortOptions: { label: string; value: BlueprintSort }[] = [
     { label: $localize`:browse.sortNewest:Newest`, value: "recent" },
+    { label: $localize`:browse.sortTrending:Trending`, value: "trending" },
     { label: $localize`:browse.sortMostLiked:Most liked`, value: "popular" },
     {
       label: $localize`:browse.sortMostForked:Most forked`,

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -16,12 +16,14 @@ import {
   BlueprintLike,
   BlueprintResponse,
   BlueprintDetailsResponse,
+  RelatedBlueprintsResponse,
   BlueprintDelete,
 } from "../../../../../lib/index";
 import * as yaml from "js-yaml";
 
 export type BlueprintSort =
   | "recent"
+  | "trending"
   | "popular"
   | "mostForked"
   | "mostViewed"
@@ -323,6 +325,21 @@ export class BlueprintService implements IObsBlueprintChange {
   getBlueprintDetails(id: string) {
     return this.http.get<BlueprintDetailsResponse>(
       `/api/blueprints/${id}`,
+      this.authService.isLoggedIn()
+        ? {
+            headers: {
+              Authorization: `Bearer ${this.authService.getToken()}`,
+            },
+          }
+        : {}
+    );
+  }
+
+  // "You might also like" shelf for the details page. Token is optional; the
+  // backend uses it to personalize likedByMe/ownedByMe on the returned cards.
+  getRelatedBlueprints(id: string) {
+    return this.http.get<RelatedBlueprintsResponse>(
+      `/api/blueprints/${id}/related`,
       this.authService.isLoggedIn()
         ? {
             headers: {

--- a/lib/src/coms/blueprint-list-response.d.ts
+++ b/lib/src/coms/blueprint-list-response.d.ts
@@ -30,6 +30,9 @@ export interface BlueprintListItem {
 export interface BlueprintDetailsResponse extends BlueprintListItem {
     researchTier?: string | null;
 }
+export interface RelatedBlueprintsResponse {
+    blueprints: BlueprintListItem[];
+}
 export interface BlueprintLike {
     blueprintId: string;
     like: boolean;

--- a/lib/src/coms/blueprint-list-response.ts
+++ b/lib/src/coms/blueprint-list-response.ts
@@ -39,6 +39,11 @@ export interface BlueprintDetailsResponse extends BlueprintListItem {
   researchTier?: string | null;
 }
 
+// "You might also like" shelf on the details page
+export interface RelatedBlueprintsResponse {
+  blueprints: BlueprintListItem[];
+}
+
 export interface BlueprintLike {
   blueprintId: string;
   like: boolean;


### PR DESCRIPTION
## Summary

Picks up two independent, unstarted slices from `spec/social/discovery-engagement.md` (Direction B — "related content & smarter ranking"), chosen specifically because they don't touch any file in the currently-open mobile-responsiveness PR chain (#135–140):

- **Related blueprints** — new `GET /api/blueprints/:id/related`, surfaced as a "You might also like" shelf on the blueprint details page (reuses the existing `app-blueprint-card` component). Candidates are scored on category/subcategory/gameVersion match plus same-author, via two cheap indexed queries merged and scored in memory — no aggregation needed at this catalog's size. Falls back to recent public blueprints when a blueprint has few signals to match on, so the shelf is never empty/sparse.
- **Trending sort** — new `trending` option in the browse page's sort dropdown. Computed as a time-decayed engagement score (`likes + 3×forks + 2×live-comment-count + 0.05×views`, divided by `(ageInDays + 2)^1.5`) via an aggregation pipeline, since there's no single stored field to sort on. Only the ordered ids come out of the pipeline; the actual documents are then fetched/populated normally.

Along the way, extracted the duplicated per-blueprint owner-id resolution into an exported `ownerIdOf` helper, and factored the browse endpoint's list-item mapping into a shared `buildListItem` used by both the existing browse list and the new related-blueprints endpoint.

## Design decisions

- Related blueprints uses in-memory scoring over two indexed `find()` queries rather than a `$lookup`-heavy aggregation — simpler, testable, and fast enough at this catalog's size (~5–10k blueprints).
- Trending's score deliberately includes live comment counts (via a `$lookup` against `comments`, matching the doc's "likes + comments + forks" ask) rather than skipping them for a cheaper likes/forks-only proxy.
- Scoped down from the doc's full recommended bundle: **cold-start feed fix** and **featured/staff picks** are deferred (noted in the spec doc's status log) since both need new admin/suggestion-query surface area beyond this slice's scope.

## Test plan

- [x] Backend: 10 new tests (`__tests__/api/blueprint-discovery.test.ts`) covering related-blueprint scoring/exclusion/fallback and trending ordering vs. plain popular sort, comment-count weighting, and sort validation. Full backend suite: 461 passing.
- [x] Frontend: 3 new tests on `blueprint-details-page.component.spec.ts` (renders shelf, hides when empty, fails silently on error). Full frontend suite: 720 passing.
- [x] `npm run tsc` clean, `ng lint` clean, `npm run build` clean.
- [x] Manually verified both endpoints against the live dev backend with real seeded data (`getblueprints?sort=trending`, `blueprints/:id/related`) — correct scoring and ordering observed.
- [ ] Not verified in an actual browser render — the shared Playwright profile was locked by another active session this run; component specs assert the rendered DOM directly as a substitute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)