### PR TITLE
Make trending fast: materialized hotScore + default Discover sort

### DIFF
--- a/__tests__/api/blueprint-counters.test.ts
+++ b/__tests__/api/blueprint-counters.test.ts
@@ -10,6 +10,7 @@ process.env.NODE_ENV = 'test';
 import { TestSetup } from '../setup/testSetup';
 import { BlueprintModel } from '../../app/api/models/blueprint';
 import { BlueprintCounterService } from '../../app/api/services/blueprint-counter-service';
+import { computeHotScore } from '../../lib/index';
 import { Types } from 'mongoose';
 
 describe('Blueprint view/download counters', function () {
@@ -79,6 +80,37 @@ describe('Blueprint view/download counters', function () {
       const service = BlueprintCounterService.instance;
       service.record('view', new Types.ObjectId().toString(), 'user-a');
       await service.flush(); // must not throw
+    });
+
+    it('refreshes hotScore on a download flush using the post-increment total', async function () {
+      const service = BlueprintCounterService.instance;
+      const doc = await BlueprintModel.model
+        .findById(blueprintId)
+        .select('ratingCount ratingAverage downloadCount createdAt')
+        .lean();
+      const expected = computeHotScore({
+        ratingCount: doc?.ratingCount ?? 0,
+        ratingAverage: doc?.ratingAverage ?? 0,
+        downloadCount: (doc?.downloadCount ?? 0) + 1,
+        createdAt: doc!.createdAt,
+      });
+
+      service.record('download', blueprintId, 'dl-1');
+      await service.flush();
+
+      const after = await BlueprintModel.model.findById(blueprintId).select('hotScore').lean();
+      expect(after?.hotScore).to.be.closeTo(expected, 1e-9);
+    });
+
+    it('leaves hotScore untouched on a view-only flush', async function () {
+      const service = BlueprintCounterService.instance;
+      const before = (await BlueprintModel.model.findById(blueprintId).select('hotScore').lean())?.hotScore ?? null;
+
+      service.record('view', blueprintId, 'viewer-1');
+      await service.flush();
+
+      const after = (await BlueprintModel.model.findById(blueprintId).select('hotScore').lean())?.hotScore ?? null;
+      expect(after).to.equal(before);
     });
   });
 

--- a/__tests__/api/blueprint-discovery.test.ts
+++ b/__tests__/api/blueprint-discovery.test.ts
@@ -8,16 +8,15 @@ dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
 process.env.NODE_ENV = 'test';
 
 import { TestSetup } from '../setup/testSetup';
-import { BlueprintController } from '../../app/api/blueprint-controller';
 import { BlueprintModel } from '../../app/api/models/blueprint';
