### PR TITLE
fix(api): eliminate $or draft clause that forced a 16s blocking sort on authed feeds

### DIFF
--- a/__tests__/api/blueprint-drafts.test.ts
+++ b/__tests__/api/blueprint-drafts.test.ts
@@ -286,6 +286,21 @@ describe('Blueprint drafts (Mocha)', function () {
       expect(names).to.include('Secret Draft Base');
     });
 
+    it('owner general feed (no filterUserId) excludes own drafts — published-only fast path', async function () {
+      // Own drafts are intentionally absent from the general feed (they live on
+      // the profile page): keeping them there required an $or that forced a
+      // blocking fetch-everything sort on count sorts (~16s on prod).
+      const response = await TestSetup.request()
+        .get('/api/getblueprintsSecure')
+        .set('Authorization', `Bearer ${ownerToken}`)
+        .query({ olderthan: Date.now() });
+
+      expect(response.status).to.equal(200);
+      const names = response.body.blueprints.map((bp: any) => bp.name);
+      expect(names).to.not.include('Secret Draft Base');
+      expect(names).to.include('Super Coal Generator Setup');
+    });
+
     it('admin general feed (no filterUserId) does not include other users\' drafts', async function () {
       const response = await TestSetup.request()
         .get('/api/getblueprintsSecure')

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -692,14 +692,18 @@ export class BlueprintController {
         ? { $and: [{ deletedAt: null }] }
         : { $and: [{ createdAt: { $lt: dateFilter } }, { deletedAt: null }] };
 
-      // Draft visibility: published blueprints for everyone, plus the viewer's
-      // own drafts. Admins browsing a specific user's list (filterUserId) see
-      // that user's drafts too, but drafts never leak into the general feed.
+      // Draft visibility: the general feed is published-only for every viewer.
+      // Owners see their own drafts when listing their own blueprints (the
+      // profile page always passes filterUserId), and admins see drafts when
+      // browsing a specific user's list — in both cases the owner clause below
+      // already bounds the query, so the published filter is simply dropped.
+      // Never combine the two as $or: [published, owner] — no index serves
+      // both branches under a count sort, so Mongo falls back to fetching
+      // every live 85KB doc into a blocking SORT (~16s on prod).
       const isAdmin = userJwt?.role === 'admin';
-      if (!(isAdmin && filterUserId != null)) {
-        const visibleTo: any[] = [{ isPublished: PUBLISHED_FILTER }];
-        if (userId !== '') visibleTo.push({ owner: userId });
-        filter.$and.push({ $or: visibleTo });
+      const viewerOwnsList = filterUserId != null && filterUserId === userId;
+      if (!viewerOwnsList && !(isAdmin && filterUserId != null)) {
+        filter.$and.push({ isPublished: PUBLISHED_FILTER });
       }
 
       if (filterUserId != null) filter.$and.push({ owner: filterUserId });


### PR DESCRIPTION
## Problem

`GET /api/getblueprintsSecure?sort=popular` took ~4s on prod (it's `no-store`, so every request hits origin). Investigation per `spec/prod-secure-popular-latency.md`:

- **H2 ruled out**: migration 8's ratings index exists on prod; anonymous origin requests are ~0.25s.
- **H1 confirmed** with a read-only prod `explain()`: the authed filter's `$or: [{isPublished: {$in:[true,null]}}, {owner: userId}]` has no index serving both branches under a count sort, so the planner fell back to fetching every live ~85KB doc into a blocking `SORT` — **9,036 docs examined, 16.5s execution** (vs 40 keys/40 docs, ~6ms for the anonymous shape).

## Fix

Spec option 2, generalized — the `$or` is eliminated entirely rather than special-cased:

- **General feed** (no `filterUserId`): published-only for every viewer. Product cut: your own drafts no longer appear in the general browse feeds — they remain on your profile, which always passes `filterUserId`.
- **Own profile** (`filterUserId === userId`) and **admin browsing a user's list**: the owner clause already bounds the query, so the published filter is simply dropped. Same visible set as before.
- `ratedBy` is unaffected: self-rating is 403'd, so a user can never have a rated draft of their own.

## Verification

- Prod-restored data (`bpni-prod`): new authed popular shape explains to **40 keys / 40 docs, no blocking sort** — identical plan to anonymous.
- Drove the running backend end-to-end (real HTTP, minted JWTs): unpublished a blueprint via `POST /unpublish`, then confirmed the draft is absent from anon + authed (admin and non-admin owner) general popular feeds, present and flagged on the owner's own profile listing, hidden from another user browsing that profile, and `recent` cursor pagination still 200s.
- Backend suites: drafts (22, incl. new general-feed-excludes-own-drafts test), discovery/blueprints/counters/forks (105) — all passing. `npm run tsc` clean.

## Deferred

- New Relic wiring from the spec (needs Kevin's signup for the license key).
- H3 (WiredTiger cache sizing) — moot; H1 fully explains the latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)