### PR TITLE
perf: fix 10s social-sort feeds — index-friendly filter, slim queries, edge caching

### DIFF
--- a/__tests__/api/blueprint-discovery.test.ts
+++ b/__tests__/api/blueprint-discovery.test.ts
@@ -8,6 +8,7 @@ dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
 process.env.NODE_ENV = 'test';
 
 import { TestSetup } from '../setup/testSetup';
+import { BlueprintController } from '../../app/api/blueprint-controller';
 import { BlueprintModel } from '../../app/api/models/blueprint';
 import { CommentModel } from '../../app/api/models/comment';
 import { Types } from 'mongoose';
@@ -222,6 +223,106 @@ describe('Discovery: related blueprints + trending sort', function () {
         .get('/api/getblueprints')
         .query({ olderthan: Date.now(), sort: 'notASort' });
       expect(response.status).to.equal(400);
+    });
+
+    it('memoizes the ranking until the cache is cleared, but never the documents', async function () {
+      const first = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), sort: 'trending' });
+      expect(first.status).to.equal(200);
+
+      const late = await makeBlueprint(testData.users.user2._id, {
+        name: 'Trending Late Arrival',
+        ratingCount: 99,
+        ratingAverage: 5,
+      });
+
+      const cached = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), sort: 'trending' });
+      expect(cached.body.blueprints.map((b: any) => b.name)).to.not.include(late.name);
+
+      BlueprintController.clearTrendingCache();
+      const fresh = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), sort: 'trending' });
+      expect(fresh.body.blueprints.map((b: any) => b.name)).to.include(late.name);
+    });
+
+    it('drops a soft-deleted blueprint from a cached ranking immediately', async function () {
+      const doomed = await makeBlueprint(testData.users.user1._id, { name: 'Trending Doomed' });
+
+      const first = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), sort: 'trending' });
+      expect(first.body.blueprints.map((b: any) => b.name)).to.include(doomed.name);
+
+      await BlueprintModel.model.updateOne({ _id: doomed._id }, { $set: { deletedAt: new Date() } });
+
+      const second = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), sort: 'trending' });
+      expect(second.body.blueprints.map((b: any) => b.name)).to.not.include(doomed.name);
+    });
+  });
+
+  describe('feed visibility filter', function () {
+    it('keeps docs predating the isPublished backfill visible in count sorts', async function () {
+      const legacy = await makeBlueprint(testData.users.user1._id, {
+        name: 'Legacy Pre Backfill',
+        ratingCount: 42,
+        ratingAverage: 5,
+      });
+      await BlueprintModel.model.updateOne({ _id: legacy._id }, { $unset: { isPublished: '' } });
+
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), sort: 'popular' });
+      expect(response.status).to.equal(200);
+      expect(response.body.blueprints.map((b: any) => b.name)).to.include(legacy.name);
+    });
+
+    it('still hides drafts from the anonymous feed in count sorts', async function () {
+      const draft = await makeBlueprint(testData.users.user1._id, {
+        name: 'Hidden Draft Popular',
+        ratingCount: 42,
+        ratingAverage: 5,
+        isPublished: false,
+      });
+
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), sort: 'popular' });
+      expect(response.status).to.equal(200);
+      expect(response.body.blueprints.map((b: any) => b.name)).to.not.include(draft.name);
+    });
+  });
+
+  describe('feed cache headers', function () {
+    const ANON_CACHE = 'public, s-maxage=60, stale-while-revalidate=300';
+
+    it('marks anonymous list responses edge-cacheable', async function () {
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now() });
+      expect(response.status).to.equal(200);
+      expect(response.headers['cache-control']).to.equal(ANON_CACHE);
+    });
+
+    it('never caches responses to requests carrying credentials', async function () {
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now() })
+        .set('Authorization', `Bearer ${testData.users.user1.generateJwt()}`);
+      expect(response.status).to.equal(200);
+      expect(response.headers['cache-control']).to.equal('no-store');
+    });
+
+    it('marks anonymous related-blueprints responses edge-cacheable', async function () {
+      const source = await makeBlueprint(testData.users.user1._id, { name: 'Cache Header Source' });
+      const response = await TestSetup.request().get(`/api/blueprints/${source._id}/related`);
+      expect(response.status).to.equal(200);
+      expect(response.headers['cache-control']).to.equal(ANON_CACHE);
     });
   });
 });

