### PR TITLE
fix(deploy): copy avatar-reference assets into deploy image

### DIFF
--- a/deploy.Dockerfile
+++ b/deploy.Dockerfile
@@ -7,6 +7,7 @@ RUN npm ci --ignore-scripts && npm cache clean --force
 
 # TODO separate build build stage for asset extract
 COPY ./assets/database/database-2024.json ./assets/database/database-2024.json
+COPY ./assets/avatar-reference ./assets/avatar-reference
 
 FROM extract as build-backend
 WORKDIR /bpni


### PR DESCRIPTION
## Summary
- `deploy.Dockerfile` only ever `COPY`'d `assets/database/database-2024.json` into the build context (an intentionally partial extraction to avoid dragging the 63M `ui_image`/8.9M `connection_sprites` dirs into the backend image). `assets/avatar-reference/duplicant-style-sheet.jpg` was never added when the avatar feature shipped, so it never reached the runtime image.
- `AvatarService.getStyleSheet()` fails closed when the file is missing (by design, per the comment at `app/api/services/avatar-service.ts:81-85` — a missing sheet can't degrade to sheet-less prompting without corrupting the request), so every `avatars:seed-batch` call on staging refused with `style sheet unavailable — refusing to generate with mismatched prompt` instead of shipping mismatched avatars.
- Fix: add `COPY ./assets/avatar-reference ./assets/avatar-reference` alongside the existing database copy so `copy_assets.sh`'s rsync picks it up.

## Test plan
- [ ] `docker build . -t bpni:latest -f deploy.Dockerfile` and confirm `assets/avatar-reference/duplicant-style-sheet.jpg` exists inside the built image
- [ ] Redeploy staging, re-run `node app/api/batch/generate-avatar-batch.js --count 20` in the app console, confirm no "style sheet unavailable" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)