### PR TITLE
feat(import): perceptual guard skips re-encode noise in sprite sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,9 +72,14 @@ run the single repeatable step:
   The `database-2024.zip` (both roots) is a **gitignored** build derivative: the backend
   reads the JSON directly, the frontend regenerates the zip from it via `prebuild`/
   `prestart` (`frontend/scripts/build-database-zip.js`). The converter emits no `.zip`.
-- Sprite sync only rewrites files whose bytes changed and prunes removed ones, so
-  unchanged icons keep their mtime; the deterministic export means git shows only real
-  changes. Re-importing the same export is a near no-op.
+- Sprite sync rewrites a file only when it actually changed and prunes removed ones, so
+  unchanged icons keep their mtime and git shows only real changes. The export is NOT
+  byte-deterministic across game updates (Klei re-rasterizes untouched art), so a PNG
+  that differs in bytes is additionally checked *perceptually* (`pngVisuallyEqual`:
+  alpha-premultiply → small Gaussian blur → count pixels still differing) and preserved
+  when the pixels are visually identical. The blur is what distinguishes real redraws from
+  sub-pixel re-rasterization jitter even on densely-textured sprites. Re-importing the same
+  export is a near no-op.
 - `ui_image_facade/` is intentionally skipped (unused by the app); one-line flip in
   `app/api/batch/convert-export-2024.ts` to enable.
 - After import: restart `npm run dev` (backend reads `database-2024.json` at startup) and

--- a/app/api/batch/convert-export-2024.md
+++ b/app/api/batch/convert-export-2024.md
@@ -25,9 +25,16 @@ Steps:
 3. Detect connectables (a `connection_sprites/<prefabId>/` dir exists) and **measure**
    each one's render scale from its `15.png`.
 4. Mirror `ui_image/` and `connection_sprites/` into both asset roots **content-aware**:
-   only files whose bytes changed are rewritten, only removed files are pruned, so
-   unchanged icons keep their mtime (no churn). `ui_image_facade/` is skipped (unused;
-   one-line flip near the top of the converter to enable).
+   a file is rewritten only when it actually changed, only removed files are pruned, so
+   unchanged icons keep their mtime (no churn). The export is **not byte-deterministic**
+   across game updates — Klei re-rasterizes untouched art, spraying sub-pixel anti-aliasing
+   jitter along icon edges — so a byte-different PNG is additionally compared *perceptually*
+   (`pngVisuallyEqual`: alpha-premultiply → 2-pass Gaussian blur → count pixels still
+   differing by more than a threshold) and **preserved** when visually identical. The blur
+   is what separates genuine redraws from re-rasterization jitter even on densely-textured
+   sprites (doors, gas blobs), where a raw pixel count cannot. Sync logs report the preserved
+   count as `preserved N re-encoded`. `ui_image_facade/` is skipped (unused; one-line flip
+   near the top of the converter to enable).
 5. Flatten `database/po_string.json` into `frontend/src/assets/strings/strings.json` —
    the English game-string map the website resolves display names against (element,
    building, category names + overlay labels). Keys are prefixed with `STRINGS.` to match

--- a/app/api/batch/convert-export-2024.ts
+++ b/app/api/batch/convert-export-2024.ts
@@ -158,9 +158,138 @@ function filesDiffer(src: string, dest: string): boolean {
   return !fs.readFileSync(src).equals(fs.readFileSync(dest));
 }
 
