### PR TITLE
Room detection phases 2+3: editor Room overlay + rooms catalog field/filter

### DIFF
--- a/__tests__/api/blueprint-rooms.test.ts
+++ b/__tests__/api/blueprint-rooms.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup } from '../setup/testSetup';
+import { BlueprintModel } from '../../app/api/models/blueprint';
+import { roomBlueprint } from '../helpers/roomFixtures';
+
+// The app import in TestSetup already bootstraps OniItem from
+// database-2024.json, so the room fixtures can build real blueprints here.
+const LATRINE_DATA = () =>
+  roomBlueprint(4, 3, [
+    { id: 'Outhouse', x: 0, y: 0 },
+    { id: 'WashBasin', x: 2, y: 0 },
+  ]).toMdbBlueprint();
+
+const BARRACKS_DATA = () => roomBlueprint(4, 3, [{ id: 'Bed', x: 0, y: 0 }]).toMdbBlueprint();
+
+const TINY_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+describe('Blueprint rooms derivation API', function () {
+  let authToken: string;
+  let testData: any;
+
+  const upload = (body: Record<string, unknown>) =>
+    TestSetup.request()
+      .post('/api/uploadblueprint')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ thumbnail: TINY_PNG, publish: true, ...body });
+
+  beforeEach(async function () {
+    this.timeout(15000);
+    testData = await TestSetup.beforeEach();
+    authToken = testData.users.user1.generateJwt();
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    await TestSetup.afterEach();
+  });
+
+  describe('save-path derivation', function () {
+    it('derives rooms from the uploaded content', async function () {
+      const response = await upload({ name: 'Latrine Base', blueprint: LATRINE_DATA() });
+      expect(response.status).to.equal(200);
+
+      const saved = await BlueprintModel.model.findById(response.body.id);
+      expect(saved!.rooms).to.deep.equal(['latrine']);
+    });
+
+    it('re-derives on overwrite', async function () {
+      const first = await upload({ name: 'Evolving Base', blueprint: LATRINE_DATA() });
+      expect(first.status).to.equal(200);
+
+      const second = await upload({
+        name: 'Evolving Base',
+        blueprint: BARRACKS_DATA(),
+        overwrite: true,
+      });
+      expect(second.status).to.equal(200);
+
+      const saved = await BlueprintModel.model.findById(second.body.id);
+      expect(saved!.rooms).to.deep.equal(['barracks']);
+    });
+
+    it('ignores a client-supplied rooms value', async function () {
+      const response = await upload({
+        name: 'Sneaky Base',
+        blueprint: BARRACKS_DATA(),
+        rooms: ['hospital', 'greatHall'],
+      });
+      expect(response.status).to.equal(200);
+
+      const saved = await BlueprintModel.model.findById(response.body.id);
+      expect(saved!.rooms).to.deep.equal(['barracks']);
+    });
+
+    it('stores [] for a blueprint with no rooms and null for unparseable data', async function () {
+      const empty = await upload({ name: 'Empty Base', blueprint: { blueprintItems: [] } });
+      expect(empty.status).to.equal(200);
+      const emptySaved = await BlueprintModel.model.findById(empty.body.id);
+      expect(emptySaved!.rooms).to.deep.equal([]);
+
+      // Legacy/foreign payload shape without blueprintItems: not derivable.
+      const legacy = await upload({ name: 'Legacy Base', blueprint: { buildings: [] } });
+      expect(legacy.status).to.equal(200);
+      const legacySaved = await BlueprintModel.model.findById(legacy.body.id);
+      expect(legacySaved!.rooms).to.equal(null);
+    });
+  });
+
+  describe('GET /api/getblueprints?rooms=', function () {
+    let latrineId: string;
+    let barracksId: string;
+
+    beforeEach(async function () {
+      this.timeout(15000);
+      latrineId = (await upload({ name: 'Latrine Base', blueprint: LATRINE_DATA() })).body.id;
+      barracksId = (await upload({ name: 'Barracks Base', blueprint: BARRACKS_DATA() })).body.id;
+    });
+
+    const list = (query: Record<string, unknown>) =>
+      TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), ...query });
+
+    it('filters by a single room type', async function () {
+      const response = await list({ rooms: 'latrine' });
+      expect(response.status).to.equal(200);
+
+      const ids = response.body.blueprints.map((bp: any) => bp.id);
+      expect(ids).to.include(latrineId);
+      expect(ids).to.not.include(barracksId);
+    });
+
+    it('matches any of a comma-separated list', async function () {
+      const response = await list({ rooms: 'latrine,barracks' });
+      expect(response.status).to.equal(200);
+
+      const ids = response.body.blueprints.map((bp: any) => bp.id);
+      expect(ids).to.include(latrineId);
+      expect(ids).to.include(barracksId);
+    });
+
+    it('exposes rooms on list items', async function () {
+      const response = await list({});
+      const item = response.body.blueprints.find((bp: any) => bp.id === latrineId);
+      expect(item.rooms).to.deep.equal(['latrine']);
+    });
+
+    it('does not match blueprints whose rooms were never derived', async function () {
+      // Seeded fixtures predate room derivation (no rooms field).
+      const response = await list({ rooms: 'latrine' });
+      const ids = response.body.blueprints.map((bp: any) => bp.id);
+      expect(ids).to.deep.equal([latrineId]);
+    });
+
+    it('rejects unknown room types with 400', async function () {
+      const response = await list({ rooms: 'latrine,notaroom' });
+      expect(response.status).to.equal(400);
+    });
+
+    it('rejects an empty rooms value with 400', async function () {
+      const response = await list({ rooms: ' , ' });
+      expect(response.status).to.equal(400);
+    });
+  });
+
+  describe('version restore', function () {
+    it('re-derives rooms from the restored data', async function () {
+      this.timeout(15000);
+      const id = (await upload({ name: 'Versioned Base', blueprint: LATRINE_DATA() })).body.id;
+
+      // Snapshot the latrine state, then overwrite with barracks content.
+      const snapshot = (
+        await TestSetup.request()
+          .post(`/api/blueprints/${id}/versions`)
+          .set('Authorization', `Bearer ${authToken}`)
+          .send({ name: 'latrine snapshot' })
+      ).body.version;
+
+      await upload({ name: 'Versioned Base', blueprint: BARRACKS_DATA(), overwrite: true });
+      let saved = await BlueprintModel.model.findById(id);
+      expect(saved!.rooms).to.deep.equal(['barracks']);
+
+      // Restoring an earlier version must re-derive from that version's data.
+      const versions = (
+        await TestSetup.request().get(`/api/blueprints/${id}/versions`)
+      ).body.versions;
+      const earlier = versions.find((v: any) => v.id !== snapshot.id) ?? snapshot;
+
+      const restore = await TestSetup.request()
+        .post(`/api/blueprints/${id}/versions/${earlier.id}/restore`)
+        .set('Authorization', `Bearer ${authToken}`);
+      expect(restore.status).to.equal(200);
+
+      saved = await BlueprintModel.model.findById(id);
+      expect(saved!.rooms).to.deep.equal(['latrine']);
+    });
+  });
+});

