### PR TITLE
Room detection phase 4: Discover room filter + room chips

### DIFF
--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.html
@@ -70,6 +70,20 @@
         i18n
         >Modded</a
       >
+      <a
+        *ngFor="let room of visibleRooms"
+        class="bni-chip bni-chip--room"
+        [routerLink]="['/discover']"
+        [queryParams]="{ rooms: room }"
+        [title]="roomTooltip(roomTypeLabel(room))"
+        >{{ roomTypeLabel(room) }}</a
+      >
+      <span
+        *ngIf="hiddenRoomCount > 0"
+        class="bni-chip bni-chip--room bni-chip--room-more"
+        [title]="hiddenRoomsTitle"
+        >+{{ hiddenRoomCount }}</span
+      >
     </div>
     <div class="card-social">
       <app-like-widget

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.spec.ts
@@ -141,6 +141,42 @@ describe("BlueprintCardComponent", () => {
     expect(modded.properties["queryParams"]).toEqual({ modded: "true" });
   });
 
+  it("renders a linked chip per detected room, using display labels", () => {
+    component.item = makeItem({ rooms: ["latrine", "messHall"] });
+    fixture.detectChanges();
+
+    const chips = fixture.debugElement.queryAll(By.css("a.bni-chip--room"));
+    expect(chips.length).toBe(2);
+    expect(chips[0].nativeElement.textContent.trim()).toBe("Latrine");
+    expect(chips[0].properties["routerLink"]).toEqual(["/discover"]);
+    expect(chips[0].properties["queryParams"]).toEqual({ rooms: "latrine" });
+    expect(chips[1].nativeElement.textContent.trim()).toBe("Mess Hall");
+  });
+
+  it("collapses room chips beyond three into a +N marker naming the rest", () => {
+    component.item = makeItem({
+      rooms: ["latrine", "barracks", "messHall", "kitchen", "stable"],
+    });
+    fixture.detectChanges();
+
+    expect(
+      fixture.debugElement.queryAll(By.css("a.bni-chip--room")).length
+    ).toBe(3);
+    const more = fixture.debugElement.query(By.css(".bni-chip--room-more"));
+    expect(more.nativeElement.textContent.trim()).toBe("+2");
+    expect(more.properties["title"]).toBe("Kitchen, Stable");
+  });
+
+  it("renders no room chips when rooms is missing or empty", () => {
+    component.item = makeItem({ rooms: null });
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css(".bni-chip--room"))).toBeNull();
+
+    component.item = makeItem({ rooms: [] });
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css(".bni-chip--room"))).toBeNull();
+  });
+
   it("passes like state through to the like widget", () => {
     component.item = makeItem({ nbLikes: 7, likedByMe: true });
     component.loggedIn = false;

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.ts
@@ -4,7 +4,11 @@ import {
   categoryTooltip,
   gameVersionTooltip,
   moddedTooltip,
+  roomTooltip,
 } from "../../utils/chip-tooltip";
+import { roomTypeLabel } from "../../utils/room-labels";
+
+const MAX_ROOM_CHIPS = 3;
 
 @Component({
   selector: "app-blueprint-card",
@@ -22,6 +26,24 @@ export class BlueprintCardComponent {
   readonly categoryTooltip = categoryTooltip;
   readonly gameVersionTooltip = gameVersionTooltip;
   readonly moddedTooltip = moddedTooltip;
+  readonly roomTooltip = roomTooltip;
+  readonly roomTypeLabel = roomTypeLabel;
+
+  // Cards stay compact: at most 3 room chips, the rest collapse into "+N".
+  get visibleRooms(): string[] {
+    return (this.item.rooms ?? []).slice(0, MAX_ROOM_CHIPS);
+  }
+
+  get hiddenRoomCount(): number {
+    return Math.max(0, (this.item.rooms?.length ?? 0) - MAX_ROOM_CHIPS);
+  }
+
+  get hiddenRoomsTitle(): string {
+    return (this.item.rooms ?? [])
+      .slice(MAX_ROOM_CHIPS)
+      .map(roomTypeLabel)
+      .join(", ");
+  }
 
   isReal(thumbnail: string): boolean {
     return thumbnail !== "svg" && thumbnail !== "svg_nothing";

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
@@ -134,6 +134,14 @@
               i18n
               >Modded</a
             >
+            <a
+              *ngFor="let room of details.rooms ?? []"
+              class="bni-chip bni-chip--room"
+              [routerLink]="['/discover']"
+              [queryParams]="{ rooms: room }"
+              [title]="roomTooltip(roomTypeLabel(room))"
+              >{{ roomTypeLabel(room) }}</a
+            >
           </div>
 
           <p *ngIf="details.description" class="details-description">

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
@@ -280,6 +280,27 @@ describe("BlueprintDetailsPageComponent", () => {
     expect(modded.properties["queryParams"]).toEqual({ modded: "true" });
   });
 
+  it("renders a linked chip per detected room and none when rooms is absent", () => {
+    blueprintService.getBlueprintDetails.mockReturnValue(
+      of(makeDetails({ rooms: ["greatHall", "powerPlant"] }))
+    );
+    fixture.detectChanges();
+
+    const chips = fixture.debugElement.queryAll(By.css(".bni-chip--room"));
+    expect(chips.length).toBe(2);
+    expect(chips[0].nativeElement.textContent.trim()).toBe("Great Hall");
+    expect(chips[0].properties["routerLink"]).toEqual(["/discover"]);
+    expect(chips[0].properties["queryParams"]).toEqual({ rooms: "greatHall" });
+    expect(chips[1].nativeElement.textContent.trim()).toBe("Power Plant");
+
+    blueprintService.getBlueprintDetails.mockReturnValue(
+      of(makeDetails({ rooms: null }))
+    );
+    component.ngOnInit();
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css(".bni-chip--room"))).toBeNull();
+  });
+
   it("links the fork count to a discover page filtered by forkedFrom", () => {
     blueprintService.getBlueprintDetails.mockReturnValue(
       of(makeDetails({ nbForks: 5 }))

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
@@ -17,7 +17,9 @@ import {
   subcategoryTooltip,
   gameVersionTooltip,
   moddedTooltip,
+  roomTooltip,
 } from "../../utils/chip-tooltip";
+import { roomTypeLabel } from "../../utils/room-labels";
 
 const BACK_TO_DISCOVER = $localize`:blueprintDetails.backToDiscover:Back to Discover`;
 const BACK_TO_PROFILE = $localize`:blueprintDetails.backToProfile:Back to Profile`;
@@ -46,6 +48,8 @@ export class BlueprintDetailsPageComponent implements OnInit {
   readonly subcategoryTooltip = subcategoryTooltip;
   readonly gameVersionTooltip = gameVersionTooltip;
   readonly moddedTooltip = moddedTooltip;
+  readonly roomTooltip = roomTooltip;
+  readonly roomTypeLabel = roomTypeLabel;
 
   private pendingFragment: string | null = null;
 

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
@@ -86,6 +86,16 @@
         placeholder="Category"
       ></p-select>
       <p-select
+        [(ngModel)]="filterRooms"
+        [options]="roomOptions"
+        optionLabel="label"
+        optionValue="value"
+        [showClear]="false"
+        (onChange)="onRoomsChange()"
+        i18n-placeholder
+        placeholder="Room"
+      ></p-select>
+      <p-select
         [(ngModel)]="sort"
         [options]="sortOptions"
         optionLabel="label"
@@ -113,7 +123,8 @@
           filterSubcategory ||
           filterName ||
           filterModded !== null ||
-          filterForkedFrom
+          filterForkedFrom ||
+          filterRooms
         "
         type="button"
         class="clear-filters"

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
@@ -160,6 +160,8 @@ describe("BrowsePageComponent", () => {
         "recent",
         undefined,
         null,
+        null,
+        null,
         null
       );
     });
@@ -180,6 +182,8 @@ describe("BrowsePageComponent", () => {
         "recent",
         undefined,
         null,
+        null,
+        null,
         null
       );
     });
@@ -197,6 +201,8 @@ describe("BrowsePageComponent", () => {
         null,
         "recent",
         undefined,
+        null,
+        null,
         null,
         null
       );
@@ -217,6 +223,8 @@ describe("BrowsePageComponent", () => {
         "recent",
         undefined,
         null,
+        null,
+        null,
         null
       );
     });
@@ -235,6 +243,8 @@ describe("BrowsePageComponent", () => {
         "recent",
         undefined,
         true,
+        null,
+        null,
         null
       );
     });
@@ -253,17 +263,71 @@ describe("BrowsePageComponent", () => {
         "recent",
         undefined,
         null,
-        "parent-1"
+        "parent-1",
+        null,
+        null
       );
     });
 
-    it("clearFilters resets all facets (including modded and forkedFrom) and refetches", () => {
+    it("passes rooms filter to getBlueprints", () => {
+      component.filterRooms = "latrine";
+      component.getBlueprints();
+
+      expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
+        expect.any(Date),
+        null,
+        null,
+        null,
+        null,
+        null,
+        "recent",
+        undefined,
+        null,
+        null,
+        null,
+        "latrine"
+      );
+    });
+
+    it("onRoomsChange resets the list, updates the URL, and refetches", () => {
+      component.blueprintListItems = [{ name: "stale" } as any];
+      component.filterRooms = "kitchen";
+      component.onRoomsChange();
+
+      expect(
+        component.blueprintListItems.some((i: any) => i.name === "stale")
+      ).toBe(false);
+      expect(router.navigate).toHaveBeenCalledWith([], {
+        queryParams: { rooms: "kitchen" },
+        replaceUrl: true,
+      });
+      const lastCall = blueprintService.getBlueprints.mock.calls.at(-1);
+      expect(lastCall[11]).toBe("kitchen");
+    });
+
+    it("offers every room type plus an All rooms option", () => {
+      expect(component.roomOptions[0].value).toBeNull();
+      expect(component.roomOptions.length).toBe(19); // 18 room types + All
+      expect(component.roomOptions.some((o) => o.value === "latrine")).toBe(
+        true
+      );
+    });
+
+    it("initializes rooms from the URL query param", () => {
+      const route = TestBed.inject(ActivatedRoute) as any;
+      route.queryParamMap = of(convertToParamMap({ rooms: "latrine" }));
+      component.ngOnInit();
+      expect(component.filterRooms).toBe("latrine");
+    });
+
+    it("clearFilters resets all facets (including modded, forkedFrom, rooms) and refetches", () => {
       component.filterGameVersion = "base";
       component.filterCategory = "cooling";
       component.filterSubcategory = "fan";
       component.filterName = "test";
       component.filterModded = true;
       component.filterForkedFrom = "parent-1";
+      component.filterRooms = "latrine";
       component.clearFilters();
 
       expect(component.filterGameVersion).toBeNull();
@@ -271,6 +335,7 @@ describe("BrowsePageComponent", () => {
       expect(component.filterSubcategory).toBeNull();
       expect(component.filterModded).toBeNull();
       expect(component.filterForkedFrom).toBeNull();
+      expect(component.filterRooms).toBeNull();
       expect(component.filterName).toBe("");
       expect(blueprintService.getBlueprints).toHaveBeenCalled();
     });

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
@@ -11,7 +11,9 @@ import {
   GAME_VERSIONS,
   CATEGORIES,
   SUBCATEGORIES,
+  ROOM_TYPE_IDS,
 } from "../../../../../../lib/index";
+import { ROOM_TYPE_LABELS } from "../../utils/room-labels";
 import {
   BlueprintService,
   BlueprintSort,
@@ -50,6 +52,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   filterSubcategory: string | null = null;
   filterModded: boolean | null = null;
   filterForkedFrom: string | null = null;
+  filterRooms: string | null = null;
   remaining = 0;
   sort: BlueprintSort = "recent";
   skipCount = 0;
@@ -83,6 +86,13 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   readonly categoryOptions = [
     { label: "All categories", value: null },
     ...CATEGORIES.map((c) => ({ label: c, value: c })),
+  ];
+  readonly roomOptions: { label: string; value: string | null }[] = [
+    { label: $localize`:browse.allRooms:All rooms`, value: null },
+    ...ROOM_TYPE_IDS.map((id) => ({
+      label: ROOM_TYPE_LABELS[id],
+      value: id as string,
+    })).sort((a, b) => a.label.localeCompare(b.label)),
   ];
 
   get subcategoryOptions(): { label: string; value: string | null }[] {
@@ -213,6 +223,9 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     const modded =
       rawModded === "true" ? true : rawModded === "false" ? false : null;
     const forkedFrom = params.get("forkedFrom");
+    // Kept as the raw param (the API accepts a comma list); the select simply
+    // shows no selection for a multi-value URL, but the filter still applies.
+    const rooms = params.get("rooms");
     const rawSort = params.get("sort");
     const sort: BlueprintSort = this.sortOptions.some(
       (option) => option.value === rawSort
@@ -227,6 +240,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
       subcategory !== this.filterSubcategory ||
       modded !== this.filterModded ||
       forkedFrom !== this.filterForkedFrom ||
+      rooms !== this.filterRooms ||
       sort !== this.sort;
 
     this.filterName = name;
@@ -235,6 +249,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     this.filterSubcategory = subcategory;
     this.filterModded = modded;
     this.filterForkedFrom = forkedFrom;
+    this.filterRooms = rooms;
     this.sort = sort;
     return changed;
   }
@@ -245,6 +260,12 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   }
 
   onSubcategoryChange() {
+    this.applyFiltersToUrl();
+    this.reset();
+    this.getBlueprints();
+  }
+
+  onRoomsChange() {
     this.applyFiltersToUrl();
     this.reset();
     this.getBlueprints();
@@ -272,6 +293,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
       queryParams["modded"] = String(this.filterModded);
     if (this.filterForkedFrom)
       queryParams["forkedFrom"] = this.filterForkedFrom;
+    if (this.filterRooms) queryParams["rooms"] = this.filterRooms;
     if (this.sort !== "recent") queryParams["sort"] = this.sort;
     this.router.navigate([], { queryParams, replaceUrl: true });
   }
@@ -283,6 +305,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     this.filterSubcategory = null;
     this.filterModded = null;
     this.filterForkedFrom = null;
+    this.filterRooms = null;
     this.applyFiltersToUrl();
     this.reset();
     this.getBlueprints();
@@ -318,7 +341,9 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
             this.sort,
             this.sort !== "recent" ? this.skipCount : undefined,
             this.filterModded,
-            this.filterForkedFrom
+            this.filterForkedFrom,
+            null,
+            this.filterRooms
           );
 
     request$.subscribe({

--- a/frontend/src/app/module-blueprint/drawing/room-overlay-geometry.ts
+++ b/frontend/src/app/module-blueprint/drawing/room-overlay-geometry.ts
@@ -6,6 +6,9 @@ import {
   RoomFamily,
   RoomTypeId,
 } from "../../../../../lib/index";
+import { ROOM_TYPE_LABELS } from "../utils/room-labels";
+
+export { ROOM_TYPE_LABELS };
 
 // Pure geometry/style derivation for the Room overlay — everything the PIXI
 // layer (draw-room-overlay.ts) needs, precomputed once per detection result so
@@ -29,27 +32,6 @@ export interface CavityOverlayGeometry {
   center: { x: number; y: number };
   spans: CavitySpan[];
 }
-
-export const ROOM_TYPE_LABELS: Record<RoomTypeId, string> = {
-  latrine: $localize`:room overlay label:Latrine`,
-  washroom: $localize`:room overlay label:Washroom`,
-  barracks: $localize`:room overlay label:Barracks`,
-  luxuryBarracks: $localize`:room overlay label:Luxury Barracks`,
-  privateBedroom: $localize`:room overlay label:Private Bedroom`,
-  messHall: $localize`:room overlay label:Mess Hall`,
-  greatHall: $localize`:room overlay label:Great Hall`,
-  banquetHall: $localize`:room overlay label:Banquet Hall`,
-  massageClinic: $localize`:room overlay label:Massage Clinic`,
-  hospital: $localize`:room overlay label:Hospital`,
-  recreationRoom: $localize`:room overlay label:Recreation Room`,
-  park: $localize`:room overlay label:Park`,
-  natureReserve: $localize`:room overlay label:Nature Reserve`,
-  kitchen: $localize`:room overlay label:Kitchen`,
-  powerPlant: $localize`:room overlay label:Power Plant`,
-  greenhouse: $localize`:room overlay label:Greenhouse`,
-  laboratory: $localize`:room overlay label:Laboratory`,
-  stable: $localize`:room overlay label:Stable`,
-};
 
 export const TOO_LARGE_NOTICE = $localize`:room overlay notice:Blueprint too large for room detection`;
 

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -361,7 +361,8 @@ export class BlueprintService implements IObsBlueprintChange {
     skip?: number,
     filterModded?: boolean | null,
     filterForkedFrom?: string | null,
-    filterLikedBy?: string | null
+    filterLikedBy?: string | null,
+    filterRooms?: string | null
   ) {
     let parameterOlderThan = "olderthan=" + olderThan.getTime().toString();
 
@@ -400,6 +401,9 @@ export class BlueprintService implements IObsBlueprintChange {
     let parameterLikedBy = "";
     if (filterLikedBy != null) parameterLikedBy = "&likedBy=" + filterLikedBy;
 
+    let parameterRooms = "";
+    if (filterRooms != null) parameterRooms = "&rooms=" + filterRooms;
+
     let parameters =
       parameterOlderThan +
       parameterFilterUserId +
@@ -410,7 +414,8 @@ export class BlueprintService implements IObsBlueprintChange {
       parameterSort +
       parameterModded +
       parameterForkedFrom +
-      parameterLikedBy;
+      parameterLikedBy +
+      parameterRooms;
 
     let request = this.authService.isLoggedIn()
       ? this.http.get("/api/getblueprintsSecure?" + parameters, {

--- a/frontend/src/app/module-blueprint/utils/chip-tooltip.ts
+++ b/frontend/src/app/module-blueprint/utils/chip-tooltip.ts
@@ -17,6 +17,10 @@ export function subcategoryTooltip(subcategory: string): string {
   return $localize`Browse ${subcategory} blueprints`;
 }
 
+export function roomTooltip(roomLabel: string): string {
+  return $localize`:chipTooltip.room:Browse blueprints containing a ${roomLabel}`;
+}
+
 export function moddedTooltip(): string {
   return $localize`:chipTooltip.modded:Uses mods not included in the base game`;
 }

--- a/frontend/src/app/module-blueprint/utils/room-labels.ts
+++ b/frontend/src/app/module-blueprint/utils/room-labels.ts
@@ -1,0 +1,30 @@
+import { RoomTypeId } from "../../../../../lib/index";
+
+// Display names for the server-derived room types (RoomTypeId). Shared by the
+// editor Room overlay, discover filter options, and blueprint card/detail chips.
+export const ROOM_TYPE_LABELS: Record<RoomTypeId, string> = {
+  latrine: $localize`:room overlay label:Latrine`,
+  washroom: $localize`:room overlay label:Washroom`,
+  barracks: $localize`:room overlay label:Barracks`,
+  luxuryBarracks: $localize`:room overlay label:Luxury Barracks`,
+  privateBedroom: $localize`:room overlay label:Private Bedroom`,
+  messHall: $localize`:room overlay label:Mess Hall`,
+  greatHall: $localize`:room overlay label:Great Hall`,
+  banquetHall: $localize`:room overlay label:Banquet Hall`,
+  massageClinic: $localize`:room overlay label:Massage Clinic`,
+  hospital: $localize`:room overlay label:Hospital`,
+  recreationRoom: $localize`:room overlay label:Recreation Room`,
+  park: $localize`:room overlay label:Park`,
+  natureReserve: $localize`:room overlay label:Nature Reserve`,
+  kitchen: $localize`:room overlay label:Kitchen`,
+  powerPlant: $localize`:room overlay label:Power Plant`,
+  greenhouse: $localize`:room overlay label:Greenhouse`,
+  laboratory: $localize`:room overlay label:Laboratory`,
+  stable: $localize`:room overlay label:Stable`,
+};
+
+// Rooms arrive as string[] from the API; unknown values (newer server enum)
+// fall back to the raw id rather than disappearing.
+export function roomTypeLabel(room: string): string {
+  return ROOM_TYPE_LABELS[room as RoomTypeId] ?? room;
+}

--- a/frontend/src/bni-skin.css
+++ b/frontend/src/bni-skin.css
@@ -420,6 +420,19 @@ a.bni-chip:hover {
   border-color: var(--bni-accent2-bd);
 }
 
+/* Server-derived room-type chips: blue-slate so they read as facts, not
+   author-picked tags (category teal / modded orange) */
+.bni-chip--room {
+  background: rgba(125, 155, 209, 0.14);
+  color: #91abd8;
+  border-color: rgba(125, 155, 209, 0.45);
+}
+
+.bni-chip--room-more {
+  background: transparent;
+  cursor: default;
+}
+
 /* Draft = work in progress: dashed outline, primary tint so it pops on
    the owner's own cards without reading as a filter chip */
 .bni-chip--draft {


### PR DESCRIPTION
## What shipped

Final phase of the room-detection plan (phase 1: #142, phases 2+3: #143) — the server-derived `rooms` field is now surfaced in the Discover UI:

- **Room filter** on the browse page: a "Room" select alongside version/category/sort, feeding the existing `?rooms=` API filter (phase 2). URL param `rooms` round-trips like the other facets (deep-linkable, Clear filters aware, back/forward safe).
- **Room chips on blueprint cards**: blue-slate chips per detected room, capped at 3 with a `+N` marker (title lists the rest) so room-heavy blueprints don't swamp the card. Each chip links to `/discover?rooms=<type>`.
- **Room chips on the details page**: all detected rooms, same links.
- `ROOM_TYPE_LABELS` moved from `drawing/room-overlay-geometry.ts` to a shared `utils/room-labels.ts` (re-exported from the old location) so product components don't import from the drawing layer.

## Design decisions

- Single-select filter (consistent with the category facet), even though the API accepts a comma list — a multi-value URL still filters correctly, the select just shows no selection.
- Room chips styled as a distinct blue-slate variant (`.bni-chip--room`) so derived facts read differently from author-picked tags (category teal / modded orange).
- Unknown room ids from a future server enum fall back to the raw id instead of disappearing.

## Verification

- Frontend suite: **750 passed** (was 670 baseline + phases; includes 9 new specs across card / browse / details).
- Verified in the dev app with Playwright: filter select renders and populates from `?rooms=luxuryBarracks`, list narrows correctly, card and details chips render with labels and link back to the filtered Discover view; backend 400s garbage values as designed.

## Deferred

- Phase 4 closes out the v1 spec. v1.5 diagnostics hover panel and category/`rooms` consolidation remain future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)