--- a/__tests__/setup/testSetup.ts
+++ b/__tests__/setup/testSetup.ts
@@ -1,11 +1,15 @@
 import request from 'supertest';
 import app from '../../app/app';
+import { BlueprintController } from '../../app/api/blueprint-controller';
 import { TestDbHelper } from '../helpers/testDb';
 
 export class TestSetup {
   static testData: any;
 
   static async beforeEach() {
+    // Trending rankings are memoized in-process; a stale ranking from a
+    // previous test would hide blueprints created in this one
+    BlueprintController.clearTrendingCache();
     await TestDbHelper.cleanDatabase();
     this.testData = await TestDbHelper.seedDatabase();
     return this.testData;

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -713,6 +713,10 @@ export class BlueprintController {
   // counts/names/thumbnails never go stale — only the ordering does.
   private static trendingIdCache = new Map<string, { expiresAt: number; ids: mongoose.Types.ObjectId[] }>();
   private static readonly TRENDING_CACHE_TTL_MS = 5 * 60 * 1000;
+  // The key embeds the whole filter (name search strings, skip, per-viewer
+  // clauses), so arbitrary requests can mint unlimited distinct keys within
+  // one TTL window — cap the map and evict oldest-inserted first.
+  private static readonly TRENDING_CACHE_MAX_ENTRIES = 200;
 
   public static clearTrendingCache() {
     BlueprintController.trendingIdCache.clear();
@@ -794,6 +798,10 @@ export class BlueprintController {
     const now = Date.now();
     for (const [key, entry] of BlueprintController.trendingIdCache) {
       if (entry.expiresAt <= now) BlueprintController.trendingIdCache.delete(key);
+    }
+    while (BlueprintController.trendingIdCache.size >= BlueprintController.TRENDING_CACHE_MAX_ENTRIES) {
+      const oldestKey = BlueprintController.trendingIdCache.keys().next().value as string;
+      BlueprintController.trendingIdCache.delete(oldestKey);
     }
     BlueprintController.trendingIdCache.set(cacheKey, {
       expiresAt: now + BlueprintController.TRENDING_CACHE_TTL_MS,

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -48,6 +48,23 @@ type BlueprintSort = (typeof SORTS)[number];
 // How many "you might also like" cards the details page shows
 const RELATED_LIMIT = 6;
 
+// Public-visibility clause for feed queries. $in's null matches docs that
+// predate the isPublished backfill (deploy→migrate window), same coverage as
+// the old { $ne: false } — but $in gives the planner point bounds, so the
+// isPublished-prefixed indexes can still provide sort order for the
+// count/rating sorts instead of fetching every live doc into a blocking SORT.
+const PUBLISHED_FILTER = { $in: [true, null] };
+
+// Anonymous feed responses are viewer-independent, so Cloudflare can cache
+// them at the edge; slightly stale lists are fine. Responses to requests
+// carrying credentials are personalized (myRating/ownedByMe/own drafts) and
+// must never be cached.
+const ANON_CACHE_CONTROL = 'public, s-maxage=60, stale-while-revalidate=300';
+
+function setFeedCacheControl(req: Request, res: Response) {
+  res.set('Cache-Control', req.headers.authorization == null ? ANON_CACHE_CONTROL : 'no-store');
+}
+
 export class BlueprintController {
   public uploadBlueprint(req: Request, res: Response) {
     console.log('uploadBlueprint' + req.clientIp);
@@ -619,11 +636,9 @@ export class BlueprintController {
       // Draft visibility: published blueprints for everyone, plus the viewer's
       // own drafts. Admins browsing a specific user's list (filterUserId) see
       // that user's drafts too, but drafts never leak into the general feed.
-      // $ne: false (not $eq: true) so docs predating the backfill migration
-      // stay visible in the deploy→migrate window.
       const isAdmin = userJwt?.role === 'admin';
       if (!(isAdmin && filterUserId != null)) {
-        const visibleTo: any[] = [{ isPublished: { $ne: false } }];
+        const visibleTo: any[] = [{ isPublished: PUBLISHED_FILTER }];
         if (userId !== '') visibleTo.push({ owner: userId });
         filter.$and.push({ $or: visibleTo });
       }
@@ -666,10 +681,18 @@ export class BlueprintController {
       // Trending has no single indexed field to sort on — it's a computed,
       // time-decayed score — so it goes through an aggregation instead of
       // the plain find().sort() every other sort uses.
+      // -data: the list never renders blueprint contents, and the blobs
+      // average ~85KB per doc — dominating the query's fetch cost otherwise
       let blueprintsPromise: Promise<Blueprint[]> =
         sort === 'trending'
           ? BlueprintController.getTrendingBlueprints(filter, skipAmount, limit)
-          : BlueprintModel.model.find(filter).sort(sortSpec).skip(skipAmount).limit(limit).populate('owner');
+          : BlueprintModel.model
+              .find(filter)
+              .sort(sortSpec)
+              .skip(skipAmount)
+              .limit(limit)
+              .select('-data')
+              .populate('owner');
 
       blueprintsPromise
         .then(blueprints => {
@@ -683,6 +706,18 @@ export class BlueprintController {
     }
   }
 
+  // Trending rankings are cached briefly (ordered ids only, keyed by the
+  // exact filter+page): the score is a full pass over every matching
+  // blueprint by design, and "what's trending" tolerates a few minutes of
+  // staleness. Documents are still fetched fresh on every request, so
+  // counts/names/thumbnails never go stale — only the ordering does.
+  private static trendingIdCache = new Map<string, { expiresAt: number; ids: mongoose.Types.ObjectId[] }>();
+  private static readonly TRENDING_CACHE_TTL_MS = 5 * 60 * 1000;
+
+  public static clearTrendingCache() {
+    BlueprintController.trendingIdCache.clear();
+  }
+
   // Time-decayed engagement score (ratings + weighted forks/comments/views,
   // divided down by age) computed in an aggregation since it isn't a stored
   // field. Only the ordered ids come out of the aggregation; the actual
@@ -693,6 +728,11 @@ export class BlueprintController {
     skip: number,
     limit: number
   ): Promise<Blueprint[]> {
+    const cacheKey = JSON.stringify({ filter, skip, limit });
+    const cached = BlueprintController.trendingIdCache.get(cacheKey);
+    if (cached != null && cached.expiresAt > Date.now()) {
+      return BlueprintController.fetchInOrder(cached.ids, filter);
+    }
     const commentLookupStage: mongoose.PipelineStage[] =
       CommentModel.model == null
         ? []
@@ -716,6 +756,9 @@ export class BlueprintController {
 
     const rows: { _id: mongoose.Types.ObjectId }[] = await BlueprintModel.model.aggregate([
       { $match: filter },
+      // Slim each doc to the scoring inputs before the $lookup so the full
+      // blueprint data blobs (~85KB avg) never stream through the pipeline
+      { $project: { ratingCount: 1, forkCount: 1, viewCount: 1, createdAt: 1 } },
       ...commentLookupStage,
       {
         $addFields: {
@@ -747,9 +790,31 @@ export class BlueprintController {
     ]);
 
     const orderedIds = rows.map(row => row._id);
-    if (orderedIds.length === 0) return [];
 
-    const docs = await BlueprintModel.model.find({ _id: { $in: orderedIds } }).populate('owner');
+    const now = Date.now();
+    for (const [key, entry] of BlueprintController.trendingIdCache) {
+      if (entry.expiresAt <= now) BlueprintController.trendingIdCache.delete(key);
+    }
+    BlueprintController.trendingIdCache.set(cacheKey, {
+      expiresAt: now + BlueprintController.TRENDING_CACHE_TTL_MS,
+      ids: orderedIds,
+    });
+
+    return BlueprintController.fetchInOrder(orderedIds, filter);
+  }
+
+  // Re-applies the visibility filter so a blueprint deleted or unpublished
+  // after the ranking was cached drops out immediately — only the ordering
+  // is ever stale, never visibility.
+  private static async fetchInOrder(
+    orderedIds: mongoose.Types.ObjectId[],
+    filter: Record<string, unknown>
+  ): Promise<Blueprint[]> {
+    if (orderedIds.length === 0) return [];
+    const docs = await BlueprintModel.model
+      .find({ $and: [{ _id: { $in: orderedIds } }, filter] })
+      .select('-data')
+      .populate('owner');
     const byId = new Map(docs.map(doc => [(doc._id as mongoose.Types.ObjectId).toString(), doc]));
     return orderedIds
       .map(id => byId.get(id.toString()))
@@ -788,12 +853,13 @@ export class BlueprintController {
   }
 
   public static async handleGetBlueprint(
-    _req: Request,
+    req: Request,
     res: Response,
     userId: string,
     blueprints: Blueprint[]
   ) {
     let browseIncrement = parseInt(process.env.BROWSE_INCREMENT as string);
+    setFeedCacheControl(req, res);
 
     let returnValueAny = {};
     let returnValue = returnValueAny as BlueprintListResponse;
@@ -947,23 +1013,25 @@ export class BlueprintController {
           ? BlueprintModel.model
               .find({
                 deletedAt: null,
-                isPublished: { $ne: false },
+                isPublished: PUBLISHED_FILTER,
                 category: source.category,
                 _id: { $ne: blueprintId },
               })
               .sort({ ratingAverage: -1, ratingCount: -1, createdAt: -1 })
               .limit(RELATED_LIMIT * 4)
+              .select('-data')
               .populate('owner')
           : Promise.resolve([]),
         BlueprintModel.model
           .find({
             deletedAt: null,
-            isPublished: { $ne: false },
+            isPublished: PUBLISHED_FILTER,
             owner: source.owner,
             _id: { $ne: blueprintId },
           })
           .sort({ createdAt: -1 })
           .limit(RELATED_LIMIT * 4)
+          .select('-data')
           .populate('owner'),
       ]);
 
@@ -974,9 +1042,10 @@ export class BlueprintController {
 
       if (candidates.size < RELATED_LIMIT) {
         const fallback = await BlueprintModel.model
-          .find({ deletedAt: null, isPublished: { $ne: false }, _id: { $ne: blueprintId } })
+          .find({ deletedAt: null, isPublished: PUBLISHED_FILTER, _id: { $ne: blueprintId } })
           .sort({ createdAt: -1 })
           .limit(RELATED_LIMIT * 4)
+          .select('-data')
           .populate('owner');
         for (const candidate of fallback) candidates.set((candidate._id as mongoose.Types.ObjectId).toString(), candidate);
       }
@@ -1035,6 +1104,7 @@ export class BlueprintController {
           BlueprintController.buildListItem(blueprint, userId, commentCounts, forkedFromNames, myRatings)
         ),
       };
+      setFeedCacheControl(req, res);
       res.json(response);
     } catch (err) {
       console.log('getRelatedBlueprints error');

--- a/app/api/models/blueprint.ts
+++ b/app/api/models/blueprint.ts
@@ -19,8 +19,9 @@ export interface Blueprint extends Document {
   deletedAt?: Date | null;
   // Draft state: false = draft (owner/admin only). Docs predating the backfill
   // migration lack the field — doc-level checks must treat missing as published
-  // (isPublished !== false); feed queries match { isPublished: { $ne: false } }
-  // so those documents stay visible until the migration runs.
+  // (isPublished !== false); feed queries match { isPublished: { $in: [true, null] } }
+  // (same coverage as $ne: false, but point index bounds — see PUBLISHED_FILTER
+  // in blueprint-controller) so those documents stay visible until the migration runs.
   isPublished?: boolean;
   gameVersion?: string | null;
   category?: string | null;

--- a/app/api/user-controller.ts
+++ b/app/api/user-controller.ts
@@ -183,6 +183,7 @@ export class UserController {
           .find({ owner: { $in: followeeIds }, deletedAt: null, createdAt: { $lt: dateFilter } })
           .sort({ createdAt: -1 })
           .limit(browseIncrement * 2)
+          .select('-data')
           .populate('owner')
           .then(blueprints => {
             return BlueprintController.handleGetBlueprint(req, res, user._id, blueprints);

--- a/deploy.Dockerfile
+++ b/deploy.Dockerfile
@@ -46,6 +46,11 @@ RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
 RUN npm rebuild canvas && node -e "require('canvas')"
 COPY --from=build-backend /bpni/build /bpni/build
 COPY --from=build-frontend /bpni/build/app/public /bpni/build/app/public
+# Migrations run from the deploy console (cd /bpni/build && npm run migrate:up);
+# migrate-mongo resolves its config and migrationsDir relative to cwd, so both
+# must ship inside the runtime image.
+COPY migrate-mongo-config.js /bpni/build/
+COPY migrations /bpni/build/migrations
 
 # glibc malloc grows one arena per thread by default; sharp/libvips's thread
 # pool spreads allocations across them and freed pages never return to the OS,


### PR DESCRIPTION
## What

Staging's `getblueprints?sort=popular` (and the other count sorts) took 10+ seconds. Three compounding causes, all fixed here, plus the deploy-image gap that blocked running migrations from the DO console.

### Root cause analysis (verified via `explain` on a prod dump)

1. **Missing index on staging** — the ratings migration (which creates `{deletedAt, isPublished, ratingAverage, ratingCount, createdAt}`) hadn't run there. Without it the planner spent **11.7s** (`optimizationTimeMillis`) trial-running candidate plans that all fetch every live doc into a blocking sort. Run `migrate:up` against staging.
2. **`isPublished: { $ne: false }` defeats the index even when it exists** — `$ne` yields multi-interval bounds on a field that precedes the sort fields, so MongoDB can't use index order: `SORT ← FETCH(4,484 docs × ~85KB)` per request. Replaced with `{ $in: [true, null] }` — identical semantics (Boolean field; `$in`'s `null` matches pre-backfill docs missing the flag) but point bounds → explode-for-sort: **4,484 docs examined → 40, 230ms → 6ms** on the dump.
3. **List queries dragged the full `data` blob** (~85KB/doc avg) that no list endpoint renders. `.select('-data')` on browse, related, follow feed, and trending fetches; early `$project` keeps blobs out of the trending pipeline.

### Caching

- **Trending**: ordered ids memoized in-process for 5 min (full-collection score pass by design). Docs are refetched each request with the visibility filter reapplied, so soft-deletes/unpublishes drop out immediately — only ordering can be stale.
- **Edge**: anonymous feed/related responses send `Cache-Control: public, s-maxage=60, stale-while-revalidate=300`; credentialed requests get `no-store` (personalized: `myRating`/`ownedByMe`/own drafts). **Requires a Cloudflare cache rule** making `/api/getblueprints` and `/api/blueprints/*/related` eligible for cache (CF doesn't cache API paths by default; it will respect these origin headers once eligible).

### Deploy image

`deploy.Dockerfile` never copied `migrate-mongo-config.js` or `migrations/` into the runtime image, so the documented console step (`cd /bpni/build && npm run migrate:status`) failed with `Cannot find module`. Both now ship into `/bpni/build`. Until this deploys, run migrations from a local checkout: `DB_URI='<staging uri>' npm run migrate:up`.

## Verification

- `npm run tsc` clean
- Full backend suite: 539 passing; 3 failures are known local flakes (2 workos-provision per CLAUDE.md, 1 drafts timeout under full-suite load — passes in isolation)
- 7 new discovery tests: pre-backfill visibility under count sorts, draft hiding under count sorts, trending memoization + immediate soft-delete drop-out, cache headers anon vs authed
- Exact controller filter shape re-explained against the prod dump: `LIMIT ← PROJECTION ← FETCH ← SORT_MERGE ← IXSCAN`, 40 keys/40 docs

## Deferred / flagged

- **Follow feed (`getFeed`) has no `isPublished` filter** — followees' drafts leak into follower feeds. Pre-existing; not changed here (only added the `-data` projection). Worth a small follow-up.
- Logged-in count sorts still blocking-sort (the `$or` with `owner` branch); anonymous is the hot path and cheap now.
- Monitoring (New Relic free tier) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)