+// The 2024 export is NOT byte-deterministic across game updates: Klei re-rasterizes untouched
+// vector art on every build, so a pure byte compare churns hundreds of visually-identical
+// sprites on re-import. The noise is always sub-pixel edge jitter — re-rasterization sprays a
+// ~1px anti-aliasing halo along every icon edge. On densely-textured sprites (e.g. the
+// diamond-mesh doors, or the gas-element blobs) that halo can be thousands of pixels, so a raw
+// per-pixel count cannot tell jitter from a real redraw. What CAN: a small Gaussian blur.
+// Blurring both images by ~1px averages out the ±1px edge jitter (it collapses to zero) while
+// a genuine fill/shape/colour change survives. So the guard premultiplies alpha (matching what
+// renders over the dark UI), blurs PNG_BLUR_PASSES times, and counts pixels still differing by
+// more than PNG_BLUR_DELTA. Verified across a full game-update import: every re-encode-only
+// sprite (all gas overlays + all automation port indicators) collapses to 0 changed pixels,
+// while the smallest genuine redraw stays > 2000 — so PNG_MAX_INCIDENTAL_PIXELS sits in an
+// enormous gap. Dimension changes and decode failures always count as changed.
+const PNG_BLUR_PASSES = 2; // 5-tap Gaussian composed twice ~= sigma 1.2
+const PNG_BLUR_DELTA = 12; // per-channel (0-255) on blurred, alpha-premultiplied RGB
+const PNG_MAX_INCIDENTAL_PIXELS = 64;
+
+// Decode a PNG to raw RGBA using canvas (already a dependency for connection-scale).
+function decodePng(file: string): { w: number; h: number; data: Uint8ClampedArray } {
+  const img = new Image();
+  img.src = fs.readFileSync(file);
+  const w = img.width;
+  const h = img.height;
+  const ctx = createCanvas(w, h).getContext('2d');
+  ctx.drawImage(img, 0, 0);
+  return { w, h, data: ctx.getImageData(0, 0, w, h).data };
+}
+
+// One pass of a separable 5-tap Gaussian ([1 4 6 4 1]/16, sigma ~0.85), edge-clamped.
+function blurPlane(src: Float32Array, w: number, h: number): Float32Array {
+  const k0 = 6 / 16;
+  const k1 = 4 / 16;
+  const k2 = 1 / 16;
+  const tmp = new Float32Array(w * h);
+  for (let y = 0; y < h; y++) {
+    const r = y * w;
+    for (let x = 0; x < w; x++) {
+      tmp[r + x] =
+        k2 * src[r + Math.max(0, x - 2)] +
+        k1 * src[r + Math.max(0, x - 1)] +
+        k0 * src[r + x] +
+        k1 * src[r + Math.min(w - 1, x + 1)] +
+        k2 * src[r + Math.min(w - 1, x + 2)];
+    }
+  }
+  const out = new Float32Array(w * h);
+  for (let y = 0; y < h; y++) {
+    const r = y * w;
+    const m2 = Math.max(0, y - 2) * w;
+    const m1 = Math.max(0, y - 1) * w;
+    const p1 = Math.min(h - 1, y + 1) * w;
+    const p2 = Math.min(h - 1, y + 2) * w;
+    for (let x = 0; x < w; x++) {
+      out[r + x] =
+        k2 * tmp[m2 + x] +
+        k1 * tmp[m1 + x] +
+        k0 * tmp[r + x] +
+        k1 * tmp[p1 + x] +
+        k2 * tmp[p2 + x];
+    }
+  }
+  return out;
+}
+
+// The three alpha-premultiplied RGB planes of an image, each blurred PNG_BLUR_PASSES times.
+function blurredPremultPlanes(img: {
+  w: number;
+  h: number;
+  data: Uint8ClampedArray;
+}): [Float32Array, Float32Array, Float32Array] {
+  const n = img.w * img.h;
+  const r = new Float32Array(n);
+  const g = new Float32Array(n);
+  const b = new Float32Array(n);
+  for (let p = 0, i = 0; p < n; p++, i += 4) {
+    const alpha = img.data[i + 3] / 255;
+    r[p] = img.data[i] * alpha;
+    g[p] = img.data[i + 1] * alpha;
+    b[p] = img.data[i + 2] * alpha;
+  }
+  const planes: [Float32Array, Float32Array, Float32Array] = [r, g, b];
+  for (let c = 0; c < 3; c++)
+    for (let pass = 0; pass < PNG_BLUR_PASSES; pass++)
+      planes[c] = blurPlane(planes[c], img.w, img.h);
+  return planes;
+}
+
+// True when two PNGs are visually identical: same dimensions and, after alpha-premultiplying
+// and blurring both, at most PNG_MAX_INCIDENTAL_PIXELS pixels still differ by more than
+// PNG_BLUR_DELTA on any channel. The blur absorbs sub-pixel edge jitter; genuine art changes
+// survive it. Any decode failure or dimension change returns false (treat as changed, so we
+// never silently drop a real update).
+function pngVisuallyEqual(src: string, dest: string): boolean {
+  let a: { w: number; h: number; data: Uint8ClampedArray };
+  let b: { w: number; h: number; data: Uint8ClampedArray };
+  try {
+    a = decodePng(src);
+    b = decodePng(dest);
+  } catch {
+    return false;
+  }
+  if (!a.w || !a.h || a.w !== b.w || a.h !== b.h) return false;
+  const [ar, ag, ab] = blurredPremultPlanes(a);
+  const [br, bg, bb] = blurredPremultPlanes(b);
+  let changed = 0;
+  for (let p = 0; p < ar.length; p++) {
+    const d = Math.max(
+      Math.abs(ar[p] - br[p]),
+      Math.abs(ag[p] - bg[p]),
+      Math.abs(ab[p] - bb[p])
+    );
+    if (d > PNG_BLUR_DELTA && ++changed > PNG_MAX_INCIDENTAL_PIXELS) return false;
+  }
+  return true;
+}
+
+type SpriteVerdict = 'identical' | 'preserved' | 'changed';
+
+// Decide whether a synced sprite should be rewritten. Byte-identical files are 'identical'
+// (skip, keep mtime). PNGs whose bytes changed but whose pixels are visually identical are
+// 'preserved' (keep the committed file, so re-import doesn't churn on export re-encode
+// jitter). Everything else is 'changed' and gets copied.
+function classifySprite(src: string, dest: string): SpriteVerdict {
+  if (!filesDiffer(src, dest)) return 'identical';
+  if (dest.toLowerCase().endsWith('.png') && pngVisuallyEqual(src, dest)) return 'preserved';
+  return 'changed';
+}
+
 interface MirrorStats {
   copied: number;
   skipped: number;
+  preserved: number;
   removed: number;
 }
 
