### PR TITLE
BlueprintsV2 import: materials, share-strings, and byte-exact round-trip

### DIFF
--- a/__tests__/api/blueprint-raw-source.test.ts
+++ b/__tests__/api/blueprint-raw-source.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+import fs from 'fs';
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup } from '../setup/testSetup';
+import { BlueprintModel } from '../../app/api/models/blueprint';
+
+// Byte-exact BlueprintsV2 round-trip (spec/blueprintsv2-import-spec.md §8):
+// the verbatim uploaded .blueprint text is stored with the save and served
+// back unmodified by GET /api/blueprints/:id/raw. Edited saves clear it.
+const FIXTURE_TEXT = fs.readFileSync(
+  path.resolve(__dirname, '../fixtures/bpv2-example-meta.blueprint'),
+  'utf8'
+);
+
+const TINY_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+const SIMPLE_DATA = { blueprintItems: [{ id: 'Tile', position: { x: 0, y: 0 } }] };
+
+describe('Blueprint raw source round-trip API', function () {
+  let authToken: string;
+  let testData: any;
+
+  const upload = (body: Record<string, unknown>) =>
+    TestSetup.request()
+      .post('/api/uploadblueprint')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ thumbnail: TINY_PNG, publish: true, blueprint: SIMPLE_DATA, ...body });
+
+  beforeEach(async function () {
+    this.timeout(15000);
+    testData = await TestSetup.beforeEach();
+    authToken = testData.users.user1.generateJwt();
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    await TestSetup.afterEach();
+  });
+
+  it('stores the verbatim upload and serves it back byte-exact', async function () {
+    const saved = await upload({
+      name: 'BPv2 Import',
+      rawSource: FIXTURE_TEXT,
+      rawSourceFormat: 'bpv2-json',
+    });
+    expect(saved.status).to.equal(200);
+
+    const raw = await TestSetup.request().get(`/api/blueprints/${saved.body.id}/raw`);
+    expect(raw.status).to.equal(200);
+    expect(raw.headers['content-type']).to.contain('application/json');
+    expect(raw.headers['content-disposition']).to.contain('.blueprint');
+    expect(raw.text).to.equal(FIXTURE_TEXT);
+  });
+
+  it('serves share-string uploads as text with a .txt filename', async function () {
+    const saved = await upload({
+      name: 'BPv2 Share String',
+      rawSource: 'SGVsbG8gd29ybGQ=',
+      rawSourceFormat: 'bpv2-sharestring',
+    });
+    expect(saved.status).to.equal(200);
+
+    const raw = await TestSetup.request().get(`/api/blueprints/${saved.body.id}/raw`);
+    expect(raw.status).to.equal(200);
+    expect(raw.headers['content-type']).to.contain('text/plain');
+    expect(raw.headers['content-disposition']).to.contain('.txt');
+    expect(raw.text).to.equal('SGVsbG8gd29ybGQ=');
+  });
+
+  it('404s when the blueprint has no stored raw source', async function () {
+    const saved = await upload({ name: 'No Raw' });
+    expect(saved.status).to.equal(200);
+
+    const raw = await TestSetup.request().get(`/api/blueprints/${saved.body.id}/raw`);
+    expect(raw.status).to.equal(404);
+  });
+
+  it('clears the stored raw when an overwrite save omits it (edited content)', async function () {
+    const first = await upload({
+      name: 'Edited Later',
+      rawSource: FIXTURE_TEXT,
+      rawSourceFormat: 'bpv2-json',
+    });
+    expect(first.status).to.equal(200);
+
+    const second = await upload({ name: 'Edited Later', overwrite: true });
+    expect(second.status).to.equal(200);
+    expect(second.body.id).to.equal(first.body.id);
+
+    const doc = await BlueprintModel.model.findById(first.body.id).select('+rawSource').lean();
+    expect(doc!.rawSource).to.equal(null);
+
+    const raw = await TestSetup.request().get(`/api/blueprints/${first.body.id}/raw`);
+    expect(raw.status).to.equal(404);
+  });
+
+  it('draft raw source is hidden from anonymous viewers', async function () {
+    const saved = await upload({
+      name: 'Draft Raw',
+      publish: false,
+      rawSource: FIXTURE_TEXT,
+      rawSourceFormat: 'bpv2-json',
+    });
+    expect(saved.status).to.equal(200);
+
+    const anonymous = await TestSetup.request().get(`/api/blueprints/${saved.body.id}/raw`);
+    expect(anonymous.status).to.equal(404);
+
+    const owner = await TestSetup.request()
+      .get(`/api/blueprints/${saved.body.id}/raw`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(owner.status).to.equal(200);
+    expect(owner.text).to.equal(FIXTURE_TEXT);
+  });
+
+  it('rejects an unknown rawSourceFormat', async function () {
+    const saved = await upload({
+      name: 'Bad Format',
+      rawSource: FIXTURE_TEXT,
+      rawSourceFormat: 'not-a-format',
+    });
+    expect(saved.status).to.equal(400);
+  });
+
+  it('rejects a rawSource above the size cap', async function () {
+    const saved = await upload({
+      name: 'Too Big',
+      rawSource: 'x'.repeat(2 * 1024 * 1024 + 1),
+      rawSourceFormat: 'bpv2-json',
+    });
+    // 413 when the whole request trips the body-parser limit first, 400 from
+    // the controller's own cap otherwise — either way the save is refused
+    expect([400, 413]).to.include(saved.status);
+  });
+
+  it('getblueprint reports hasRawSource so clients can prefer the raw download', async function () {
+    const saved = await upload({
+      name: 'Flagged',
+      rawSource: FIXTURE_TEXT,
+      rawSourceFormat: 'bpv2-json',
+    });
+    expect(saved.status).to.equal(200);
+
+    const response = await TestSetup.request().get(`/api/getblueprint/${saved.body.id}`);
+    expect(response.status).to.equal(200);
+    expect(response.body.hasRawSource).to.equal(true);
+    expect(response.body.rawSourceFormat).to.equal('bpv2-json');
+  });
+});

