### PR TITLE
feat(discover): CSS blueprint grid backdrop

### DIFF
--- a/frontend/src/bni-skin.css
+++ b/frontend/src/bni-skin.css
@@ -217,17 +217,18 @@
   inset: 0;
   z-index: var(--bni-z-backdrop);
   background-color: var(--bni-grid-field);
-  /* major lines painted last so they sit over the minor grid */
+  /* major lines listed first so they paint over the minor grid
+   * (earlier background layers render on top) */
   background-image:
-    linear-gradient(var(--bni-grid-minor-line) 1px, transparent 1px),
-    linear-gradient(90deg, var(--bni-grid-minor-line) 1px, transparent 1px),
     linear-gradient(var(--bni-grid-major-line) 1px, transparent 1px),
-    linear-gradient(90deg, var(--bni-grid-major-line) 1px, transparent 1px);
+    linear-gradient(90deg, var(--bni-grid-major-line) 1px, transparent 1px),
+    linear-gradient(var(--bni-grid-minor-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--bni-grid-minor-line) 1px, transparent 1px);
   background-size:
-    var(--bni-grid-minor) var(--bni-grid-minor),
-    var(--bni-grid-minor) var(--bni-grid-minor),
     var(--bni-grid-major) var(--bni-grid-major),
-    var(--bni-grid-major) var(--bni-grid-major);
+    var(--bni-grid-major) var(--bni-grid-major),
+    var(--bni-grid-minor) var(--bni-grid-minor),
+    var(--bni-grid-minor) var(--bni-grid-minor);
 }
 
 .bni-cave::after {

--- a/frontend/src/bni-skin.css
+++ b/frontend/src/bni-skin.css
@@ -190,11 +190,11 @@
 }
 
 /* ---- key-art backdrop (Effect A) ----
- * Full-viewport illustration behind floating content panels: heavily
- * blurred, desaturated, darkened, then sunk under a vertical gradient so
- * panels float over ambiance rather than an image. Layers (bottom to
- * top): page bg color -> blurred illustration (::before) -> gradient
- * overlay (::after) -> content.
+ * Full-viewport blueprint grid behind floating content panels: a flat
+ * dark-slate field ruled with a fine minor grid and a brighter major
+ * grid every 5th line — the schematic-paper look, echoing the game's
+ * build view rather than a photo. Layers (bottom to top): page bg color
+ * -> grid (::before) -> subtle legibility gradient (::after) -> content.
  *
  * isolation creates a stacking context so the negative-z pseudos paint
  * above this element's own background but below ALL in-flow content —
@@ -203,6 +203,12 @@
  */
 .bni-cave {
   isolation: isolate;
+  /* grid geometry — minor cell; major = 5 minors */
+  --bni-grid-minor: 24px;
+  --bni-grid-major: calc(var(--bni-grid-minor) * 5);
+  --bni-grid-field: #272c35; /* slate-blue paper */
+  --bni-grid-minor-line: rgba(150, 170, 200, 0.05);
+  --bni-grid-major-line: rgba(150, 170, 200, 0.11);
 }
 
 .bni-cave::before {
@@ -210,12 +216,18 @@
   position: fixed;
   inset: 0;
   z-index: var(--bni-z-backdrop);
-  background-image: url("/assets/images/bni-background.webp");
-  background-size: cover;
-  background-position: center;
-  filter: blur(2px) saturate(0.7) brightness(0.55);
-  /* blur samples past the viewport edge; overscan hides the fringe */
-  transform: scale(1.1);
+  background-color: var(--bni-grid-field);
+  /* major lines painted last so they sit over the minor grid */
+  background-image:
+    linear-gradient(var(--bni-grid-minor-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--bni-grid-minor-line) 1px, transparent 1px),
+    linear-gradient(var(--bni-grid-major-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--bni-grid-major-line) 1px, transparent 1px);
+  background-size:
+    var(--bni-grid-minor) var(--bni-grid-minor),
+    var(--bni-grid-minor) var(--bni-grid-minor),
+    var(--bni-grid-major) var(--bni-grid-major),
+    var(--bni-grid-major) var(--bni-grid-major);
 }
 
 .bni-cave::after {
@@ -224,9 +236,10 @@
   inset: 0;
   z-index: var(--bni-z-backdrop);
   pointer-events: none;
+  /* faint vertical sink so panels keep contrast without hiding the grid */
   background: linear-gradient(
-    rgba(31, 35, 42, 0.55) 0%,
-    rgba(31, 35, 42, 0.92) 100%
+    rgba(31, 35, 42, 0) 0%,
+    rgba(31, 35, 42, 0.35) 100%
   );
 }
 


### PR DESCRIPTION
## What

Replaces the blurred `bni-background.webp` key-art behind the discover panels (`.bni-cave`) with a pure-CSS blueprint grid.

- Flat slate-blue field (`#272c35`)
- Fine minor grid (24px cells) + brighter major grid every 5th line (120px), layered so major rules sit over minor
- Lightened the `::after` legibility gradient (`0 → 0.35`, was `0.55 → 0.92`) so it no longer swallows the grid
- Drops an image fetch; geometry/colors exposed as `--bni-grid-*` custom props for tuning

## Why

Cleaner, on-theme schematic look echoing the game's build view, no raster asset.

## Verified

CSS-only diff on the discover backdrop; no logic touched. Visual change — grid renders behind floating panels at `/discover`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)