### PR TITLE
fix: stop unknown building ids crashing blueprint import

### DIFF
--- a/__tests__/helpers/roomFixtures.ts
+++ b/__tests__/helpers/roomFixtures.ts
@@ -49,7 +49,8 @@ export interface Placement {
 // Places a building with its footprint's bottom-left corner at (x, y) — easier
 // to reason about in fixtures than the game's centered anchor position.
 export function place(blueprint: Blueprint, id: string, x: number, y: number): void {
-  const item = BlueprintHelpers.createInstance(id);
+  // Fixture ids are always known-good; a null here means the fixture itself is broken.
+  const item = BlueprintHelpers.createInstance(id)!;
   const tileOffset = item.oniItem.tileOffset;
   item.position = new Vector2(x - tileOffset.x, y - tileOffset.y);
   item.prepareBoundingBox();

--- a/__tests__/lib/blueprint-import.test.ts
+++ b/__tests__/lib/blueprint-import.test.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+import { Blueprint, BlueprintHelpers, MdbBlueprint } from '../../lib';
+import { loadGameDatabase } from '../helpers/roomFixtures';
+
+// Regression coverage for a real prod crash: a legacy blueprint referencing a
+// building id the current database no longer knows (a stale mod id, or a
+// prefab renamed upstream — e.g. CosmicResearchCenter -> DLC1CosmicResearchCenter)
+// must degrade to `hadUnknownBuildings`, not throw and abort the whole import.
+describe('Blueprint import: unknown building ids', function () {
+  before(function () {
+    loadGameDatabase();
+  });
+
+  it('BlueprintHelpers.createInstance returns null for an unknown id instead of throwing', () => {
+    expect(() => BlueprintHelpers.createInstance('NotARealBuildingId')).to.not.throw();
+    expect(BlueprintHelpers.createInstance('NotARealBuildingId')).to.equal(null);
+  });
+
+  it('importFromMdb skips unknown buildings, flags hadUnknownBuildings, and keeps known ones', () => {
+    const mdb: MdbBlueprint = {
+      blueprintItems: [{ id: 'Tile' }, { id: 'NotARealBuildingId' }],
+    };
+
+    const blueprint = new Blueprint();
+    expect(() => blueprint.importFromMdb(mdb)).to.not.throw();
+
+    expect(blueprint.hadUnknownBuildings).to.equal(true);
+    expect(blueprint.blueprintItems).to.have.length(1);
+    expect(blueprint.blueprintItems[0].id).to.equal('Tile');
+  });
+
+  it('importFromMdb leaves hadUnknownBuildings false when every id is known', () => {
+    const mdb: MdbBlueprint = { blueprintItems: [{ id: 'Tile' }] };
+
+    const blueprint = new Blueprint();
+    blueprint.importFromMdb(mdb);
+
+    expect(blueprint.hadUnknownBuildings).to.equal(false);
+    expect(blueprint.blueprintItems).to.have.length(1);
+  });
+});

--- a/frontend/src/app/module-blueprint/components/side-bar/build-tool/build-tool.component.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/build-tool/build-tool.component.ts
@@ -56,8 +56,9 @@ export class ComponentSideBuildToolComponent
   databaseLoaded: boolean = false;
   oniItemsLoaded() {
     //this.toolService.buildTool.changeItem(BlueprintHelpers.createInstance('SteamTurbine2'));
+    // "Tile" is always present in the database, so this is never null.
     this.toolService.buildTool.changeItem(
-      BlueprintHelpers.createInstance("Tile"),
+      BlueprintHelpers.createInstance("Tile")!,
     );
     this.databaseLoaded = true;
   }
@@ -146,8 +147,9 @@ export class ComponentSideBuildToolComponent
   }
 
   uiItemChanged() {
+    // this.currentItem is itself an existing OniItem, so its id is known good.
     this.toolService.buildTool.changeItem(
-      BlueprintHelpers.createInstance(this.currentItem.id),
+      BlueprintHelpers.createInstance(this.currentItem.id)!,
     );
   }
 

--- a/lib/src/blueprint/blueprint-helpers.d.ts
+++ b/lib/src/blueprint/blueprint-helpers.d.ts
@@ -1,6 +1,6 @@
 import { BlueprintItem } from './blueprint-item';
 export declare class BlueprintHelpers {
-    static createInstance(id: string): BlueprintItem;
+    static createInstance(id: string): BlueprintItem | null;
     static cloneBlueprintItem(original: BlueprintItem, withConnections?: boolean, withOrientation?: boolean): BlueprintItem;
 }
 //# sourceMappingURL=blueprint-helpers.d.ts.map

--- a/lib/src/blueprint/blueprint-helpers.ts
+++ b/lib/src/blueprint/blueprint-helpers.ts
@@ -6,11 +6,20 @@ import { OniItem } from '../oni-item';
 import { BlueprintItemInfo } from './blueprint-item-info';
 
 export class BlueprintHelpers {
-  static createInstance(id: string): BlueprintItem {
+  static createInstance(id: string): BlueprintItem | null {
     let newTemplateItem;
-    let oniItem = OniItem.getOniItem(id);
+    let oniItem: OniItem;
 
-    if (oniItem == null) throw new Error('BlueprintHelpers.createInstance : OniItem id not found');
+    // OniItem.getOniItem throws rather than returning undefined, so a
+    // building id absent from the current database (legacy save, stripped
+    // mod, renamed prefab id) must be caught here — this is what lets
+    // Blueprint.importFromMdb/importFromBni skip it and flag
+    // hadUnknownBuildings instead of the import blowing up.
+    try {
+      oniItem = OniItem.getOniItem(id);
+    } catch {
+      return null;
+    }
 
     if (oniItem.isWire) newTemplateItem = new BlueprintItemWire(id);
     else if (oniItem.isTile) newTemplateItem = new BlueprintItemTile(id);
@@ -26,7 +35,8 @@ export class BlueprintHelpers {
     withConnections: boolean = false,
     withOrientation: boolean = false
   ) {
-    let returnValue = BlueprintHelpers.createInstance(original.id);
+    // original is an already-instantiated BlueprintItem, so its id is known good.
+    let returnValue = BlueprintHelpers.createInstance(original.id)!;
 
     let mdbClone = original.toMdbBuilding();
     if (!withConnections) mdbClone.connections = undefined;


### PR DESCRIPTION
## Summary

Found while backfilling room categorization on prod (`npm run derive-rooms`): one legacy blueprint threw `OniItem id not found : CosmicResearchCenter` instead of being handled by the existing "unknown/modded building" fallback.

Root cause: `OniItem.getOniItem` throws on a miss rather than returning `undefined`, so `BlueprintHelpers.createInstance`'s `if (oniItem == null)` guard was unreachable dead code — the throw always won first. That broke the graceful-degradation path `Blueprint.importFromMdb`/`importFromBni` are built around (skip the unknown item, set `hadUnknownBuildings = true`) for **any** blueprint referencing a building id the current database doesn't recognize — a stripped mod, or a prefab Klei renamed upstream (confirmed here: `CosmicResearchCenter` → `DLC1CosmicResearchCenter` in the current U59 export).

Only `deriveRooms` survived this, purely because it happens to wrap the call in its own try/catch. The same unguarded path is hit by:
- the live editor's "open blueprint" flow (`blueprint-service.ts`)
- the ONI in-game mod's blueprint-download endpoint (`blueprint-controller.ts`)
- server-side preview/thumbnail rendering (`preview-render-worker.ts`)

All of those would throw/500 instead of degrading gracefully for a user opening this kind of legacy blueprint.

## Change

`BlueprintHelpers.createInstance` now catches the throw from `getOniItem` and returns `null`, letting the existing `hadUnknownBuildings` flagging in `importFromMdb`/`importFromBni` actually run. Widened the return type to `BlueprintItem | null` and updated the small number of call sites that assumed non-null (all provably safe — cloning an already-instantiated item, or a hardcoded/known-good id).

## Test plan
- [x] `npm run tsc` — clean (lib + backend + frontend app typecheck)
- [x] `npm run test` — 559 passing, 1 pre-existing local-only WorkOS flake (unrelated, documented in CLAUDE.md)
- [x] Added `__tests__/lib/blueprint-import.test.ts`: `createInstance` returns `null` instead of throwing; `importFromMdb` skips the unknown item, sets `hadUnknownBuildings`, and still imports the known ones; flag stays `false` when everything is known
- [x] `frontend` `build-tool.component.spec.ts` — 17/17 passing
- [x] `frontend` lint — clean on the touched component
- [ ] Re-run `npm run derive-rooms` against prod after deploy to pick up the previously-failing blueprint

🤖 Generated with [Claude Code](https://claude.com/claude-code)