--- a/__tests__/fixtures/bpv2-example-meta.blueprint
+++ b/__tests__/fixtures/bpv2-example-meta.blueprint
@@ -1,0 +1,1605 @@
+{
+  "blueprintVersion": 3,
+  "friendlyname": "example meta",
+  "userdesc": "this blueprint has a custom icon and also material overides",
+  "icon": "Snow",
+  "icontint": "FF0000FF",
+  "buildings": [
+    {
+      "offset": {
+        "x": 2,
+        "y": 2
+      },
+      "buildingdef": "RubberTile",
+      "selected_elements": [
+        -351425712
+      ]
+    },
+    {
+      "offset": {
+        "x": 3,
+        "y": 3
+      },
+      "buildingdef": "LiquidBottler",
+      "selected_elements": [
+        -1921520130
+      ],
+      "buildingData": [
+        {
+          "Key": "Prioritizable",
+          "Value": {
+            "masterPrioritySetting": "{\"priority_class\":0,\"priority_value\":9}"
+          }
+        },
+        {
+          "Key": "BuildingEnabledButton",
+          "Value": {
+            "IsEnabled": true
+          }
+        },
+        {
+          "Key": "IUserControlledCapacity",
+          "Value": {
+            "UserMaxCapacity": 200.0
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 2,
+        "y": 5
+      },
+      "buildingdef": "LiquidConduit",
+      "selected_elements": [
+        -1921520130
+      ],
+      "flags": 2
+    },
+    {
+      "offset": {
+        "x": 2,
+        "y": 6
+      },
+      "buildingdef": "StorageTile",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 3,
+        "y": 2
+      },
+      "buildingdef": "RubberTile",
+      "selected_elements": [
+        -351425712
+      ]
+    },
+    {
+      "offset": {
+        "x": 3,
+        "y": 3
+      },
+      "buildingdef": "LiquidConduit",
+      "selected_elements": [
+        -1921520130
+      ],
+      "flags": 4
+    },
+    {
+      "offset": {
+        "x": 3,
+        "y": 4
+      },
+      "buildingdef": "LiquidConduit",
+      "selected_elements": [
+        -1921520130
+      ],
+      "flags": 12
+    },
+    {
+      "offset": {
+        "x": 3,
+        "y": 5
+      },
+      "buildingdef": "LiquidConduit",
+      "selected_elements": [
+        -1921520130
+      ],
+      "flags": 15
+    },
+    {
+      "offset": {
+        "x": 3,
+        "y": 6
+      },
+      "buildingdef": "StorageTile",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 3,
+        "y": 6
+      },
+      "buildingdef": "LiquidConduit",
+      "selected_elements": [
+        -1921520130
+      ],
+      "flags": 14
+    },
+    {
+      "offset": {
+        "x": 3,
+        "y": 7
+      },
+      "buildingdef": "LiquidConduit",
+      "selected_elements": [
+        -1921520130
+      ],
+      "flags": 10
+    },
+    {
+      "offset": {
+        "x": 4,
+        "y": 2
+      },
+      "buildingdef": "RubberTile",
+      "selected_elements": [
+        -351425712
+      ]
+    },
+    {
+      "offset": {
+        "x": 4,
+        "y": 3
+      },
+      "buildingdef": "WireRubber",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 6
+    },
+    {
+      "offset": {
+        "x": 4,
+        "y": 4
+      },
+      "buildingdef": "WireRubber",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 12
+    },
+    {
+      "offset": {
+        "x": 4,
+        "y": 5
+      },
+      "buildingdef": "LiquidConduit",
+      "selected_elements": [
+        -1921520130
+      ],
+      "flags": 7
+    },
+    {
+      "offset": {
+        "x": 4,
+        "y": 5
+      },
+      "buildingdef": "WireRubber",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 10
+    },
+    {
+      "offset": {
+        "x": 4,
+        "y": 6
+      },
+      "buildingdef": "StorageTile",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 4,
+        "y": 6
+      },
+      "buildingdef": "LiquidConduit",
+      "selected_elements": [
+        -1921520130
+      ],
+      "flags": 15
+    },
+    {
+      "offset": {
+        "x": 4,
+        "y": 7
+      },
+      "buildingdef": "LiquidConduit",
+      "selected_elements": [
+        -1921520130
+      ],
+      "flags": 11
+    },
+    {
+      "offset": {
+        "x": 5,
+        "y": 2
+      },
+      "buildingdef": "RubberTile",
+      "selected_elements": [
+        -351425712
+      ]
+    },
+    {
+      "offset": {
+        "x": 6,
+        "y": 3
+      },
+      "buildingdef": "FabricatedWoodMaker",
+      "selected_elements": [
+        -1921520130
+      ],
+      "buildingData": [
+        {
+          "Key": "BuildingEnabledButton",
+          "Value": {
+            "IsEnabled": true
+          }
+        },
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 5,
+        "y": 3
+      },
+      "buildingdef": "WireRubber",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 3
+    },
+    {
+      "offset": {
+        "x": 5,
+        "y": 5
+      },
+      "buildingdef": "LiquidConduit",
+      "selected_elements": [
+        -1921520130
+      ],
+      "flags": 5
+    },
+    {
+      "offset": {
+        "x": 5,
+        "y": 5
+      },
+      "buildingdef": "WireRubber",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 3
+    },
+    {
+      "offset": {
+        "x": 5,
+        "y": 6
+      },
+      "buildingdef": "StorageTile",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 5,
+        "y": 6
+      },
+      "buildingdef": "LiquidConduit",
+      "selected_elements": [
+        -1921520130
+      ],
+      "flags": 13
+    },
+    {
+      "offset": {
+        "x": 5,
+        "y": 7
+      },
+      "buildingdef": "LiquidValve",
+      "selected_elements": [
+        -1921520130
+      ],
+      "orientation": 1,
+      "buildingData": [
+        {
+          "Key": "Valve",
+          "Value": {
+            "DesiredFlow": 4.832
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 5,
+        "y": 7
+      },
+      "buildingdef": "LiquidConduit",
+      "selected_elements": [
+        -1921520130
+      ],
+      "flags": 9
+    },
+    {
+      "offset": {
+        "x": 6,
+        "y": 2
+      },
+      "buildingdef": "RubberTile",
+      "selected_elements": [
+        -351425712
+      ]
+    },
+    {
+      "offset": {
+        "x": 6,
+        "y": 3
+      },
+      "buildingdef": "WireRubber",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 7
+    },
+    {
+      "offset": {
+        "x": 6,
+        "y": 4
+      },
+      "buildingdef": "WireRubber",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 10
+    },
+    {
+      "offset": {
+        "x": 6,
+        "y": 5
+      },
+      "buildingdef": "WireRubber",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 3
+    },
+    {
+      "offset": {
+        "x": 6,
+        "y": 6
+      },
+      "buildingdef": "StorageTile",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 7,
+        "y": 2
+      },
+      "buildingdef": "RubberTile",
+      "selected_elements": [
+        -351425712
+      ]
+    },
+    {
+      "offset": {
+        "x": 7,
+        "y": 3
+      },
+      "buildingdef": "WireRubber",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 7
+    },
+    {
+      "offset": {
+        "x": 7,
+        "y": 4
+      },
+      "buildingdef": "WireRubber",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 11
+    },
+    {
+      "offset": {
+        "x": 7,
+        "y": 5
+      },
+      "buildingdef": "WireRubber",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 1
+    },
+    {
+      "offset": {
+        "x": 8,
+        "y": 5
+      },
+      "buildingdef": "WireRubberBridge",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 1
+    },
+    {
+      "offset": {
+        "x": 7,
+        "y": 6
+      },
+      "buildingdef": "StorageTile",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 7,
+        "y": 7
+      },
+      "buildingdef": "LogicPressureSensorGas",
+      "selected_elements": [
+        -1725038055
+      ],
+      "buildingData": [
+        {
+          "Key": "Switch",
+          "Value": {
+            "switchedOn": true
+          }
+        },
+        {
+          "Key": "IThresholdSwitch",
+          "Value": {
+            "Threshold": 6.63,
+            "ActivateAboveThreshold": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 8,
+        "y": 2
+      },
+      "buildingdef": "RubberTile",
+      "selected_elements": [
+        -351425712
+      ]
+    },
+    {
+      "offset": {
+        "x": 8,
+        "y": 3
+      },
+      "buildingdef": "WireRubber",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 3
+    },
+    {
+      "offset": {
+        "x": 8,
+        "y": 4
+      },
+      "buildingdef": "WireRubber",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 3
+    },
+    {
+      "offset": {
+        "x": 8,
+        "y": 6
+      },
+      "buildingdef": "StorageTile",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 8,
+        "y": 7
+      },
+      "buildingdef": "LogicSwitch",
+      "selected_elements": [
+        -1725038055
+      ],
+      "buildingData": [
+        {
+          "Key": "Switch",
+          "Value": {
+            "switchedOn": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 9,
+        "y": 2
+      },
+      "buildingdef": "RubberTile",
+      "selected_elements": [
+        -351425712
+      ]
+    },
+    {
+      "offset": {
+        "x": 9,
+        "y": 3
+      },
+      "buildingdef": "PressureDoor",
+      "selected_elements": [
+        -1921520130
+      ],
+      "buildingData": [
+        {
+          "Key": "AccessControl",
+          "Value": {
+            "defaultPermissionByTag": "[]",
+            "savedPermissionsById": "[{\"Key\":6190,\"Value\":1},{\"Key\":6305,\"Value\":2},{\"Key\":6312,\"Value\":3},{\"Key\":6317,\"Value\":0}]"
+          }
+        },
+        {
+          "Key": "Door",
+          "Value": {
+            "requestedState": 0
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 9,
+        "y": 3
+      },
+      "buildingdef": "WireRubber",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 5
+    },
+    {
+      "offset": {
+        "x": 9,
+        "y": 4
+      },
+      "buildingdef": "WireRubber",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 13
+    },
+    {
+      "offset": {
+        "x": 9,
+        "y": 5
+      },
+      "buildingdef": "WireRubber",
+      "selected_elements": [
+        -1725038055,
+        -1142341158
+      ],
+      "flags": 8
+    },
+    {
+      "offset": {
+        "x": 9,
+        "y": 6
+      },
+      "buildingdef": "StorageTile",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 10,
+        "y": 2
+      },
+      "buildingdef": "RubberTile",
+      "selected_elements": [
+        -351425712
+      ]
+    },
+    {
+      "offset": {
+        "x": 11,
+        "y": 3
+      },
+      "buildingdef": "Chlorinator",
+      "selected_elements": [
+        -1725038055
+      ],
+      "buildingData": [
+        {
+          "Key": "BuildingEnabledButton",
+          "Value": {
+            "IsEnabled": true
+          }
+        },
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 10,
+        "y": 6
+      },
+      "buildingdef": "StorageTile",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 11,
+        "y": 2
+      },
+      "buildingdef": "RubberTile",
+      "selected_elements": [
+        -351425712
+      ]
+    },
+    {
+      "offset": {
+        "x": 11,
+        "y": 6
+      },
+      "buildingdef": "StorageTile",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 12,
+        "y": 2
+      },
+      "buildingdef": "RubberTile",
+      "selected_elements": [
+        -351425712
+      ]
+    },
+    {
+      "offset": {
+        "x": 12,
+        "y": 6
+      },
+      "buildingdef": "StorageTile",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 13,
+        "y": 2
+      },
+      "buildingdef": "RubberTile",
+      "selected_elements": [
+        -351425712
+      ]
+    },
+    {
+      "offset": {
+        "x": 14,
+        "y": 3
+      },
+      "buildingdef": "ChemicalRefinery",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "BuildingEnabledButton",
+          "Value": {
+            "IsEnabled": true
+          }
+        },
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 13,
+        "y": 6
+      },
+      "buildingdef": "StorageTile",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 14,
+        "y": 2
+      },
+      "buildingdef": "RubberTile",
+      "selected_elements": [
+        -351425712
+      ]
+    },
+    {
+      "offset": {
+        "x": 14,
+        "y": 6
+      },
+      "buildingdef": "StorageTile",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 15,
+        "y": 2
+      },
+      "buildingdef": "RubberTile",
+      "selected_elements": [
+        -351425712
+      ]
+    },
+    {
+      "offset": {
+        "x": 15,
+        "y": 6
+      },
+      "buildingdef": "StorageTile",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 16,
+        "y": 2
+      },
+      "buildingdef": "RubberTile",
+      "selected_elements": [
+        -351425712
+      ]
+    },
+    {
+      "offset": {
+        "x": 16,
+        "y": 6
+      },
+      "buildingdef": "StorageTile",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 17,
+        "y": 2
+      },
+      "buildingdef": "RubberTile",
+      "selected_elements": [
+        -351425712
+      ]
+    },
+    {
+      "offset": {
+        "x": 17,
+        "y": 3
+      },
+      "buildingdef": "StorageLocker",
+      "selected_elements": [
+        -1921520130
+      ],
+      "buildingData": [
+        {
+          "Key": "BuildingEnabledButton",
+          "Value": {
+            "IsEnabled": true
+          }
+        },
+        {
+          "Key": "TreeFilterable",
+          "Value": {
+            "acceptedTagSet": "[{\"Name\":\"BasicSingleHarvestPlantSeed\",\"IsValid\":true},{\"Name\":\"DreckoEgg\",\"IsValid\":true},{\"Name\":\"HatchEgg\",\"IsValid\":true},{\"Name\":\"PacuEgg\",\"IsValid\":true},{\"Name\":\"LightBugEgg\",\"IsValid\":true}]",
+            "onlyFetchMarkedItems": false
+          }
+        },
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        },
+        {
+          "Key": "IUserControlledCapacity",
+          "Value": {
+            "UserMaxCapacity": 20000.0
+          }
+        },
+        {
+          "Key": "UserNameable",
+          "Value": {
+            "savedName": "<link=\"STORAGELOCKER\">Storage Bin</link>"
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 17,
+        "y": 6
+      },
+      "buildingdef": "StorageTile",
+      "selected_elements": [
+        -1725038055,
+        623986332
+      ],
+      "buildingData": [
+        {
+          "Key": "Automatable",
+          "Value": {
+            "automationOnly": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 19,
+        "y": 3
+      },
+      "buildingdef": "PAirlockDoor",
+      "selected_elements": [
+        -1725038055
+      ],
+      "buildingData": [
+        {
+          "Key": "AccessControl",
+          "Value": {
+            "defaultPermissionByTag": "[]",
+            "savedPermissionsById": "[]"
+          }
+        }
+      ]
+    }
+  ],
+  "digcommands": [
+    {
+      "x": 0,
+      "y": 0
+    },
+    {
+      "x": 0,
+      "y": 1
+    },
+    {
+      "x": 0,
+      "y": 2
+    },
+    {
+      "x": 0,
+      "y": 3
+    },
+    {
+      "x": 0,
+      "y": 4
+    },
+    {
+      "x": 0,
+      "y": 5
+    },
+    {
+      "x": 0,
+      "y": 6
+    },
+    {
+      "x": 0,
+      "y": 7
+    },
+    {
+      "x": 0,
+      "y": 8
+    },
+    {
+      "x": 0,
+      "y": 9
+    },
+    {
+      "x": 1,
+      "y": 0
+    },
+    {
+      "x": 1,
+      "y": 1
+    },
+    {
+      "x": 1,
+      "y": 2
+    },
+    {
+      "x": 1,
+      "y": 3
+    },
+    {
+      "x": 1,
+      "y": 4
+    },
+    {
+      "x": 1,
+      "y": 5
+    },
+    {
+      "x": 1,
+      "y": 6
+    },
+    {
+      "x": 1,
+      "y": 7
+    },
+    {
+      "x": 1,
+      "y": 8
+    },
+    {
+      "x": 1,
+      "y": 9
+    },
+    {
+      "x": 2,
+      "y": 0
+    },
+    {
+      "x": 2,
+      "y": 1
+    },
+    {
+      "x": 2,
+      "y": 7
+    },
+    {
+      "x": 2,
+      "y": 8
+    },
+    {
+      "x": 2,
+      "y": 9
+    },
+    {
+      "x": 3,
+      "y": 0
+    },
+    {
+      "x": 3,
+      "y": 1
+    },
+    {
+      "x": 3,
+      "y": 8
+    },
+    {
+      "x": 3,
+      "y": 9
+    },
+    {
+      "x": 4,
+      "y": 0
+    },
+    {
+      "x": 4,
+      "y": 1
+    },
+    {
+      "x": 4,
+      "y": 8
+    },
+    {
+      "x": 4,
+      "y": 9
+    },
+    {
+      "x": 5,
+      "y": 0
+    },
+    {
+      "x": 5,
+      "y": 1
+    },
+    {
+      "x": 5,
+      "y": 8
+    },
+    {
+      "x": 5,
+      "y": 9
+    },
+    {
+      "x": 6,
+      "y": 0
+    },
+    {
+      "x": 6,
+      "y": 1
+    },
+    {
+      "x": 6,
+      "y": 8
+    },
+    {
+      "x": 6,
+      "y": 9
+    },
+    {
+      "x": 7,
+      "y": 0
+    },
+    {
+      "x": 7,
+      "y": 1
+    },
+    {
+      "x": 7,
+      "y": 8
+    },
+    {
+      "x": 7,
+      "y": 9
+    },
+    {
+      "x": 8,
+      "y": 0
+    },
+    {
+      "x": 8,
+      "y": 1
+    },
+    {
+      "x": 8,
+      "y": 8
+    },
+    {
+      "x": 8,
+      "y": 9
+    },
+    {
+      "x": 9,
+      "y": 0
+    },
+    {
+      "x": 9,
+      "y": 1
+    },
+    {
+      "x": 9,
+      "y": 7
+    },
+    {
+      "x": 9,
+      "y": 8
+    },
+    {
+      "x": 9,
+      "y": 9
+    },
+    {
+      "x": 10,
+      "y": 0
+    },
+    {
+      "x": 10,
+      "y": 1
+    },
+    {
+      "x": 10,
+      "y": 7
+    },
+    {
+      "x": 10,
+      "y": 8
+    },
+    {
+      "x": 10,
+      "y": 9
+    },
+    {
+      "x": 11,
+      "y": 0
+    },
+    {
+      "x": 11,
+      "y": 1
+    },
+    {
+      "x": 11,
+      "y": 7
+    },
+    {
+      "x": 11,
+      "y": 8
+    },
+    {
+      "x": 11,
+      "y": 9
+    },
+    {
+      "x": 12,
+      "y": 0
+    },
+    {
+      "x": 12,
+      "y": 1
+    },
+    {
+      "x": 12,
+      "y": 7
+    },
+    {
+      "x": 12,
+      "y": 8
+    },
+    {
+      "x": 12,
+      "y": 9
+    },
+    {
+      "x": 13,
+      "y": 0
+    },
+    {
+      "x": 13,
+      "y": 1
+    },
+    {
+      "x": 13,
+      "y": 7
+    },
+    {
+      "x": 13,
+      "y": 8
+    },
+    {
+      "x": 13,
+      "y": 9
+    },
+    {
+      "x": 14,
+      "y": 0
+    },
+    {
+      "x": 14,
+      "y": 1
+    },
+    {
+      "x": 14,
+      "y": 7
+    },
+    {
+      "x": 14,
+      "y": 8
+    },
+    {
+      "x": 14,
+      "y": 9
+    },
+    {
+      "x": 15,
+      "y": 0
+    },
+    {
+      "x": 15,
+      "y": 1
+    },
+    {
+      "x": 15,
+      "y": 7
+    },
+    {
+      "x": 15,
+      "y": 8
+    },
+    {
+      "x": 15,
+      "y": 9
+    },
+    {
+      "x": 16,
+      "y": 0
+    },
+    {
+      "x": 16,
+      "y": 1
+    },
+    {
+      "x": 16,
+      "y": 7
+    },
+    {
+      "x": 16,
+      "y": 8
+    },
+    {
+      "x": 16,
+      "y": 9
+    },
+    {
+      "x": 17,
+      "y": 0
+    },
+    {
+      "x": 17,
+      "y": 1
+    },
+    {
+      "x": 17,
+      "y": 5
+    },
+    {
+      "x": 17,
+      "y": 7
+    },
+    {
+      "x": 17,
+      "y": 8
+    },
+    {
+      "x": 17,
+      "y": 9
+    },
+    {
+      "x": 18,
+      "y": 0
+    },
+    {
+      "x": 18,
+      "y": 1
+    },
+    {
+      "x": 18,
+      "y": 2
+    },
+    {
+      "x": 18,
+      "y": 5
+    },
+    {
+      "x": 18,
+      "y": 6
+    },
+    {
+      "x": 18,
+      "y": 7
+    },
+    {
+      "x": 18,
+      "y": 8
+    },
+    {
+      "x": 18,
+      "y": 9
+    },
+    {
+      "x": 19,
+      "y": 0
+    },
+    {
+      "x": 19,
+      "y": 1
+    },
+    {
+      "x": 19,
+      "y": 2
+    },
+    {
+      "x": 19,
+      "y": 5
+    },
+    {
+      "x": 19,
+      "y": 6
+    },
+    {
+      "x": 19,
+      "y": 7
+    },
+    {
+      "x": 19,
+      "y": 8
+    },
+    {
+      "x": 19,
+      "y": 9
+    },
+    {
+      "x": 20,
+      "y": 0
+    },
+    {
+      "x": 20,
+      "y": 1
+    },
+    {
+      "x": 20,
+      "y": 2
+    },
+    {
+      "x": 20,
+      "y": 5
+    },
+    {
+      "x": 20,
+      "y": 6
+    },
+    {
+      "x": 20,
+      "y": 7
+    },
+    {
+      "x": 20,
+      "y": 8
+    },
+    {
+      "x": 20,
+      "y": 9
+    },
+    {
+      "x": 21,
+      "y": 0
+    },
+    {
+      "x": 21,
+      "y": 1
+    },
+    {
+      "x": 21,
+      "y": 2
+    },
+    {
+      "x": 21,
+      "y": 3
+    },
+    {
+      "x": 21,
+      "y": 4
+    },
+    {
+      "x": 21,
+      "y": 5
+    },
+    {
+      "x": 21,
+      "y": 6
+    },
+    {
+      "x": 21,
+      "y": 7
+    },
+    {
+      "x": 21,
+      "y": 8
+    },
+    {
+      "x": 21,
+      "y": 9
+    }
+  ],
+  "worldNotes": [
+    {
+      "x": 4,
+      "y": 2,
+      "type": 1,
+      "id": -1736594426,
+      "mass": 791.79,
+      "temp": 296.15
+    },
+    {
+      "x": 15,
+      "y": 3,
+      "type": 0,
+      "title": "important title!",
+      "text": "important title!",
+      "tinthex": "0000FFFF"
+    },
+    {
+      "x": 16,
+      "y": 4,
+      "type": 0,
+      "title": "Unnamed Note",
+      "text": "Unnamed Note",
+      "tinthex": "FFFFFFFF"
+    }
+  ]
+}

--- a/__tests__/lib/bpv2-import.test.ts
+++ b/__tests__/lib/bpv2-import.test.ts
@@ -1,0 +1,136 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import path from 'path';
+import zlib from 'zlib';
+import {
+  Blueprint,
+  BniBlueprint,
+  BuildableElement,
+  decodeBniShareString,
+  encodeBniShareString,
+  looksLikeBniShareString,
+} from '../../lib';
+import { loadGameDatabase } from '../helpers/roomFixtures';
+
+// BlueprintsV2 v3 import coverage (spec/blueprintsv2-import-spec.md), driven
+// by a real mod export: 70 buildings, material overrides, custom icon, both
+// note kinds, and one modded building (PAirlockDoor) we don't know.
+const FIXTURE_PATH = path.join(__dirname, '../fixtures/bpv2-example-meta.blueprint');
+
+describe('BlueprintsV2 import', function () {
+  let fixtureText: string;
+  let fixture: BniBlueprint;
+
+  before(function () {
+    loadGameDatabase();
+    fixtureText = fs.readFileSync(FIXTURE_PATH, 'utf8');
+    fixture = JSON.parse(fixtureText);
+  });
+
+  describe('importFromBni on the real sample export', function () {
+    let blueprint: Blueprint;
+
+    before(function () {
+      blueprint = new Blueprint();
+      blueprint.importFromBni(fixture);
+    });
+
+    it('imports every known building and skips only the modded one', () => {
+      // 71 buildings in the file, exactly 1 (the modded PAirlockDoor) unknown
+      expect(fixture.buildings).to.have.length(71);
+      expect(blueprint.blueprintItems).to.have.length(70);
+    });
+
+    it('collects the unknown building defs (Q8) instead of dropping silently', () => {
+      expect(blueprint.hadUnknownBuildings).to.equal(true);
+      expect(blueprint.unknownBuildingDefs).to.deep.equal(['PAirlockDoor']);
+    });
+
+    it('resolves material tag hashes to elements (P1/Q1)', () => {
+      const rubberTile = blueprint.blueprintItems.find(item => item.id == 'RubberTile');
+      expect(rubberTile).to.not.equal(undefined);
+      // -351425712 is Rubber in the game export
+      const rubber = BuildableElement.getElementByTag(-351425712);
+      expect(rubber).to.not.equal(undefined);
+      expect(rubberTile!.buildableElements[0].id).to.equal(rubber!.id);
+    });
+
+    it('resolves multi-ingredient materials in recipe order (WireRubber: Copper, Plastic)', () => {
+      const wire = blueprint.blueprintItems.find(item => item.id == 'WireRubber');
+      expect(wire).to.not.equal(undefined);
+      const copper = BuildableElement.getElementByTag(-1725038055);
+      const plastic = BuildableElement.getElementByTag(-1142341158);
+      expect(wire!.buildableElements[0].id).to.equal(copper!.id);
+      expect(wire!.buildableElements[1].id).to.equal(plastic!.id);
+    });
+
+    it('falls back to the default material for unknown hashes', () => {
+      const bni: BniBlueprint = JSON.parse(fixtureText);
+      const tileEntry = bni.buildings.find(b => b.buildingdef == 'RubberTile')!;
+      tileEntry.selected_elements = [123456789];
+
+      const reimported = new Blueprint();
+      expect(() => reimported.importFromBni(bni)).to.not.throw();
+      const tile = reimported.blueprintItems.find(item => item.id == 'RubberTile');
+      // Unknown hash -> default element, not a crash or an empty slot
+      expect(tile!.buildableElements[0]).to.not.equal(undefined);
+      expect(tile!.buildableElements[0].id).to.equal(tile!.oniItem.defaultElement[0].id);
+    });
+
+    it('keeps the v3 metadata available on the parsed blueprint (P0)', () => {
+      expect(blueprint.bniMetadata).to.not.equal(null);
+      expect(blueprint.bniMetadata!.blueprintVersion).to.equal(3);
+      expect(blueprint.bniMetadata!.userdesc).to.equal(
+        'this blueprint has a custom icon and also material overides'
+      );
+      expect(blueprint.bniMetadata!.icon).to.equal('Snow');
+      expect(blueprint.bniMetadata!.icontint).to.equal('FF0000FF');
+      expect(blueprint.bniMetadata!.worldNotes).to.have.length(3);
+    });
+
+    it('element world-note ids resolve through the same tag lookup (Q2)', () => {
+      const elementNote = blueprint.bniMetadata!.worldNotes!.find(note => note.type == 1)!;
+      const element = BuildableElement.getElementByTag(elementNote.id!);
+      expect(element).to.not.equal(undefined);
+      // Sample note is Copper Ore (Cuprite)
+      expect(element!.id).to.equal('Cuprite');
+    });
+  });
+
+  describe('share-string transport (P2, §1.2)', function () {
+    // Build a share-string exactly the way the mod does: 4-byte little-endian
+    // uncompressed length + gzip, base64'd. Proves our decoder against the
+    // wire format, independent of our own encoder.
+    function modEncode(json: string): string {
+      const utf8 = Buffer.from(json, 'utf8');
+      const header = Buffer.alloc(4);
+      header.writeInt32LE(utf8.length, 0);
+      return Buffer.concat([header, zlib.gzipSync(utf8)]).toString('base64');
+    }
+
+    it('decodes a mod-style share-string of the sample export', async () => {
+      const decoded = await decodeBniShareString(modEncode(fixtureText));
+      expect(decoded).to.equal(fixtureText);
+    });
+
+    it('round-trips through our own encoder', async () => {
+      const encoded = await encodeBniShareString(fixtureText);
+      expect(await decodeBniShareString(encoded)).to.equal(fixtureText);
+    });
+
+    it('rejects text that is not a share-string', async () => {
+      let threw = false;
+      try {
+        await decodeBniShareString('definitely not base64 gzip !!!');
+      } catch {
+        threw = true;
+      }
+      expect(threw).to.equal(true);
+    });
+
+    it('looksLikeBniShareString distinguishes share-strings from JSON', () => {
+      expect(looksLikeBniShareString(modEncode(fixtureText))).to.equal(true);
+      expect(looksLikeBniShareString(fixtureText)).to.equal(false);
+    });
+  });
+});

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -18,6 +18,8 @@ import {
   SUBCATEGORIES,
   RESEARCH_TIERS,
   ROOM_TYPE_IDS,
+  RAW_SOURCE_FORMATS,
+  RawSourceFormat,
 } from '../../lib/index';
 import { Blueprint as sharedBlueprint, BlueprintDetailsResponse } from '../../lib/index';
 import { computeHotScore } from '../../lib/index';
@@ -48,6 +50,11 @@ type BlueprintSort = (typeof SORTS)[number];
 
 // How many "you might also like" cards the details page shows
 const RELATED_LIMIT = 6;
+
+// Upper bound for the verbatim BlueprintsV2 upload we store for byte-exact
+// re-download. Real .blueprint files are tens of KB; the cap only guards the
+// 16MB Mongo document limit (data + thumbnail + rawSource share it).
+const MAX_RAW_SOURCE_BYTES = 2 * 1024 * 1024;
 
 // Public-visibility clause for feed queries. $in's null matches docs that
 // predate the isPublished backfill (deploy→migrate window), same coverage as
@@ -157,6 +164,25 @@ export class BlueprintController {
 
       const metadata = { gameVersion, category, subcategory, description, researchTier, modded };
 
+      // Verbatim BlueprintsV2 source for byte-exact re-download (§8). The
+      // client only sends it when the saved data still equals the imported
+      // content; absence clears any previously stored raw so a stale original
+      // can never be served for edited data.
+      let rawSource: { source: string; format: RawSourceFormat } | null = null;
+      if (req.body.rawSource != null) {
+        const source = req.body.rawSource;
+        const format = req.body.rawSourceFormat;
+        if (typeof source !== 'string' || Buffer.byteLength(source, 'utf8') > MAX_RAW_SOURCE_BYTES) {
+          res.status(400).json(apiError(400, 'rawSource must be a string of at most 2MB'));
+          return;
+        }
+        if (!(RAW_SOURCE_FORMATS as readonly string[]).includes(format)) {
+          res.status(400).json(apiError(400, `rawSourceFormat must be one of ${RAW_SOURCE_FORMATS.join(', ')}`));
+          return;
+        }
+        rawSource = { source, format };
+      }
+
       // Copy-as-fork: when the editor saves a blueprint it loaded from
       // someone else's document, the client passes the source id so the new
       // copy is attributed as a fork. Malformed ids are treated as absent —
@@ -183,7 +209,9 @@ export class BlueprintController {
                 thumbnail,
                 false,
                 metadata,
-                publish
+                publish,
+                null,
+                rawSource
               );
             else res.json({ overwrite: true });
           } else {
@@ -204,7 +232,8 @@ export class BlueprintController {
               true,
               metadata,
               publish,
-              forkSource
+              forkSource,
+              rawSource
             );
           }
         })