--- a/app/api/batch/derive-rooms.ts
+++ b/app/api/batch/derive-rooms.ts
@@ -1,0 +1,105 @@
+// Backfill script: derive the `rooms` field for all non-deleted blueprints
+// using the same shared detector as the save path (room-derivation-service).
+//
+// Usage:
+//   ts-node app/api/batch/derive-rooms.ts [--dry-run]
+//
+// Loads database-2024.json and bootstraps the OniItem statics (same as the
+// server startup) because room derivation parses each document's stored data
+// into a real Blueprint. Rerunnable: recomputes and $sets `rooms` on every
+// document whose value changed; --dry-run only reports counts per room type.
+// In the deploy image run the compiled output instead:
+//   cd /bpni/build && node app/api/batch/derive-rooms.js [--dry-run]
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as mongoose from 'mongoose';
+import * as dotenv from 'dotenv';
+import {
+  BuildableElement,
+  BuildMenuCategory,
+  BuildMenuItem,
+  ImageSource,
+  OniItem,
+  SpriteInfo,
+  SpriteModifier,
+} from '../../../lib/index';
+import { BlueprintModel } from '../models/blueprint';
+import { deriveRooms } from '../services/room-derivation-service';
+
+dotenv.config();
+
+// Same bootstrap as app.ts: OniItem.load needs the static tables populated.
+function loadGameDatabase() {
+  const dbPath = path.resolve(__dirname, '../../../assets/database/database-2024.json');
+  const json = JSON.parse(fs.readFileSync(dbPath, 'utf8'));
+  ImageSource.init();
+  BuildableElement.init();
+  BuildableElement.load(json.elements);
+  BuildMenuCategory.init();
+  BuildMenuCategory.load(json.buildMenuCategories);
+  BuildMenuItem.init();
+  BuildMenuItem.load(json.buildMenuItems);
+  SpriteInfo.init();
+  SpriteInfo.load(json.uiSprites);
+  SpriteModifier.init();
+  SpriteModifier.load(json.spriteModifiers);
+  OniItem.init();
+  OniItem.load(json.buildings);
+}
+
+function sameRooms(a: string[] | null | undefined, b: string[] | null): boolean {
+  if (a == null || b == null) return a == null && b == null;
+  return a.length === b.length && a.every((tag, i) => tag === b[i]);
+}
+
+async function run(dryRun: boolean) {
+  loadGameDatabase();
+
+  const mongoUri = process.env.DB_URI;
+  if (!mongoUri) throw new Error('DB_URI not set in environment');
+
+  await mongoose.connect(mongoUri);
+  BlueprintModel.init();
+
+  const cursor = BlueprintModel.model.find({ deletedAt: null }).cursor();
+  let processed = 0;
+  let updated = 0;
+  let unchanged = 0;
+  let nullResults = 0;
+  const perType = new Map<string, number>();
+
+  for await (const doc of cursor) {
+    processed++;
+    const rooms = deriveRooms(doc.data);
+
+    if (rooms == null) nullResults++;
+    else for (const tag of rooms) perType.set(tag, (perType.get(tag) ?? 0) + 1);
+
+    if (sameRooms(doc.rooms, rooms)) {
+      unchanged++;
+      continue;
+    }
+
+    updated++;
+    if (!dryRun) {
+      await BlueprintModel.model.updateOne({ _id: doc._id }, { $set: { rooms } });
+    }
+  }
+
+  console.log(
+    `Processed: ${processed}, updated: ${updated}, unchanged: ${unchanged}, not derivable: ${nullResults}${dryRun ? ' (dry run)' : ''}`
+  );
+  const typeReport = [...perType.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([tag, count]) => `${tag}: ${count}`)
+    .join(', ');
+  console.log(`Rooms by type — ${typeReport || 'none detected'}`);
+  await mongoose.disconnect();
+}
+
+const dryRun = process.argv.includes('--dry-run');
+run(dryRun).catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -16,6 +16,7 @@ import {
   CATEGORIES,
   SUBCATEGORIES,
   RESEARCH_TIERS,
+  ROOM_TYPE_IDS,
 } from '../../lib/index';
 import { Blueprint as sharedBlueprint, BlueprintDetailsResponse } from '../../lib/index';
 import { UserModel, UserJwt } from './models/user';
@@ -34,6 +35,7 @@ import {
   syncCurrentVersion,
 } from './services/blueprint-version-service';
 import { PreviewImageService } from './services/preview-image-service';
+import { deriveRooms } from './services/room-derivation-service';
 import mongoose from 'mongoose';
 
 const MAX_SKIP = 10000;
@@ -361,6 +363,7 @@ export class BlueprintController {
         description: blueprint.description ?? null,
         researchTier: blueprint.researchTier ?? null,
         modded: blueprint.modded ?? null,
+        rooms: blueprint.rooms ?? null,
         isPublished: blueprint.isPublished !== false,
       };
 
