### PR TITLE
fix(nav): append user menu overlay to body so it opens when scrolled

### DIFF
--- a/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.html
+++ b/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.html
@@ -1,4 +1,9 @@
-<p-menu #userMenu [model]="userMenuItems" [popup]="true"></p-menu>
+<p-menu
+  #userMenu
+  [model]="userMenuItems"
+  [popup]="true"
+  [appendTo]="'body'"
+></p-menu>
 <ng-container *ngIf="authService.isLoggedIn(); else loginButton">
   <button
     pButton


### PR DESCRIPTION
## What

One-line fix: `[appendTo]="'body'"` on the topnav user-menu popup `p-menu`.

## Why

The profile/user menu only opened when the page was scrolled to the top. Anywhere else, clicking it caused a small page jump and no menu appeared.

Root cause: the popup menu rendered inline inside the menubar, which is `position: sticky`. PrimeNG positions popup overlays with document-absolute coordinates (target rect + scrollY), but the sticky bar — pinned to the viewport top — is the overlay's containing block. So when scrolled down by N pixels, the menu landed N pixels below the viewport. The "page jump" was the browser scrolling toward the focused offscreen menu.

The notification-bell popover already uses `appendTo="body"` and never had the bug.

## Verification

- Reproduced in browser via Playwright: at scrollY=800, menu rect top was 847px (viewport 659px tall — invisible) and the click jumped scrollY 800→1421.
- After fix: menu parent is `BODY`, opens at top 47px directly under the nav, scrollY stays at 800.
- `user-menu.component.spec.ts`: 8/8 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)