@@ -462,6 +491,8 @@ export class BlueprintController {
         modded: blueprint.modded ?? null,
         rooms: blueprint.rooms ?? null,
         isPublished: blueprint.isPublished !== false,
+        hasRawSource: blueprint.rawSource != null,
+        rawSourceFormat: blueprint.rawSourceFormat ?? null,
       };
 
       // Editor open counts as a view; the dedupe window makes the common
@@ -509,6 +540,58 @@ export class BlueprintController {
       console.log('Blueprint find error');
       console.log(err);
       res.status(500).json(apiError(500, 'Failed to retrieve blueprint'));
+    }
+  }
+
+  // GET /api/blueprints/:id/raw — the verbatim BlueprintsV2 upload, served
+  // byte-exact (spec/blueprintsv2-import-spec.md §8). 404 when the blueprint
+  // has no stored raw (never imported, or edited since import). Never
+  // regenerated from the parsed model.
+  public async getBlueprintRawSource(req: Request, res: Response): Promise<void> {
+    if (BlueprintModel.model == null) {
+      res.status(503).send();
+      return;
+    }
+
+    const id = String(req.params.id);
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      res.status(400).send();
+      return;
+    }
+
+    try {
+      const blueprint = await BlueprintModel.model
+        .findOne({ _id: id, deletedAt: null })
+        .select('name owner isPublished rawSource rawSourceFormat')
+        .lean();
+      if (
+        !blueprint ||
+        !canViewBlueprint(blueprint, optionalViewer(req)) ||
+        blueprint.rawSource == null
+      ) {
+        res.status(404).json(apiError(404, 'No raw blueprint source available'));
+        return;
+      }
+
+      // Fetching the original file is a download
+      BlueprintController.recordCounter('download', req, blueprint);
+
+      // Blueprint names are schema-restricted to [a-zA-Z0-9-_ ], safe to
+      // embed in the disposition header as-is.
+      const isShareString = blueprint.rawSourceFormat === 'bpv2-sharestring';
+      res.set(
+        'Content-Type',
+        isShareString ? 'text/plain; charset=utf-8' : 'application/json; charset=utf-8'
+      );
+      res.set(
+        'Content-Disposition',
+        `attachment; filename="${blueprint.name}${isShareString ? '.txt' : '.blueprint'}"`
+      );
+      res.send(blueprint.rawSource);
+    } catch (err) {
+      console.log('Blueprint raw source error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to retrieve blueprint source'));
     }
   }
 
@@ -770,7 +853,7 @@ export class BlueprintController {
         .sort(sortSpec)
         .skip(skipAmount)
         .limit(limit)
-        .select('-data -thumbnail')
+        .select('-data -thumbnail -rawSource')
         .populate('owner')
         .then(blueprints => {
           return BlueprintController.handleGetBlueprint(req, res, blueprints);
@@ -962,7 +1045,7 @@ export class BlueprintController {
               })
               .sort({ ratingAverage: -1, ratingCount: -1, createdAt: -1 })
               .limit(RELATED_LIMIT * 4)
-              .select('-data -thumbnail')
+              .select('-data -thumbnail -rawSource')
               .populate('owner')
           : Promise.resolve([]),
         BlueprintModel.model
@@ -974,7 +1057,7 @@ export class BlueprintController {
           })
           .sort({ createdAt: -1 })
           .limit(RELATED_LIMIT * 4)
-          .select('-data -thumbnail')
+          .select('-data -thumbnail -rawSource')
           .populate('owner'),
       ]);
 
@@ -988,7 +1071,7 @@ export class BlueprintController {
           .find({ deletedAt: null, isPublished: PUBLISHED_FILTER, _id: { $ne: blueprintId } })
           .sort({ createdAt: -1 })
           .limit(RELATED_LIMIT * 4)
-          .select('-data -thumbnail')
+          .select('-data -thumbnail -rawSource')
           .populate('owner');
         for (const candidate of fallback) candidates.set((candidate._id as mongoose.Types.ObjectId).toString(), candidate);
       }
@@ -1298,7 +1381,8 @@ export class BlueprintController {
       modded: boolean | null;
     },
     publish?: boolean | null,
