### PR TITLE
fix(nav): remove redundant My Blueprints entry from site nav

### DIFF
--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
@@ -3,7 +3,6 @@
   <app-site-nav
     (about)="aboutDialog.toggleDialog()"
     (sendFeedback)="feedbackDialog.open()"
-    (myBlueprintsRequested)="goToProfile($event)"
   ></app-site-nav>
 
   <app-dialog-about #aboutDialog></app-dialog-about>

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewChild } from "@angular/core";
 import { Location } from "@angular/common";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute } from "@angular/router";
 import { EMPTY, Observable } from "rxjs";
 import { catchError, finalize, switchMap, tap } from "rxjs/operators";
 import {
@@ -12,7 +12,6 @@ import { MessageService } from "primeng/api";
 import { BlueprintService } from "../../services/blueprint-service";
 import { AuthenticationService } from "../../services/authentification-service";
 import { VersionHistoryDialogComponent } from "../dialogs/version-history-dialog/version-history-dialog.component";
-import { BrowseData } from "../user-menu/user-menu.component";
 import {
   categoryTooltip,
   subcategoryTooltip,
@@ -56,16 +55,11 @@ export class BlueprintDetailsPageComponent implements OnInit {
 
   constructor(
     private route: ActivatedRoute,
-    private router: Router,
     private location: Location,
     private blueprintService: BlueprintService,
     private messageService: MessageService,
     public authService: AuthenticationService,
   ) {}
-
-  goToProfile(data: BrowseData) {
-    this.router.navigate(["/profile", data.filterUserName]);
-  }
 
   // Complete singular/plural messages (not a conditional suffix) so
   // translators control each form

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
@@ -4,7 +4,6 @@
   <app-site-nav
     (about)="aboutDialog.toggleDialog()"
     (sendFeedback)="feedbackDialog.open()"
-    (myBlueprintsRequested)="showMyBlueprints($event)"
   ></app-site-nav>
 
   <app-dialog-about #aboutDialog></app-dialog-about>

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
@@ -11,7 +11,6 @@ import { BrowsePageComponent } from "./browse-page.component";
 import { BlueprintService } from "src/app/module-blueprint/services/blueprint-service";
 import { AuthenticationService } from "src/app/module-blueprint/services/authentification-service";
 import { UserService } from "src/app/module-blueprint/services/user-service";
-import { BrowseData } from "../user-menu/user-menu.component";
 
 function makeResponse(blueprints: any[] = [], remaining = 0) {
   return {
@@ -148,32 +147,6 @@ describe("BrowsePageComponent", () => {
         remaining: 0,
       } as any);
       expect(component.oldestDate).toBe(cursor);
-    });
-  });
-
-  describe("showMyBlueprints", () => {
-    it("filters the feed by the requesting user's id", () => {
-      const data: BrowseData = {
-        filterUserId: "user-123",
-        filterUserName: "alice",
-      };
-      component.showMyBlueprints(data);
-
-      expect(component.filterUserId).toBe("user-123");
-      expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
-        null,
-        "user-123",
-        null,
-        null,
-        null,
-        null,
-        "recent",
-        undefined,
-        null,
-        null,
-        null,
-        null,
-      );
     });
   });
 

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
@@ -25,7 +25,6 @@ import { Subject, Subscription } from "rxjs";
 import { debounceTime } from "rxjs/operators";
 import { DialogAboutComponent } from "../dialogs/dialog-about/dialog-about.component";
 import { FeedbackDialogComponent } from "../dialogs/feedback-dialog/feedback-dialog.component";
-import { BrowseData } from "../user-menu/user-menu.component";
 
 const LOADING_STR = $localize`Loading...`;
 const NO_RESULTS_STR = $localize`:browse.noResults:No Results`;
@@ -67,7 +66,6 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   // here would make every page-1 URL unique and defeat the CDN cache.
   oldestDate: Date | null = null;
   filterName = "";
-  filterUserId: string | null = null;
   filterGameVersion: string | null = null;
   filterCategory: string | null = null;
   filterSubcategory: string | null = null;
@@ -557,7 +555,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
           this.userService.getFeed(this.oldestDate ?? new Date())
         : this.blueprintService.getBlueprints(
             this.oldestDate,
-            this.filterUserId,
+            null,
             this.filterName.trim() || null,
             this.filterGameVersion,
             this.filterCategory,
@@ -610,11 +608,6 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
       return;
     }
     this.handleError();
-  }
-
-  showMyBlueprints(data: BrowseData) {
-    this.filterUserId = data.filterUserId;
-    this.transitionList();
   }
 
   handleError() {

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.html
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.html
@@ -2,7 +2,6 @@
   <app-site-nav
     (about)="aboutDialog.toggleDialog()"
     (sendFeedback)="feedbackDialog.open()"
-    (myBlueprintsRequested)="goToProfile($event)"
   ></app-site-nav>
 
   <app-dialog-about #aboutDialog></app-dialog-about>

--- a/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/profile-page/profile-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, HostListener, OnInit } from "@angular/core";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute } from "@angular/router";
 import { DatePipe } from "@angular/common";
 import { UserService } from "../../services/user-service";
 import { BlueprintService } from "../../services/blueprint-service";