@@ -454,6 +457,7 @@ export class BlueprintController {
       let filterCategory: string | null = null;
       let filterSubcategory: string | null = null;
       let filterModded: boolean | null = null;
+      let filterRooms: string[] | null = null;
       let filterForkedFrom: string | null = null;
       let filterLikedBy: string | null = null;
       let sort: BlueprintSort;
@@ -497,6 +501,27 @@ export class BlueprintController {
           return;
         }
         filterModded = rawModded != null ? rawModded === 'true' : null;
+
+        // ?rooms=latrine,park -> blueprints containing ANY of the room types.
+        // Values validated against the shared enum (400 on garbage, consistent
+        // with category). Docs never derived (rooms null/absent) never match.
+        const rawRooms = req.query.rooms as string | undefined;
+        if (rawRooms != null) {
+          const requested = rawRooms
+            .split(',')
+            .map(room => room.trim())
+            .filter(room => room.length > 0);
+          const invalid = requested.filter(
+            room => !(ROOM_TYPE_IDS as readonly string[]).includes(room)
+          );
+          if (requested.length === 0 || invalid.length > 0) {
+            res
+              .status(400)
+              .json(apiError(400, `Invalid rooms: must be a comma-separated list of ${ROOM_TYPE_IDS.join(', ')}`));
+            return;
+          }
+          filterRooms = requested;
+        }
 
         const rawForkedFrom = req.query.forkedFrom as string | undefined;
         if (rawForkedFrom != null && !mongoose.Types.ObjectId.isValid(rawForkedFrom)) {
@@ -566,6 +591,7 @@ export class BlueprintController {
       if (filterCategory != null) filter.$and.push({ category: filterCategory });
       if (filterSubcategory != null) filter.$and.push({ subcategory: filterSubcategory });
       if (filterModded != null) filter.$and.push({ modded: filterModded });
+      if (filterRooms != null) filter.$and.push({ rooms: { $in: filterRooms } });
       if (filterForkedFrom != null) filter.$and.push({ 'forkedFrom.blueprintId': filterForkedFrom });
       if (filterLikedBy != null) filter.$and.push({ likes: filterLikedBy });
 
@@ -801,6 +827,7 @@ export class BlueprintController {
       subcategory: blueprint.subcategory ?? null,
       description: blueprint.description ?? null,
       modded: blueprint.modded ?? null,
+      rooms: blueprint.rooms ?? null,
       isPublished: blueprint.isPublished !== false,
       nbForks: blueprint.forkCount ?? 0,
       nbViews: blueprint.viewCount ?? 0,
@@ -1075,6 +1102,7 @@ export class BlueprintController {
         description: blueprint.description ?? null,
         researchTier: blueprint.researchTier ?? null,
         modded: blueprint.modded ?? null,
+        rooms: blueprint.rooms ?? null,
         isPublished: blueprint.isPublished !== false,
         nbForks: blueprint.forkCount ?? 0,
         nbViews: blueprint.viewCount ?? 0,
@@ -1199,6 +1227,9 @@ export class BlueprintController {
     blueprint.markModified('data');
     blueprint.thumbnail = thumbnail;
     blueprint.deletedAt = null;
+    // Derived fact, never client-supplied — any `rooms` key in the request
+    // body is ignored (same policy as a client trying to set likeCount).
+    blueprint.rooms = deriveRooms(data);
 
     if (metadata) {
       blueprint.gameVersion = metadata.gameVersion;

--- a/app/api/blueprint-version-controller.ts
+++ b/app/api/blueprint-version-controller.ts
@@ -8,6 +8,7 @@ import { apiError } from './utils/apiError';
 import { optionalViewer } from './utils/optionalViewer';
 import { canViewBlueprint } from './utils/blueprint-visibility';
 import { BlueprintEventService } from './services/blueprint-event-service';
+import { deriveRooms } from './services/room-derivation-service';
 import {
   ensureCurrentVersion,
   resolveCurrentData,
@@ -310,6 +311,8 @@ export class BlueprintVersionController {
       // The rendered content changed: bumping modifiedAt invalidates both the
       // disk preview cache and the frontend's versioned (?v=) preview urls.
       blueprint.modifiedAt = new Date();
+      // The live content changed, so the derived room tags change with it.
+      blueprint.rooms = deriveRooms(version.data);
       await blueprint.save();
 
       // Render-on-write: warm the preview cache with the restored data (Phase 2).

--- a/app/api/models/blueprint.ts
+++ b/app/api/models/blueprint.ts
@@ -1,5 +1,5 @@
 import mongoose, { Schema, Document, Model } from 'mongoose';
-import { GAME_VERSIONS, CATEGORIES, RESEARCH_TIERS } from '../../../lib/index';
+import { GAME_VERSIONS, CATEGORIES, RESEARCH_TIERS, ROOM_TYPE_IDS } from '../../../lib/index';
 
 export interface Blueprint extends Document {
   owner: string;
@@ -26,6 +26,10 @@ export interface Blueprint extends Document {
   description?: string | null;
   researchTier?: string | null;
   modded?: boolean | null;
+  // Room types detected in the blueprint content, server-derived on every save
+  // (never client-supplied). null/absent = never derived or blueprint too large
+  // for detection; [] = derived, no rooms found.
+  rooms?: string[] | null;
   currentVersionId?: mongoose.Types.ObjectId | null;
   forkedFrom?: {
     blueprintId: mongoose.Types.ObjectId;
@@ -78,6 +82,9 @@ export class BlueprintModel {
       description: { type: String, maxlength: 500 },
       researchTier: { type: String, enum: [...RESEARCH_TIERS, null] },
       modded: { type: Boolean },
+      // No default: absent means "never derived", distinct from [] = "derived,
+      // none found" (mirrors the gameVersion nullability convention).
+      rooms: { type: [String], enum: ROOM_TYPE_IDS, default: undefined },
       currentVersionId: {
         type: Schema.Types.ObjectId,
         ref: 'BlueprintVersion',
@@ -111,6 +118,8 @@ export class BlueprintModel {
     blueprintSchema.index({ deletedAt: 1, isPublished: 1, gameVersion: 1, createdAt: -1 });
     blueprintSchema.index({ deletedAt: 1, isPublished: 1, category: 1, createdAt: -1 });
     blueprintSchema.index({ deletedAt: 1, isPublished: 1, gameVersion: 1, category: 1, createdAt: -1 });
+    // Room-type filter on the public feed (multikey on rooms)
+    blueprintSchema.index({ deletedAt: 1, isPublished: 1, rooms: 1, createdAt: -1 });
     // "Most liked" sort on the public feed
     blueprintSchema.index({ deletedAt: 1, isPublished: 1, likeCount: -1, createdAt: -1 });
     // "Most forked" sort

--- a/app/api/services/room-derivation-service.ts
+++ b/app/api/services/room-derivation-service.ts
@@ -1,0 +1,29 @@
+import {
+  Blueprint as SharedBlueprint,
+  detectRooms,
+  MdbBlueprint,
+  roomSearchTags,
+  RoomTypeId,
+} from '../../../lib/index';
+
+// Server-side room derivation: parse stored blueprint data and run the shared
+// detector. The client never supplies `rooms` — this is the only writer.
+// Requires the game database to be loaded (OniItem.load in app.ts startup).
+//
+// Returns the sorted deduped room tag list, or null when detection was not
+// possible (blueprint too large, unparseable data). Never throws: a derivation
+// failure must never fail a save.
+export function deriveRooms(data: unknown): RoomTypeId[] | null {
+  try {
+    const parsed = new SharedBlueprint();
+    parsed.importFromMdb(data as MdbBlueprint);
+    const result = detectRooms(parsed);
+    // 'empty' is a successful derivation (no buildings -> no rooms); only
+    // 'too-large' means "could not compute".
+    return result.status === 'too-large' ? null : roomSearchTags(result);
+  } catch (error) {
+    console.log('room derivation error');
+    console.log(error);
+    return null;
+  }
+}

--- a/frontend/src/app/module-blueprint/components/component-canvas/component-canvas.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/component-canvas/component-canvas.component.spec.ts
@@ -15,12 +15,20 @@ import { DrawPixi } from "src/app/module-blueprint/drawing/draw-pixi";
 
 // The real DrawPixi constructs a PIXI.Application (WebGL) in Init(), which jsdom
 // cannot provide. Inject a mock so the renderer never boots in the unit test.
+// DrawRoomOverlay (created in ngOnInit) needs container/graphics/text factories
+// and the stage to attach to — plain stubs keep it inert.
 function mockDrawPixi(): Partial<DrawPixi> {
   return {
-    getNewContainer: () => ({} as any),
+    getNewContainer: () => ({ addChild: () => {}, visible: true } as any),
+    getNewGraphics: () => ({ clear: () => {} } as any),
+    getNewText: () => ({ anchor: { set: () => {} }, visible: true } as any),
     Init: () => {},
     InitAnimation: () => {},
     blueprintContainer: {} as any,
+    pixiApp: {
+      stage: { addChild: () => {} },
+      renderer: { width: 0, height: 0 },
+    } as any,
   };
 }
 

--- a/frontend/src/app/module-blueprint/components/component-canvas/component-canvas.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-canvas/component-canvas.component.ts
@@ -30,6 +30,8 @@ import {
 
 import { DrawPixi } from "../../drawing/draw-pixi";
 import { DrawMiniUi } from "../../drawing/draw-mini-ui";
+import { DrawRoomOverlay } from "../../drawing/draw-room-overlay";
+import { RoomDetectionService } from "../../services/room-detection-service";
 import { GoogleAnalyticsService } from "ngx-google-analytics";
 import JSZip from "jszip";
 import {
@@ -73,6 +75,7 @@ export class ComponentCanvasComponent
   forcedSize!: Vector2;
 
   drawPixi: DrawPixi;
+  drawRoomOverlay!: DrawRoomOverlay;
 
   private cameraService: CameraService;
 
@@ -84,6 +87,7 @@ export class ComponentCanvasComponent
     private blueprintService: BlueprintService,
     private toolService: ToolService,
     private gaService: GoogleAnalyticsService,
+    private roomDetectionService: RoomDetectionService,
     drawPixi: DrawPixi
   ) {
     this.drawPixi = drawPixi;
@@ -108,6 +112,7 @@ export class ComponentCanvasComponent
       this.drawPixi.Init(this.canvasRef, this);
       this.drawPixi.InitAnimation();
       this.cameraService.container = this.drawPixi.blueprintContainer;
+      this.drawRoomOverlay = new DrawRoomOverlay(this.drawPixi);
 
       if (this.forceSize) {
         let miniUi = new DrawMiniUi();
@@ -1055,6 +1060,20 @@ export class ComponentCanvasComponent
       }
 
       this.toolService.draw(this.drawPixi, this.cameraService);
+
+      // Room overlay: cavity tints + labels above everything. Only the main
+      // editor canvas drives detection activity — export/thumbnail canvases
+      // (forceSize) never show the Room overlay and must not fight the flag.
+      if (!this.forceSize) {
+        const roomOverlayActive = this.cameraService.overlay == Overlay.Room;
+        this.roomDetectionService.active = roomOverlayActive;
+        if (roomOverlayActive)
+          this.drawRoomOverlay.draw(
+            this.roomDetectionService.result,
+            this.cameraService
+          );
+        else this.drawRoomOverlay.clear();
+      }
     }
 
     if (this.pendingRenderMetric != null) this.checkRenderMetric();

--- a/frontend/src/app/module-blueprint/components/component-menu/component-menu.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/component-menu/component-menu.component.spec.ts
@@ -3,7 +3,7 @@ import { LOCALE_ID, NO_ERRORS_SCHEMA } from "@angular/core";
 import { Router } from "@angular/router";
 import { MessageService } from "primeng/api";
 
-import { CameraService } from "../../../../../../lib/index";
+import { CameraService, Overlay } from "../../../../../../lib/index";
 import { AuthenticationService } from "src/app/module-blueprint/services/authentification-service";
 import { BlueprintService } from "src/app/module-blueprint/services/blueprint-service";
 import { ToolService } from "src/app/module-blueprint/services/tool-service";
@@ -50,5 +50,13 @@ describe("ComponentMenuComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("offers the Rooms overlay in the overlay switcher", () => {
+    const roomsItem = component.overlayMenuItems.find(
+      (item) => item.id == Overlay.Room.toString()
+    );
+    expect(roomsItem).toBeTruthy();
+    expect(roomsItem!.label).toBe("Rooms");
   });
 });

--- a/frontend/src/app/module-blueprint/components/component-menu/component-menu.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-menu/component-menu.component.ts
@@ -113,6 +113,7 @@ export class ComponentMenuComponent
         id: Overlay.Conveyor,
         name: $localize`:overlay switch on the menu:Shipment`,
       },
+      { id: Overlay.Room, name: $localize`:overlay switch on the menu:Rooms` },
     ];
     this.overlayMenuItems = [];
     overlayList.map((overlay) => {

--- a/frontend/src/app/module-blueprint/drawing/draw-room-overlay.ts
+++ b/frontend/src/app/module-blueprint/drawing/draw-room-overlay.ts
@@ -1,0 +1,129 @@
+import { CameraService, RoomDetectionResult } from "../../../../../lib/index";
+import { DrawPixi } from "./draw-pixi";
+import {
+  buildRoomOverlayGeometry,
+  CavityOverlayGeometry,
+  TOO_LARGE_NOTICE,
+} from "./room-overlay-geometry";
+
+import {} from "pixi.js-legacy";
+declare var PIXI: any;
+
+const LABEL_STYLE = {
+  fontFamily: "Arial",
+  fontSize: 14,
+  fill: "#ffffff",
+  stroke: "#000000",
+  strokeThickness: 3,
+  align: "center",
+};
+
+// Renders the Room overlay: a translucent family-colored fill per detected
+// cavity plus a room-name label, drawn above everything (like the game's F11
+// view). Geometry is precomputed per detection result (room-overlay-geometry);
+// each frame only redoes the camera transform. Labels are retained PIXI.Text
+// objects pooled across results — restyling text every frame would re-rasterize.
+export class DrawRoomOverlay {
+  private container: any;
+  private graphics: any;
+  private labels: any[] = [];
+  private notice: any = null;
+
+  private lastResult: RoomDetectionResult | null = null;
+  private geometry: CavityOverlayGeometry[] = [];
+
+  constructor(private drawPixi: DrawPixi) {
+    this.container = drawPixi.getNewContainer();
+    this.graphics = drawPixi.getNewGraphics();
+    this.container.addChild(this.graphics);
+    // Stage children render in add order; the canvas adds this after
+    // frontGraphics, so the overlay sits above items and tool feedback.
+    drawPixi.pixiApp.stage.addChild(this.container);
+  }
+
+  clear() {
+    if (!this.container.visible) return;
+    this.container.visible = false;
+    this.graphics.clear();
+  }
+
+  draw(result: RoomDetectionResult | null, camera: CameraService) {
+    this.container.visible = true;
+    this.graphics.clear();
+
+    if (result !== this.lastResult) {
+      this.lastResult = result;
+      this.geometry = result != null ? buildRoomOverlayGeometry(result) : [];
+      this.syncLabels();
+    }
+
+    if (result == null) return;
+
+    if (result.status == "too-large") {
+      this.drawTooLargeNotice();
+      return;
+    }
+    if (this.notice != null) this.notice.visible = false;
+
+    const zoom = camera.currentZoom;
+    const offset = camera.cameraOffset;
+
+    for (let i = 0; i < this.geometry.length; i++) {
+      const cavity = this.geometry[i];
+
+      this.graphics.beginFill(cavity.color, cavity.alpha);
+      for (const span of cavity.spans)
+        this.graphics.drawRect(
+          (span.x + offset.x) * zoom,
+          (offset.y - span.y) * zoom,
+          span.length * zoom,
+          zoom
+        );
+      this.graphics.endFill();
+
+      const label = this.labels[i];
+      if (label != null) {
+        label.x = (cavity.center.x + offset.x + 0.5) * zoom;
+        label.y = (offset.y - cavity.center.y + 0.5) * zoom;
+      }
+    }
+  }
+
+  // One pooled PIXI.Text per labeled cavity, indexed like this.geometry
+  // (null for unlabeled ones). Text content only changes here, never per frame.
+  private syncLabels() {
+    for (const label of this.labels) if (label != null) label.visible = false;
+
+    const labels: any[] = [];
+    let poolIndex = 0;
+    const pool = this.labels.filter((l) => l != null);
+
+    for (const cavity of this.geometry) {
+      if (cavity.label == null) {
+        labels.push(null);
+        continue;
+      }
+      let label = pool[poolIndex++];
+      if (label == null) {
+        label = this.drawPixi.getNewText(cavity.label, LABEL_STYLE);
+        label.anchor.set(0.5, 0.5);
+        this.container.addChild(label);
+      } else if (label.text !== cavity.label) label.text = cavity.label;
+      label.visible = true;
+      labels.push(label);
+    }
+
+    this.labels = labels;
+  }
+
+  private drawTooLargeNotice() {
+    if (this.notice == null) {
+      this.notice = this.drawPixi.getNewText(TOO_LARGE_NOTICE, LABEL_STYLE);
+      this.notice.anchor.set(0.5, 0.5);
+      this.container.addChild(this.notice);
+    }
+    this.notice.visible = true;
+    this.notice.x = this.drawPixi.pixiApp.renderer.width / 2;
+    this.notice.y = this.drawPixi.pixiApp.renderer.height / 2;
+  }
+}

--- a/frontend/src/app/module-blueprint/drawing/room-overlay-geometry.spec.ts
+++ b/frontend/src/app/module-blueprint/drawing/room-overlay-geometry.spec.ts
@@ -1,0 +1,159 @@
+import {
+  Cavity,
+  DrawHelpers,
+  RoomDetectionResult,
+  Vector2,
+} from "../../../../../lib/index";
+import {
+  buildRoomOverlayGeometry,
+  ROOM_TYPE_LABELS,
+} from "./room-overlay-geometry";
+
+const tile = (x: number, y: number) =>
+  DrawHelpers.getTileIndex(new Vector2(x, y));
+
+// Cells sorted ascending, matching the detector's output contract.
+const cells = (positions: [number, number][]) =>
+  positions.map(([x, y]) => tile(x, y)).sort((a, b) => a - b);
+
+const cavity = (id: number, overrides: Partial<Cavity>): Cavity => ({
+  id,
+  cells: [],
+  size: 0,
+  result: "miscellaneous",
+  matchedTypes: [],
+  ...overrides,
+});
+
+const result = (
+  cavities: Cavity[],
+  rooms: RoomDetectionResult["rooms"] = []
+): RoomDetectionResult => ({ status: "ok", cavities, rooms });
+
+describe("buildRoomOverlayGeometry", () => {
+  it("merges row-consecutive cells into spans", () => {
+    // 3x2 block plus one detached cell on the same row.
+    const block = cells([
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [5, 0],
+      [0, 1],
+      [1, 1],
+      [2, 1],
+    ]);
+    const geometry = buildRoomOverlayGeometry(
+      result([cavity(0, { cells: block, size: block.length })])
+    );
+
+    expect(geometry[0].spans).toEqual([
+      { x: 0, y: 0, length: 3 },
+      { x: 5, y: 0, length: 1 },
+      { x: 0, y: 1, length: 3 },
+    ]);
+  });
+
+  it("centers the label on the cavity bounding box", () => {
+    const block = cells([
+      [2, 3],
+      [3, 3],
+      [2, 4],
+      [3, 4],
+    ]);
+    const geometry = buildRoomOverlayGeometry(
+      result([cavity(0, { cells: block, size: 4 })])
+    );
+    expect(geometry[0].center).toEqual({ x: 2.5, y: 3.5 });
+  });
+
+  it("labels rooms with their display name and colors them by family", () => {
+    const roomCells = cells([[0, 0]]);
+    const geometry = buildRoomOverlayGeometry(
+      result(
+        [
+          cavity(0, {
+            cells: roomCells,
+            size: 1,
+            result: "room",
+            matchedTypes: ["latrine"],
+          }),
+        ],
+        [{ type: "latrine", cavityId: 0, cells: roomCells, size: 1 }]
+      )
+    );
+    expect(geometry[0].label).toBe(ROOM_TYPE_LABELS.latrine);
+    expect(geometry[0].color).toBeGreaterThan(0);
+  });
+
+  it("shows both names for a possible upgrade (Park / Nature Reserve)", () => {
+    const roomCells = cells([[0, 0]]);
+    const geometry = buildRoomOverlayGeometry(
+      result(
+        [
+          cavity(0, {
+            cells: roomCells,
+            size: 1,
+            result: "room",
+            matchedTypes: ["park"],
+          }),
+        ],
+        [
+          {
+            type: "park",
+            possibleUpgrade: "natureReserve",
+            cavityId: 0,
+            cells: roomCells,
+            size: 1,
+          },
+        ]
+      )
+    );
+    expect(geometry[0].label).toBe(
+      `${ROOM_TYPE_LABELS.park} / ${ROOM_TYPE_LABELS.natureReserve}`
+    );
+  });
+
+  it("labels conflicts with the qualifying types", () => {
+    const geometry = buildRoomOverlayGeometry(
+      result([
+        cavity(0, {
+          cells: cells([[0, 0]]),
+          size: 1,
+          result: "conflict",
+          matchedTypes: ["barracks", "messHall"],
+        }),
+      ])
+    );
+    expect(geometry[0].label).toBe(
+      `${ROOM_TYPE_LABELS.barracks} / ${ROOM_TYPE_LABELS.messHall}`
+    );
+  });
+
+  it("leaves miscellaneous cavities unlabeled with a faint fill", () => {
+    const roomGeometry = buildRoomOverlayGeometry(
+      result(
+        [
+          cavity(0, {
+            cells: cells([[0, 0]]),
+            size: 1,
+            result: "room",
+            matchedTypes: ["latrine"],
+          }),
+        ],
+        [{ type: "latrine", cavityId: 0, cells: cells([[0, 0]]), size: 1 }]
+      )
+    );
+    const miscGeometry = buildRoomOverlayGeometry(
+      result([cavity(0, { cells: cells([[0, 0]]), size: 1 })])
+    );
+    expect(miscGeometry[0].label).toBeNull();
+    expect(miscGeometry[0].alpha).toBeLessThan(roomGeometry[0].alpha);
+  });
+
+  it("has a display label for every room type", () => {
+    for (const label of Object.values(ROOM_TYPE_LABELS)) {
+      expect(typeof label).toBe("string");
+      expect(label.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/frontend/src/app/module-blueprint/drawing/room-overlay-geometry.ts
+++ b/frontend/src/app/module-blueprint/drawing/room-overlay-geometry.ts
@@ -1,0 +1,164 @@
+import {
+  Cavity,
+  DrawHelpers,
+  ROOM_DEFINITIONS,
+  RoomDetectionResult,
+  RoomFamily,
+  RoomTypeId,
+} from "../../../../../lib/index";
+
+// Pure geometry/style derivation for the Room overlay — everything the PIXI
+// layer (draw-room-overlay.ts) needs, precomputed once per detection result so
+// the per-frame work is only camera transforms. No PIXI here: this module is
+// unit-tested directly (renderer stays mocked per repo test rules).
+
+// One horizontal run of cavity cells (tile coords, y-up world).
+export interface CavitySpan {
+  x: number;
+  y: number;
+  length: number;
+}
+
+export interface CavityOverlayGeometry {
+  cavityId: number;
+  color: number;
+  alpha: number;
+  label: string | null;
+  // Center cell coordinates of the cavity bounding box (may be fractional).
+  // Screen position: ((center.x + offset.x + 0.5) * zoom, (offset.y - center.y + 0.5) * zoom).
+  center: { x: number; y: number };
+  spans: CavitySpan[];
+}
+
+export const ROOM_TYPE_LABELS: Record<RoomTypeId, string> = {
+  latrine: $localize`:room overlay label:Latrine`,
+  washroom: $localize`:room overlay label:Washroom`,
+  barracks: $localize`:room overlay label:Barracks`,
+  luxuryBarracks: $localize`:room overlay label:Luxury Barracks`,
+  privateBedroom: $localize`:room overlay label:Private Bedroom`,
+  messHall: $localize`:room overlay label:Mess Hall`,
+  greatHall: $localize`:room overlay label:Great Hall`,
+  banquetHall: $localize`:room overlay label:Banquet Hall`,
+  massageClinic: $localize`:room overlay label:Massage Clinic`,
+  hospital: $localize`:room overlay label:Hospital`,
+  recreationRoom: $localize`:room overlay label:Recreation Room`,
+  park: $localize`:room overlay label:Park`,
+  natureReserve: $localize`:room overlay label:Nature Reserve`,
+  kitchen: $localize`:room overlay label:Kitchen`,
+  powerPlant: $localize`:room overlay label:Power Plant`,
+  greenhouse: $localize`:room overlay label:Greenhouse`,
+  laboratory: $localize`:room overlay label:Laboratory`,
+  stable: $localize`:room overlay label:Stable`,
+};
+
+export const TOO_LARGE_NOTICE = $localize`:room overlay notice:Blueprint too large for room detection`;
+
+// One color per room family (visually matching the game's F11 palette spirit).
+const FAMILY_COLORS: Record<RoomFamily, number> = {
+  washroom: 0x26c6da,
+  sleep: 0x5c7cfa,
+  dining: 0xffa94d,
+  "medical:massage": 0xf783ac,
+  "medical:hospital": 0xff6b6b,
+  recreation: 0xda77f2,
+  park: 0x69db7c,
+  kitchen: 0xffd43b,
+  power: 0xff922b,
+  "agriculture:greenhouse": 0x94d82d,
+  "agriculture:stable": 0xa9805b,
+  science: 0x9775fa,
+};
+
+const MISC_COLOR = 0xadb5bd;
+const CONFLICT_COLOR = 0xfa5252;
+const TOO_LARGE_COLOR = 0x868e96;
+
+const ROOM_ALPHA = 0.32;
+const MISC_ALPHA = 0.16;
+const CONFLICT_ALPHA = 0.3;
+const TOO_LARGE_ALPHA = 0.1;
+
+const familyById = new Map<RoomTypeId, RoomFamily>(
+  ROOM_DEFINITIONS.map((def) => [def.id, def.family])
+);
+
+export function buildRoomOverlayGeometry(
+  result: RoomDetectionResult
+): CavityOverlayGeometry[] {
+  const roomByCavity = new Map(
+    result.rooms.map((room) => [room.cavityId, room])
+  );
+
+  return result.cavities.map((cavity) => {
+    let color: number;
+    let alpha: number;
+    let label: string | null = null;
+
+    const room = roomByCavity.get(cavity.id);
+    if (cavity.result == "room" && room != null) {
+      color = FAMILY_COLORS[familyById.get(room.type)!];
+      alpha = ROOM_ALPHA;
+      label = room.possibleUpgrade
+        ? `${ROOM_TYPE_LABELS[room.type]} / ${
+            ROOM_TYPE_LABELS[room.possibleUpgrade]
+          }`
+        : ROOM_TYPE_LABELS[room.type];
+    } else if (cavity.result == "conflict") {
+      color = CONFLICT_COLOR;
+      alpha = CONFLICT_ALPHA;
+      label = cavity.matchedTypes.map((t) => ROOM_TYPE_LABELS[t]).join(" / ");
+    } else if (cavity.result == "too-large-for-room") {
+      color = TOO_LARGE_COLOR;
+      alpha = TOO_LARGE_ALPHA;
+    } else {
+      color = MISC_COLOR;
+      alpha = MISC_ALPHA;
+    }
+
+    return {
+      cavityId: cavity.id,
+      color,
+      alpha,
+      label,
+      center: cavityCenter(cavity),
+      spans: cellsToSpans(cavity.cells),
+    };
+  });
+}
+
+// Cavity cells arrive sorted by ascending tileIndex (row-major: y, then x), so
+// horizontal runs are consecutive entries — merge them into spans to keep the
+// per-frame rect count low even for large miscellaneous cavities.
+function cellsToSpans(cells: number[]): CavitySpan[] {
+  const spans: CavitySpan[] = [];
+  let current: CavitySpan | null = null;
+  let previous = { x: 0, y: 0 };
+
+  for (const cell of cells) {
+    const p = DrawHelpers.getTilePosition(cell);
+    if (current != null && p.y == previous.y && p.x == previous.x + 1)
+      current.length++;
+    else {
+      current = { x: p.x, y: p.y, length: 1 };
+      spans.push(current);
+    }
+    previous = p;
+  }
+
+  return spans;
+}
+
+function cavityCenter(cavity: Cavity): { x: number; y: number } {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const cell of cavity.cells) {
+    const p = DrawHelpers.getTilePosition(cell);
+    if (p.x < minX) minX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y > maxY) maxY = p.y;
+  }
+  return { x: (minX + maxX) / 2, y: (minY + maxY) / 2 };
+}

--- a/frontend/src/app/module-blueprint/services/room-detection-service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/room-detection-service.spec.ts
@@ -1,0 +1,83 @@
+import { Blueprint } from "../../../../../lib/index";
+import { RoomDetectionService } from "./room-detection-service";
+import { BlueprintService } from "./blueprint-service";
+
+// The service only touches blueprintService.blueprint, so a bare Blueprint in
+// a stub is enough — no TestBed/HTTP wiring needed. An empty blueprint gives a
+// real (status 'empty') detection result; recomputes are observed through
+// result object identity (detectRooms returns a fresh object per run).
+describe("RoomDetectionService", () => {
+  let blueprint: Blueprint;
+  let service: RoomDetectionService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    blueprint = new Blueprint();
+    service = new RoomDetectionService({ blueprint } as BlueprintService);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stays lazy while inactive: changes only mark the result dirty", () => {
+    blueprint.emitBlueprintChanged();
+    vi.advanceTimersByTime(1000);
+    expect(service.result).toBeNull();
+  });
+
+  it("computes immediately on activation", () => {
+    service.active = true;
+    expect(service.result).not.toBeNull();
+    expect(service.result!.status).toBe("empty");
+  });
+
+  it("debounces changes while active: one recompute after the stroke settles", () => {
+    service.active = true;
+    const initial = service.result;
+
+    blueprint.emitBlueprintChanged();
+    blueprint.emitBlueprintChanged();
+    blueprint.emitBlueprintChanged();
+
+    vi.advanceTimersByTime(RoomDetectionService.debounceMs - 1);
+    expect(service.result).toBe(initial); // still pending
+
+    vi.advanceTimersByTime(1);
+    const recomputed = service.result;
+    expect(recomputed).not.toBe(initial);
+
+    vi.advanceTimersByTime(1000);
+    expect(service.result).toBe(recomputed); // exactly one recompute
+  });
+
+  it("re-activation without changes does not recompute", () => {
+    service.active = true;
+    const initial = service.result;
+    service.active = false;
+    service.active = true;
+    expect(service.result).toBe(initial);
+  });
+
+  it("deactivation cancels a pending recompute", () => {
+    service.active = true;
+    const initial = service.result;
+    blueprint.emitBlueprintChanged();
+    service.active = false;
+    vi.advanceTimersByTime(1000);
+    expect(service.result).toBe(initial);
+  });
+
+  it("detectNow bypasses the debounce and returns a fresh result", () => {
+    service.active = true;
+    const initial = service.result;
+    blueprint.emitBlueprintChanged();
+
+    const fresh = service.detectNow();
+    expect(fresh).not.toBe(initial);
+    expect(service.result).toBe(fresh);
+
+    vi.advanceTimersByTime(1000);
+    expect(service.result).toBe(fresh); // pending debounce was cancelled
+  });
+});

--- a/frontend/src/app/module-blueprint/services/room-detection-service.ts
+++ b/frontend/src/app/module-blueprint/services/room-detection-service.ts
@@ -1,0 +1,82 @@
+import { Injectable } from "@angular/core";
+import {
+  detectRooms,
+  IObsBlueprintChange,
+  RoomDetectionResult,
+} from "../../../../../lib/index";
+import { BlueprintService } from "./blueprint-service";
+
+// Keeps a lazily-recomputed room detection result for the editor blueprint.
+// Recomputes only while a consumer is active (Room overlay visible) — inactive
+// changes just mark the result dirty. While active, changes are debounced so a
+// 40-tile drag triggers one detection after the stroke settles.
+@Injectable({ providedIn: "root" })
+export class RoomDetectionService implements IObsBlueprintChange {
+  static readonly debounceMs = 250;
+
+  private result_: RoomDetectionResult | null = null;
+  private dirty = true;
+  private active_ = false;
+  private debounceHandle: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private blueprintService: BlueprintService) {
+    // The editor mutates one long-lived Blueprint instance (loadNewBlueprint
+    // copies into it), so subscribing once covers loads and edits alike.
+    this.blueprintService.blueprint.subscribeBlueprintChanged(this);
+  }
+
+  get active(): boolean {
+    return this.active_;
+  }
+  // The canvas sets this every frame from "is the Room overlay on"; activation
+  // recomputes immediately so the overlay never shows a stale result.
+  set active(value: boolean) {
+    if (value == this.active_) return;
+    this.active_ = value;
+    if (value) {
+      if (this.dirty) this.recompute();
+    } else this.cancelPending();
+  }
+
+  // Latest computed result; null until the first recompute (or after a failure).
+  get result(): RoomDetectionResult | null {
+    return this.result_;
+  }
+
+  // Fresh result right now, bypassing the debounce (save dialog).
+  detectNow(): RoomDetectionResult | null {
+    this.cancelPending();
+    if (this.dirty) this.recompute();
+    return this.result_;
+  }
+
+  // IObsBlueprintChange
+  itemAdded() {}
+  itemDestroyed() {}
+  blueprintChanged() {
+    this.dirty = true;
+    if (!this.active_) return;
+    this.cancelPending();
+    this.debounceHandle = setTimeout(() => {
+      this.debounceHandle = null;
+      this.recompute();
+    }, RoomDetectionService.debounceMs);
+  }
+
+  private cancelPending() {
+    if (this.debounceHandle != null) {
+      clearTimeout(this.debounceHandle);
+      this.debounceHandle = null;
+    }
+  }
+
+  private recompute() {
+    try {
+      this.result_ = detectRooms(this.blueprintService.blueprint);
+    } catch (error) {
+      // Detection must never break the editor; drop the result and move on.
+      this.result_ = null;
+    }
+    this.dirty = false;
+  }
+}

--- a/lib/src/blueprint/blueprint-item.ts
+++ b/lib/src/blueprint/blueprint-item.ts
@@ -513,15 +513,19 @@ export class BlueprintItem {
     // TODO general case for elements
     if (camera.overlay == Overlay.Unknown) Overlay.Base;
 
+    // The Room overlay tints cavities on top of the normal Base render (like the
+    // game's F11 view); items themselves keep their Base opacity and depth.
+    const itemOverlay = camera.overlay == Overlay.Room ? Overlay.Base : camera.overlay;
+
     this.isOpaque =
-      this.oniItem.isOverlayPrimary(camera.overlay) ||
-      this.oniItem.isOverlaySecondary(camera.overlay);
+      this.oniItem.isOverlayPrimary(itemOverlay) ||
+      this.oniItem.isOverlaySecondary(itemOverlay);
 
     if (this.isOpaque) this.alpha = 1;
     else this.alpha = 0.3;
 
-    if (this.oniItem.isOverlayPrimary(camera.overlay)) this.depth = this.oniItem.zIndex + 100;
-    else if (this.oniItem.isOverlaySecondary(camera.overlay)) this.depth = this.oniItem.zIndex + 50;
+    if (this.oniItem.isOverlayPrimary(itemOverlay)) this.depth = this.oniItem.zIndex + 100;
+    else if (this.oniItem.isOverlaySecondary(itemOverlay)) this.depth = this.oniItem.zIndex + 50;
     else this.depth = this.oniItem.zIndex;
 
     // Wall-plane decals always render behind whatever they're placed against -

--- a/lib/src/coms/blueprint-list-response.d.ts
+++ b/lib/src/coms/blueprint-list-response.d.ts
@@ -21,6 +21,7 @@ export interface BlueprintListItem {
     subcategory?: string | null;
     description?: string | null;
     modded?: boolean | null;
+    rooms?: string[] | null;
     isPublished: boolean;
     nbForks: number;
     nbViews: number;
@@ -52,6 +53,7 @@ export interface BlueprintResponse {
     description?: string | null;
     researchTier?: string | null;
     modded?: boolean | null;
+    rooms?: string[] | null;
     isPublished: boolean;
 }
 //# sourceMappingURL=blueprint-list-response.d.ts.map

--- a/lib/src/coms/blueprint-list-response.ts
+++ b/lib/src/coms/blueprint-list-response.ts
@@ -23,6 +23,9 @@ export interface BlueprintListItem {
   subcategory?: string | null;
   description?: string | null;
   modded?: boolean | null;
+  // Server-derived room types contained in the blueprint (see RoomTypeId);
+  // null = never derived or too large for detection
+  rooms?: string[] | null;
   isPublished: boolean;
   nbForks: number;
   // Approximate by design: served from throttled write-behind counters
@@ -65,5 +68,6 @@ export interface BlueprintResponse {
   description?: string | null;
   researchTier?: string | null;
   modded?: boolean | null;
+  rooms?: string[] | null;
   isPublished: boolean;
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "fixHtmlLabels": "ts-node-dev --expose_gc --max_old_space_size=4096 --transpile-only ./app/api/batch/fix-html-labels.ts",
     "derive-metadata": "TS_NODE_TRANSPILE_ONLY=true ts-node app/api/batch/derive-blueprint-metadata.ts",
     "derive-metadata:dry-run": "TS_NODE_TRANSPILE_ONLY=true ts-node app/api/batch/derive-blueprint-metadata.ts --dry-run",
+    "derive-rooms": "TS_NODE_TRANSPILE_ONLY=true ts-node app/api/batch/derive-rooms.ts",
+    "derive-rooms:dry-run": "TS_NODE_TRANSPILE_ONLY=true ts-node app/api/batch/derive-rooms.ts --dry-run",
     "backfill-previews": "TS_NODE_TRANSPILE_ONLY=true ts-node app/api/batch/backfill-preview-images.ts",
     "backfill-previews:dry-run": "TS_NODE_TRANSPILE_ONLY=true ts-node app/api/batch/backfill-preview-images.ts --dry-run",
     "seed:dev-blueprints": "TS_NODE_TRANSPILE_ONLY=true ts-node app/api/batch/seed-dev-blueprints.ts",


### PR DESCRIPTION
## What shipped

Builds on the merged detector core (#142). Two phases, one commit each:

### Editor Room overlay (phase 3)
- **Overlay > Rooms** menu entry; the canvas draws a translucent family-colored tint per detected cavity with a room-name label, visually matching the game's F11 view. Conflicts label as "A / B"; the Park/Nature Reserve ambiguity shows both names; over-cap blueprints show a "too large for room detection" notice.
- `BlueprintItem.cameraChanged` maps the Room overlay to Base for item opacity/depth, so buildings render fully opaque under the tint (without this every building dimmed to 0.3 alpha).
- `RoomDetectionService`: lazy — while the overlay is off, blueprint changes only set a dirty flag; while on, changes are debounced 250 ms trailing so a 40-tile drag detects once; activation recomputes immediately. `detectNow()` is ready for the save-dialog chips (deferred).
- Rendering splits into a pure geometry module (`room-overlay-geometry.ts`: row-merged spans, bbox centers, colors, labels — unit-tested directly) and a thin PIXI layer with pooled `PIXI.Text` labels; per-frame work is only the camera transform.

### Server-derived `rooms` catalog field (phase 2)
- `blueprint.rooms: [String] enum ROOM_TYPE_IDS` — no schema default: absent = never derived, `[]` = derived/none found (gameVersion nullability convention). Multikey index `{deletedAt, isPublished, rooms, createdAt}`.
- Save and overwrite derive `rooms` from the uploaded content via the shared lib detector; any client-sent `rooms` key is ignored (likeCount policy). Version restore re-derives from the restored data. Derivation never throws — a failure stores `null`, never fails the save.
- `GET /api/getblueprints?rooms=latrine,park` filters with `$in`; values validated against the shared enum (400 on garbage). `rooms` exposed on list/details/editor-load responses for the phase-4 Discover UI.
- `npm run derive-rooms[:dry-run]` backfill script (derive-metadata pattern; deploy-image note included for the DO console).

## Verification

- **Visual**: drove the real app with Playwright — loaded the seeded "Compact Luxury Bedrooms" blueprint, switched to Overlay > Rooms: Washroom (teal) and Luxury Barracks (blue) cavities tinted and labeled; overlay clears on switch-back.
- **End-to-end**: ran the backfill against the local dev DB (20 processed / 19 updated), then `?rooms=luxuryBarracks` returned exactly that blueprint with its rooms array; garbage values 400.
- **Suites**: backend 530 passing (11 new rooms-API tests; the 2 `workos-provision` timeouts are the documented local-only flakes), frontend 742 passing (15 new/updated specs), `npm run tsc` clean.

## Deferred

Phase 4 (Discover filter UI + card chips) and the save-dialog "Rooms detected" chip list. Prod backfill (`derive-rooms`) to run post-deploy per the batch-script checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)