-    forkSource?: { source: Blueprint; versionId: mongoose.Types.ObjectId } | null
+    forkSource?: { source: Blueprint; versionId: mongoose.Types.ObjectId } | null,
+    rawSource?: { source: string; format: RawSourceFormat } | null
   ): Promise<void> {
     // New blueprints start as drafts (set explicitly — see the schema comment
     // on isPublished for why there is no schema default). Resurrect-via-
@@ -1328,6 +1412,10 @@ export class BlueprintController {
     // Derived fact, never client-supplied — any `rooms` key in the request
     // body is ignored (same policy as a client trying to set ratingCount).
     blueprint.rooms = deriveRooms(data);
+    // Set on every save: absence clears a previously stored raw so it can
+    // never go stale relative to `data` (see the model field comment).
+    blueprint.rawSource = rawSource?.source ?? null;
+    blueprint.rawSourceFormat = rawSource?.format ?? null;
 
     if (metadata) {
       blueprint.gameVersion = metadata.gameVersion;

--- a/app/api/blueprint-version-controller.ts
+++ b/app/api/blueprint-version-controller.ts
@@ -311,6 +311,10 @@ export class BlueprintVersionController {
       blueprint.modifiedAt = new Date();
       // The live content changed, so the derived room tags change with it.
       blueprint.rooms = deriveRooms(version.data);
+      // A stored verbatim upload no longer matches the restored data — drop
+      // it rather than serve an original that disagrees with the render.
+      blueprint.rawSource = null;
+      blueprint.rawSourceFormat = null;
       await blueprint.save();
 
       // Render-on-write: warm the preview cache with the restored data (Phase 2).

--- a/app/api/blueprint-version-controller.ts
+++ b/app/api/blueprint-version-controller.ts
@@ -261,6 +261,10 @@ export class BlueprintVersionController {
           .sort({ createdAt: -1 });
         // liveCount > 1 guarantees a next version exists
         blueprint.currentVersionId = next!._id as mongoose.Types.ObjectId;
+        // The live content changed — a stored verbatim upload no longer
+        // matches it (same rule as restoreVersion)
+        blueprint.rawSource = null;
+        blueprint.rawSourceFormat = null;
         await blueprint.save();
       }
 

--- a/app/api/models/blueprint.ts
+++ b/app/api/models/blueprint.ts
@@ -1,5 +1,12 @@
 import mongoose, { Schema, Document, Model } from 'mongoose';
-import { GAME_VERSIONS, CATEGORIES, RESEARCH_TIERS, ROOM_TYPE_IDS } from '../../../lib/index';
+import {
+  GAME_VERSIONS,
+  CATEGORIES,
+  RESEARCH_TIERS,
+  ROOM_TYPE_IDS,
+  RAW_SOURCE_FORMATS,
+  RawSourceFormat,
+} from '../../../lib/index';
 
 // Discriminator for the stored thumbnail: 'real' = data-URI image, the other
 // two are placeholder sentinels stored verbatim in `thumbnail`. Exists so list
@@ -63,6 +70,14 @@ export interface Blueprint extends Document {
   // BlueprintCounterService, not per request
   viewCount?: number;
   downloadCount?: number;
+  // Verbatim BlueprintsV2 upload (the .blueprint JSON text or share-string)
+  // — the byte-exact source of truth for re-download (spec/blueprintsv2-
+  // import-spec.md §8). Present only while the stored `data` still matches
+  // the imported content: any edit-save or version restore clears it, so a
+  // served raw file can never disagree with the rendered blueprint. Must be
+  // excluded from every list query (like `data`).
+  rawSource?: string | null;
+  rawSourceFormat?: RawSourceFormat | null;
   // Materialized trending score ("new but also good"), computed by
   // lib computeHotScore and refreshed on every engagement write (ratings,
   // download flush) + at creation. Static per document (recency term is keyed
@@ -134,6 +149,8 @@ export class BlueprintModel {
       forkCount: { type: Number, default: 0 },
       viewCount: { type: Number, default: 0 },
       downloadCount: { type: Number, default: 0 },
+      rawSource: { type: String, default: null },
+      rawSourceFormat: { type: String, enum: [...RAW_SOURCE_FORMATS, null], default: null },
       // No default: absent = not yet materialized (pre-backfill), so those
       // docs sort last under { hotScore: -1 } rather than tying at 0.
       hotScore: { type: Number },

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -89,6 +89,8 @@ export class Routes {
     // Fallback image for cards when the preview render errors — the stored
     // save-time thumbnail decoded from its data URI
     app.route('/api/blueprints/:id/thumbnail').get(this.uploadBlueprintController.getBlueprintThumbnail);
+    // Verbatim BlueprintsV2 upload (byte-exact round-trip); 404 when absent
+    app.route('/api/blueprints/:id/raw').get(this.uploadBlueprintController.getBlueprintRawSource);
     app.route('/api/blueprints/:id/comments').get(this.commentController.list);
     app.route('/api/blueprints/:id/versions').get(this.blueprintVersionController.listVersions);
     // Download beacon: anonymous (the editor's file export works logged out);

--- a/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.html
+++ b/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.html
@@ -65,3 +65,7 @@
   (saveImages)="saveImages($event)"
 ></app-dialog-export-images>
 <app-feedback-dialog *ngIf="!forceSize" #feedbackDialog></app-feedback-dialog>
+<app-dialog-import-string
+  *ngIf="!forceSize"
+  #importStringDialog
+></app-dialog-import-string>

--- a/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.ts
@@ -166,6 +166,7 @@ export class ComponentBlueprintParentComponent
     BuildableElement.init();
 
     this.blueprintService.subscribeBlueprintChanged(this);
+    this.blueprintService.subscribeImportError(this.onImportError);
 
     this.fetchDatabase().then(() => {
       if (!this.forceSize) {
@@ -218,7 +219,18 @@ export class ComponentBlueprintParentComponent
 
   ngOnDestroy() {
     this.blueprintService.unsubscribeBlueprintChanged(this);
+    this.blueprintService.unsubscribeImportError(this.onImportError);
   }
+
+  // File-upload imports fail inside a FileReader callback — the service
+  // surfaces them here so the user sees more than a console line
+  private onImportError = (_error: unknown) => {
+    this.messageService.add({
+      severity: "error",
+      summary: $localize`Could not import blueprint`,
+      detail: $localize`The file is not a valid .blueprint file or blueprint share string`,
+    });
+  };
 
   blueprintChanged(blueprint: Blueprint) {
     this.loadTemplateIntoCanvas(blueprint);

--- a/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.ts
@@ -11,7 +11,6 @@ import {
 import { ActivatedRoute, Params, UrlSegment } from "@angular/router";
 import JSZip from "jszip";
 import { MessageService } from "primeng/api";
-import sanitize from "sanitize-filename";
 import {
   BBuilding,
   Blueprint,
@@ -49,6 +48,7 @@ import { DialogBrowseComponent } from "../dialogs/dialog-browse/dialog-browse.co
 import { DialogExportImagesComponent } from "../dialogs/dialog-export-images/dialog-export-images.component";
 import { DialogShareUrlComponent } from "../dialogs/dialog-share-url/dialog-share-url.component";
 import { FeedbackDialogComponent } from "../dialogs/feedback-dialog/feedback-dialog.component";
+import { DialogImportStringComponent } from "../dialogs/dialog-import-string/dialog-import-string.component";
 import { ComponentSideBuildToolComponent } from "../side-bar/build-tool/build-tool.component";
 import { ComponentSideSelectionToolComponent } from "../side-bar/selection-tool/selection-tool.component";
 
@@ -102,6 +102,9 @@ export class ComponentBlueprintParentComponent
 
   @ViewChild("feedbackDialog", { static: false })
   feedbackDialog!: FeedbackDialogComponent;
+
+  @ViewChild("importStringDialog", { static: false })
+  importStringDialog!: DialogImportStringComponent;
 
   // The left ui panel is not static, because when in a iframe we don't load it
   @ViewChild("sidePanelLeft", { static: false })
@@ -360,6 +363,8 @@ export class ComponentBlueprintParentComponent
       this.addElementsTiles();
     else if (menuCommand.type == MenuCommandType.sendFeedback)
       this.feedbackDialog.open();
+    else if (menuCommand.type == MenuCommandType.importBlueprintText)
+      this.importStringDialog.showDialog();
   }
 
   saveImages(exportOptions: ExportImageOptions) {
@@ -377,6 +382,16 @@ export class ComponentBlueprintParentComponent
       summary: $localize`Loaded blueprint: ${this.blueprintService.name}`,
       detail: $localize`${template.blueprintItems.length} items loaded`,
     });
+
+    // Q8: unknown (modded) buildings are skipped in the render but retained
+    // in the stored raw file — tell the user instead of dropping silently
+    if (template.unknownBuildingDefs.length > 0)
+      this.messageService.add({
+        severity: "warn",
+        summary: $localize`Unrecognized buildings`,
+        detail: $localize`${template.unknownBuildingDefs.length} building types are not in our database (probably from mods) and are not shown: ${template.unknownBuildingDefs.join(", ")}`,
+        sticky: true,
+      });
   }
 
   saveBlueprint() {
@@ -410,21 +425,9 @@ export class ComponentBlueprintParentComponent
       if (this.blueprintService.name != undefined)
         friendlyname = this.blueprintService.name;
 
-      const bniBlueprint =
-        this.blueprintService.blueprint.toBniBlueprint(friendlyname);
-
-      const a = document.createElement("a");
-      document.body.append(a);
-      a.download = sanitize(friendlyname) + ".blueprint";
-      a.href = URL.createObjectURL(
-        new Blob([JSON.stringify(bniBlueprint)], {}),
-      );
-      a.click();
-      a.remove();
-
-      // Only saved blueprints have a counter to increment
-      if (this.blueprintService.id != null)
-        this.blueprintService.trackDownload(this.blueprintService.id);
+      // Serves the byte-exact imported file when the blueprint is an
+      // unedited import; otherwise generates from the parsed model
+      this.blueprintService.exportBlueprintFile(friendlyname);
     }
   }
 

--- a/frontend/src/app/module-blueprint/components/component-menu/component-menu.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-menu/component-menu.component.ts
@@ -239,6 +239,15 @@ export class ComponentMenuComponent
                   this.uploadBsonTemplate();
                 },
               },
+              {
+                label: $localize`Blueprint (paste text)`,
+                command: (_event: any) => {
+                  this.menuCommand.emit({
+                    type: MenuCommandType.importBlueprintText,
+                    data: null,
+                  });
+                },
+              },
             ],
           },
           {
@@ -472,6 +481,7 @@ export enum MenuCommandType {
   newBlueprint,
   uploadBlueprint,
   uploadYaml,
+  importBlueprintText,
   changeTool,
   changeOverlay,
   about,

--- a/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.ts
@@ -258,6 +258,12 @@ export class ComponentSaveDialogComponent {
         subcategory: m.subcategory ?? null,
         description: m.description ?? null,
       });
+    } else if (this.blueprintService.metadata.description) {
+      // First save of an imported BlueprintsV2 file: its userdesc was mapped
+      // onto metadata.description at import — offer it as the description
+      this.saveBlueprintForm.patchValue({
+        description: this.blueprintService.metadata.description,
+      });
     }
 
     this.computeDerivedMetadata();

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-import-string/dialog-import-string.component.css
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-import-string/dialog-import-string.component.css
@@ -1,0 +1,7 @@
+.import-textarea {
+  width: 100%;
+  margin-top: 0.75rem;
+  resize: vertical;
+  font-family: monospace;
+  font-size: 0.85rem;
+}

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-import-string/dialog-import-string.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-import-string/dialog-import-string.component.html
@@ -1,0 +1,45 @@
+<p-dialog
+  i18n-header
+  header="Import blueprint from text"
+  [(visible)]="visible"
+  [modal]="true"
+  [dismissableMask]="true"
+  [closable]="true"
+  [focusOnShow]="true"
+  [maximizable]="false"
+  [draggable]="false"
+  [resizable]="false"
+  [style]="{ width: '560px' }"
+  [breakpoints]="{ '640px': '92vw' }"
+>
+  <div i18n>
+    Paste a blueprint copied to the clipboard by the BlueprintsV2 mod (or the
+    contents of a .blueprint file):
+  </div>
+  <textarea
+    class="import-textarea"
+    rows="8"
+    [(ngModel)]="blueprintText"
+    i18n-placeholder
+    placeholder="Paste blueprint text here"
+  ></textarea>
+  <ng-template pTemplate="footer">
+    <button
+      pButton
+      type="button"
+      i18n-label
+      label="Cancel"
+      class="p-button-text"
+      (click)="hideDialog()"
+    ></button>
+    <button
+      pButton
+      type="button"
+      i18n-label
+      label="Import"
+      icon="pi pi-upload"
+      [disabled]="!canImport"
+      (click)="import()"
+    ></button>
+  </ng-template>
+</p-dialog>

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-import-string/dialog-import-string.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-import-string/dialog-import-string.component.spec.ts
@@ -1,0 +1,87 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from "@angular/common/http";
+import { RouterTestingModule } from "@angular/router/testing";
+import { MessageService } from "primeng/api";
+
+import { DialogImportStringComponent } from "./dialog-import-string.component";
+import { BlueprintService } from "src/app/module-blueprint/services/blueprint-service";
+import { AuthenticationService } from "src/app/module-blueprint/services/authentification-service";
+
+describe("DialogImportStringComponent", () => {
+  let component: DialogImportStringComponent;
+  let fixture: ComponentFixture<DialogImportStringComponent>;
+  let blueprintService: BlueprintService;
+  let messageService: MessageService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DialogImportStringComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [RouterTestingModule.withRoutes([])],
+      providers: [
+        AuthenticationService,
+        MessageService,
+        provideHttpClient(withInterceptorsFromDi()),
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DialogImportStringComponent);
+    component = fixture.componentInstance;
+    blueprintService = TestBed.inject(BlueprintService);
+    messageService = TestBed.inject(MessageService);
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("showDialog clears previous text and opens", () => {
+    component.blueprintText = "stale";
+    component.showDialog();
+    expect(component.visible).toBe(true);
+    expect(component.blueprintText).toBe("");
+  });
+
+  it("canImport is false for blank text", () => {
+    component.blueprintText = "   ";
+    expect(component.canImport).toBe(false);
+    component.blueprintText = "{}";
+    expect(component.canImport).toBe(true);
+  });
+
+  it("import() hands the trimmed text to the service and closes on success", async () => {
+    const open = vi
+      .spyOn(blueprintService, "openBlueprintFromShareString")
+      .mockResolvedValue();
+    component.showDialog();
+    component.blueprintText = '  {"friendlyname":"x","buildings":[]}  ';
+
+    component.import();
+    await vi.waitFor(() => expect(component.visible).toBe(false));
+
+    expect(open).toHaveBeenCalledWith('{"friendlyname":"x","buildings":[]}');
+  });
+
+  it("import() surfaces a toast and stays open on failure", async () => {
+    vi.spyOn(
+      blueprintService,
+      "openBlueprintFromShareString",
+    ).mockRejectedValue(new Error("bad input"));
+    const toast = vi.spyOn(messageService, "add");
+    component.showDialog();
+    component.blueprintText = "garbage";
+
+    component.import();
+    await vi.waitFor(() => expect(toast).toHaveBeenCalled());
+
+    expect(component.visible).toBe(true);
+    expect(toast.mock.calls[0][0].severity).toBe("error");
+  });
+});

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-import-string/dialog-import-string.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-import-string/dialog-import-string.component.ts
@@ -1,0 +1,50 @@
+import { Component } from "@angular/core";
+import { BlueprintService } from "../../../services/blueprint-service";
+import { MessageService } from "primeng/api";
+
+// Paste-import for the BlueprintsV2 mod's copy-to-clipboard share-string
+// (also accepts raw .blueprint JSON, mirroring the mod's tolerant import).
+@Component({
+  selector: "app-dialog-import-string",
+  templateUrl: "./dialog-import-string.component.html",
+  styleUrls: ["./dialog-import-string.component.css"],
+  standalone: false,
+})
+export class DialogImportStringComponent {
+  visible: boolean = false;
+  blueprintText: string = "";
+
+  constructor(
+    private blueprintService: BlueprintService,
+    private messageService: MessageService,
+  ) {}
+
+  showDialog() {
+    this.blueprintText = "";
+    this.visible = true;
+  }
+
+  hideDialog() {
+    this.visible = false;
+  }
+
+  get canImport(): boolean {
+    return this.blueprintText.trim().length > 0;
+  }
+
+  import() {
+    const text = this.blueprintText.trim();
+    if (text.length === 0) return;
+
+    this.blueprintService
+      .openBlueprintFromShareString(text)
+      .then(() => this.hideDialog())
+      .catch(() => {
+        this.messageService.add({
+          severity: "error",
+          summary: $localize`Could not import blueprint`,
+          detail: $localize`The pasted text is not a valid blueprint share string or .blueprint file content`,
+        });
+      });
+  }
+}

--- a/frontend/src/app/module-blueprint/module-blueprint.module.ts
+++ b/frontend/src/app/module-blueprint/module-blueprint.module.ts
@@ -53,6 +53,7 @@ import { BuildTool } from "./common/tools/build-tool";
 import { ScissorsTool } from "./common/tools/scissors-tool";
 import { ComponentSaveDialogComponent } from "./components/dialogs/component-save-dialog/component-save-dialog.component";
 import { DialogShareUrlComponent } from "./components/dialogs/dialog-share-url/dialog-share-url.component";
+import { DialogImportStringComponent } from "./components/dialogs/dialog-import-string/dialog-import-string.component";
 import { ComponentSideBuildToolComponent } from "./components/side-bar/build-tool/build-tool.component";
 import { ItemCollectionInfoComponent } from "./components/side-bar/item-collection-info/item-collection-info.component";
 import { DialogBrowseComponent } from "./components/dialogs/dialog-browse/dialog-browse.component";
@@ -120,6 +121,7 @@ import { ToolbarButtonComponent } from "./components/toolbar-button/toolbar-butt
     ComponentSideBuildToolComponent,
     ComponentSideSelectionToolComponent,
     DialogShareUrlComponent,
+    DialogImportStringComponent,
     ItemCollectionInfoComponent,
     DialogBrowseComponent,
     DialogExportImagesComponent,

--- a/frontend/src/app/module-blueprint/services/blueprint-service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.spec.ts
@@ -654,17 +654,17 @@ describe("BlueprintService", () => {
   });
 
   describe("loadJsonBlueprint()", () => {
-    it("sets name from the BNI blueprint friendlyname", () => {
+    it("sets name from the BNI blueprint friendlyname", async () => {
       const json = JSON.stringify({
         friendlyname: "My JSON Blueprint",
         buildings: [],
         digcommands: [],
       });
-      (service as any).loadJsonBlueprint(json);
+      await (service as any).loadJsonBlueprint(json);
       expect(service.name).toBe("My JSON Blueprint");
     });
 
-    it("notifies observers with a Blueprint instance", () => {
+    it("notifies observers with a Blueprint instance", async () => {
       const obs = { blueprintChanged: vi.fn() };
       service.subscribeBlueprintChanged(obs);
       obs.blueprintChanged.mockClear();
@@ -673,7 +673,7 @@ describe("BlueprintService", () => {
         buildings: [],
         digcommands: [],
       });
-      (service as any).loadJsonBlueprint(json);
+      await (service as any).loadJsonBlueprint(json);
       expect(obs.blueprintChanged).toHaveBeenCalled();
     });
   });
@@ -719,6 +719,34 @@ describe("BlueprintService", () => {
       await expect(
         service.openBlueprintFromShareString("not a blueprint at all"),
       ).rejects.toThrow();
+    });
+
+    it("leaves the current session state untouched when the paste is invalid", async () => {
+      service.id = "open-blueprint";
+      service.metadata = { description: "existing" };
+      await expect(
+        service.openBlueprintFromShareString("not a blueprint at all"),
+      ).rejects.toThrow();
+      expect(service.id).toBe("open-blueprint");
+      expect(service.metadata.description).toBe("existing");
+    });
+
+    it("notifies import-error observers when a file upload fails to parse", async () => {
+      const onError = vi.fn();
+      service.subscribeImportError(onError);
+      const reader = {
+        readAsText: vi.fn(),
+        onloadend: null as null | (() => void),
+        result: "garbage that is not a blueprint",
+      };
+      vi.stubGlobal(
+        "FileReader",
+        vi.fn(() => reader),
+      );
+      (service as any).openJsonBlueprint({} as File);
+      reader.onloadend!();
+      await vi.waitFor(() => expect(onError).toHaveBeenCalled());
+      vi.unstubAllGlobals();
     });
 
     it("getValidRawSource returns the import while content is unedited", async () => {
@@ -817,6 +845,34 @@ describe("BlueprintService", () => {
       service.downloadBlueprintFile("bp1", "My Blueprint").subscribe();
 
       expect(saveSpy).toHaveBeenCalledWith("SHARE-STRING", "My Blueprint.txt");
+    });
+
+    it("falls back to generating the file when the raw fetch fails", () => {
+      const saveSpy = vi
+        .spyOn(BlueprintService, "saveTextFile")
+        .mockImplementation(() => {});
+      mockHttp.post.mockReturnValue(of({}));
+      mockHttp.get.mockImplementation((url: string) =>
+        url.endsWith("/raw")
+          ? throwError(() => new Error("404"))
+          : of({
+              hasRawSource: true,
+              rawSourceFormat: "bpv2-json",
+              data: { blueprintItems: [] },
+            }),
+      );
+
+      service.downloadBlueprintFile("bp1", "My Blueprint").subscribe();
+
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.stringContaining("friendlyname"),
+        "My Blueprint.blueprint",
+      );
+      expect(mockHttp.post).toHaveBeenCalledWith(
+        "/api/blueprints/bp1/downloads",
+        {},
+        expect.anything(),
+      );
     });
 
     it("generates the file from parsed data when no raw is stored", () => {

--- a/frontend/src/app/module-blueprint/services/blueprint-service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.spec.ts
@@ -694,4 +694,183 @@ describe("BlueprintService", () => {
       expect(obs.blueprintChanged).toHaveBeenCalled();
     });
   });
+
+  describe("BlueprintsV2 raw source round-trip", () => {
+    const BNI_JSON = JSON.stringify({
+      blueprintVersion: 3,
+      friendlyname: "Imported",
+      userdesc: "a description from the mod",
+      buildings: [],
+      digcommands: [],
+    });
+
+    it("keeps the verbatim import text and format after a JSON import", async () => {
+      await service.openBlueprintFromShareString(BNI_JSON);
+      expect(service.rawSource).toBe(BNI_JSON);
+      expect(service.rawSourceFormat).toBe("bpv2-json");
+    });
+
+    it("prefills metadata.description from userdesc", async () => {
+      await service.openBlueprintFromShareString(BNI_JSON);
+      expect(service.metadata.description).toBe("a description from the mod");
+    });
+
+    it("rejects text that is neither JSON nor a share-string", async () => {
+      await expect(
+        service.openBlueprintFromShareString("not a blueprint at all"),
+      ).rejects.toThrow();
+    });
+
+    it("getValidRawSource returns the import while content is unedited", async () => {
+      await service.openBlueprintFromShareString(BNI_JSON);
+      expect(service.getValidRawSource()).toEqual({
+        text: BNI_JSON,
+        format: "bpv2-json",
+      });
+    });
+
+    it("getValidRawSource returns null once the blueprint diverges", async () => {
+      await service.openBlueprintFromShareString(BNI_JSON);
+      vi.spyOn(service.blueprint, "toMdbBlueprint").mockReturnValue({
+        blueprintItems: [{ id: "Tile" }],
+      } as any);
+      expect(service.getValidRawSource()).toBeNull();
+    });
+
+    it("getValidRawSource returns null when nothing was imported", () => {
+      expect(service.getValidRawSource()).toBeNull();
+    });
+
+    it("saveBlueprint sends rawSource only while the import is unedited", async () => {
+      mockAuth.isLoggedIn.mockReturnValue(true);
+      mockHttp.post.mockReturnValue(of({ id: "new-id" }));
+      await service.openBlueprintFromShareString(BNI_JSON);
+
+      service.saveBlueprint(false).subscribe();
+      const body = mockHttp.post.mock.calls[0][1];
+      expect(body.rawSource).toBe(BNI_JSON);
+      expect(body.rawSourceFormat).toBe("bpv2-json");
+      expect(service.serverHasRawSource).toBe(true);
+    });
+
+    it("saveBlueprint omits rawSource for edited content", async () => {
+      mockAuth.isLoggedIn.mockReturnValue(true);
+      mockHttp.post.mockReturnValue(of({ id: "new-id" }));
+      await service.openBlueprintFromShareString(BNI_JSON);
+      vi.spyOn(service.blueprint, "toMdbBlueprint").mockReturnValue({
+        blueprintItems: [{ id: "Tile" }],
+      } as any);
+
+      service.saveBlueprint(false).subscribe();
+      const body = mockHttp.post.mock.calls[0][1];
+      expect(body.rawSource).toBeUndefined();
+      expect(body.rawSourceFormat).toBeUndefined();
+      expect(service.serverHasRawSource).toBe(false);
+    });
+
+    it("reset clears the held raw source", async () => {
+      await service.openBlueprintFromShareString(BNI_JSON);
+      service.reset();
+      expect(service.rawSource).toBeNull();
+      expect(service.getValidRawSource()).toBeNull();
+    });
+  });
+
+  describe("downloadBlueprintFile()", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("serves the server's raw copy byte-exact when available", () => {
+      const saveSpy = vi
+        .spyOn(BlueprintService, "saveTextFile")
+        .mockImplementation(() => {});
+      mockHttp.get.mockImplementation((url: string) =>
+        url.endsWith("/raw")
+          ? of("RAW-TEXT")
+          : of({ hasRawSource: true, rawSourceFormat: "bpv2-json" }),
+      );
+
+      service.downloadBlueprintFile("bp1", "My Blueprint").subscribe();
+
+      expect(mockHttp.get).toHaveBeenCalledWith("/api/blueprints/bp1/raw", {
+        responseType: "text",
+      });
+      expect(saveSpy).toHaveBeenCalledWith(
+        "RAW-TEXT",
+        "My Blueprint.blueprint",
+      );
+      // The raw endpoint records the download server-side — no beacon
+      expect(mockHttp.post).not.toHaveBeenCalled();
+    });
+
+    it("uses a .txt extension for share-string raws", () => {
+      const saveSpy = vi
+        .spyOn(BlueprintService, "saveTextFile")
+        .mockImplementation(() => {});
+      mockHttp.get.mockImplementation((url: string) =>
+        url.endsWith("/raw")
+          ? of("SHARE-STRING")
+          : of({ hasRawSource: true, rawSourceFormat: "bpv2-sharestring" }),
+      );
+
+      service.downloadBlueprintFile("bp1", "My Blueprint").subscribe();
+
+      expect(saveSpy).toHaveBeenCalledWith("SHARE-STRING", "My Blueprint.txt");
+    });
+
+    it("generates the file from parsed data when no raw is stored", () => {
+      const saveSpy = vi
+        .spyOn(BlueprintService, "saveTextFile")
+        .mockImplementation(() => {});
+      mockHttp.post.mockReturnValue(of({}));
+      mockHttp.get.mockReturnValue(
+        of({ hasRawSource: false, data: { blueprintItems: [] } }),
+      );
+
+      service.downloadBlueprintFile("bp1", "My Blueprint").subscribe();
+
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.stringContaining("friendlyname"),
+        "My Blueprint.blueprint",
+      );
+      // Client-side generation reports the download via the beacon
+      expect(mockHttp.post).toHaveBeenCalledWith(
+        "/api/blueprints/bp1/downloads",
+        {},
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("exportBlueprintFile()", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("serves the held raw import when the blueprint is unedited", async () => {
+      const saveSpy = vi
+        .spyOn(BlueprintService, "saveTextFile")
+        .mockImplementation(() => {});
+      const json = JSON.stringify({ friendlyname: "T", buildings: [] });
+      await service.openBlueprintFromShareString(json);
+
+      service.exportBlueprintFile("T");
+
+      expect(saveSpy).toHaveBeenCalledWith(json, "T.blueprint");
+    });
+
+    it("generates from the parsed model when there is no raw", () => {
+      const saveSpy = vi
+        .spyOn(BlueprintService, "saveTextFile")
+        .mockImplementation(() => {});
+
+      service.exportBlueprintFile("Fresh");
+
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.stringContaining("friendlyname"),
+        "Fresh.blueprint",
+      );
+    });
+  });
 });

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -2,7 +2,8 @@ import { Injectable } from "@angular/core";
 import { Location } from "@angular/common";
 import { HttpClient } from "@angular/common/http";
 import { AuthenticationService } from "./authentification-service";
-import { map, switchMap, tap } from "rxjs/operators";
+import { of } from "rxjs";
+import { catchError, map, switchMap, tap } from "rxjs/operators";
 import {
   decodeBniShareString,
   RawSourceFormat,
@@ -88,6 +89,21 @@ export class BlueprintService implements IObsBlueprintChange {
     if (index !== -1) this.observersBlueprintChanged.splice(index, 1);
   }
 
+  // File-upload import failures happen in a FileReader callback where no
+  // caller can catch them — surface them so the UI can toast (the paste
+  // dialog handles its own errors via the returned promise)
+  private importErrorObservers: ((error: unknown) => void)[] = [];
+  subscribeImportError(observer: (error: unknown) => void) {
+    this.importErrorObservers.push(observer);
+  }
+  unsubscribeImportError(observer: (error: unknown) => void) {
+    const index = this.importErrorObservers.indexOf(observer);
+    if (index !== -1) this.importErrorObservers.splice(index, 1);
+  }
+  private emitImportError(error: unknown) {
+    this.importErrorObservers.map((observer) => observer(error));
+  }
+
   openBlueprintFromUpload(fileType: BlueprintFileType, fileList: FileList) {
     if (fileList.length > 0) {
       this.reset();
@@ -126,26 +142,35 @@ export class BlueprintService implements IObsBlueprintChange {
   private openJsonBlueprint(file: File) {
     const reader = new FileReader();
     reader.onloadend = () => {
-      this.loadJsonBlueprint(reader.result as string).catch((error) =>
-        console.error("Blueprint import failed", error),
-      );
+      this.loadJsonBlueprint(reader.result as string).catch((error) => {
+        console.error("Blueprint import failed", error);
+        this.emitImportError(error);
+      });
     };
     reader.readAsText(file);
   }
 
-  // Accepts both BlueprintsV2 transports: the .blueprint JSON file text and
-  // the mod's clipboard share-string (base64 + 4-byte length header + gzip).
+  // Parses either BlueprintsV2 transport: .blueprint JSON file text, or the
+  // mod's clipboard share-string (base64 + 4-byte length header + gzip).
+  // Throws when the text is neither.
+  private static async parseBniText(
+    text: string,
+  ): Promise<{ bni: BniBlueprint; format: RawSourceFormat }> {
+    try {
+      return { bni: JSON.parse(text), format: "bpv2-json" };
+    } catch {
+      return {
+        bni: JSON.parse(await decodeBniShareString(text)),
+        format: "bpv2-sharestring",
+      };
+    }
+  }
+
   // The original text is kept verbatim (rawSource) so a save can offer the
   // byte-exact file back to downloaders.
   private async loadJsonBlueprint(template: string) {
-    let templateJson: BniBlueprint;
-    let format: RawSourceFormat = "bpv2-json";
-    try {
-      templateJson = JSON.parse(template);
-    } catch {
-      templateJson = JSON.parse(await decodeBniShareString(template));
-      format = "bpv2-sharestring";
-    }
+    const { bni: templateJson, format } =
+      await BlueprintService.parseBniText(template);
 
     const newBlueprint = new Blueprint();
     this.name = templateJson.friendlyname;
@@ -153,10 +178,11 @@ export class BlueprintService implements IObsBlueprintChange {
 
     this.rawSource = template;
     this.rawSourceFormat = format;
-    // Fingerprint of the imported content: the raw text is only sent along
-    // with a save while the blueprint still hashes to this (edits invalidate
-    // the original file, which must never disagree with the stored data).
-    this.rawSourceMdbHash = this.hashMdb(newBlueprint.toMdbBlueprint());
+    // Canonical serialization of the imported content: the raw text is only
+    // sent with a save while the blueprint still serializes to exactly this
+    // (edits invalidate the original file, which must never disagree with
+    // the stored data).
+    this.rawSourceMdbJson = JSON.stringify(newBlueprint.toMdbBlueprint());
 
     // The mod's user description maps onto our description metadata
     if (templateJson.userdesc && !this.metadata.description)
@@ -170,6 +196,9 @@ export class BlueprintService implements IObsBlueprintChange {
   // Paste-import of the mod's copy-to-clipboard share-string (also tolerates
   // raw .blueprint JSON, mirroring the mod's own tolerant import)
   async openBlueprintFromShareString(text: string) {
+    // Validate before touching any state: an invalid paste must leave the
+    // currently open blueprint and its metadata untouched
+    await BlueprintService.parseBniText(text);
     this.reset();
     await this.loadJsonBlueprint(text);
     this.resetUndoStates();
@@ -224,27 +253,36 @@ export class BlueprintService implements IObsBlueprintChange {
   // currently open saved blueprint has a stored raw on the server.
   rawSource: string | null = null;
   rawSourceFormat: RawSourceFormat | null = null;
-  private rawSourceMdbHash: number | null = null;
+  private rawSourceMdbJson: string | null = null;
   serverHasRawSource = false;
   private serverRawSourceFormat: string | null = null;
-  private serverRawSourceMdbHash: number | null = null;
+  private serverRawSourceMdbJson: string | null = null;
 
   private clearRawSource() {
     this.rawSource = null;
     this.rawSourceFormat = null;
-    this.rawSourceMdbHash = null;
+    this.rawSourceMdbJson = null;
     this.serverHasRawSource = false;
     this.serverRawSourceFormat = null;
-    this.serverRawSourceMdbHash = null;
+    this.serverRawSourceMdbJson = null;
   }
 
-  // The held raw text, provided the open blueprint still matches the import
-  // it came from — null once the user edits anything.
+  // The held raw text, provided the open blueprint still serializes to
+  // exactly the import it came from — null once the user edits anything.
+  // Exact string equality, not a hash: a collision must never let a stale
+  // original ship with edited data.
   getValidRawSource(): { text: string; format: RawSourceFormat } | null {
     if (this.rawSource == null || this.rawSourceFormat == null) return null;
-    if (this.rawSourceMdbHash !== this.hashMdb(this.blueprint.toMdbBlueprint()))
+    if (
+      this.rawSourceMdbJson !== JSON.stringify(this.blueprint.toMdbBlueprint())
+    )
       return null;
     return { text: this.rawSource, format: this.rawSourceFormat };
+  }
+
+  // Download filename extension for a stored raw-source format
+  static rawSourceExtension(format: string | null | undefined): string {
+    return format === "bpv2-sharestring" ? ".txt" : ".blueprint";
   }
 
   suppressChanges!: boolean;
@@ -382,11 +420,11 @@ export class BlueprintService implements IObsBlueprintChange {
               modded: response.modded ?? null,
             };
             blueprint.importFromMdb(response.data);
-            // Fingerprint the opened content through the same serializer the
+            // Serialize the opened content through the same serializer the
             // editor uses, so the Download menu can tell "unedited since
             // open" and serve the server's byte-exact raw copy
             if (this.serverHasRawSource)
-              this.serverRawSourceMdbHash = this.hashMdb(
+              this.serverRawSourceMdbJson = JSON.stringify(
                 blueprint.toMdbBlueprint(),
               );
             return blueprint;
@@ -418,35 +456,44 @@ export class BlueprintService implements IObsBlueprintChange {
       )
       .pipe(
         switchMap((response: BlueprintResponse) => {
+          const generate = () => {
+            const blueprint = new Blueprint();
+            blueprint.importFromMdb(response.data);
+            const bniBlueprint = blueprint.toBniBlueprint(friendlyName);
+
+            BlueprintService.saveTextFile(
+              JSON.stringify(bniBlueprint),
+              sanitize(friendlyName) + ".blueprint",
+            );
+
+            this.trackDownload(id);
+          };
+
           if (response.hasRawSource)
             return this.http
               .get(`/api/blueprints/${id}/raw`, { responseType: "text" })
               .pipe(
                 tap((raw: string) => {
-                  const extension =
-                    response.rawSourceFormat === "bpv2-sharestring"
-                      ? ".txt"
-                      : ".blueprint";
                   BlueprintService.saveTextFile(
                     raw,
-                    sanitize(friendlyName) + extension,
+                    sanitize(friendlyName) +
+                      BlueprintService.rawSourceExtension(
+                        response.rawSourceFormat,
+                      ),
                   );
                   // The raw endpoint records the download server-side —
                   // no beacon needed
                 }),
+                // The raw copy may have vanished (e.g. concurrent edit) —
+                // still deliver a generated file rather than failing
+                catchError(() => {
+                  generate();
+                  return of(response);
+                }),
               );
 
-          const blueprint = new Blueprint();
-          blueprint.importFromMdb(response.data);
-          const bniBlueprint = blueprint.toBniBlueprint(friendlyName);
-
-          BlueprintService.saveTextFile(
-            JSON.stringify(bniBlueprint),
-            sanitize(friendlyName) + ".blueprint",
-          );
-
-          this.trackDownload(id);
-          return [response];
+          generate();
+          return of(response);
         }),
       );
   }
@@ -461,7 +508,7 @@ export class BlueprintService implements IObsBlueprintChange {
       BlueprintService.saveTextFile(
         localRaw.text,
         sanitize(friendlyName) +
-          (localRaw.format === "bpv2-sharestring" ? ".txt" : ".blueprint"),
+          BlueprintService.rawSourceExtension(localRaw.format),
       );
       if (this.id != null) this.trackDownload(this.id);
       return;
@@ -479,14 +526,13 @@ export class BlueprintService implements IObsBlueprintChange {
     if (
       this.id != null &&
       this.serverHasRawSource &&
-      this.serverRawSourceMdbHash != null &&
-      this.serverRawSourceMdbHash ===
-        this.hashMdb(this.blueprint.toMdbBlueprint())
+      this.serverRawSourceMdbJson != null &&
+      this.serverRawSourceMdbJson ===
+        JSON.stringify(this.blueprint.toMdbBlueprint())
     ) {
-      const extension =
-        this.serverRawSourceFormat === "bpv2-sharestring"
-          ? ".txt"
-          : ".blueprint";
+      const extension = BlueprintService.rawSourceExtension(
+        this.serverRawSourceFormat,
+      );
       this.http
         .get(`/api/blueprints/${this.id}/raw`, { responseType: "text" })
         .subscribe({
@@ -703,8 +749,8 @@ export class BlueprintService implements IObsBlueprintChange {
             // previously stored raw (edited content)
             this.serverHasRawSource = validRaw != null;
             this.serverRawSourceFormat = validRaw?.format ?? null;
-            this.serverRawSourceMdbHash =
-              validRaw != null ? this.rawSourceMdbHash : null;
+            this.serverRawSourceMdbJson =
+              validRaw != null ? this.rawSourceMdbJson : null;
           }
           return response;
         }),

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -2,8 +2,10 @@ import { Injectable } from "@angular/core";
 import { Location } from "@angular/common";
 import { HttpClient } from "@angular/common/http";
 import { AuthenticationService } from "./authentification-service";
-import { map, tap } from "rxjs/operators";
+import { map, switchMap, tap } from "rxjs/operators";
 import {
+  decodeBniShareString,
+  RawSourceFormat,
   Blueprint,
   IObsBlueprintChange,
   BlueprintItem,
@@ -124,21 +126,53 @@ export class BlueprintService implements IObsBlueprintChange {
   private openJsonBlueprint(file: File) {
     const reader = new FileReader();
     reader.onloadend = () => {
-      this.loadJsonBlueprint(reader.result as string);
+      this.loadJsonBlueprint(reader.result as string).catch((error) =>
+        console.error("Blueprint import failed", error),
+      );
     };
     reader.readAsText(file);
   }
 
-  private loadJsonBlueprint(template: string) {
-    const templateJson: BniBlueprint = JSON.parse(template);
+  // Accepts both BlueprintsV2 transports: the .blueprint JSON file text and
+  // the mod's clipboard share-string (base64 + 4-byte length header + gzip).
+  // The original text is kept verbatim (rawSource) so a save can offer the
+  // byte-exact file back to downloaders.
+  private async loadJsonBlueprint(template: string) {
+    let templateJson: BniBlueprint;
+    let format: RawSourceFormat = "bpv2-json";
+    try {
+      templateJson = JSON.parse(template);
+    } catch {
+      templateJson = JSON.parse(await decodeBniShareString(template));
+      format = "bpv2-sharestring";
+    }
 
     const newBlueprint = new Blueprint();
     this.name = templateJson.friendlyname;
     newBlueprint.importFromBni(templateJson);
 
+    this.rawSource = template;
+    this.rawSourceFormat = format;
+    // Fingerprint of the imported content: the raw text is only sent along
+    // with a save while the blueprint still hashes to this (edits invalidate
+    // the original file, which must never disagree with the stored data).
+    this.rawSourceMdbHash = this.hashMdb(newBlueprint.toMdbBlueprint());
+
+    // The mod's user description maps onto our description metadata
+    if (templateJson.userdesc && !this.metadata.description)
+      this.metadata.description = String(templateJson.userdesc).slice(0, 500);
+
     this.observersBlueprintChanged.map((observer) => {
       observer.blueprintChanged(newBlueprint);
     });
+  }
+
+  // Paste-import of the mod's copy-to-clipboard share-string (also tolerates
+  // raw .blueprint JSON, mirroring the mod's own tolerant import)
+  async openBlueprintFromShareString(text: string) {
+    this.reset();
+    await this.loadJsonBlueprint(text);
+    this.resetUndoStates();
   }
 
   private openBsonBlueprint(file: File) {
@@ -182,6 +216,35 @@ export class BlueprintService implements IObsBlueprintChange {
     this.rating = 0;
     this.nbRatings = 0;
     this.metadata = {};
+    this.clearRawSource();
+  }
+
+  // Verbatim BlueprintsV2 import text (file or share-string) held for the
+  // next save; see loadJsonBlueprint. serverHasRawSource mirrors whether the
+  // currently open saved blueprint has a stored raw on the server.
+  rawSource: string | null = null;
+  rawSourceFormat: RawSourceFormat | null = null;
+  private rawSourceMdbHash: number | null = null;
+  serverHasRawSource = false;
+  private serverRawSourceFormat: string | null = null;
+  private serverRawSourceMdbHash: number | null = null;
+
+  private clearRawSource() {
+    this.rawSource = null;
+    this.rawSourceFormat = null;
+    this.rawSourceMdbHash = null;
+    this.serverHasRawSource = false;
+    this.serverRawSourceFormat = null;
+    this.serverRawSourceMdbHash = null;
+  }
+
+  // The held raw text, provided the open blueprint still matches the import
+  // it came from — null once the user edits anything.
+  getValidRawSource(): { text: string; format: RawSourceFormat } | null {
+    if (this.rawSource == null || this.rawSourceFormat == null) return null;
+    if (this.rawSourceMdbHash !== this.hashMdb(this.blueprint.toMdbBlueprint()))
+      return null;
+    return { text: this.rawSource, format: this.rawSourceFormat };
   }
 
   suppressChanges!: boolean;
@@ -308,6 +371,9 @@ export class BlueprintService implements IObsBlueprintChange {
             this.rating = response.rating;
             this.myRating = response.myRating;
             this.isPublished = response.isPublished;
+            this.clearRawSource();
+            this.serverHasRawSource = response.hasRawSource === true;
+            this.serverRawSourceFormat = response.rawSourceFormat ?? null;
             this.metadata = {
               gameVersion: response.gameVersion ?? null,
               category: response.category ?? null,
@@ -316,6 +382,13 @@ export class BlueprintService implements IObsBlueprintChange {
               modded: response.modded ?? null,
             };
             blueprint.importFromMdb(response.data);
+            // Fingerprint the opened content through the same serializer the
+            // editor uses, so the Download menu can tell "unedited since
+            // open" and serve the server's byte-exact raw copy
+            if (this.serverHasRawSource)
+              this.serverRawSourceMdbHash = this.hashMdb(
+                blueprint.toMdbBlueprint(),
+              );
             return blueprint;
           }
           return undefined;
@@ -328,6 +401,9 @@ export class BlueprintService implements IObsBlueprintChange {
   // Downloads the game-ready .blueprint (json) file for a saved blueprint
   // without disturbing the editor's currently-open blueprint state — used by
   // the details page, which never opens the blueprint into the editor.
+  // When the server holds the verbatim uploaded file it is served byte-exact
+  // (spec/blueprintsv2-import-spec.md §8); otherwise the file is generated
+  // from the parsed data as before.
   downloadBlueprintFile(id: string, friendlyName: string) {
     return this.http
       .get<BlueprintResponse>(
@@ -341,25 +417,105 @@ export class BlueprintService implements IObsBlueprintChange {
           : {},
       )
       .pipe(
-        tap((response: BlueprintResponse) => {
+        switchMap((response: BlueprintResponse) => {
+          if (response.hasRawSource)
+            return this.http
+              .get(`/api/blueprints/${id}/raw`, { responseType: "text" })
+              .pipe(
+                tap((raw: string) => {
+                  const extension =
+                    response.rawSourceFormat === "bpv2-sharestring"
+                      ? ".txt"
+                      : ".blueprint";
+                  BlueprintService.saveTextFile(
+                    raw,
+                    sanitize(friendlyName) + extension,
+                  );
+                  // The raw endpoint records the download server-side —
+                  // no beacon needed
+                }),
+              );
+
           const blueprint = new Blueprint();
           blueprint.importFromMdb(response.data);
           const bniBlueprint = blueprint.toBniBlueprint(friendlyName);
 
-          const url = URL.createObjectURL(
-            new Blob([JSON.stringify(bniBlueprint)], {}),
+          BlueprintService.saveTextFile(
+            JSON.stringify(bniBlueprint),
+            sanitize(friendlyName) + ".blueprint",
           );
-          const a = document.createElement("a");
-          document.body.append(a);
-          a.download = sanitize(friendlyName) + ".blueprint";
-          a.href = url;
-          a.click();
-          a.remove();
-          URL.revokeObjectURL(url);
 
           this.trackDownload(id);
+          return [response];
         }),
       );
+  }
+
+  // Editor "Download → Blueprint (json)": serve byte-exact raw when the open
+  // blueprint is an unedited import (local raw text, or the server's stored
+  // raw for a blueprint opened by id); otherwise generate from the parsed
+  // model as before.
+  exportBlueprintFile(friendlyName: string) {
+    const localRaw = this.getValidRawSource();
+    if (localRaw != null) {
+      BlueprintService.saveTextFile(
+        localRaw.text,
+        sanitize(friendlyName) +
+          (localRaw.format === "bpv2-sharestring" ? ".txt" : ".blueprint"),
+      );
+      if (this.id != null) this.trackDownload(this.id);
+      return;
+    }
+
+    const generate = () => {
+      const bniBlueprint = this.blueprint.toBniBlueprint(friendlyName);
+      BlueprintService.saveTextFile(
+        JSON.stringify(bniBlueprint),
+        sanitize(friendlyName) + ".blueprint",
+      );
+      if (this.id != null) this.trackDownload(this.id);
+    };
+
+    if (
+      this.id != null &&
+      this.serverHasRawSource &&
+      this.serverRawSourceMdbHash != null &&
+      this.serverRawSourceMdbHash ===
+        this.hashMdb(this.blueprint.toMdbBlueprint())
+    ) {
+      const extension =
+        this.serverRawSourceFormat === "bpv2-sharestring"
+          ? ".txt"
+          : ".blueprint";
+      this.http
+        .get(`/api/blueprints/${this.id}/raw`, { responseType: "text" })
+        .subscribe({
+          next: (raw) => {
+            // Raw endpoint records the download server-side
+            BlueprintService.saveTextFile(
+              raw,
+              sanitize(friendlyName) + extension,
+            );
+          },
+          // The raw copy may have vanished (e.g. concurrent edit) — fall
+          // back to the generated file rather than failing the download
+          error: () => generate(),
+        });
+      return;
+    }
+
+    generate();
+  }
+
+  static saveTextFile(text: string, filename: string) {
+    const url = URL.createObjectURL(new Blob([text], {}));
+    const a = document.createElement("a");
+    document.body.append(a);
+    a.download = filename;
+    a.href = url;
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
   }
 
   // Meta only (no blueprint data) — for the details page. Token is optional;
@@ -522,6 +678,14 @@ export class BlueprintService implements IObsBlueprintChange {
     // blueprint, name it as the source — the server records forkedFrom when
     // the save creates a copy because the requester isn't the owner
     if (this.id != null) body.sourceBlueprintId = this.id;
+    // Byte-exact round-trip: send the verbatim imported file only while the
+    // saved content still matches it; an edited blueprint saves without raw
+    // (the server clears any previously stored raw on such saves)
+    const validRaw = this.getValidRawSource();
+    if (validRaw != null) {
+      body.rawSource = validRaw.text;
+      body.rawSourceFormat = validRaw.format;
+    }
     Object.assign(body, this.metadata);
     const request = this.http
       .post("/api/uploadblueprint", body, {
@@ -535,6 +699,12 @@ export class BlueprintService implements IObsBlueprintChange {
             this.location.replaceState(`/b/${this.id}`);
             if (publish === true) this.isPublished = true;
             else if (isNewBlueprint) this.isPublished = false;
+            // The save either stored the raw import verbatim or cleared any
+            // previously stored raw (edited content)
+            this.serverHasRawSource = validRaw != null;
+            this.serverRawSourceFormat = validRaw?.format ?? null;
+            this.serverRawSourceMdbHash =
+              validRaw != null ? this.rawSourceMdbHash : null;
           }
           return response;
         }),
@@ -615,6 +785,10 @@ export class SaveBlueprintMessage {
   subcategory?: string | null;
   description?: string | null;
   modded?: boolean | null;
+  // Verbatim BlueprintsV2 import text, present only when the saved data still
+  // equals the imported content (byte-exact round-trip, §8)
+  rawSource?: string;
+  rawSourceFormat?: RawSourceFormat;
 }
 
 export enum BlueprintFileType {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -12,6 +12,7 @@ export * from './src/enums/z-index';
 export * from './src/enums/build-location-rule';
 export * from './src/io/bni/bni-building';
 export * from './src/io/bni/bni-blueprint';
+export * from './src/io/bni/bni-share-string';
 export * from './src/io/mdb/mdb-building';
 export * from './src/io/mdb/mdb-blueprint';
 export * from './src/io/oni/oni-cell';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,6 +14,7 @@ export * from './src/enums/build-location-rule';
 
 export * from './src/io/bni/bni-building';
 export * from './src/io/bni/bni-blueprint';
+export * from './src/io/bni/bni-share-string';
 export * from './src/io/mdb/mdb-building';
 export * from './src/io/mdb/mdb-blueprint';
 export * from './src/io/oni/oni-cell';

--- a/lib/src/b-export/b-element.d.ts
+++ b/lib/src/b-export/b-element.d.ts
@@ -15,6 +15,7 @@ export declare class BuildableElement {
     static init(): void;
     static load(originals: BuildableElement[]): void;
     static getElement(id: string): BuildableElement;
+    static getElementByTag(tag: number): BuildableElement | undefined;
     static getElementsFromTag(tag: string): BuildableElement[];
     static getElementsFromTags(tags: string[]): BuildableElement[][];
 }

--- a/lib/src/b-export/b-element.ts
+++ b/lib/src/b-export/b-element.ts
@@ -64,6 +64,14 @@ export class BuildableElement {
     throw new Error('BuildableElement.getElement : Element not found');
   }
 
+  // Resolve a Klei tag hash (BlueprintsV2 selected_elements / element-note id)
+  // to an element. Returns undefined for unknown hashes — callers keep the
+  // default material rather than failing the import.
+  public static getElementByTag(tag: number): BuildableElement | undefined {
+    for (let element of BuildableElement.elements) if (element.tag == tag) return element;
+    return undefined;
+  }
+
   // Get a list of elements that have the parameter tag
   public static getElementsFromTag(tag: string): BuildableElement[] {
     let returnValue: BuildableElement[] = [];

--- a/lib/src/blueprint/blueprint-item.ts
+++ b/lib/src/blueprint/blueprint-item.ts
@@ -202,6 +202,20 @@ export class BlueprintItem {
 
     this.changeOrientation(building.orientation);
 
+    // Construction materials: each entry is a Klei tag hash in recipe order
+    // (BlueprintsV2 §2.3). Unknown hashes or surplus slots keep the default
+    // material — cleanUp() backfills every unset slot.
+    if (building.selected_elements != null)
+      for (
+        let indexElement = 0;
+        indexElement < building.selected_elements.length &&
+        indexElement < this.oniItem.buildableElementsArray.length;
+        indexElement++
+      ) {
+        let element = BuildableElement.getElementByTag(building.selected_elements[indexElement]);
+        if (element != null) this.setElement(element.id, indexElement);
+      }
+
     this.cleanUp();
     this.prepareBoundingBox();
   }

--- a/lib/src/blueprint/blueprint.d.ts
+++ b/lib/src/blueprint/blueprint.d.ts
@@ -9,6 +9,8 @@ export declare class Blueprint {
     blueprintItems: BlueprintItem[];
     templateTiles: BlueprintItem[][];
     hadUnknownBuildings: boolean;
+    unknownBuildingDefs: string[];
+    bniMetadata: BniBlueprint | null;
     utilities: UtilityConnectionTracker[][];
     innerYaml: any;
     constructor();

--- a/lib/src/blueprint/blueprint.ts
+++ b/lib/src/blueprint/blueprint.ts
@@ -19,6 +19,15 @@ export class Blueprint {
   // Set to true when any building ID was not found in OniItem.oniItemsMap during
   // import. Indicates the blueprint was created with mods installed.
   hadUnknownBuildings: boolean = false;
+  // Distinct building defs that were skipped during import because they are
+  // not in our database (modded prefabs, e.g. 'PAirlockDoor') — surfaced as a
+  // "contains N unrecognized buildings" hint. The entries themselves survive
+  // in the verbatim raw upload stored server-side (Q8).
+  unknownBuildingDefs: string[] = [];
+  // BlueprintsV2 metadata parsed from the imported file (userdesc, icon,
+  // icontint, worldNotes, …) — display/prefill only, never the round-trip
+  // source of truth.
+  bniMetadata: BniBlueprint | null = null;
 
   // We need a utility map because some objects have utilities outside of their size (HighWattageWireBridge)
   utilities: UtilityConnectionTracker[][] = [];
@@ -85,12 +94,16 @@ export class Blueprint {
   public importFromBni(bniBlueprint: BniBlueprint) {
     this.blueprintItems = [];
     this.hadUnknownBuildings = false;
+    this.unknownBuildingDefs = [];
+    this.bniMetadata = bniBlueprint;
 
-    for (let building of bniBlueprint.buildings) {
+    for (let building of bniBlueprint.buildings ?? []) {
       try {
         let newTemplateItem = BlueprintHelpers.createInstance(building.buildingdef);
         if (newTemplateItem == null) {
           this.hadUnknownBuildings = true;
+          if (this.unknownBuildingDefs.indexOf(building.buildingdef) == -1)
+            this.unknownBuildingDefs.push(building.buildingdef);
           continue;
         }
 
@@ -106,6 +119,8 @@ export class Blueprint {
   public importFromMdb(mdbBlueprint: MdbBlueprint) {
     this.blueprintItems = [];
     this.hadUnknownBuildings = false;
+    this.unknownBuildingDefs = [];
+    this.bniMetadata = null;
 
     for (let originalTemplateItem of mdbBlueprint.blueprintItems) {
       let newTemplateItem = BlueprintHelpers.createInstance(originalTemplateItem.id);
@@ -113,6 +128,8 @@ export class Blueprint {
       // Don't import buildings we don't recognise
       if (newTemplateItem == null) {
         this.hadUnknownBuildings = true;
+        if (this.unknownBuildingDefs.indexOf(originalTemplateItem.id) == -1)
+          this.unknownBuildingDefs.push(originalTemplateItem.id);
         continue;
       }
 

--- a/lib/src/coms/blueprint-list-response.d.ts
+++ b/lib/src/coms/blueprint-list-response.d.ts
@@ -62,5 +62,7 @@ export interface BlueprintResponse {
     modded?: boolean | null;
     rooms?: string[] | null;
     isPublished: boolean;
+    hasRawSource?: boolean;
+    rawSourceFormat?: string | null;
 }
 //# sourceMappingURL=blueprint-list-response.d.ts.map

--- a/lib/src/coms/blueprint-list-response.d.ts
+++ b/lib/src/coms/blueprint-list-response.d.ts
@@ -1,4 +1,5 @@
 import { ForkedFromDto } from './blueprint-version';
+import { RawSourceFormat } from '../io/bni/bni-share-string';
 export interface BlueprintListResponse {
     blueprints: BlueprintListItem[];
     oldest: Date;
@@ -63,6 +64,6 @@ export interface BlueprintResponse {
     rooms?: string[] | null;
     isPublished: boolean;
     hasRawSource?: boolean;
-    rawSourceFormat?: string | null;
+    rawSourceFormat?: RawSourceFormat | null;
 }
 //# sourceMappingURL=blueprint-list-response.d.ts.map

--- a/lib/src/coms/blueprint-list-response.ts
+++ b/lib/src/coms/blueprint-list-response.ts
@@ -1,4 +1,5 @@
 import { ForkedFromDto } from './blueprint-version';
+import { RawSourceFormat } from '../io/bni/bni-share-string';
 
 export interface BlueprintListResponse {
   blueprints: BlueprintListItem[];
@@ -92,5 +93,5 @@ export interface BlueprintResponse {
   // should fetch GET /api/blueprints/:id/raw instead of regenerating the
   // file from the parsed data.
   hasRawSource?: boolean;
-  rawSourceFormat?: string | null;
+  rawSourceFormat?: RawSourceFormat | null;
 }

--- a/lib/src/coms/blueprint-list-response.ts
+++ b/lib/src/coms/blueprint-list-response.ts
@@ -88,4 +88,9 @@ export interface BlueprintResponse {
   modded?: boolean | null;
   rooms?: string[] | null;
   isPublished: boolean;
+  // True when the server holds the verbatim BlueprintsV2 upload — downloads
+  // should fetch GET /api/blueprints/:id/raw instead of regenerating the
+  // file from the parsed data.
+  hasRawSource?: boolean;
+  rawSourceFormat?: string | null;
 }

--- a/lib/src/io/bni/bni-blueprint.d.ts
+++ b/lib/src/io/bni/bni-blueprint.d.ts
@@ -1,7 +1,30 @@
 import { BniBuilding } from './bni-building';
+export interface BniWorldNote {
+    x: number;
+    y: number;
+    type: number;
+    title?: string;
+    text?: string;
+    tinthex?: string;
+    id?: number;
+    mass?: number;
+    temp?: number;
+}
+export interface BniPlanShape {
+    x: number;
+    y: number;
+    shape: number;
+    color: number;
+}
 export declare class BniBlueprint {
     friendlyname: string;
     buildings: BniBuilding[];
     digcommands: any[];
+    blueprintVersion?: number;
+    userdesc?: string;
+    icon?: string;
+    icontint?: string;
+    worldNotes?: BniWorldNote[];
+    planningtoolmod_shapecollection?: BniPlanShape[];
 }
 //# sourceMappingURL=bni-blueprint.d.ts.map

--- a/lib/src/io/bni/bni-blueprint.ts
+++ b/lib/src/io/bni/bni-blueprint.ts
@@ -1,7 +1,40 @@
 import { BniBuilding } from './bni-building';
 
+// BlueprintsV2 world-note annotation pins (spec/blueprintsv2-import-spec.md §2.4).
+// type 0 = text note, type 1 = element note (id is the element tag hash,
+// mass in kg, temp in Kelvin).
+export interface BniWorldNote {
+  x: number;
+  y: number;
+  type: number;
+  title?: string;
+  text?: string;
+  tinthex?: string;
+  id?: number;
+  mass?: number;
+  temp?: number;
+}
+
+// Planning Tool mod overlay cell (§2.5) — decorative only.
+export interface BniPlanShape {
+  x: number;
+  y: number;
+  shape: number;
+  color: number;
+}
+
 export class BniBlueprint {
   friendlyname: string = '';
   buildings: BniBuilding[] = [];
   digcommands: any[] = [];
+
+  // BlueprintsV2 v3 metadata (all optional — the mod omits empty keys).
+  // Parsed for display/prefill; the byte-exact source of truth for round-trip
+  // is the raw upload stored server-side, never this parsed view.
+  blueprintVersion?: number;
+  userdesc?: string;
+  icon?: string;
+  icontint?: string;
+  worldNotes?: BniWorldNote[];
+  planningtoolmod_shapecollection?: BniPlanShape[];
 }

--- a/lib/src/io/bni/bni-building.d.ts
+++ b/lib/src/io/bni/bni-building.d.ts
@@ -1,10 +1,15 @@
 import { Vector2 } from '../../vector2';
 import { Orientation } from '../../enums/orientation';
+export interface BniBuildingData {
+    Key: string;
+    Value: any;
+}
 export declare class BniBuilding {
     offset: Vector2;
     buildingdef: string;
     orientation: Orientation;
     flags: number;
     selected_elements: number[];
+    buildingData?: BniBuildingData[];
 }
 //# sourceMappingURL=bni-building.d.ts.map

--- a/lib/src/io/bni/bni-building.ts
+++ b/lib/src/io/bni/bni-building.ts
@@ -1,10 +1,20 @@
 import { Vector2 } from '../../vector2';
 import { Orientation } from '../../enums/orientation';
 
+// One per-component settings entry from BlueprintsV2 (§3). Value shapes are
+// component-specific and version-fragile — treated as opaque passthrough.
+export interface BniBuildingData {
+  Key: string;
+  Value: any;
+}
+
 export class BniBuilding {
   offset: Vector2 = new Vector2();
   buildingdef: string = '';
   orientation: Orientation = Orientation.Neutral;
   flags: number = 0;
+  // Construction materials as Klei tag hashes, recipe-ingredient order —
+  // each resolves to BuildableElement.tag (§2.3).
   selected_elements: number[] = [];
+  buildingData?: BniBuildingData[];
 }

--- a/lib/src/io/bni/bni-share-string.d.ts
+++ b/lib/src/io/bni/bni-share-string.d.ts
@@ -1,0 +1,6 @@
+export declare const RAW_SOURCE_FORMATS: readonly ["bpv2-json", "bpv2-sharestring"];
+export type RawSourceFormat = (typeof RAW_SOURCE_FORMATS)[number];
+export declare function looksLikeBniShareString(text: string): boolean;
+export declare function decodeBniShareString(shareString: string): Promise<string>;
+export declare function encodeBniShareString(json: string): Promise<string>;
+//# sourceMappingURL=bni-share-string.d.ts.map

--- a/lib/src/io/bni/bni-share-string.ts
+++ b/lib/src/io/bni/bni-share-string.ts
@@ -1,0 +1,57 @@
+// BlueprintsV2 clipboard/share-string transport (spec/blueprintsv2-import-spec.md §1.2):
+// base64( 4-byte little-endian uncompressed-length ++ gzip(utf8(json)) ).
+// Decoding uses the standard DecompressionStream API, available in every
+// modern browser and in Node 18+ — no gzip dependency on either tier.
+
+// Discriminator for the verbatim raw upload stored on a blueprint record
+// (§8): 'bpv2-json' = the .blueprint file text, 'bpv2-sharestring' = the
+// clipboard share-string text. Downloads serve the stored text unmodified.
+export const RAW_SOURCE_FORMATS = ['bpv2-json', 'bpv2-sharestring'] as const;
+export type RawSourceFormat = (typeof RAW_SOURCE_FORMATS)[number];
+
+// Cheap shape check so import UIs can route pasted/uploaded text without
+// attempting a full decode. Deliberately loose: decode remains the authority.
+export function looksLikeBniShareString(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length < 12) return false;
+  return /^[A-Za-z0-9+/]+={0,2}$/.test(trimmed);
+}
+
+// Decodes a share-string to the underlying blueprint JSON text. Throws on
+// anything that is not a valid share-string (bad base64, bad gzip payload).
+export async function decodeBniShareString(shareString: string): Promise<string> {
+  const bytes = base64ToBytes(shareString.trim());
+  // First 4 bytes are the informational uncompressed-length prefix; gzip is
+  // self-terminating so the prefix is skipped, not trusted.
+  if (bytes.length <= 4) throw new Error('Share string too short');
+  const gzipped = bytes.subarray(4);
+
+  const stream = new Blob([gzipped]).stream().pipeThrough(new DecompressionStream('gzip'));
+  const decompressed = await new Response(stream).arrayBuffer();
+  return new TextDecoder().decode(decompressed);
+}
+
+function base64ToBytes(base64: string): Uint8Array<ArrayBuffer> {
+  // atob exists in browsers and Node 16+; keeps this module runtime-agnostic.
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+// Encodes blueprint JSON text back into a share-string — the inverse of
+// decodeBniShareString, byte-compatible with the mod's ExportToClipboard.
+export async function encodeBniShareString(json: string): Promise<string> {
+  const utf8 = new TextEncoder().encode(json);
+
+  const stream = new Blob([utf8]).stream().pipeThrough(new CompressionStream('gzip'));
+  const gzipped = new Uint8Array(await new Response(stream).arrayBuffer());
+
+  const withHeader = new Uint8Array(4 + gzipped.length);
+  new DataView(withHeader.buffer).setInt32(0, utf8.length, true);
+  withHeader.set(gzipped, 4);
+
+  let binary = '';
+  for (let i = 0; i < withHeader.length; i++) binary += String.fromCharCode(withHeader[i]);
+  return btoa(binary);
+}


### PR DESCRIPTION
Implements the shippable core of `spec/blueprintsv2-import-spec.md` (local spec doc): the site can now ingest what the BlueprintsV2 in-game mod exports and hand the original file back **byte-exact**, instead of stripping everything but geometry.

## What shipped

**Lib (shared parsing)**
- `BniBlueprint`/`BniBuilding` extended to the v3 schema: `userdesc`, `icon`, `icontint`, `worldNotes`, `planningtoolmod_shapecollection`, per-building `buildingData` (opaque passthrough).
- **P1 materials**: `selected_elements` Klei tag hashes resolve via new `BuildableElement.getElementByTag` → `setElement`, in recipe order; unknown hashes fall back to the default material. Imported blueprints now render with their chosen materials.
- **P2 share-string transport**: `decodeBniShareString`/`encodeBniShareString` implement the mod's clipboard format (base64 + 4-byte LE length header + gzip) using `DecompressionStream` — zero new dependencies, works in browsers and Node 18+.
- **Q8 unknown buildings**: imports collect `unknownBuildingDefs` (e.g. the sample's modded `PAirlockDoor`) instead of dropping silently.

**Backend (the §8/Q7 mandate)**
- `rawSource`/`rawSourceFormat` on the blueprint document: the verbatim uploaded text, stored only while the saved `data` matches the imported content. Edit-saves and version restores clear it — a served original can never disagree with the rendered blueprint.
- `GET /api/blueprints/:id/raw` serves the stored text verbatim with download headers (draft-gated, counts a download). `getblueprint` reports `hasRawSource`/`rawSourceFormat`; list projections exclude the blob.
- Upload validates a 2MB cap + format allowlist.

**Frontend**
- New **Upload → Blueprint (paste text)** dialog for the mod's copy-to-clipboard share-string (file upload path is share-string tolerant too).
- The held raw text ships with a save only while the blueprint still hashes to the imported content (`hashMdb` fingerprint).
- Downloads (details page + editor menu) prefer the server's raw copy for unedited imports, fall back to generation otherwise.
- Sticky "Unrecognized buildings" toast naming skipped modded defs; save dialog prefills description from the mod's `userdesc`.

## Deliberately not in scope (per spec decisions)
- Rendering `buildingData` settings, world notes overlay, planning-tool shapes, blueprint icons (Q4/Q6: preserve verbatim, interpret later).
- Placeholder art for unknown buildings (toast + retention now; art is follow-up).

## Verification
- Backend: 8 new API tests (`blueprint-raw-source.test.ts`) — byte-exact serve, share-string content type, clear-on-edit, draft gating, format/size validation. Suite green except the 2 known local-only workos-provision flakes.
- Lib: 11 new tests (`bpv2-import.test.ts`) driven by a real mod export committed as a fixture — materials incl. multi-ingredient order, unknown-hash fallback, metadata, wire-format decode proven against a Node-zlib-crafted share-string.
- Frontend: 832 specs passing (new coverage for raw round-trip, tolerant parse, download preference, import dialog); lint clean; `npm run tsc` clean.
- **End-to-end in a real browser** (Playwright against dev servers): pasted a mod-style share-string of the sample export → import rendered 70 buildings with correct materials + PAirlockDoor warning toast → saved ("Save & Publish", description prefilled from userdesc) → `diff`'d `/api/blueprints/:id/raw` against the pasted text: **byte-exact**, correct `text/plain` + `.txt` disposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)