@@ -192,11 +321,16 @@ function mirrorDir(src: string, dest: string, stats: MirrorStats): void {
       // Clear a same-named dir before writing a file (type changed src->dest).
       if (fs.existsSync(destPath) && fs.statSync(destPath).isDirectory())
         fs.rmSync(destPath, { recursive: true, force: true });
-      if (filesDiffer(srcPath, destPath)) {
-        fs.copyFileSync(srcPath, destPath);
-        stats.copied++;
-      } else {
-        stats.skipped++;
+      switch (classifySprite(srcPath, destPath)) {
+        case 'changed':
+          fs.copyFileSync(srcPath, destPath);
+          stats.copied++;
+          break;
+        case 'preserved':
+          stats.preserved++;
+          break;
+        default:
+          stats.skipped++;
       }
     }
   }
@@ -209,14 +343,15 @@ function syncAssetDir(src: string, targets: string[], label: string): void {
     return;
   }
   for (const target of targets) {
-    const stats: MirrorStats = { copied: 0, skipped: 0, removed: 0 };
+    const stats: MirrorStats = { copied: 0, skipped: 0, preserved: 0, removed: 0 };
     mirrorDir(src, target, stats);
     console.log(
       '--- synced',
       label,
       '->',
       path.normalize(target),
-      `(updated ${stats.copied}, unchanged ${stats.skipped}, removed ${stats.removed}) ---`
+      `(updated ${stats.copied}, unchanged ${stats.skipped}, ` +
+        `preserved ${stats.preserved} re-encoded, removed ${stats.removed}) ---`
     );
   }
 }
@@ -696,7 +831,7 @@ export function convertExport2024(opts: ConvertOptions): void {
   for (const name of UTILITY_INDICATOR_NAMES) {
     const src = path.join(uiImageDir, name + '.png');
     const dest = path.join(imagesDir, name + '.png');
-    if (fs.existsSync(src) && filesDiffer(src, dest)) {
+    if (fs.existsSync(src) && classifySprite(src, dest) === 'changed') {
       fs.copyFileSync(src, dest);
       indicatorsCopied++;
     }


### PR DESCRIPTION
## What

`npm run import:2024` churned hundreds of visually-identical sprite PNGs on every re-import. Root cause: the 2024 export is **not byte-deterministic** across game updates — Klei re-rasterizes untouched vector art on every build, spraying a ~1px anti-aliasing halo along icon edges. The byte-only sprite sync treated all of that as "changed." One real game update produced **589 modified sprites, of which only 6 were genuine changes**.

This adds a perceptual gate to the sync path so re-encode noise is preserved (committed file kept) while real art changes still sync.

## How

When a synced PNG's bytes differ, `pngVisuallyEqual` decides whether to rewrite:
1. **alpha-premultiply** both images (matches what renders over the dark game UI; makes RGB noise under transparent pixels invisible)
2. **2-pass separable Gaussian blur** (~σ 1.2)
3. **count pixels** still differing by more than a per-channel threshold; preserve if under a small budget

The blur is the crux. Raw pixel-counting can't distinguish sub-pixel edge jitter from a real redraw on densely-textured sprites (the diamond-mesh doors, the gas blobs generate thousands of edge-delta pixels either way). Blurring averages out the ±1px jitter — it collapses to zero — while genuine fill/shape/colour changes survive.

Byte-identical files keep the existing fast path. Dimension changes and decode failures always count as changed, so a real update is never silently dropped.

## Verification

Ran against a real game-update export, reverting to the committed baseline and re-importing:

| category | count | outcome |
|---|--:|---|
| whole-image low-bit jitter | 474 | preserved (0 changed px) |
| gas/element edge-halo jitter | 31 | preserved (0) |
| automation port indicators | 7 | preserved (0) |
| connection-sprite jitter | 36 | preserved (0) |
| **genuine redraws** (doors, wall, locker) | 5 | written (2310–41000 px) |
| **dimension change** (SnailEgg) | 1 | written |

**589 → 12 modified PNGs** (6 sprites × 2 asset roots). 0-vs-2310 separation between noise and the smallest real change. Each surviving sprite was visually confirmed to be a genuine change. Adds ~1s to a 32s import. `npm run tsc` clean.

## Scope

Tooling + docs only (`convert-export-2024.ts`, `convert-export-2024.md`, `CLAUDE.md`). The game-update asset re-import is committed separately by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)