### PR TITLE
perf(api): drop base64 thumbnails from list responses

### DIFF
--- a/__tests__/api/blueprint-drafts.test.ts
+++ b/__tests__/api/blueprint-drafts.test.ts
@@ -302,14 +302,14 @@ describe('Blueprint drafts (Mocha)', function () {
     it('404s for anonymous and other users on every read endpoint; 200 for owner and admin', async function () {
       this.timeout(10000);
       const id = draft._id.toString();
-      // getblueprintmod/getblueprintthumbnail 500 on the synthetic fixture
-      // data (not a real MdbBlueprint) once past the gate — assert "not 404"
-      // for owner/admin there instead of 200
+      // getblueprintmod 500s on the synthetic fixture data (not a real
+      // MdbBlueprint) once past the gate — assert "not 404" for owner/admin
+      // there instead of 200
       const readEndpoints = [
         { url: `/api/blueprints/${id}`, passStatus: 200 },
         { url: `/api/getblueprint/${id}`, passStatus: 200 },
         { url: `/api/getblueprintmod/${id}`, passStatus: null },
-        { url: `/api/getblueprintthumbnail/${id}`, passStatus: null },
+        { url: `/api/blueprints/${id}/thumbnail`, passStatus: 200 },
         { url: `/api/blueprints/${id}/versions`, passStatus: 200 },
         { url: `/api/blueprints/${id}/comments`, passStatus: 200 },
       ];

--- a/__tests__/api/blueprint-thumbnail.test.ts
+++ b/__tests__/api/blueprint-thumbnail.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, beforeEach, afterEach, before } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+import mongoose, { Types } from 'mongoose';
+
+// Load test environment first
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup, TestDbHelper } from '../setup/testSetup';
+import { BlueprintModel } from '../../app/api/models/blueprint';
+
+const thumbnailTypeMigration = require('../../migrations/20260717000000_blueprint-thumbnail-type.js');
+
+const TINY_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+const TINY_PNG = `data:image/png;base64,${TINY_PNG_BASE64}`;
+
+const SAMPLE_BLUEPRINT_DATA = {
+  version: '1.0',
+  buildings: [{ id: 'Generator', x: 0, y: 0, element: 'Coal' }],
+  info: { name: 'Test', description: 'Test blueprint' },
+};
+
+describe('Blueprint thumbnails (slim lists)', function () {
+  let testData: any;
+  let blueprintId: string;
+
+  before(async function () {
+    this.timeout(10000);
+    await new Promise(resolve => setTimeout(resolve, 2000));
+  });
+
+  beforeEach(async function () {
+    this.timeout(5000);
+    testData = await TestSetup.beforeEach();
+    blueprintId = testData.blueprints.popularBlueprint._id.toString();
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    await TestSetup.afterEach();
+  });
+
+  describe('GET /api/blueprints/:id/thumbnail', function () {
+    it('serves the stored data URI decoded to binary with its own mime type', async function () {
+      const response = await TestSetup.request().get(`/api/blueprints/${blueprintId}/thumbnail`);
+
+      expect(response.status).to.equal(200);
+      expect(response.headers['content-type']).to.match(/image\/png/);
+      expect(response.headers['cache-control']).to.equal('public, max-age=86400');
+      expect(Buffer.from(response.body).equals(Buffer.from(TINY_PNG_BASE64, 'base64'))).to.equal(
+        true
+      );
+    });
+
+    it('does not assume png — a jpeg data URI comes back as image/jpeg', async function () {
+      const jpeg = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Jpeg Thumb',
+        thumbnail: `data:image/jpeg;base64,${TINY_PNG_BASE64}`,
+      });
+
+      const response = await TestSetup.request().get(`/api/blueprints/${jpeg._id}/thumbnail`);
+      expect(response.status).to.equal(200);
+      expect(response.headers['content-type']).to.match(/image\/jpeg/);
+    });
+
+    it('serves 304 when the ETag matches', async function () {
+      const first = await TestSetup.request().get(`/api/blueprints/${blueprintId}/thumbnail`);
+      expect(first.headers['etag']).to.contain(blueprintId);
+
+      const response = await TestSetup.request()
+        .get(`/api/blueprints/${blueprintId}/thumbnail`)
+        .set('If-None-Match', first.headers['etag']);
+      expect(response.status).to.equal(304);
+    });
+
+    it('404s for sentinel thumbnails', async function () {
+      for (const sentinel of ['svg', 'svg_nothing']) {
+        const doc = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+          name: `Sentinel ${sentinel}`,
+          thumbnail: sentinel,
+          thumbnailType: sentinel as any,
+        });
+        const response = await TestSetup.request().get(`/api/blueprints/${doc._id}/thumbnail`);
+        expect(response.status, sentinel).to.equal(404);
+      }
+    });
+
+    it('rejects malformed ids and 404s missing/deleted blueprints', async function () {
+      expect(
+        (await TestSetup.request().get('/api/blueprints/not-an-id/thumbnail')).status
+      ).to.equal(400);
+      expect(
+        (await TestSetup.request().get(`/api/blueprints/${new Types.ObjectId()}/thumbnail`)).status
+      ).to.equal(404);
+
+      await BlueprintModel.model.updateOne({ _id: blueprintId }, { deletedAt: new Date() });
+      expect(
+        (await TestSetup.request().get(`/api/blueprints/${blueprintId}/thumbnail`)).status
+      ).to.equal(404);
+    });
+
+    it('gates drafts: 404 for anon and other users, 200 (never shared-cached) for owner and admin', async function () {
+      const draft = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Draft Thumb',
+        isPublished: false,
+      });
+      const url = `/api/blueprints/${draft._id}/thumbnail`;
+
+      expect((await TestSetup.request().get(url)).status).to.equal(404);
+
+      const otherToken = testData.users.user2.generateJwt();
+      expect(
+        (await TestSetup.request().get(url).set('Authorization', `Bearer ${otherToken}`)).status
+      ).to.equal(404);
+
+      const ownerToken = testData.users.user1.generateJwt();
+      const owner = await TestSetup.request().get(url).set('Authorization', `Bearer ${ownerToken}`);
+      expect(owner.status).to.equal(200);
+      expect(owner.headers['cache-control']).to.equal('private, no-store');
+
+      const adminToken = testData.users.user3.generateJwt('admin');
+      expect(
+        (await TestSetup.request().get(url).set('Authorization', `Bearer ${adminToken}`)).status
+      ).to.equal(200);
+    });
+  });
+
+  describe('list responses carry the sentinel, never the blob', function () {
+    it('sends thumbnail: "real" for real thumbnails and no data URI anywhere in the page', async function () {
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now() });
+
+      expect(response.status).to.equal(200);
+      expect(response.body.blueprints.length).to.be.greaterThan(0);
+      for (const item of response.body.blueprints) {
+        expect(item.thumbnail).to.equal('real');
+      }
+      expect(JSON.stringify(response.body)).to.not.contain('data:image');
+    });
+
+    it('passes stored sentinels through and treats missing thumbnailType as real', async function () {
+      // Sentinel doc (post-migration shape)
+      await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Sentinel Listed',
+        thumbnail: 'svg',
+        thumbnailType: 'svg',
+      });
+      // The seeded fixtures have no thumbnailType at all (the deploy-to-
+      // migration window) — they must read as 'real', not undefined.
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now() });
+
+      expect(response.status).to.equal(200);
+      const byName = new Map(
+        response.body.blueprints.map((item: any) => [item.name, item.thumbnail])
+      );
+      expect(byName.get('Sentinel Listed')).to.equal('svg');
+      expect(byName.get('Super Coal Generator Setup')).to.equal('real');
+    });
+  });
+
+  describe('write sites set thumbnailType', function () {
+    it('upload stores real vs sentinel discriminators', async function () {
+      const token = testData.users.user1.generateJwt();
+
+      const real = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'Real Upload', blueprint: SAMPLE_BLUEPRINT_DATA, thumbnail: TINY_PNG });
+      expect(real.status).to.equal(200);
+      expect((await BlueprintModel.model.findById(real.body.id).lean())!.thumbnailType).to.equal(
+        'real'
+      );
+
+      const sentinel = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'Sentinel Upload', blueprint: SAMPLE_BLUEPRINT_DATA, thumbnail: 'svg' });
+      expect(sentinel.status).to.equal(200);
+      expect(
+        (await BlueprintModel.model.findById(sentinel.body.id).lean())!.thumbnailType
+      ).to.equal('svg');
+    });
+
+    it('forking stores the discriminator for the copied thumbnail', async function () {
+      const token = testData.users.user2.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/fork`)
+        .set('Authorization', `Bearer ${token}`);
+      expect(response.status).to.equal(200);
+
+      const fork = await BlueprintModel.model.findById(response.body.id).lean();
+      expect(fork!.thumbnailType).to.equal('real');
+    });
+  });
+
+  describe('migration 20260717000000_blueprint-thumbnail-type', function () {
+    it('backfills from the stored thumbnail value and is idempotent', async function () {
+      const db = mongoose.connection.db!;
+      await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Sentinel Doc',
+        thumbnail: 'svg_nothing',
+      });
+
+      await thumbnailTypeMigration.up(db);
+      await thumbnailTypeMigration.up(db);
+
+      expect(await BlueprintModel.model.countDocuments({ thumbnailType: { $exists: false } })).to.equal(0);
+      const sentinelDoc = await BlueprintModel.model.findOne({ name: 'Sentinel Doc' }).lean();
+      expect(sentinelDoc!.thumbnailType).to.equal('svg_nothing');
+      const realDoc = await BlueprintModel.model.findById(blueprintId).lean();
+      expect(realDoc!.thumbnailType).to.equal('real');
+    });
+
+    it('leaves documents that already have a discriminator untouched', async function () {
+      const db = mongoose.connection.db!;
+      // A doc written by the new code whose thumbnail was later hand-edited to
+      // a sentinel string must keep its stored discriminator.
+      await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Already Typed',
+        thumbnail: 'svg',
+        thumbnailType: 'real',
+      });
+
+      await thumbnailTypeMigration.up(db);
+
+      const doc = await BlueprintModel.model.findOne({ name: 'Already Typed' }).lean();
+      expect(doc!.thumbnailType).to.equal('real');
+    });
+
+    it('down unsets the discriminator everywhere', async function () {
+      const db = mongoose.connection.db!;
+      await thumbnailTypeMigration.up(db);
+      await thumbnailTypeMigration.down(db);
+      expect(await BlueprintModel.model.countDocuments({ thumbnailType: { $exists: true } })).to.equal(0);
+    });
+  });
+});

--- a/__tests__/api/blueprint-thumbnail.test.ts
+++ b/__tests__/api/blueprint-thumbnail.test.ts
@@ -16,6 +16,10 @@ const thumbnailTypeMigration = require('../../migrations/20260717000000_blueprin
 const TINY_PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
 const TINY_PNG = `data:image/png;base64,${TINY_PNG_BASE64}`;
+// Genuine 1x1 JPEG (node-canvas toDataURL('image/jpeg')) — the endpoint sniffs
+// the decoded bytes, so a jpeg test must actually be jpeg-encoded.
+const TINY_JPEG_BASE64 =
+  '/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD5/ooooA//2Q==';
 
 const SAMPLE_BLUEPRINT_DATA = {
   version: '1.0',
@@ -58,12 +62,35 @@ describe('Blueprint thumbnails (slim lists)', function () {
     it('does not assume png — a jpeg data URI comes back as image/jpeg', async function () {
       const jpeg = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
         name: 'Jpeg Thumb',
-        thumbnail: `data:image/jpeg;base64,${TINY_PNG_BASE64}`,
+        thumbnail: `data:image/jpeg;base64,${TINY_JPEG_BASE64}`,
       });
 
       const response = await TestSetup.request().get(`/api/blueprints/${jpeg._id}/thumbnail`);
       expect(response.status).to.equal(200);
       expect(response.headers['content-type']).to.match(/image\/jpeg/);
+    });
+
+    it('404s when the declared mime does not match the decoded bytes', async function () {
+      const mislabeled = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Mislabeled Thumb',
+        thumbnail: `data:image/jpeg;base64,${TINY_PNG_BASE64}`,
+      });
+
+      const response = await TestSetup.request().get(`/api/blueprints/${mislabeled._id}/thumbnail`);
+      expect(response.status).to.equal(404);
+    });
+
+    it('404s for svg data URIs — scriptable formats are never served', async function () {
+      const svgBase64 = Buffer.from(
+        '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+      ).toString('base64');
+      const svg = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Svg Thumb',
+        thumbnail: `data:image/svg+xml;base64,${svgBase64}`,
+      });
+
+      const response = await TestSetup.request().get(`/api/blueprints/${svg._id}/thumbnail`);
+      expect(response.status).to.equal(404);
     });
 
     it('serves 304 when the ETag matches', async function () {

--- a/__tests__/api/blueprints.test.ts
+++ b/__tests__/api/blueprints.test.ts
@@ -107,12 +107,16 @@ describe('Blueprint API (Mocha)', function () {
       expect(blueprintNames).to.include('Super Coal Generator Setup'); // Original should still be included
     });
 
-    it('should return 400 error with proper validation for missing olderthan parameter', async function () {
-      const response = await TestSetup.request().get('/api/getblueprints');
+    it('treats a missing olderthan parameter as "older than now" (stable page-1 URLs)', async function () {
+      const withParam = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now() });
+      const withoutParam = await TestSetup.request().get('/api/getblueprints');
 
-      expect(response.status).to.equal(400);
-      expect(response.body.errors).to.be.an('array');
-      expect(response.body.errors[0].status).to.equal('400');
+      expect(withoutParam.status).to.equal(200);
+      expect(withoutParam.body.blueprints.map((bp: any) => bp.name)).to.deep.equal(
+        withParam.body.blueprints.map((bp: any) => bp.name)
+      );
     });
 
     it('should return 400 error for invalid olderthan parameter formats', async function () {
@@ -124,13 +128,12 @@ describe('Blueprint API (Mocha)', function () {
       expect(response1.status).to.equal(400);
       expect(response1.body.errors).to.be.an('array');
 
-      // Test empty parameter
+      // Empty parameter reads as absent — the "older than now" default
       const response2 = await TestSetup.request()
         .get('/api/getblueprints')
         .query({ olderthan: '' });
 
-      expect(response2.status).to.equal(400);
-      expect(response2.body.errors).to.be.an('array');
+      expect(response2.status).to.equal(200);
 
       // Test mixed alphanumeric
       const response3 = await TestSetup.request()

--- a/__tests__/factories/testData.ts
+++ b/__tests__/factories/testData.ts
@@ -18,6 +18,9 @@ export interface TestBlueprint {
   createdAt: Date;
   modifiedAt: Date;
   thumbnail: string;
+  // Absent by default: fixtures represent pre-backfill documents; tests that
+  // need post-migration behavior override it explicitly
+  thumbnailType?: 'real' | 'svg' | 'svg_nothing';
   isCopy?: boolean;
   copyOf?: Types.ObjectId;
   data: any;

--- a/app/api/batch/seed-dev-blueprints.ts
+++ b/app/api/batch/seed-dev-blueprints.ts
@@ -40,7 +40,7 @@ import {
   CategoryLookup,
 } from '../../../lib/index';
 import { UserModel } from '../models/user';
-import { BlueprintModel, Blueprint } from '../models/blueprint';
+import { BlueprintModel, Blueprint, thumbnailTypeOf } from '../models/blueprint';
 import { BlueprintVersionModel } from '../models/blueprint-version';
 import { CommentModel } from '../models/comment';
 import { FollowModel } from '../models/follow';
@@ -333,6 +333,7 @@ async function forkBlueprint(source: Blueprint, ownerId: mongoose.Types.ObjectId
     name: `${source.name} fork`,
     data: sourceVersion.data,
     thumbnail: sourceVersion.thumbnail,
+    thumbnailType: thumbnailTypeOf(sourceVersion.thumbnail),
     createdAt: now,
     modifiedAt: now,
     deletedAt: null,
@@ -480,6 +481,7 @@ async function run() {
       owner: idOf(spec.owner),
       name: spec.name,
       thumbnail: THUMBNAIL,
+      thumbnailType: thumbnailTypeOf(THUMBNAIL),
       data: blueprintData(spec.prefabIds),
       gameVersion,
       category,
@@ -518,6 +520,7 @@ async function run() {
     owner: idOf(PROTECTED_USER.username),
     name: 'My Test Base',
     thumbnail: THUMBNAIL,
+    thumbnailType: thumbnailTypeOf(THUMBNAIL),
     data: blueprintData(myPrefabs),
     gameVersion: deriveGameVersion(myPrefabs.map(id => dlcIdsMap.get(id) ?? [])),
     category: deriveCategory(myPrefabs, categoryLookup),

--- a/app/api/batch/update-thumbnail.ts
+++ b/app/api/batch/update-thumbnail.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 import * as fs from 'fs';
 import { Database } from '../db';
-import { BlueprintModel,} from '../models/blueprint';
+import { BlueprintModel, thumbnailTypeOf } from '../models/blueprint';
 import {
   Blueprint as sharedBlueprint,
 //   Vector2,
@@ -94,6 +94,7 @@ export class UpdateThumbnail {
           global.gc && global.gc();
 
           blueprints[index].thumbnail = newThumbnail;
+          blueprints[index].thumbnailType = thumbnailTypeOf(newThumbnail);
           blueprints[index]
             .save()
             .then(() => {

--- a/app/api/batch/update-thumbnail.ts
+++ b/app/api/batch/update-thumbnail.ts
@@ -95,6 +95,10 @@ export class UpdateThumbnail {
 
           blueprints[index].thumbnail = newThumbnail;
           blueprints[index].thumbnailType = thumbnailTypeOf(newThumbnail);
+          // The thumbnail endpoint's ETag and the client's ?v= cache key are
+          // derived from modifiedAt — without this bump caches keep serving
+          // the old image.
+          blueprints[index].modifiedAt = new Date();
           blueprints[index]
             .save()
             .then(() => {

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { BlueprintModel, Blueprint } from './models/blueprint';
+import { BlueprintModel, Blueprint, thumbnailTypeOf } from './models/blueprint';
 import {
   MdbBlueprint,
   BlueprintResponse,
@@ -475,35 +475,61 @@ export class BlueprintController {
     }
   }
 
-  public getBlueprintThumbnail(req: Request, res: Response) {
-    console.log('getBlueprintThumbnail' + req.clientIp);
-    if (BlueprintModel.model == null) res.status(503).send();
-    else {
-      // TODO checks here
-      let id = String(req.params.id);
-//       let _userId = req.query.userId;
+  // GET /api/blueprints/:id/thumbnail — the stored save-time thumbnail decoded
+  // to its binary image. Only ever requested as the card's fallback when the
+  // server-rendered preview errors; list responses carry the 'real' sentinel
+  // instead of inlining this blob.
+  public async getBlueprintThumbnail(req: Request, res: Response): Promise<void> {
+    if (BlueprintModel.model == null) {
+      res.status(503).send();
+      return;
+    }
 
-      BlueprintModel.model
-        .find({ _id: id })
-        .then(blueprints => {
-          if (blueprints.length > 0 && canViewBlueprint(blueprints[0], optionalViewer(req))) {
-            let blueprint = blueprints[0];
+    const id = String(req.params.id);
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      res.status(400).send();
+      return;
+    }
 
-            let mdbBlueprint = blueprint.data as MdbBlueprint;
-            let angularBlueprint = new sharedBlueprint();
-            angularBlueprint.importFromMdb(mdbBlueprint);
+    try {
+      const blueprint = await BlueprintModel.model
+        .findOne({ _id: id, deletedAt: null })
+        .select('thumbnail modifiedAt owner isPublished')
+        .lean();
+      if (!blueprint || !canViewBlueprint(blueprint, optionalViewer(req))) {
+        res.status(404).send();
+        return;
+      }
 
-            // TODO not sure if I should allow users to regen, or just serve the save thumbnail
-            //PixiBackend.pixiBackend.generateThumbnail(angularBlueprint);
+      // Parse rather than trust thumbnailType: sentinels ('svg'/'svg_nothing')
+      // and pre-migration junk all fail the match and 404, and the stored mime
+      // comes out of the data URI itself (not always png).
+      const match = /^data:(image\/[a-z0-9.+-]+);base64,(.+)$/i.exec(blueprint.thumbnail ?? '');
+      if (!match) {
+        res.status(404).send();
+        return;
+      }
 
-            res.json({ status: 'ok' });
-          } else res.status(404).json(apiError(404, 'Blueprint not found'));
-        })
-        .catch(err => {
-          console.log('Blueprint find error');
-          console.log(err);
-          res.status(500).json(apiError(500, 'Failed to retrieve blueprint'));
-        });
+      const modifiedAt = blueprint.modifiedAt ?? null;
+      const etag = `"${id}-${modifiedAt ? new Date(modifiedAt).getTime() : 0}-thumbnail"`;
+      if (req.headers['if-none-match'] === etag) {
+        res.set({ ETag: etag });
+        res.status(304).end();
+        return;
+      }
+
+      // Clients pass ?v=<modifiedAt ms> (same scheme as the preview urls), so
+      // a long shared max-age is safe; draft thumbnails are owner/admin-only
+      // and must never sit in a shared cache.
+      const cacheControl =
+        blueprint.isPublished === false ? 'private, no-store' : 'public, max-age=86400';
+
+      res.set({ 'Content-Type': match[1], 'Cache-Control': cacheControl, ETag: etag });
+      res.send(Buffer.from(match[2], 'base64'));
+    } catch (err) {
+      console.log('getBlueprintThumbnail error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to retrieve thumbnail'));
     }
   }
 
@@ -681,8 +707,9 @@ export class BlueprintController {
       // Trending has no single indexed field to sort on — it's a computed,
       // time-decayed score — so it goes through an aggregation instead of
       // the plain find().sort() every other sort uses.
-      // -data: the list never renders blueprint contents, and the blobs
-      // average ~85KB per doc — dominating the query's fetch cost otherwise
+      // -data -thumbnail: the list renders neither blueprint contents (~85KB
+      // avg) nor the inline thumbnail data URI (~10-20KB) — together they
+      // dominate the query's fetch cost otherwise
       let blueprintsPromise: Promise<Blueprint[]> =
         sort === 'trending'
           ? BlueprintController.getTrendingBlueprints(filter, skipAmount, limit)
@@ -691,7 +718,7 @@ export class BlueprintController {
               .sort(sortSpec)
               .skip(skipAmount)
               .limit(limit)
-              .select('-data')
+              .select('-data -thumbnail')
               .populate('owner');
 
       blueprintsPromise
@@ -821,7 +848,7 @@ export class BlueprintController {
     if (orderedIds.length === 0) return [];
     const docs = await BlueprintModel.model
       .find({ $and: [{ _id: { $in: orderedIds } }, filter] })
-      .select('-data')
+      .select('-data -thumbnail')
       .populate('owner');
     const byId = new Map(docs.map(doc => [(doc._id as mongoose.Types.ObjectId).toString(), doc]));
     return orderedIds
@@ -959,7 +986,10 @@ export class BlueprintController {
       ownerName: username,
       createdAt: blueprint.createdAt,
       modifiedAt: blueprint.modifiedAt,
-      thumbnail: blueprint.thumbnail,
+      // Sentinel only, never the ~10-20KB data URI — real images are fetched
+      // via /api/blueprints/:id/thumbnail. Missing thumbnailType (docs in the
+      // deploy→backfill-migration window) reads as 'real', the common case.
+      thumbnail: blueprint.thumbnailType ?? 'real',
       nbRatings: blueprint.ratingCount ?? 0,
       rating: blueprint.ratingAverage ?? 0,
       myRating: myRatings.get(id) ?? null,
@@ -1027,7 +1057,7 @@ export class BlueprintController {
               })
               .sort({ ratingAverage: -1, ratingCount: -1, createdAt: -1 })
               .limit(RELATED_LIMIT * 4)
-              .select('-data')
+              .select('-data -thumbnail')
               .populate('owner')
           : Promise.resolve([]),
         BlueprintModel.model
@@ -1039,7 +1069,7 @@ export class BlueprintController {
           })
           .sort({ createdAt: -1 })
           .limit(RELATED_LIMIT * 4)
-          .select('-data')
+          .select('-data -thumbnail')
           .populate('owner'),
       ]);
 
@@ -1053,7 +1083,7 @@ export class BlueprintController {
           .find({ deletedAt: null, isPublished: PUBLISHED_FILTER, _id: { $ne: blueprintId } })
           .sort({ createdAt: -1 })
           .limit(RELATED_LIMIT * 4)
-          .select('-data')
+          .select('-data -thumbnail')
           .populate('owner');
         for (const candidate of fallback) candidates.set((candidate._id as mongoose.Types.ObjectId).toString(), candidate);
       }
@@ -1399,6 +1429,7 @@ export class BlueprintController {
     blueprint.data = data;
     blueprint.markModified('data');
     blueprint.thumbnail = thumbnail;
+    blueprint.thumbnailType = thumbnailTypeOf(thumbnail);
     blueprint.deletedAt = null;
     // Derived fact, never client-supplied — any `rooms` key in the request
     // body is ignored (same policy as a client trying to set ratingCount).

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -65,6 +65,26 @@ function setFeedCacheControl(req: Request, res: Response) {
   res.set('Cache-Control', req.headers.authorization == null ? ANON_CACHE_CONTROL : 'no-store');
 }
 
+// The stored thumbnail data URI is user-supplied, so its declared mime cannot
+// be trusted: a URI claiming image/svg+xml (scriptable when opened directly)
+// or mislabeled bytes must never be echoed back as a Content-Type. Sniff the
+// decoded bytes and only serve allowlisted raster formats.
+function sniffImageMime(bytes: Buffer): string | null {
+  if (bytes.length >= 8 && bytes.subarray(0, 8).equals(PNG_SIGNATURE)) return 'image/png';
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff)
+    return 'image/jpeg';
+  const ascii6 = bytes.subarray(0, 6).toString('latin1');
+  if (ascii6 === 'GIF87a' || ascii6 === 'GIF89a') return 'image/gif';
+  if (
+    bytes.length >= 12 &&
+    bytes.subarray(0, 4).toString('latin1') === 'RIFF' &&
+    bytes.subarray(8, 12).toString('latin1') === 'WEBP'
+  )
+    return 'image/webp';
+  return null;
+}
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
 export class BlueprintController {
   public uploadBlueprint(req: Request, res: Response) {
     console.log('uploadBlueprint' + req.clientIp);
@@ -502,10 +522,18 @@ export class BlueprintController {
       }
 
       // Parse rather than trust thumbnailType: sentinels ('svg'/'svg_nothing')
-      // and pre-migration junk all fail the match and 404, and the stored mime
-      // comes out of the data URI itself (not always png).
+      // and pre-migration junk all fail the match and 404. The mime comes from
+      // sniffing the decoded bytes (not always png), and must agree with the
+      // declared one — mismatches and non-raster formats (svg) 404.
       const match = /^data:(image\/[a-z0-9.+-]+);base64,(.+)$/i.exec(blueprint.thumbnail ?? '');
       if (!match) {
+        res.status(404).send();
+        return;
+      }
+      const bytes = Buffer.from(match[2], 'base64');
+      const declared = match[1].toLowerCase();
+      const detected = sniffImageMime(bytes);
+      if (!detected || detected !== (declared === 'image/jpg' ? 'image/jpeg' : declared)) {
         res.status(404).send();
         return;
       }
@@ -524,8 +552,13 @@ export class BlueprintController {
       const cacheControl =
         blueprint.isPublished === false ? 'private, no-store' : 'public, max-age=86400';
 
-      res.set({ 'Content-Type': match[1], 'Cache-Control': cacheControl, ETag: etag });
-      res.send(Buffer.from(match[2], 'base64'));
+      res.set({
+        'Content-Type': detected,
+        'X-Content-Type-Options': 'nosniff',
+        'Cache-Control': cacheControl,
+        ETag: etag,
+      });
+      res.send(bytes);
     } catch (err) {
       console.log('getBlueprintThumbnail error');
       console.log(err);

--- a/app/api/blueprint-version-controller.ts
+++ b/app/api/blueprint-version-controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import mongoose from 'mongoose';
-import { BlueprintModel } from './models/blueprint';
+import { BlueprintModel, thumbnailTypeOf } from './models/blueprint';
 import { BlueprintVersionModel, BlueprintVersion } from './models/blueprint-version';
 import { UserJwt } from './models/user';
 import { NotificationController } from './notification-controller';
@@ -79,6 +79,7 @@ export class BlueprintVersionController {
         name: forkName(source.name),
         data: sourceVersion.data,
         thumbnail: sourceVersion.thumbnail,
+        thumbnailType: thumbnailTypeOf(sourceVersion.thumbnail),
         createdAt: now,
         modifiedAt: now,
         deletedAt: null,

--- a/app/api/models/blueprint.ts
+++ b/app/api/models/blueprint.ts
@@ -1,6 +1,21 @@
 import mongoose, { Schema, Document, Model } from 'mongoose';
 import { GAME_VERSIONS, CATEGORIES, RESEARCH_TIERS, ROOM_TYPE_IDS } from '../../../lib/index';
 
+// Discriminator for the stored thumbnail: 'real' = data-URI image, the other
+// two are placeholder sentinels stored verbatim in `thumbnail`. Exists so list
+// queries can know real-vs-sentinel without fetching the blob (a find()
+// projection can't prefix-test a field).
+export const THUMBNAIL_TYPES = ['real', 'svg', 'svg_nothing'] as const;
+export type ThumbnailType = (typeof THUMBNAIL_TYPES)[number];
+
+// Shared by every write site that sets `thumbnail` (upload/save, fork, seeds)
+// and by the backfill migration: sentinels map to themselves, anything else is
+// a real image.
+export function thumbnailTypeOf(thumbnail: string | null | undefined): ThumbnailType {
+  if (thumbnail === 'svg' || thumbnail === 'svg_nothing') return thumbnail;
+  return 'real';
+}
+
 export interface Blueprint extends Document {
   owner: string;
   name: string;
@@ -13,6 +28,10 @@ export interface Blueprint extends Document {
   createdAt: Date;
   modifiedAt: Date;
   thumbnail: string;
+  // No schema default (same hydration rationale as isPublished): docs
+  // predating the backfill migration lack the field — readers fall back to
+  // 'real', the overwhelmingly common case.
+  thumbnailType?: ThumbnailType;
   isCopy?: boolean;
   copyOf?: string;
   data: any;
@@ -67,6 +86,7 @@ export class BlueprintModel {
       createdAt: Date,
       modifiedAt: Date,
       thumbnail: String,
+      thumbnailType: { type: String, enum: THUMBNAIL_TYPES },
       isCopy: Boolean,
       copyOf: {
         type: Schema.Types.ObjectId,

--- a/app/api/user-controller.ts
+++ b/app/api/user-controller.ts
@@ -183,7 +183,7 @@ export class UserController {
           .find({ owner: { $in: followeeIds }, deletedAt: null, createdAt: { $lt: dateFilter } })
           .sort({ createdAt: -1 })
           .limit(browseIncrement * 2)
-          .select('-data')
+          .select('-data -thumbnail')
           .populate('owner')
           .then(blueprints => {
             return BlueprintController.handleGetBlueprint(req, res, user._id, blueprints);

--- a/app/api/utils/pagination.ts
+++ b/app/api/utils/pagination.ts
@@ -2,9 +2,12 @@ import { Request, Response } from 'express';
 import { apiError } from './apiError';
 
 export function parseOlderThan(req: Request, res: Response): Date | null {
+  // Absent (or empty) means "everything older than now" — the first-page
+  // request. Clients omit it there on purpose: a Date.now() cursor makes
+  // every page-1 URL unique, which defeats the edge cache on the feed
+  // endpoints. Explicit values (page 2+ cursors) are validated as before.
   if (!req.query.olderthan || req.query.olderthan === '') {
-    res.status(400).json(apiError(400, 'Missing required parameter: olderthan'));
-    return null;
+    return new Date();
   }
 
   const dateInt = parseInt(req.query.olderthan as string);

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -73,9 +73,6 @@ export class Routes {
     // Anonymous access
     app.route('/api/getblueprint/:id').get(this.uploadBlueprintController.getBlueprint);
     app.route('/api/getblueprintmod/:id').get(this.uploadBlueprintController.getBlueprintMod);
-    app
-      .route('/api/getblueprintthumbnail/:id')
-      .get(this.uploadBlueprintController.getBlueprintThumbnail);
     app.route('/api/getblueprints').get(this.uploadBlueprintController.getBlueprints);
     app.route('/api/version').get(this.versionController.getVersion);
     app.route('/api/health').get(this.healthController.getHealth);
@@ -85,6 +82,9 @@ export class Routes {
     app.route('/api/blueprints/:id').get(this.uploadBlueprintController.getBlueprintDetails);
     app.route('/api/blueprints/:id/related').get(this.uploadBlueprintController.getRelatedBlueprints);
     app.route('/api/blueprints/:id/preview/:variant').get(this.previewController.getPreview);
+    // Fallback image for cards when the preview render errors — the stored
+    // save-time thumbnail decoded from its data URI
+    app.route('/api/blueprints/:id/thumbnail').get(this.uploadBlueprintController.getBlueprintThumbnail);
     app.route('/api/blueprints/:id/comments').get(this.commentController.list);
     app.route('/api/blueprints/:id/versions').get(this.blueprintVersionController.listVersions);
     // Download beacon: anonymous (the editor's file export works logged out);

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.html
@@ -10,7 +10,7 @@
   >
     <img
       [appQueuedPreview]="cardPreviewUrl()"
-      [previewFallback]="item.thumbnail"
+      [previewFallback]="thumbnailFallbackUrl()"
       [alt]="item.name"
       width="480"
       height="480"

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.spec.ts
@@ -13,7 +13,7 @@ function makeItem(overrides: any = {}) {
     ownerName: "alice",
     createdAt: new Date("2026-01-01"),
     modifiedAt: new Date("2026-01-01"),
-    thumbnail: "data:image/png;base64,xyz",
+    thumbnail: "real",
     nbRatings: 7,
     rating: 4.5,
     myRating: null,
@@ -74,8 +74,8 @@ describe("BlueprintCardComponent", () => {
     );
   });
 
-  it("falls back to the inline thumbnail when the server preview errors", () => {
-    component.item = makeItem();
+  it("falls back to the stored-thumbnail endpoint when the server preview errors", () => {
+    component.item = makeItem({ modifiedAt: new Date(1700000000000) });
     fixture.detectChanges();
 
     const img = fixture.debugElement.query(By.css(".bni-card__thumb img"));
@@ -83,8 +83,13 @@ describe("BlueprintCardComponent", () => {
     fixture.detectChanges();
 
     expect(img.nativeElement.getAttribute("src")).toBe(
-      "data:image/png;base64,xyz",
+      "/api/blueprints/bp-1/thumbnail?v=1700000000000",
     );
+  });
+
+  it("provides no fallback url for sentinel thumbnails", () => {
+    component.item = makeItem({ thumbnail: "svg" });
+    expect(component.thumbnailFallbackUrl()).toBeNull();
   });
 
   it("shows the Draft chip only when the blueprint is unpublished", () => {

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.ts
@@ -55,4 +55,15 @@ export class BlueprintCardComponent {
       : 0;
     return `/api/blueprints/${this.item.id}/preview/card.webp?v=${version}`;
   }
+
+  // Fallback img src for when the preview request errors: the stored
+  // save-time thumbnail. List responses carry the 'real' sentinel instead of
+  // inlining the image, so the fallback is a URL, not a data URI.
+  thumbnailFallbackUrl(): string | null {
+    if (this.item.thumbnail !== "real") return null;
+    const version = this.item.modifiedAt
+      ? new Date(this.item.modifiedAt).getTime()
+      : 0;
+    return `/api/blueprints/${this.item.id}/thumbnail?v=${version}`;
+  }
 }

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
@@ -577,7 +577,7 @@ describe("BrowsePageComponent", () => {
       ownerName: "alice",
       createdAt: new Date(),
       modifiedAt: new Date(),
-      thumbnail: "data:image/png;base64,xyz",
+      thumbnail: "real",
       nbRatings: 7,
       rating: 4.5,
       myRating: null,

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
@@ -151,7 +151,7 @@ describe("BrowsePageComponent", () => {
 
       expect(component.filterUserId).toBe("user-123");
       expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
-        expect.any(Date),
+        null,
         "user-123",
         null,
         null,
@@ -173,7 +173,7 @@ describe("BrowsePageComponent", () => {
       component.getBlueprints();
 
       expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
-        expect.any(Date),
+        null,
         null,
         null,
         "spacedOut",
@@ -193,7 +193,7 @@ describe("BrowsePageComponent", () => {
       component.getBlueprints();
 
       expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
-        expect.any(Date),
+        null,
         null,
         null,
         null,
@@ -214,7 +214,7 @@ describe("BrowsePageComponent", () => {
       component.getBlueprints();
 
       expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
-        expect.any(Date),
+        null,
         null,
         null,
         null,
@@ -234,7 +234,7 @@ describe("BrowsePageComponent", () => {
       component.getBlueprints();
 
       expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
-        expect.any(Date),
+        null,
         null,
         null,
         null,
@@ -254,7 +254,7 @@ describe("BrowsePageComponent", () => {
       component.getBlueprints();
 
       expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
-        expect.any(Date),
+        null,
         null,
         null,
         null,
@@ -274,7 +274,7 @@ describe("BrowsePageComponent", () => {
       component.getBlueprints();
 
       expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
-        expect.any(Date),
+        null,
         null,
         null,
         null,

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
@@ -44,7 +44,9 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   working = true;
   noMoreBlueprints = false;
   loadError = false;
-  oldestDate = new Date();
+  // null = first page ("older than now" server-side). A concrete Date.now()
+  // here would make every page-1 URL unique and defeat the CDN cache.
+  oldestDate: Date | null = null;
   filterName = "";
   filterUserId: string | null = null;
   filterGameVersion: string | null = null;
@@ -384,7 +386,8 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
 
     const request$ =
       this.viewMode === "feed"
-        ? this.userService.getFeed(this.oldestDate)
+        ? // feed is always authed (no-store), so a concrete cursor costs nothing
+          this.userService.getFeed(this.oldestDate ?? new Date())
         : this.blueprintService.getBlueprints(
             this.oldestDate,
             this.filterUserId,
@@ -460,7 +463,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
 
   reset() {
     this.blueprintListItems = [];
-    this.oldestDate = new Date();
+    this.oldestDate = null;
     this.skipCount = 0;
     this.noMoreBlueprints = false;
     this.working = true;

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.html
@@ -43,7 +43,7 @@
         <img
           *ngIf="isReal(item.thumbnail)"
           [appQueuedPreview]="previewUrl(item)"
-          [previewFallback]="item.thumbnail"
+          [previewFallback]="thumbnailFallbackUrl(item)"
         />
         <svg
           *ngIf="item.thumbnail === 'svg'"

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-browse/dialog-browse.component.ts
@@ -104,6 +104,14 @@ export class DialogBrowseComponent implements OnInit {
     return `/api/blueprints/${item.id}/preview/card.webp?v=${version}`;
   }
 
+  // Fallback img src when the preview errors — list responses carry the
+  // 'real' sentinel, the actual image is served by the thumbnail endpoint.
+  thumbnailFallbackUrl(item: BlueprintListItem): string | null {
+    if (item.thumbnail !== "real") return null;
+    const version = item.modifiedAt ? new Date(item.modifiedAt).getTime() : 0;
+    return `/api/blueprints/${item.id}/thumbnail?v=${version}`;
+  }
+
   ngOnInit() {
     this.browseDialog.onShow.subscribe({
       next: this.handleOnShow.bind(this),

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.spec.ts
@@ -84,7 +84,7 @@ describe("ProfilePageComponent", () => {
   it("loads that owner's blueprints once the profile resolves", () => {
     fixture.detectChanges();
     expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
-      expect.any(Date),
+      null,
       "owner-1",
       null,
     );
@@ -122,7 +122,7 @@ describe("ProfilePageComponent", () => {
         component.blueprintListItems.some((i: any) => i.name === "stale"),
       ).toBe(false);
       expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
-        expect.any(Date),
+        null,
         null,
         null,
         undefined,
@@ -144,7 +144,7 @@ describe("ProfilePageComponent", () => {
       component.setTab("blueprints");
 
       expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
-        expect.any(Date),
+        null,
         "owner-1",
         null,
       );

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.ts
@@ -36,7 +36,8 @@ export class ProfilePageComponent implements OnInit {
   blueprintListItems: BlueprintListItem[] = [];
   working = true;
   noMoreBlueprints = false;
-  oldestDate = new Date();
+  // null = first page ("older than now" server-side); keeps page-1 URLs stable
+  oldestDate: Date | null = null;
   remaining = 0;
   activeTab: "blueprints" | "rated" = "blueprints";
 
@@ -119,7 +120,7 @@ export class ProfilePageComponent implements OnInit {
     this.blueprintListItems = [];
     this.working = true;
     this.noMoreBlueprints = false;
-    this.oldestDate = new Date();
+    this.oldestDate = null;
     this.remaining = 0;
     this.activeTab = "blueprints";
   }
@@ -228,7 +229,7 @@ export class ProfilePageComponent implements OnInit {
     this.blueprintListItems = [];
     this.working = true;
     this.noMoreBlueprints = false;
-    this.oldestDate = new Date();
+    this.oldestDate = null;
     this.remaining = 0;
     this.appendLoading();
     this.loadBlueprints();

--- a/frontend/src/app/module-blueprint/directives/queued-preview.directive.ts
+++ b/frontend/src/app/module-blueprint/directives/queued-preview.directive.ts
@@ -21,7 +21,7 @@ const LOAD_SAFETY_TIMEOUT_MS = 30_000;
 /**
  * Loads a server-rendered preview through PreviewQueueService: the img gets
  * its src only when no earlier preview is still loading, and swaps to the
- * legacy inline thumbnail if the preview request errors. Do not combine with
+ * fallback src if the preview request errors. Do not combine with
  * loading="lazy" — a deferred offscreen fetch never fires load and would
  * stall the queue.
  */
@@ -31,7 +31,7 @@ const LOAD_SAFETY_TIMEOUT_MS = 30_000;
 })
 export class QueuedPreviewDirective implements OnChanges, OnDestroy {
   @Input("appQueuedPreview") previewUrl!: string;
-  /** Legacy inline thumbnail (data url) used when the preview request errors. */
+  /** Fallback src (stored-thumbnail endpoint url) used when the preview request errors. */
   @Input() previewFallback: string | null = null;
 
   private ticket: PreviewQueueTicket | null = null;

--- a/frontend/src/app/module-blueprint/services/blueprint-service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.spec.ts
@@ -389,6 +389,31 @@ describe("BlueprintService", () => {
       expect(url).toContain("olderthan=" + date.getTime());
     });
 
+    it("omits olderthan on the first page (null cursor) so the URL is cacheable", () => {
+      service.getBlueprints(null, null, null);
+      const url: string = mockHttp.get.mock.calls[0][0];
+      expect(url).not.toContain("olderthan");
+      expect(url).not.toContain("?&");
+    });
+
+    it("omits olderthan for count sorts, which paginate via skip", () => {
+      service.getBlueprints(
+        new Date(1_000_000),
+        null,
+        null,
+        null,
+        null,
+        null,
+        "popular",
+        10,
+      );
+      const url: string = mockHttp.get.mock.calls[0][0];
+      expect(url).not.toContain("olderthan");
+      expect(url).toContain("sort=popular");
+      expect(url).toContain("skip=10");
+      expect(url).not.toContain("?&");
+    });
+
     it("includes filterUserId when provided", () => {
       service.getBlueprints(new Date(), "user123", null);
       const url: string = mockHttp.get.mock.calls[0][0];

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -355,7 +355,7 @@ export class BlueprintService implements IObsBlueprintChange {
   }
 
   getBlueprints(
-    olderThan: Date,
+    olderThan: Date | null,
     filterUserId: string | null,
     filterName: string | null,
     filterGameVersion?: string | null,
@@ -368,7 +368,16 @@ export class BlueprintService implements IObsBlueprintChange {
     filterRatedBy?: string | null,
     filterRooms?: string | null,
   ) {
-    const parameterOlderThan = "olderthan=" + olderThan.getTime().toString();
+    // olderthan is a cache-buster when it isn't doing real work, so send it
+    // only where it is the pagination cursor: the recent sort past page 1
+    // (null = first page = "older than now", the server default). Count
+    // sorts paginate via skip and ignore it entirely. Stable URLs let the
+    // CDN actually serve anonymous browse requests from the edge.
+    const usesCursor = sort == null || sort === "recent";
+    const parameterOlderThan =
+      usesCursor && olderThan != null
+        ? "olderthan=" + olderThan.getTime().toString()
+        : "";
 
     let parameterFilterUserId = "";
     if (filterUserId != null)
@@ -408,7 +417,7 @@ export class BlueprintService implements IObsBlueprintChange {
     let parameterRooms = "";
     if (filterRooms != null) parameterRooms = "&rooms=" + filterRooms;
 
-    const parameters =
+    const parameters = (
       parameterOlderThan +
       parameterFilterUserId +
       parameterFilterName +
@@ -419,7 +428,8 @@ export class BlueprintService implements IObsBlueprintChange {
       parameterModded +
       parameterForkedFrom +
       parameterRatedBy +
-      parameterRooms;
+      parameterRooms
+    ).replace(/^&/, "");
 
     const request = this.authService.isLoggedIn()
       ? this.http.get("/api/getblueprintsSecure?" + parameters, {

--- a/lib/src/coms/blueprint-list-response.ts
+++ b/lib/src/coms/blueprint-list-response.ts
@@ -13,6 +13,10 @@ export interface BlueprintListItem {
   ownerName: string;
   createdAt: Date;
   modifiedAt: Date;
+  // List responses send a sentinel, never image data: 'real' = fetch the
+  // stored thumbnail via GET /api/blueprints/:id/thumbnail (used only as the
+  // preview's error fallback); 'svg'/'svg_nothing' render placeholder
+  // branches. (BlueprintDetailsResponse still inlines the data URI here.)
   thumbnail: string;
   // Star-rating aggregate (denormalized onto the blueprint; recomputed
   // out of band so the algorithm can evolve — plain average for now)

--- a/migrations/20260717000000_blueprint-thumbnail-type.js
+++ b/migrations/20260717000000_blueprint-thumbnail-type.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// Migration 9: thumbnailType discriminator (spec/thumbnail-slim-lists.md).
+//
+// List responses stop inlining the base64 `thumbnail` blob and send a
+// sentinel instead; list queries need to know real-vs-sentinel without
+// fetching the blob, so the discriminator is stored per document.
+//
+// up:   backfill thumbnailType from the existing thumbnail value —
+//       the 'svg'/'svg_nothing' sentinels map to themselves, anything else
+//       (data URIs, and any junk, which the serve endpoint re-validates) is
+//       'real'. Only touches docs without the field, so re-runs and docs
+//       written by the new code are untouched.
+// down: unset thumbnailType everywhere.
+//
+// Both directions are idempotent — safe to re-run if interrupted.
+
+module.exports = {
+  async up(db) {
+    const blueprints = db.collection('blueprints');
+
+    for (const sentinel of ['svg', 'svg_nothing']) {
+      await blueprints.updateMany(
+        { thumbnailType: { $exists: false }, thumbnail: sentinel },
+        { $set: { thumbnailType: sentinel } }
+      );
+    }
+    await blueprints.updateMany(
+      { thumbnailType: { $exists: false } },
+      { $set: { thumbnailType: 'real' } }
+    );
+  },
+
+  async down(db) {
+    await db.collection('blueprints').updateMany({}, { $unset: { thumbnailType: '' } });
+  },
+};


### PR DESCRIPTION
Implements `spec/thumbnail-slim-lists.md`.

## What shipped

`getblueprints` pages were ~700KB (`content-length: 715365` for 40 items), almost entirely per-item `thumbnail` data URIs that cards only use as an **error fallback** for the server-rendered preview (PR #115). Lists now ship a sentinel instead of the blob.

- **`Blueprint.thumbnailType`** (`'real' | 'svg' | 'svg_nothing'`): stored discriminator so list queries know real-vs-sentinel without fetching the blob. No schema default (same hydration rationale as `isPublished`); every write site (upload/save, fork, dev seeds, `update-thumbnail` batch) sets it via a shared `thumbnailTypeOf()` helper.
- **Migration** `20260717000000_blueprint-thumbnail-type.js`: backfills from the stored value, insert-only on re-run (`thumbnailType: { $exists: false }` filter), `down` unsets.
- **`GET /api/blueprints/:id/thumbnail`** replaces the vestigial `/api/getblueprintthumbnail/:id` stub (which loaded the full doc and returned `{status:'ok'}` JSON — nothing called it). Decodes the stored data URI to binary with its own mime (not assumed png), ETag from `modifiedAt` + 304 support, `public, max-age=86400` (drafts: `private, no-store`, owner/admin only, deleted 404, sentinels 404).
- **List responses**: `buildListItem` sends `thumbnailType ?? 'real'` (missing = deploy→migrate window fallback); every list query (`getBlueprints`, trending `fetchInOrder`, related shelf, `getFeed`) selects `-data -thumbnail`.
- **Frontend**: card + dialog-browse bind `previewFallback` to the thumbnail endpoint URL (`?v=<modifiedAt ms>`) when `thumbnail === 'real'`, `null` for sentinels. `isReal()` and the placeholder branches are unchanged. Details page hero is untouched (details endpoint intentionally keeps the inline data URI, per spec).

## Verification

- Backend: 553 passing (new `blueprint-thumbnail.test.ts`: endpoint mime/304/404s/draft gating, list-sentinel + no-`data:`-anywhere, write-site discriminators, migration idempotency; the 2 workos-provision failures are the known local flakes, green in CI).
- Frontend: 769 passing, lint clean.
- Migration run against a **fresh prod dump** (`bpni-prod` locally): 5,217/5,217 docs backfilled `real` — prod stores no sentinel thumbnails and every thumbnail parses as a data URI — and re-runs are no-ops.
- Live dev check: list page went from ~700KB-shaped payloads to 6.2KB with `"thumbnail":"real"`, endpoint serves the stored 200×200 PNG with correct headers, 304 on ETag.

## Compatibility / deploy

Stale cached frontend bundles would set `img.src = 'real'` as the fallback — only visible when the preview request *also* failed; accepted per spec (single-image deploys, one stale-bundle session). Run `npm run migrate:up` post-deploy as usual.

## Out of scope (per spec)

Version-history dialog thumbnails; dropping the stored blob entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also in this PR: stop `olderthan` cache-busting (18cf918f)

Edge caching is live (`cf-cache-status: HIT`), but every page-1 request sent `olderthan=Date.now()`, making each URL unique — the hottest queries could never share a cache entry.

- **Backend**: `olderthan` is now optional; absent/empty means "older than now" (exactly what page 1 was asking for). Explicit values validate as before.
- **Frontend**: the cursor starts `null` and is only sent once it comes from a response's `oldest` (page 2+ — deterministic, shared across users), and never for count sorts (`popular`/`trending`/… paginate via `skip`; the backend ignores `olderthan` there entirely).

First-page URLs are now stable (`?sort=trending&skip=0`), so anonymous browsing is served from the edge; freshness is bounded by `s-maxage=60`.

Verified: backend 70 blueprint/social tests green (missing-param test updated to pin the new default), full frontend suite 771 passing (page-1 cursor matchers updated to `null`).