-import { CommentModel } from '../../app/api/models/comment';
+import { computeHotScore } from '../../lib/index';
 import { Types } from 'mongoose';
 
 const TINY_PNG =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
 
 async function makeBlueprint(owner: Types.ObjectId, overrides: Record<string, any> = {}) {
-  return BlueprintModel.model.create({
+  const doc: Record<string, any> = {
     owner,
     name: `Discovery Test Blueprint ${new Types.ObjectId().toString()}`,
     ratingCount: 0,
@@ -32,7 +31,18 @@ async function makeBlueprint(owner: Types.ObjectId, overrides: Record<string, an
     deletedAt: null,
     isPublished: true,
     ...overrides,
-  });
+  };
+  // saveBlueprint materializes hotScore on every write; fixtures bypass it, so
+  // mirror it here from the (possibly overridden) scoring inputs.
+  if (doc.hotScore == null) {
+    doc.hotScore = computeHotScore({
+      ratingCount: doc.ratingCount,
+      ratingAverage: doc.ratingAverage,
+      downloadCount: doc.downloadCount,
+      createdAt: doc.createdAt,
+    });
+  }
+  return BlueprintModel.model.create(doc);
 }
 
 function daysAgo(n: number): Date {
@@ -189,33 +199,28 @@ describe('Discovery: related blueprints + trending sort', function () {
       expect(trendingNames.indexOf(newSmall.name)).to.be.lessThan(trendingNames.indexOf(oldButLiked.name));
     });
 
-    it('factors live comment counts into the score', async function () {
-      const discussed = await makeBlueprint(testData.users.user1._id, {
-        name: 'Trending Discussed',
+    it('ranks a more-downloaded blueprint above a same-age, same-rating one', async function () {
+      const popular = await makeBlueprint(testData.users.user1._id, {
+        name: 'Trending More Downloads',
+        ratingCount: 4,
+        ratingAverage: 4,
+        downloadCount: 500,
         createdAt: new Date(),
       });
-      const quiet = await makeBlueprint(testData.users.user2._id, {
-        name: 'Trending Quiet',
+      const obscure = await makeBlueprint(testData.users.user2._id, {
+        name: 'Trending Few Downloads',
+        ratingCount: 4,
+        ratingAverage: 4,
+        downloadCount: 2,
         createdAt: new Date(),
       });
-
-      await CommentModel.model.create([
-        { blueprintId: discussed._id, authorId: testData.users.user2._id, body: 'one' },
-        { blueprintId: discussed._id, authorId: testData.users.user3._id, body: 'two' },
-        {
-          blueprintId: discussed._id,
-          authorId: testData.users.user3._id,
-          body: 'removed',
-          deletedAt: new Date(),
-        },
-      ]);
 
       const response = await TestSetup.request()
         .get('/api/getblueprints')
         .query({ olderthan: Date.now(), sort: 'trending' });
 
       const names: string[] = response.body.blueprints.map((b: any) => b.name);
-      expect(names.indexOf(discussed.name)).to.be.lessThan(names.indexOf(quiet.name));
+      expect(names.indexOf(popular.name)).to.be.lessThan(names.indexOf(obscure.name));
     });
 
     it('rejects an unknown sort value', async function () {
@@ -225,31 +230,20 @@ describe('Discovery: related blueprints + trending sort', function () {
       expect(response.status).to.equal(400);
     });
 
-    it('memoizes the ranking until the cache is cleared, but never the documents', async function () {
-      const first = await TestSetup.request()
-        .get('/api/getblueprints')
-        .query({ olderthan: Date.now(), sort: 'trending' });
-      expect(first.status).to.equal(200);
-
+    it('surfaces a newly created blueprint (no cache) with a materialized hotScore', async function () {
       const late = await makeBlueprint(testData.users.user2._id, {
         name: 'Trending Late Arrival',
         ratingCount: 99,
         ratingAverage: 5,
       });
 
-      const cached = await TestSetup.request()
-        .get('/api/getblueprints')
-        .query({ olderthan: Date.now(), sort: 'trending' });
-      expect(cached.body.blueprints.map((b: any) => b.name)).to.not.include(late.name);
-
-      BlueprintController.clearTrendingCache();
       const fresh = await TestSetup.request()
         .get('/api/getblueprints')
         .query({ olderthan: Date.now(), sort: 'trending' });
       expect(fresh.body.blueprints.map((b: any) => b.name)).to.include(late.name);
     });
 
-    it('drops a soft-deleted blueprint from a cached ranking immediately', async function () {
+    it('excludes a soft-deleted blueprint from the trending feed', async function () {
       const doomed = await makeBlueprint(testData.users.user1._id, { name: 'Trending Doomed' });
 
       const first = await TestSetup.request()

--- a/__tests__/api/blueprint-discovery.test.ts
+++ b/__tests__/api/blueprint-discovery.test.ts
@@ -200,19 +200,22 @@ describe('Discovery: related blueprints + trending sort', function () {
     });
 
     it('ranks a more-downloaded blueprint above a same-age, same-rating one', async function () {
+      // One shared timestamp so the recency term is identical — isolates the
+      // download signal as the only differentiator.
+      const createdAt = new Date();
       const popular = await makeBlueprint(testData.users.user1._id, {
         name: 'Trending More Downloads',
         ratingCount: 4,
         ratingAverage: 4,
         downloadCount: 500,
-        createdAt: new Date(),
+        createdAt,
       });
       const obscure = await makeBlueprint(testData.users.user2._id, {
         name: 'Trending Few Downloads',
         ratingCount: 4,
         ratingAverage: 4,
         downloadCount: 2,
-        createdAt: new Date(),
+        createdAt,
       });
 
       const response = await TestSetup.request()
@@ -220,6 +223,8 @@ describe('Discovery: related blueprints + trending sort', function () {
         .query({ olderthan: Date.now(), sort: 'trending' });
 
       const names: string[] = response.body.blueprints.map((b: any) => b.name);
+      expect(names).to.include(popular.name);
+      expect(names).to.include(obscure.name);
       expect(names.indexOf(popular.name)).to.be.lessThan(names.indexOf(obscure.name));
     });
 

--- a/__tests__/api/blueprint-metadata.test.ts
+++ b/__tests__/api/blueprint-metadata.test.ts
@@ -8,6 +8,7 @@ process.env.NODE_ENV = 'test';
 
 import { TestSetup } from '../setup/testSetup';
 import { BlueprintModel } from '../../app/api/models/blueprint';
+import { computeHotScore } from '../../lib/index';
 
 const TINY_PNG =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
@@ -398,6 +399,35 @@ describe('Blueprint metadata API', function () {
         .query({ olderthan: Date.now(), ratedBy: testData.users.user2._id.toString() });
 
       expect(response.status).to.equal(403);
+    });
+  });
+
+  describe('trending hotScore materialization on rating', function () {
+    it('refreshes hotScore when a rating lands', async function () {
+      const otherToken = testData.users.user2.generateJwt();
+      const created = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ ...BASE_BODY, name: 'Rating Bumps HotScore' });
+      const id = created.body.id;
+
+      const before = (await BlueprintModel.model.findById(id).select('hotScore createdAt').lean())!;
+
+      await TestSetup.request()
+        .post('/api/rateblueprint')
+        .set('Authorization', `Bearer ${otherToken}`)
+        .send({ blueprintId: id, rating: 5 });
+
+      const after = (await BlueprintModel.model.findById(id).select('hotScore ratingCount ratingAverage downloadCount createdAt').lean())!;
+      const expected = computeHotScore({
+        ratingCount: after.ratingCount ?? 0,
+        ratingAverage: after.ratingAverage ?? 0,
+        downloadCount: after.downloadCount ?? 0,
+        createdAt: after.createdAt,
+      });
+      expect(after.hotScore).to.be.closeTo(expected, 1e-9);
+      // A first 5★ rating raises the quality term above the 0-vote baseline.
+      expect(after.hotScore).to.be.greaterThan(before.hotScore as number);
     });
   });
 });

--- a/__tests__/lib/blueprint-hotscore.test.ts
+++ b/__tests__/lib/blueprint-hotscore.test.ts
@@ -1,0 +1,84 @@
+import { expect } from 'chai';
+import { HotScoreInputs, HOT_SCORE, bayesianRating, computeHotScore } from '../../lib';
+
+// A day in ms, to build createdAt values relative to a fixed "now".
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 0, 1);
+// createdAt for a blueprint published `ageDays` before NOW.
+const aged = (ageDays: number): Date => new Date(NOW - ageDays * DAY);
+
+const bp = (o: Partial<HotScoreInputs> & { ageDays?: number }): HotScoreInputs => ({
+  ratingCount: o.ratingCount ?? 0,
+  ratingAverage: o.ratingAverage ?? 0,
+  downloadCount: o.downloadCount ?? 0,
+  createdAt: o.createdAt ?? aged(o.ageDays ?? 0),
+});
+
+describe('computeHotScore (trending "new but also good")', () => {
+  describe('bayesianRating shrinkage', () => {
+    it('returns exactly the prior mean for zero votes', () => {
+      expect(bayesianRating(0, 0)).to.equal(HOT_SCORE.PRIOR_MEAN);
+    });
+
+    it('pulls a single 5-star vote well below face value', () => {
+      const wr = bayesianRating(1, 5);
+      expect(wr).to.be.greaterThan(HOT_SCORE.PRIOR_MEAN);
+      expect(wr).to.be.lessThan(4.2); // nowhere near 5.0
+    });
+
+    it('lets a well-established average win over a lone perfect score', () => {
+      expect(bayesianRating(50, 4.5)).to.be.greaterThan(bayesianRating(1, 5));
+    });
+
+    it('approaches the true average as vote count grows', () => {
+      expect(bayesianRating(1000, 4.5)).to.be.closeTo(4.5, 0.05);
+    });
+  });
+
+  describe('ordering properties', () => {
+    it('ranks the newer of two equally-good blueprints higher', () => {
+      const older = bp({ ratingCount: 10, ratingAverage: 4, downloadCount: 100, ageDays: 10 });
+      const newer = bp({ ratingCount: 10, ratingAverage: 4, downloadCount: 100, ageDays: 0 });
+      expect(computeHotScore(newer)).to.be.greaterThan(computeHotScore(older));
+    });
+
+    it('ranks the better-rated of two same-age blueprints higher', () => {
+      const worse = bp({ ratingCount: 10, ratingAverage: 3, ageDays: 2 });
+      const better = bp({ ratingCount: 10, ratingAverage: 5, ageDays: 2 });
+      expect(computeHotScore(better)).to.be.greaterThan(computeHotScore(worse));
+    });
+
+    it('is monotonic in downloads at equal age and rating', () => {
+      const few = bp({ ratingCount: 5, ratingAverage: 4, downloadCount: 10, ageDays: 3 });
+      const many = bp({ ratingCount: 5, ratingAverage: 4, downloadCount: 1000, ageDays: 3 });
+      expect(computeHotScore(many)).to.be.greaterThan(computeHotScore(few));
+    });
+
+    it('does not let a brand-new mediocre blueprint outrank a new good one', () => {
+      const newBad = bp({ ratingCount: 4, ratingAverage: 2, ageDays: 0 });
+      const newGood = bp({ ratingCount: 4, ratingAverage: 4.5, downloadCount: 20, ageDays: 0 });
+      expect(computeHotScore(newGood)).to.be.greaterThan(computeHotScore(newBad));
+    });
+  });
+
+  describe('"new but also good" crossover (rotates faster than Top, slower than Newest)', () => {
+    // A genuinely great but older blueprint vs a decent brand-new one.
+    const oldGreat = bp({ ratingCount: 40, ratingAverage: 4.7, downloadCount: 400, ageDays: 10 });
+    const newDecent = bp({ ratingCount: 3, ratingAverage: 4.0, downloadCount: 10, ageDays: 0 });
+
+    it('keeps a great blueprint competitive at ~10 days (not buried like Newest would)', () => {
+      // Within striking distance — same order of magnitude, still on the board.
+      expect(computeHotScore(oldGreat)).to.be.greaterThan(computeHotScore(newDecent) - 1);
+    });
+
+    it('lets fresh content overtake it by the ~2-week window (unlike Top, which never rotates)', () => {
+      const veryOldGreat = bp({ ...oldGreat, createdAt: aged(21) });
+      expect(computeHotScore(newDecent)).to.be.greaterThan(computeHotScore(veryOldGreat));
+    });
+  });
+
+  it('is deterministic and independent of the current clock (static per document)', () => {
+    const input = bp({ ratingCount: 7, ratingAverage: 4.2, downloadCount: 50, ageDays: 5 });
+    expect(computeHotScore(input)).to.equal(computeHotScore(input));
+  });
+});

--- a/__tests__/setup/testSetup.ts
+++ b/__tests__/setup/testSetup.ts
@@ -1,15 +1,11 @@
 import request from 'supertest';
 import app from '../../app/app';
-import { BlueprintController } from '../../app/api/blueprint-controller';
 import { TestDbHelper } from '../helpers/testDb';
 
 export class TestSetup {
   static testData: any;
 
   static async beforeEach() {
-    // Trending rankings are memoized in-process; a stale ranking from a
-    // previous test would hide blueprints created in this one
-    BlueprintController.clearTrendingCache();
     await TestDbHelper.cleanDatabase();
     this.testData = await TestDbHelper.seedDatabase();
     return this.testData;

--- a/agent/TODO.md
+++ b/agent/TODO.md
@@ -52,6 +52,22 @@ guide items, both needing backend work:
   - **Likes cleanup migration**: `$unset` the orphaned `likes`/`likeCount` fields once
     the rollout is proven (they're out of the mongoose schema already).
 
+## Trending ranking (hotScore) follow-ups
+
+Trending is now a materialized, indexed `hotScore` ("new but also good": bayesian-shrunk
+rating + log downloads + a static recency term) and the default Discover sort. Design +
+calibration: `spec/trending-hotscore-plan.md`; scoring lives in `lib` `computeHotScore`.
+Deferred, both metrics-gated:
+
+- **Filter-scoped trending indexes** — only the unfiltered `{deletedAt, isPublished,
+  hotScore:-1, createdAt:-1}` index shipped. Whether to add gameVersion/category/rooms +
+  hotScore compound indexes depends on which filters users actually pair with trending;
+  instrument that first (filtered trending currently falls back to a non-covered sort).
+- **Re-tune constants against real data** — `PRIOR_MEAN` (`C`, provisional 3.5) and
+  `W_RECENCY` (0.18 → ~2-week window) were set before there was meaningful rating volume.
+  Revisit once ratings/downloads accumulate; any change is a one-line edit to `HOT_SCORE`
+  plus a fresh backfill migration to re-materialize.
+
 ## Future directions (product)
 
 - **Blueprint forks** — fork/remix an existing blueprint with attribution (was queued with

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -20,6 +20,7 @@ import {
   ROOM_TYPE_IDS,
 } from '../../lib/index';
 import { Blueprint as sharedBlueprint, BlueprintDetailsResponse } from '../../lib/index';
+import { computeHotScore } from '../../lib/index';
 import { UserModel, UserJwt } from './models/user';
 import { CommentModel } from './models/comment';
 import { BlueprintRatingModel } from './models/blueprint-rating';
@@ -365,10 +366,26 @@ export class BlueprintController {
       { $project: { _id: 0, count: 1, average: 1 } },
     ]);
     const aggregate = rows[0] ?? { count: 0, average: 0 };
-    await BlueprintModel.model.updateOne(
-      { _id: blueprintId },
-      { $set: { ratingCount: aggregate.count, ratingAverage: aggregate.average } }
-    );
+    const update: Record<string, number> = {
+      ratingCount: aggregate.count,
+      ratingAverage: aggregate.average,
+    };
+    // Refresh the materialized trending score with the new rating aggregate.
+    // Needs the doc's createdAt + current downloadCount (the other scoring
+    // inputs) — one small projected read, off the request-critical path.
+    const doc = await BlueprintModel.model
+      .findById(blueprintId)
+      .select('createdAt downloadCount')
+      .lean();
+    if (doc?.createdAt != null) {
+      update.hotScore = computeHotScore({
+        ratingCount: aggregate.count,
+        ratingAverage: aggregate.average,
+        downloadCount: doc.downloadCount ?? 0,
+        createdAt: doc.createdAt,
+      });
+    }
+    await BlueprintModel.model.updateOne({ _id: blueprintId }, { $set: update });
     return aggregate;
   }
 
@@ -736,29 +753,25 @@ export class BlueprintController {
       else if (sort === 'mostForked') sortSpec = { forkCount: -1, createdAt: -1 };
       else if (sort === 'mostViewed') sortSpec = { viewCount: -1, createdAt: -1 };
       else if (sort === 'mostDownloaded') sortSpec = { downloadCount: -1, createdAt: -1 };
+      // Trending sorts on the materialized hotScore (lib computeHotScore),
+      // refreshed on every engagement write — so it's a plain indexed sort
+      // like every other sort, not a full-collection aggregation.
+      else if (sort === 'trending') sortSpec = { hotScore: -1, createdAt: -1 };
 
       let browseIncrement = parseInt(process.env.BROWSE_INCREMENT as string);
       let skipAmount = usesOffsetPagination ? skip : 0;
       let limit = browseIncrement * 2;
 
-      // Trending has no single indexed field to sort on — it's a computed,
-      // time-decayed score — so it goes through an aggregation instead of
-      // the plain find().sort() every other sort uses.
       // -data -thumbnail: the list renders neither blueprint contents (~85KB
       // avg) nor the inline thumbnail data URI (~10-20KB) — together they
       // dominate the query's fetch cost otherwise
-      let blueprintsPromise: Promise<Blueprint[]> =
-        sort === 'trending'
-          ? BlueprintController.getTrendingBlueprints(filter, skipAmount, limit)
-          : BlueprintModel.model
-              .find(filter)
-              .sort(sortSpec)
-              .skip(skipAmount)
-              .limit(limit)
-              .select('-data -thumbnail')
-              .populate('owner');
-
-      blueprintsPromise
+      BlueprintModel.model
+        .find(filter)
+        .sort(sortSpec)
+        .skip(skipAmount)
+        .limit(limit)
+        .select('-data -thumbnail')
+        .populate('owner')
         .then(blueprints => {
           return BlueprintController.handleGetBlueprint(req, res, blueprints);
         })
@@ -768,129 +781,6 @@ export class BlueprintController {
           res.status(500).json(apiError(500, 'Failed to retrieve blueprints'));
         });
     }
-  }
-
-  // Trending rankings are cached briefly (ordered ids only, keyed by the
-  // exact filter+page): the score is a full pass over every matching
-  // blueprint by design, and "what's trending" tolerates a few minutes of
-  // staleness. Documents are still fetched fresh on every request, so
-  // counts/names/thumbnails never go stale — only the ordering does.
-  private static trendingIdCache = new Map<string, { expiresAt: number; ids: mongoose.Types.ObjectId[] }>();
-  private static readonly TRENDING_CACHE_TTL_MS = 5 * 60 * 1000;
-  // The key embeds the whole filter (name search strings, skip, per-viewer
-  // clauses), so arbitrary requests can mint unlimited distinct keys within
-  // one TTL window — cap the map and evict oldest-inserted first.
-  private static readonly TRENDING_CACHE_MAX_ENTRIES = 200;
-
-  public static clearTrendingCache() {
-    BlueprintController.trendingIdCache.clear();
-  }
-
-  // Time-decayed engagement score (ratings + weighted forks/comments/views,
-  // divided down by age) computed in an aggregation since it isn't a stored
-  // field. Only the ordered ids come out of the aggregation; the actual
-  // documents are then fetched + populated normally and put back in that
-  // order — cheaper than populating owner inside the pipeline via $lookup.
-  private static async getTrendingBlueprints(
-    filter: Record<string, unknown>,
-    skip: number,
-    limit: number
-  ): Promise<Blueprint[]> {
-    const cacheKey = JSON.stringify({ filter, skip, limit });
-    const cached = BlueprintController.trendingIdCache.get(cacheKey);
-    if (cached != null && cached.expiresAt > Date.now()) {
-      return BlueprintController.fetchInOrder(cached.ids, filter);
-    }
-    const commentLookupStage: mongoose.PipelineStage[] =
-      CommentModel.model == null
-        ? []
-        : [
-            {
-              $lookup: {
-                from: CommentModel.model.collection.name,
-                let: { blueprintId: '$_id' },
-                pipeline: [
-                  {
-                    $match: {
-                      $expr: { $and: [{ $eq: ['$blueprintId', '$$blueprintId'] }, { $eq: ['$deletedAt', null] }] },
-                    },
-                  },
-                  { $count: 'count' },
-                ],
-                as: 'commentAgg',
-              },
-            },
-          ];
-
-    const rows: { _id: mongoose.Types.ObjectId }[] = await BlueprintModel.model.aggregate([
-      { $match: filter },
-      // Slim each doc to the scoring inputs before the $lookup so the full
-      // blueprint data blobs (~85KB avg) never stream through the pipeline
-      { $project: { ratingCount: 1, forkCount: 1, viewCount: 1, createdAt: 1 } },
-      ...commentLookupStage,
-      {
-        $addFields: {
-          commentCount: { $ifNull: [{ $arrayElemAt: ['$commentAgg.count', 0] }, 0] },
-          ageInDays: { $divide: [{ $subtract: ['$$NOW', '$createdAt'] }, 1000 * 60 * 60 * 24] },
-        },
-      },
-      {
-        $addFields: {
-          trendingScore: {
-            $divide: [
-              {
-                $add: [
-                  { $ifNull: ['$ratingCount', 0] },
-                  { $multiply: [{ $ifNull: ['$forkCount', 0] }, 3] },
-                  { $multiply: ['$commentCount', 2] },
-                  { $multiply: [{ $ifNull: ['$viewCount', 0] }, 0.05] },
-                ],
-              },
-              { $pow: [{ $add: ['$ageInDays', 2] }, 1.5] },
-            ],
-          },
-        },
-      },
-      { $sort: { trendingScore: -1, createdAt: -1 } },
-      { $skip: skip },
-      { $limit: limit },
-      { $project: { _id: 1 } },
-    ]);
-
-    const orderedIds = rows.map(row => row._id);
-
-    const now = Date.now();
-    for (const [key, entry] of BlueprintController.trendingIdCache) {
-      if (entry.expiresAt <= now) BlueprintController.trendingIdCache.delete(key);
-    }
-    while (BlueprintController.trendingIdCache.size >= BlueprintController.TRENDING_CACHE_MAX_ENTRIES) {
-      const oldestKey = BlueprintController.trendingIdCache.keys().next().value as string;
-      BlueprintController.trendingIdCache.delete(oldestKey);
-    }
-    BlueprintController.trendingIdCache.set(cacheKey, {
-      expiresAt: now + BlueprintController.TRENDING_CACHE_TTL_MS,
-      ids: orderedIds,
-    });
-
-    return BlueprintController.fetchInOrder(orderedIds, filter);
-  }
-
-  // Re-applies the visibility filter so a blueprint deleted or unpublished
-  // after the ranking was cached drops out immediately — only the ordering
-  // is ever stale, never visibility.
-  private static async fetchInOrder(
-    orderedIds: mongoose.Types.ObjectId[],
-    filter: Record<string, unknown>
-  ): Promise<Blueprint[]> {
-    if (orderedIds.length === 0) return [];
-    const docs = await BlueprintModel.model
-      .find({ $and: [{ _id: { $in: orderedIds } }, filter] })
-      .select('-data -thumbnail')
-      .populate('owner');
-    const byId = new Map(docs.map(doc => [(doc._id as mongoose.Types.ObjectId).toString(), doc]));
-    return orderedIds
-      .map(id => byId.get(id.toString()))
-      .filter((doc): doc is NonNullable<typeof doc> => doc != null);
   }
 
   // Visible (non-deleted) comment counts for a page of blueprints, one aggregate.
@@ -1450,6 +1340,16 @@ export class BlueprintController {
 
     if (overwriteCreateDate || blueprint.createdAt == null) blueprint.createdAt = new Date();
     blueprint.modifiedAt = new Date();
+
+    // Materialize the trending score so a newly created (or resurrected)
+    // blueprint is sortable by trending immediately — new docs enter at the
+    // prior-mean quality baseline + a high recency term (see computeHotScore).
+    blueprint.hotScore = computeHotScore({
+      ratingCount: blueprint.ratingCount ?? 0,
+      ratingAverage: blueprint.ratingAverage ?? 0,
+      downloadCount: blueprint.downloadCount ?? 0,
+      createdAt: blueprint.createdAt,
+    });
 
     let newBlueprint;
     try {

--- a/app/api/models/blueprint.ts
+++ b/app/api/models/blueprint.ts
@@ -63,6 +63,13 @@ export interface Blueprint extends Document {
   // BlueprintCounterService, not per request
   viewCount?: number;
   downloadCount?: number;
+  // Materialized trending score ("new but also good"), computed by
+  // lib computeHotScore and refreshed on every engagement write (ratings,
+  // download flush) + at creation. Static per document (recency term is keyed
+  // on createdAt, not the clock), so the trending sort is a plain indexed
+  // sort. No schema default: docs predating the backfill lack it and sort last
+  // under { hotScore: -1 } until the migration runs.
+  hotScore?: number;
 }
 
 export class BlueprintModel {
@@ -127,6 +134,9 @@ export class BlueprintModel {
       forkCount: { type: Number, default: 0 },
       viewCount: { type: Number, default: 0 },
       downloadCount: { type: Number, default: 0 },
+      // No default: absent = not yet materialized (pre-backfill), so those
+      // docs sort last under { hotScore: -1 } rather than tying at 0.
+      hotScore: { type: Number },
     });
 
     // Listing query: filter by createdAt range, sort by createdAt desc
@@ -156,6 +166,10 @@ export class BlueprintModel {
     // "Most viewed" / "Most downloaded" sorts
     blueprintSchema.index({ deletedAt: 1, isPublished: 1, viewCount: -1, createdAt: -1 });
     blueprintSchema.index({ deletedAt: 1, isPublished: 1, downloadCount: -1, createdAt: -1 });
+    // "Trending" sort — materialized hotScore. Unfiltered feed only for now;
+    // filter-scoped (gameVersion/category/rooms) hotScore indexes are a
+    // metrics-gated TODO (spec/trending-hotscore-plan.md §6).
+    blueprintSchema.index({ deletedAt: 1, isPublished: 1, hotScore: -1, createdAt: -1 });
 
     BlueprintModel.model = mongoose.model<Blueprint>('Blueprint', blueprintSchema);
   }

--- a/app/api/services/blueprint-counter-service.ts
+++ b/app/api/services/blueprint-counter-service.ts
@@ -1,5 +1,6 @@
 import { AnyBulkWriteOperation } from 'mongoose';
 import { BlueprintModel } from '../models/blueprint';
+import { computeHotScore } from '../../../lib/index';
 
 export type CounterKind = 'view' | 'download';
 
@@ -83,13 +84,51 @@ export class BlueprintCounterService {
     const batch = this.pending;
     this.pending = new Map();
 
+    // Downloads feed the trending hot-score, so those blueprints need their
+    // materialized score refreshed. Views don't (not a scoring input), so
+    // view-only ids skip the read entirely. One projected read of just the
+    // download-affected ids — the batch is only what changed this interval.
+    const downloadIds = [...batch].filter(([, c]) => c.downloads > 0).map(([id]) => id);
+    const scoringInputs = new Map<string, { ratingCount: number; ratingAverage: number; downloadCount: number; createdAt: Date }>();
+    if (downloadIds.length > 0) {
+      try {
+        const docs = await BlueprintModel.model
+          .find({ _id: { $in: downloadIds } })
+          .select('ratingCount ratingAverage downloadCount createdAt')
+          .lean();
+        for (const d of docs) {
+          if (d.createdAt == null) continue;
+          scoringInputs.set(String(d._id), {
+            ratingCount: d.ratingCount ?? 0,
+            ratingAverage: d.ratingAverage ?? 0,
+            downloadCount: d.downloadCount ?? 0,
+            createdAt: d.createdAt,
+          });
+        }
+      } catch (err) {
+        console.log('blueprint counter hotScore read error');
+        console.log(err);
+      }
+    }
+
     const operations: AnyBulkWriteOperation[] = [];
     for (const [blueprintId, counts] of batch) {
       const inc: Record<string, number> = {};
       if (counts.views > 0) inc.viewCount = counts.views;
       if (counts.downloads > 0) inc.downloadCount = counts.downloads;
+      const set: Record<string, number> = {};
+      const inputs = scoringInputs.get(blueprintId);
+      if (inputs != null) {
+        // Score the post-increment download total (applied in this same write).
+        set.hotScore = computeHotScore({
+          ...inputs,
+          downloadCount: inputs.downloadCount + counts.downloads,
+        });
+      }
+      const update: Record<string, Record<string, number>> = { $inc: inc };
+      if (set.hotScore != null) update.$set = set;
       operations.push({
-        updateOne: { filter: { _id: blueprintId }, update: { $inc: inc } },
+        updateOne: { filter: { _id: blueprintId }, update },
       });
     }
 

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
@@ -162,8 +162,8 @@ describe("BrowsePageComponent", () => {
         "spacedOut",
         null,
         null,
-        "recent",
-        undefined,
+        "trending",
+        0,
         null,
         null,
         null,
@@ -182,8 +182,8 @@ describe("BrowsePageComponent", () => {
         null,
         "power",
         null,
-        "recent",
-        undefined,
+        "trending",
+        0,
         null,
         null,
         null,
@@ -203,8 +203,8 @@ describe("BrowsePageComponent", () => {
         null,
         "power",
         "generator",
-        "recent",
-        undefined,
+        "trending",
+        0,
         null,
         null,
         null,
@@ -223,8 +223,8 @@ describe("BrowsePageComponent", () => {
         null,
         null,
         null,
-        "recent",
-        undefined,
+        "trending",
+        0,
         true,
         null,
         null,
@@ -243,8 +243,8 @@ describe("BrowsePageComponent", () => {
         null,
         null,
         null,
-        "recent",
-        undefined,
+        "trending",
+        0,
         null,
         "parent-1",
         null,
@@ -263,8 +263,8 @@ describe("BrowsePageComponent", () => {
         null,
         null,
         null,
-        "recent",
-        undefined,
+        "trending",
+        0,
         null,
         null,
         null,
@@ -375,7 +375,7 @@ describe("BrowsePageComponent", () => {
       });
     });
 
-    it("does not pass skip for the default recent sort", () => {
+    it("does not pass skip for the cursor-paginated recent sort", () => {
       component.sort = "recent";
       component.getBlueprints();
 
@@ -421,7 +421,7 @@ describe("BrowsePageComponent", () => {
       expect(component.sort).toBe("mostForked");
     });
 
-    it("accepts the count sorts and falls back to recent on junk", () => {
+    it("accepts the count sorts and falls back to the trending default on junk", () => {
       const route = TestBed.inject(ActivatedRoute) as any;
       route.queryParamMap = of(convertToParamMap({ sort: "mostViewed" }));
       component.ngOnInit();
@@ -433,7 +433,23 @@ describe("BrowsePageComponent", () => {
 
       route.queryParamMap = of(convertToParamMap({ sort: "bogus" }));
       component.ngOnInit();
-      expect(component.sort).toBe("recent");
+      expect(component.sort).toBe("trending");
+    });
+
+    it("defaults to trending and keeps it out of the URL", () => {
+      expect(component.sort).toBe("trending");
+
+      component.sort = "trending";
+      component.getBlueprints();
+      const lastCall = blueprintService.getBlueprints.mock.calls.at(-1);
+      expect(lastCall[6]).toBe("trending");
+
+      // Switching back to the default must clear the sort query param.
+      (component as any).applyFiltersToUrl();
+      expect(router.navigate).toHaveBeenCalledWith([], {
+        queryParams: {},
+        replaceUrl: true,
+      });
     });
   });
 
@@ -539,7 +555,7 @@ describe("BrowsePageComponent", () => {
 
     it("selectSort is a no-op when the sort is already active", () => {
       const callsBefore = blueprintService.getBlueprints.mock.calls.length;
-      component.selectSort("recent");
+      component.selectSort("trending"); // the default/current sort
       expect(blueprintService.getBlueprints.mock.calls.length).toBe(
         callsBefore,
       );

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
@@ -48,6 +48,11 @@ const LIST_FADE_OUT_MS = 160;
  * fast response can't flash them for a single frame. */
 const MIN_PLACEHOLDER_MS = 300;
 
+/** Default Discover sort — "new but also good". Omitted from the URL (a bare
+ * /discover shows trending) and used as the fallback when the sort param is
+ * absent or invalid. */
+const DEFAULT_SORT: BlueprintSort = "trending";
+
 @Component({
   selector: "app-browse-page",
   templateUrl: "./browse-page.component.html",
@@ -73,7 +78,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   filterForkedFrom: string | null = null;
   filterRooms: string | null = null;
   remaining = 0;
-  sort: BlueprintSort = "recent";
+  sort: BlueprintSort = DEFAULT_SORT;
   skipCount = 0;
   private requestId = 0;
 
@@ -92,8 +97,9 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   private placeholdersShownAt = 0;
 
   readonly sortOptions: { label: string; value: BlueprintSort }[] = [
-    { label: $localize`:browse.sortNewest:Newest`, value: "recent" },
+    // Trending is the default (DEFAULT_SORT) — listed first.
     { label: $localize`:browse.sortTrending:Trending`, value: "trending" },
+    { label: $localize`:browse.sortNewest:Newest`, value: "recent" },
     { label: $localize`:browse.sortTopRated:Top rated`, value: "popular" },
     {
       label: $localize`:browse.sortMostForked:Most forked`,
@@ -320,7 +326,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
       (option) => option.value === rawSort,
     )
       ? (rawSort as BlueprintSort)
-      : "recent";
+      : DEFAULT_SORT;
 
     const changed =
       name !== this.filterName ||
@@ -516,7 +522,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     if (this.filterForkedFrom)
       queryParams["forkedFrom"] = this.filterForkedFrom;
     if (this.filterRooms) queryParams["rooms"] = this.filterRooms;
-    if (this.sort !== "recent") queryParams["sort"] = this.sort;
+    if (this.sort !== DEFAULT_SORT) queryParams["sort"] = this.sort;
     this.router.navigate([], { queryParams, replaceUrl: true });
   }
 

--- a/lib/src/blueprint/blueprint-analyzer.d.ts
+++ b/lib/src/blueprint/blueprint-analyzer.d.ts
@@ -2,6 +2,22 @@ import { Category, GameVersion } from './blueprint-metadata';
 type DlcId = string;
 export declare function deriveGameVersion(buildingDlcIds: DlcId[][]): GameVersion;
 export declare function deriveModded(prefabIds: string[], knownIds: Set<string>): boolean;
+export interface HotScoreInputs {
+    ratingCount: number;
+    ratingAverage: number;
+    downloadCount: number;
+    createdAt: Date;
+}
+export declare const HOT_SCORE: {
+    readonly PRIOR_MEAN: 3.5;
+    readonly SHRINK_VOTES: 3;
+    readonly W_RATING: 1;
+    readonly W_DOWNLOAD: 0.5;
+    readonly W_RECENCY: 0.18;
+    readonly MS_PER_DAY: 86400000;
+};
+export declare function bayesianRating(ratingCount: number, ratingAverage: number): number;
+export declare function computeHotScore(i: HotScoreInputs): number;
 export interface CategoryLookup {
     gameCategoryByPrefabId: Map<string, string>;
 }

--- a/lib/src/blueprint/blueprint-analyzer.ts
+++ b/lib/src/blueprint/blueprint-analyzer.ts
@@ -32,6 +32,60 @@ export function deriveModded(prefabIds: string[], knownIds: Set<string>): boolea
   return prefabIds.some(id => !knownIds.has(id));
 }
 
+// --- Trending "hot score" ----------------------------------------------
+//
+// A materialized, indexable trending score: "new but also good". Unlike a
+// time-decay score that references the current clock, time enters here only as
+// the blueprint's own createdAt, so the value is STATIC per document and only
+// needs recomputing when engagement (ratings/downloads) changes — which lets
+// it be stored and sorted on a plain index instead of a full-collection
+// aggregation. Newer blueprints are minted with a higher recency term and
+// naturally sort above older ones as content flows in; nothing has to decay.
+//
+// Design rationale, worked examples, and calibration: spec/trending-hotscore-plan.md.
+
+export interface HotScoreInputs {
+  ratingCount: number; // number of ratings (v)
+  ratingAverage: number; // mean rating 1..5 (R)
+  downloadCount: number; // lifetime downloads (d)
+  createdAt: Date;
+}
+
+// All tunables live here — changing any is a one-line edit; re-run the backfill
+// migration (blueprint-hotscore-backfill) to re-materialize stored scores.
+export const HOT_SCORE = {
+  // Bayesian shrinkage: blend each blueprint's average toward a prior so a
+  // brand-new 1-vote 5★ can't rocket to the top. PRIOR_MEAN is provisional —
+  // ratings are too new to have a meaningful mean yet (see spec §6).
+  PRIOR_MEAN: 3.5, // C — prior/global mean rating
+  SHRINK_VOTES: 3, // m — prior votes blended in
+  // Signal weights.
+  W_RATING: 1.0, // bayesianRating spans ~2.5–5
+  W_DOWNLOAD: 0.5, // log10(downloads+1) spans ~0–3.5
+  // Recency in quality-points per day of newness. 0.18 gives a ~2-week
+  // visibility window for a great blueprint (spec §3).
+  W_RECENCY: 0.18,
+  // Convert createdAt to epoch-days for the (static) recency term.
+  MS_PER_DAY: 86_400_000,
+} as const;
+
+// Noise-resistant quality: an IMDb-style weighted rating that pulls
+// low-vote-count averages toward the prior mean. 0 votes → exactly PRIOR_MEAN.
+export function bayesianRating(ratingCount: number, ratingAverage: number): number {
+  const v = Math.max(0, ratingCount);
+  const m = HOT_SCORE.SHRINK_VOTES;
+  return (v / (v + m)) * ratingAverage + (m / (v + m)) * HOT_SCORE.PRIOR_MEAN;
+}
+
+// Materialized trending score. Higher = more "trending". See HotScoreInputs.
+export function computeHotScore(i: HotScoreInputs): number {
+  const quality =
+    HOT_SCORE.W_RATING * bayesianRating(i.ratingCount, i.ratingAverage) +
+    HOT_SCORE.W_DOWNLOAD * Math.log10(Math.max(0, i.downloadCount) + 1);
+  const recency = HOT_SCORE.W_RECENCY * (i.createdAt.getTime() / HOT_SCORE.MS_PER_DAY);
+  return quality + recency;
+}
+
 // --- Category derivation -----------------------------------------------
 //
 // The game's own buildMenuCategories/buildMenuItems taxonomy is a build-menu

--- a/migrations/20260718000000_blueprint-hotscore-backfill.js
+++ b/migrations/20260718000000_blueprint-hotscore-backfill.js
@@ -27,7 +27,8 @@ const HOT_SCORE_EXPR = {
     vars: {
       v: { $ifNull: ['$ratingCount', 0] },
       r: { $ifNull: ['$ratingAverage', 0] },
-      d: { $ifNull: ['$downloadCount', 0] },
+      // clamp to >= 0 to match computeHotScore's Math.max(0, downloadCount)
+      d: { $max: [{ $ifNull: ['$downloadCount', 0] }, 0] },
     },
     in: {
       $let: {

--- a/migrations/20260718000000_blueprint-hotscore-backfill.js
+++ b/migrations/20260718000000_blueprint-hotscore-backfill.js
@@ -1,0 +1,75 @@
+'use strict';
+
+// Materialize the trending "hot score" on every blueprint + add its index.
+//
+// Trending switched from a per-request full-collection aggregation to a stored,
+// indexed `hotScore` (spec/trending-hotscore-plan.md). The app recomputes
+// hotScore on every engagement write (ratings, download flush) and at creation;
+// this migration seeds the value for all pre-existing documents and creates the
+// index the trending sort uses.
+//
+// up:   createIndex {deletedAt, isPublished, hotScore:-1, createdAt:-1}, then
+//       compute hotScore for every doc with a real createdAt in one server-side
+//       aggregation-pipeline updateMany. Deterministic → safe to re-run; it
+//       overwrites hotScore each run, which is intended (re-materialize).
+// down: drop the index and unset hotScore everywhere.
+//
+// The formula below is a FROZEN snapshot of lib computeHotScore / HOT_SCORE
+// (PRIOR_MEAN 3.5, SHRINK_VOTES 3, W_RATING 1, W_DOWNLOAD 0.5, W_RECENCY 0.18).
+// The running app is the live source of truth; if the constants change, author
+// a new backfill migration rather than editing this one.
+
+const INDEX_NAME = 'deletedAt_1_isPublished_1_hotScore_-1_createdAt_-1';
+
+// Aggregation-expression form of computeHotScore, keyed on the doc's own fields.
+const HOT_SCORE_EXPR = {
+  $let: {
+    vars: {
+      v: { $ifNull: ['$ratingCount', 0] },
+      r: { $ifNull: ['$ratingAverage', 0] },
+      d: { $ifNull: ['$downloadCount', 0] },
+    },
+    in: {
+      $let: {
+        vars: { vpm: { $add: ['$$v', 3] } }, // v + SHRINK_VOTES
+        in: {
+          $add: [
+            // W_RATING * bayesianRating = (v/vpm)*R + (m/vpm)*C
+            {
+              $add: [
+                { $multiply: [{ $divide: ['$$v', '$$vpm'] }, '$$r'] },
+                { $multiply: [{ $divide: [3, '$$vpm'] }, 3.5] },
+              ],
+            },
+            // W_DOWNLOAD * log10(downloadCount + 1)
+            { $multiply: [0.5, { $log10: { $add: ['$$d', 1] } }] },
+            // W_RECENCY * (createdAt_ms / MS_PER_DAY)
+            { $multiply: [0.18, { $divide: [{ $toLong: '$createdAt' }, 86400000] }] },
+          ],
+        },
+      },
+    },
+  },
+};
+
+module.exports = {
+  async up(db) {
+    const col = db.collection('blueprints');
+    await col.createIndex(
+      { deletedAt: 1, isPublished: 1, hotScore: -1, createdAt: -1 },
+      { background: true, name: INDEX_NAME }
+    );
+    // Only docs with a real createdAt — a null date would produce a null score.
+    await col.updateMany({ createdAt: { $type: 'date' } }, [{ $set: { hotScore: HOT_SCORE_EXPR } }]);
+  },
+
+  async down(db) {
+    const col = db.collection('blueprints');
+    try {
+      await col.dropIndex(INDEX_NAME);
+    } catch (err) {
+      if (err.codeName !== 'IndexNotFound') throw err;
+    }
+    await col.updateMany({ hotScore: { $exists: true } }, { $unset: { hotScore: '' } });
+  },
+};


### PR DESCRIPTION
## What & why

Trending was too slow to use as a default: it ran a **per-request full-collection aggregation** (scan every matching doc + a per-doc comment `$lookup`), hidden behind a 5-min in-process id cache. This replaces it with a **stored, indexed `hotScore`** so trending sorts on the same `find().sort()` fast path as every other sort — and makes it the default Discover list sort.

Design + calibration doc: `spec/trending-hotscore-plan.md` (gitignored).

## The algorithm — "new but also good"

Static, indexable score (time enters as the doc's own `createdAt`, not the clock, so it only changes on engagement events):

```
hotScore = 1.0·bayesianRating + 0.5·log10(downloadCount+1) + 0.18·(createdAt_ms/86_400_000)
   bayesianRating = (v/(v+3))·R + (3/(v+3))·3.5      // v=ratingCount, R=ratingAverage
```

- **Ratings** shrunk toward a prior mean so a lone 5★ can't rocket to the top; **downloads** log-scaled. These are the two signals Kevin called out — comments/forks/views dropped from the score (and the score no longer needs the comment `$lookup`).
- **Recency** is the one knob: `W_RECENCY=0.18` ≈ a **2-week visibility window** for a great blueprint. Rotates faster than Top (which never rotates), slower than Newest.
- All constants in one `HOT_SCORE` object in `lib` (`computeHotScore`), TDD-covered.

## What shipped

- **lib**: `computeHotScore` + ordering/shrinkage/2-week-crossover specs.
- **schema**: `hotScore` field + `{deletedAt, isPublished, hotScore:-1, createdAt:-1}` index (unfiltered only — filter-scoped variants deferred, see below).
- **recompute hooks** (all off the request-critical path, single lib source of truth): `saveBlueprint` at create/overwrite, `recomputeRatingAggregate` on rating change, and the download branch of the counter-service flush (view-only flushes skip it).
- **controller**: trending → `sort({ hotScore:-1, createdAt:-1 })`; deleted `getTrendingBlueprints`, the id cache, `fetchInOrder`, and the `clearTrendingCache` test hook. Trending is now edge-cacheable for anonymous viewers like the other sorts.
- **migration** `20260718000000_blueprint-hotscore-backfill`: creates the index + materializes `hotScore` for all existing docs via one server-side pipeline `updateMany`. Idempotent; `down` drops both.
- **frontend**: trending is the default Discover sort via a single `DEFAULT_SORT` constant (initial value, absent/invalid-param fallback, omitted from the URL so a bare `/discover` is clean + cacheable; recent → `?sort=recent`). Listed first in the dropdown.

## Design decisions / deviations
- Dropped comments & forks from the trending score (ratings + downloads only) — removes the expensive `$lookup` and needs no denormalized `commentCount`.
- `PRIOR_MEAN=3.5` is a **provisional guess** (ratings too new for a real mean); `W_RECENCY=0.18` from the 2-week target. Both flagged for re-tuning.

## Deferred (logged in `agent/TODO.md`)
- Filter-scoped `hotScore` indexes — gated on metrics for which filters get paired with trending.
- Re-tune `PRIOR_MEAN` / `W_RECENCY` once real rating/download volume exists.

## Verification
- Backend **612 passing** (added lib ordering specs + write-hook coverage for the rating and download paths).
- Frontend **813 passing** (2 pre-existing skips); `npm run lint` clean.
- `npm run tsc` clean.
- Migration exercised end-to-end against a scratch Mongo: stored scores match `computeHotScore`, null-createdAt docs skipped, index created, idempotent re-run, `down` reverses cleanly.
- Migration expression verified bit-for-bit equal to the lib function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)