@@ -76,7 +76,6 @@ export class ProfilePageComponent implements OnInit {
 
   constructor(
     private route: ActivatedRoute,
-    private router: Router,
     private userService: UserService,
     private blueprintService: BlueprintService,
     public authService: AuthenticationService,
@@ -116,10 +115,6 @@ export class ProfilePageComponent implements OnInit {
       nbViews: 0,
       nbDownloads: 0,
     };
-  }
-
-  goToProfile(data: { filterUserName: string }) {
-    this.router.navigate(["/profile", data.filterUserName]);
   }
 
   ngOnInit() {

--- a/frontend/src/app/module-blueprint/components/site-nav/site-nav.component.html
+++ b/frontend/src/app/module-blueprint/components/site-nav/site-nav.component.html
@@ -22,9 +22,9 @@
       *ngIf="authService.isLoggedIn()"
     ></app-notification-bell>
     <app-user-menu
+      [myBlueprintsEnabled]="false"
       (about)="about.emit()"
       (sendFeedback)="sendFeedback.emit()"
-      (myBlueprintsRequested)="myBlueprintsRequested.emit($event)"
     ></app-user-menu>
   </ng-template>
 </p-menubar>

--- a/frontend/src/app/module-blueprint/components/site-nav/site-nav.component.ts
+++ b/frontend/src/app/module-blueprint/components/site-nav/site-nav.component.ts
@@ -1,6 +1,5 @@
 import { Component, EventEmitter, Output } from "@angular/core";
 import { AuthenticationService } from "../../services/authentification-service";
-import { BrowseData } from "../user-menu/user-menu.component";
 
 @Component({
   selector: "app-site-nav",
@@ -11,7 +10,6 @@ import { BrowseData } from "../user-menu/user-menu.component";
 export class SiteNavComponent {
   @Output() about = new EventEmitter<void>();
   @Output() sendFeedback = new EventEmitter<void>();
-  @Output() myBlueprintsRequested = new EventEmitter<BrowseData>();
 
   constructor(public authService: AuthenticationService) {}
 }

--- a/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.spec.ts
@@ -114,6 +114,29 @@ describe("UserMenuComponent", () => {
     });
   });
 
+  describe("My Blueprints", () => {
+    it("is visible when logged in (default, e.g. the editor menu)", () => {
+      authService.isLoggedIn.mockReturnValue(true);
+      authService.getUserDetails.mockReturnValue(makeUser("user"));
+      component.ngOnInit();
+      const item = component.userMenuItems.find(
+        (i) => i.label === "My Blueprints",
+      );
+      expect(item?.visible).toBe(true);
+    });
+
+    it("is hidden when myBlueprintsEnabled is false (e.g. the site nav)", () => {
+      authService.isLoggedIn.mockReturnValue(true);
+      authService.getUserDetails.mockReturnValue(makeUser("user"));
+      component.myBlueprintsEnabled = false;
+      component.ngOnInit();
+      const item = component.userMenuItems.find(
+        (i) => i.label === "My Blueprints",
+      );
+      expect(item?.visible).toBe(false);
+    });
+  });
+
   describe("myBlueprintsRequested output", () => {
     it("emits BrowseData for the current user", () => {
       authService.getUserDetails.mockReturnValue(makeUser("user"));

--- a/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.ts
+++ b/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   EventEmitter,
+  Input,
   OnInit,
   Output,
   ViewChild,
@@ -23,6 +24,11 @@ export interface BrowseData {
 })
 export class UserMenuComponent implements OnInit {
   @ViewChild("userMenu") userMenu!: Menu;
+
+  // Only the in-editor menu wires this up (opens the browse dialog filtered
+  // to your own blueprints, for picking one to open) — the standalone site
+  // pages hide it since the profile page already covers "see my blueprints".
+  @Input() myBlueprintsEnabled = true;
 
   @Output() about = new EventEmitter<void>();
   @Output() sendFeedback = new EventEmitter<void>();
@@ -54,7 +60,7 @@ export class UserMenuComponent implements OnInit {
         label: $localize`My Blueprints`,
         icon: "pi pi-images",
         command: () => this.userProfile(),
-        visible: loggedIn,
+        visible: loggedIn && this.myBlueprintsEnabled,
       },
       {
         label: $localize`Switch account`,


### PR DESCRIPTION
## Summary
- Removes the "My Blueprints" item from the standalone site nav (`browse-page`, `profile-page`, `blueprint-details-page`). It was either a straight duplicate of "My Profile" (same navigation on the profile/details pages) or a worse version of what the profile page already offers (on the discover list it applied a user filter with no visible indicator and no way to clear it via "Clear filters").
- The editor's own toolbar keeps the entry: there it opens the in-editor "Browse Blueprints" dialog pre-filtered to your own blueprints, letting you pick one to open directly in the editor — a distinct, non-redundant use the profile page doesn't cover.
- `UserMenuComponent` gains a `myBlueprintsEnabled` input (default `true`, so the editor is unaffected); `site-nav` passes `false`.
- Cleaned up the now-dead wiring: `showMyBlueprints`/`filterUserId` in `browse-page`, `goToProfile` in `profile-page`/`blueprint-details-page` (plus their now-unused `Router` injections), and `site-nav`'s pass-through output.

## Test plan
- [x] `npx tsc -p tsconfig.app.json --noEmit` clean
- [x] `npm test -- --include='**/user-menu.component.spec.ts' --include='**/browse-page.component.spec.ts' --include='**/profile-page.component.spec.ts' --include='**/blueprint-details-page.component.spec.ts' --include='**/component-menu.component.spec.ts'` — 130 passing
- [x] Added coverage for the new `myBlueprintsEnabled` input (visible by default, hidden when set false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)