### PR TITLE
Add Planning Tool note support

### DIFF
--- a/__tests__/lib/blueprint-import.test.ts
+++ b/__tests__/lib/blueprint-import.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { Blueprint, BlueprintHelpers, MdbBlueprint } from '../../lib';
+import { Blueprint, BlueprintHelpers, MdbBlueprint, Vector2 } from '../../lib';
 import { loadGameDatabase } from '../helpers/roomFixtures';
 
 // Regression coverage for a real prod crash: a legacy blueprint referencing a
@@ -37,5 +37,49 @@ describe('Blueprint import: unknown building ids', function () {
 
     expect(blueprint.hadUnknownBuildings).to.equal(false);
     expect(blueprint.blueprintItems).to.have.length(1);
+  });
+});
+
+describe('Blueprint import: Planning Tool shapes', function () {
+  const plans = [
+    { x: 0, y: 0, shape: 0, color: 1 },
+    { x: 2, y: 1, shape: 2, color: 10 },
+  ];
+
+  it('imports shapes from BlueprintsV2 and preserves them through MDB', () => {
+    const imported = new Blueprint();
+    imported.importFromBni({
+      friendlyname: 'plans',
+      buildings: [],
+      digcommands: plans.map(({ x, y }) => ({ x, y })),
+      planningtoolmod_shapecollection: plans,
+    });
+
+    expect(imported.planningToolShapes).to.deep.equal(plans);
+    const reopened = new Blueprint();
+    reopened.importFromMdb(imported.toMdbBlueprint());
+    expect(reopened.planningToolShapes).to.deep.equal(plans);
+  });
+
+  it('exports game-compatible planning cells and dig commands', () => {
+    const blueprint = new Blueprint();
+    blueprint.planningToolShapes = plans;
+    const exported = blueprint.toBniBlueprint('plans');
+
+    expect(exported.blueprintVersion).to.equal(3);
+    expect(exported.planningtoolmod_shapecollection).to.deep.equal(plans);
+    expect(exported.digcommands).to.deep.equal([
+      { x: 0, y: 0 },
+      { x: 2, y: 1 },
+    ]);
+  });
+
+  it('includes planning-only cells in the camera bounds', () => {
+    const blueprint = new Blueprint();
+    blueprint.planningToolShapes = plans;
+    expect(blueprint.getBoundingBox()).to.deep.equal([
+      new Vector2(0, 0),
+      new Vector2(2, 1),
+    ]);
   });
 });

--- a/frontend/src/app/module-blueprint/common/tools/planning-tool.spec.ts
+++ b/frontend/src/app/module-blueprint/common/tools/planning-tool.spec.ts
@@ -1,14 +1,21 @@
 import { PlanningTool } from "./planning-tool";
 import { ToolType } from "./tool";
-import { Vector2 } from "../../../../../../lib/index";
+import { BniPlanShape, Vector2 } from "../../../../../../lib/index";
+import { BlueprintService } from "../../services/blueprint-service";
+
+interface PlanningBlueprintMock {
+  planningToolShapes: BniPlanShape[];
+  emitBlueprintChanged: ReturnType<typeof vi.fn>;
+}
 
 describe("PlanningTool", () => {
   let tool: PlanningTool;
-  let blueprint: any;
+  let blueprint: PlanningBlueprintMock;
 
   beforeEach(() => {
     blueprint = { planningToolShapes: [], emitBlueprintChanged: vi.fn() };
-    tool = new PlanningTool({ blueprint } as any);
+    const blueprintService = { blueprint } as unknown as BlueprintService;
+    tool = new PlanningTool(blueprintService);
   });
 
   it("is an exclusive input tool", () => {

--- a/frontend/src/app/module-blueprint/common/tools/planning-tool.spec.ts
+++ b/frontend/src/app/module-blueprint/common/tools/planning-tool.spec.ts
@@ -1,0 +1,48 @@
+import { PlanningTool } from "./planning-tool";
+import { ToolType } from "./tool";
+import { Vector2 } from "../../../../../../lib/index";
+
+describe("PlanningTool", () => {
+  let tool: PlanningTool;
+  let blueprint: any;
+
+  beforeEach(() => {
+    blueprint = { planningToolShapes: [], emitBlueprintChanged: vi.fn() };
+    tool = new PlanningTool({ blueprint } as any);
+  });
+
+  it("is an exclusive input tool", () => {
+    expect(tool.toolType).toBe(ToolType.planning);
+    expect(tool.toolGroup).toBe(1);
+    expect(tool.captureInput).toBe(true);
+  });
+
+  it("adds a shape using the selected shape and color", () => {
+    tool.shape = 2;
+    tool.color = 8;
+    tool.mouseDown(new Vector2(4, 5));
+    expect(blueprint.planningToolShapes).to.deep.equal([
+      { x: 4, y: 5, shape: 2, color: 8 },
+    ]);
+    expect(blueprint.emitBlueprintChanged).toHaveBeenCalledOnce();
+  });
+
+  it("replaces an existing shape at the same cell", () => {
+    blueprint.planningToolShapes.push({ x: 4, y: 5, shape: 0, color: 0 });
+    tool.shape = 1;
+    tool.color = 3;
+    tool.mouseDown(new Vector2(4, 5));
+    expect(blueprint.planningToolShapes).to.deep.equal([
+      { x: 4, y: 5, shape: 1, color: 3 },
+    ]);
+  });
+
+  it("erases a shape and ignores empty cells", () => {
+    blueprint.planningToolShapes.push({ x: 1, y: 2, shape: 0, color: 1 });
+    tool.erase = true;
+    tool.mouseDown(new Vector2(1, 2));
+    tool.mouseDown(new Vector2(9, 9));
+    expect(blueprint.planningToolShapes).to.deep.equal([]);
+    expect(blueprint.emitBlueprintChanged).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/app/module-blueprint/common/tools/planning-tool.ts
+++ b/frontend/src/app/module-blueprint/common/tools/planning-tool.ts
@@ -18,7 +18,7 @@ export class PlanningTool implements ITool {
   color = 1;
   erase = false;
   private hoverTile: Vector2 | null = null;
-  private preview: any = null;
+  private preview: PIXI.Graphics | null = null;
 
   constructor(private blueprintService: BlueprintService) {}
 
@@ -77,15 +77,18 @@ export class PlanningTool implements ITool {
   keyDown(_keyCode: string) {}
 
   draw(drawPixi: DrawPixi, camera: CameraService) {
-    if (this.preview == null) {
-      this.preview = drawPixi.getNewGraphics();
-      drawPixi.pixiApp.stage.addChild(this.preview);
+    let preview = this.preview;
+    if (preview == null) {
+      const created = drawPixi.getNewGraphics() as PIXI.Graphics;
+      drawPixi.pixiApp.stage.addChild(created);
+      this.preview = created;
+      preview = created;
     }
-    this.preview.clear();
-    this.preview.visible = this.hoverTile != null && !this.erase;
-    if (this.preview.visible)
+    preview.clear();
+    preview.visible = this.hoverTile != null && !this.erase;
+    if (preview.visible)
       drawPlanningShape(
-        this.preview,
+        preview,
         { ...this.hoverTile!, shape: this.shape, color: this.color },
         camera,
         0.55,

--- a/frontend/src/app/module-blueprint/common/tools/planning-tool.ts
+++ b/frontend/src/app/module-blueprint/common/tools/planning-tool.ts
@@ -11,7 +11,7 @@ import { drawPlanningShape } from "../../drawing/draw-planning-overlay";
 import { ITool, ToolType } from "./tool";
 import { ToolService } from "../../services/tool-service";
 
-@Injectable()
+@Injectable({ providedIn: "root" })
 export class PlanningTool implements ITool {
   parent!: ToolService;
   shape = 0;

--- a/frontend/src/app/module-blueprint/common/tools/planning-tool.ts
+++ b/frontend/src/app/module-blueprint/common/tools/planning-tool.ts
@@ -1,0 +1,100 @@
+import { Injectable } from "@angular/core";
+import {
+  BniPlanShape,
+  CameraService,
+  DrawHelpers,
+  Vector2,
+} from "../../../../../../lib/index";
+import { BlueprintService } from "../../services/blueprint-service";
+import { DrawPixi } from "../../drawing/draw-pixi";
+import { drawPlanningShape } from "../../drawing/draw-planning-overlay";
+import { ITool, ToolType } from "./tool";
+import { ToolService } from "../../services/tool-service";
+
+@Injectable()
+export class PlanningTool implements ITool {
+  parent!: ToolService;
+  shape = 0;
+  color = 1;
+  erase = false;
+  private hoverTile: Vector2 | null = null;
+  private preview: any = null;
+
+  constructor(private blueprintService: BlueprintService) {}
+
+  private apply(tile: Vector2) {
+    const position = DrawHelpers.getIntegerTile(tile);
+    const plans = this.blueprintService.blueprint.planningToolShapes;
+    const existing = plans.findIndex(
+      (plan) => plan.x === position.x && plan.y === position.y,
+    );
+
+    if (this.erase) {
+      if (existing < 0) return;
+      plans.splice(existing, 1);
+    } else {
+      const plan: BniPlanShape = {
+        x: position.x,
+        y: position.y,
+        shape: this.shape,
+        color: this.color,
+      };
+      if (
+        existing >= 0 &&
+        plans[existing].shape === plan.shape &&
+        plans[existing].color === plan.color
+      )
+        return;
+      if (existing >= 0) plans[existing] = plan;
+      else plans.push(plan);
+    }
+    this.blueprintService.blueprint.emitBlueprintChanged();
+  }
+
+  switchFrom() {
+    this.hoverTile = null;
+    if (this.preview != null) this.preview.visible = false;
+  }
+  switchTo() {}
+  mouseOut() {
+    this.hoverTile = null;
+  }
+  mouseDown(tile: Vector2) {
+    this.apply(tile);
+  }
+  leftClick(_tile: Vector2) {}
+  rightClick(_tile: Vector2) {
+    this.parent.changeTool(ToolType.select);
+  }
+  hover(tile: Vector2) {
+    this.hoverTile = DrawHelpers.getIntegerTile(tile);
+  }
+  drag(_tileStart: Vector2, tileStop: Vector2) {
+    this.hoverTile = DrawHelpers.getIntegerTile(tileStop);
+    this.apply(tileStop);
+  }
+  dragStop() {}
+  keyDown(_keyCode: string) {}
+
+  draw(drawPixi: DrawPixi, camera: CameraService) {
+    if (this.preview == null) {
+      this.preview = drawPixi.getNewGraphics();
+      drawPixi.pixiApp.stage.addChild(this.preview);
+    }
+    this.preview.clear();
+    this.preview.visible = this.hoverTile != null && !this.erase;
+    if (this.preview.visible)
+      drawPlanningShape(
+        this.preview,
+        { ...this.hoverTile!, shape: this.shape, color: this.color },
+        camera,
+        0.55,
+      );
+  }
+
+  toggleable = false;
+  visible = false;
+  captureInput = true;
+  toolType = ToolType.planning;
+  toolGroup = 1;
+}

--- a/frontend/src/app/module-blueprint/common/tools/tool.ts
+++ b/frontend/src/app/module-blueprint/common/tools/tool.ts
@@ -6,6 +6,7 @@ export enum ToolType {
   build,
   elementReport,
   scissors,
+  planning,
 }
 
 export interface ITool {

--- a/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.html
+++ b/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.html
@@ -24,6 +24,9 @@
       </app-selection-tool>
       <app-build-tool #buildTool [hidden]="!toolService.buildTool.visible">
       </app-build-tool>
+      <app-planning-tool
+        [hidden]="!toolService.planningTool.visible"
+      ></app-planning-tool>
     </div>
     <div class="side-panel-right">
       <app-element-report-tool *ngIf="showElementReport" #elementReportTool>
@@ -41,6 +44,13 @@
       i18n-label
       [active]="toolService.selectTool.visible"
       (buttonClick)="toolService.changeTool(ToolType.select)"
+    ></app-toolbar-button>
+    <app-toolbar-button
+      iconUrl="assets/images/icon-planning.svg"
+      label="Planning Notes"
+      i18n-label
+      [active]="toolService.planningTool.visible"
+      (buttonClick)="toolService.changeTool(ToolType.planning)"
     ></app-toolbar-button>
     <app-toolbar-button
       iconUrl="assets/images/icon-scissors.png"

--- a/frontend/src/app/module-blueprint/components/component-canvas/component-canvas.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-canvas/component-canvas.component.ts
@@ -33,6 +33,7 @@ import { DrawPixi } from "../../drawing/draw-pixi";
 import { DrawMiniUi } from "../../drawing/draw-mini-ui";
 import { DrawRoomOverlay } from "../../drawing/draw-room-overlay";
 import { DrawNotesOverlay } from "../../drawing/draw-notes-overlay";
+import { DrawPlanningOverlay } from "../../drawing/draw-planning-overlay";
 import { RoomDetectionService } from "../../services/room-detection-service";
 import { WorldNoteService } from "../../services/world-note.service";
 import { GoogleAnalyticsService } from "ngx-google-analytics";
@@ -80,6 +81,7 @@ export class ComponentCanvasComponent
   drawPixi: DrawPixi;
   drawRoomOverlay!: DrawRoomOverlay;
   drawNotesOverlay!: DrawNotesOverlay;
+  drawPlanningOverlay!: DrawPlanningOverlay;
 
   private cameraService: CameraService;
 
@@ -119,6 +121,7 @@ export class ComponentCanvasComponent
       this.cameraService.container = this.drawPixi.blueprintContainer;
       this.drawRoomOverlay = new DrawRoomOverlay(this.drawPixi);
       this.drawNotesOverlay = new DrawNotesOverlay(this.drawPixi);
+      this.drawPlanningOverlay = new DrawPlanningOverlay(this.drawPixi);
 
       if (this.forceSize) {
         const miniUi = new DrawMiniUi();
@@ -239,7 +242,10 @@ export class ComponentCanvasComponent
       new Vector2(rect.width - rect.left, rect.height - rect.top),
     );
 
-    if (source.blueprintItems.length > 0) {
+    if (
+      source.blueprintItems.length > 0 ||
+      source.planningToolShapes.length > 0
+    ) {
       const boundingBox = this.blueprint.getBoundingBox();
       const topLeft = boundingBox[0];
       const bottomRight = boundingBox[1];
@@ -1089,6 +1095,13 @@ export class ComponentCanvasComponent
       }
 
       this.toolService.draw(this.drawPixi, this.cameraService);
+
+      // Planning Tool cells are blueprint content, so include them in the
+      // editor, thumbnails, and exported images.
+      this.drawPlanningOverlay.draw(
+        this.blueprint.planningToolShapes,
+        this.cameraService,
+      );
 
       // Room overlay: cavity tints + labels above everything. Only the main
       // editor canvas drives detection activity — export/thumbnail canvases

--- a/frontend/src/app/module-blueprint/components/side-bar/planning-tool/planning-tool.component.css
+++ b/frontend/src/app/module-blueprint/components/side-bar/planning-tool/planning-tool.component.css
@@ -1,0 +1,58 @@
+.planning-card {
+  padding: 12px;
+}
+.section-label {
+  margin: 12px 0 6px;
+  font-weight: 600;
+}
+.shape-grid,
+.color-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+.choice-button,
+.color-button,
+.eraser-button {
+  border: 2px solid #6a6256;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.choice-button {
+  width: 52px;
+  height: 52px;
+  background: #d5c5a7;
+}
+.shape {
+  display: inline-block;
+  width: 27px;
+  height: 27px;
+  background: #4169e1;
+  border: 2px solid #4a4134;
+}
+.shape.circle {
+  border-radius: 50%;
+}
+.shape.diamond {
+  transform: rotate(45deg);
+  width: 23px;
+  height: 23px;
+}
+.color-button {
+  width: 32px;
+  height: 32px;
+}
+.selected {
+  outline: 3px solid #fff;
+  box-shadow: 0 0 0 5px #3b82f6;
+}
+.eraser-button {
+  display: block;
+  margin-top: 14px;
+  padding: 8px 10px;
+  background: #d5c5a7;
+}
+.hint {
+  margin: 12px 0 0;
+  font-size: 0.85rem;
+}

--- a/frontend/src/app/module-blueprint/components/side-bar/planning-tool/planning-tool.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/planning-tool/planning-tool.component.html
@@ -1,0 +1,45 @@
+<div class="box-card ui-widget planning-card">
+  <div class="box-card-title" i18n>Planning Notes</div>
+  <div class="section-label" i18n>Shape</div>
+  <div class="shape-grid">
+    <button
+      *ngFor="let shape of shapes"
+      type="button"
+      class="choice-button"
+      [class.selected]="!tool.erase && tool.shape === shape.value"
+      (click)="tool.erase = false; tool.shape = shape.value"
+      [attr.aria-label]="shape.label"
+      [pTooltip]="shape.label"
+    >
+      <span
+        class="shape"
+        [class.circle]="shape.value === 1"
+        [class.diamond]="shape.value === 2"
+      ></span>
+    </button>
+  </div>
+  <div class="section-label" i18n>Color</div>
+  <div class="color-grid">
+    <button
+      *ngFor="let color of colors"
+      type="button"
+      class="color-button"
+      [class.selected]="!tool.erase && tool.color === color.value"
+      [style.background-color]="color.css"
+      (click)="tool.erase = false; tool.color = color.value"
+      [attr.aria-label]="'Color ' + color.value"
+    ></button>
+  </div>
+  <button
+    type="button"
+    class="eraser-button"
+    [class.selected]="tool.erase"
+    (click)="tool.erase = !tool.erase"
+    i18n
+  >
+    Erase planning notes
+  </button>
+  <p class="hint" i18n>
+    Click or drag on the blueprint to paint. Right-click to return to Select.
+  </p>
+</div>

--- a/frontend/src/app/module-blueprint/components/side-bar/planning-tool/planning-tool.component.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/planning-tool/planning-tool.component.ts
@@ -1,0 +1,23 @@
+import { Component } from "@angular/core";
+import { PlanningTool } from "../../../common/tools/planning-tool";
+import { PLANNING_COLORS } from "../../../drawing/draw-planning-overlay";
+
+@Component({
+  selector: "app-planning-tool",
+  templateUrl: "./planning-tool.component.html",
+  styleUrls: ["./planning-tool.component.css"],
+  standalone: false,
+})
+export class PlanningToolComponent {
+  readonly shapes = [
+    { value: 0, label: $localize`Square` },
+    { value: 1, label: $localize`Circle` },
+    { value: 2, label: $localize`Diamond` },
+  ];
+  readonly colors = PLANNING_COLORS.map((color, value) => ({
+    value,
+    css: `#${color.toString(16).padStart(6, "0")}`,
+  }));
+
+  constructor(public tool: PlanningTool) {}
+}

--- a/frontend/src/app/module-blueprint/drawing/draw-planning-overlay.ts
+++ b/frontend/src/app/module-blueprint/drawing/draw-planning-overlay.ts
@@ -9,7 +9,7 @@ export const PLANNING_COLORS = [
 const OUTLINE = 0x4a4134;
 
 export function drawPlanningShape(
-  graphics: any,
+  graphics: PIXI.Graphics,
   plan: BniPlanShape,
   camera: CameraService,
   alpha = 0.9,
@@ -48,7 +48,7 @@ export function drawPlanningShape(
 
 /** Cell-sized decorative markers written by the Planning Tool mod. */
 export class DrawPlanningOverlay {
-  private graphics: any;
+  private graphics: PIXI.Graphics;
 
   constructor(drawPixi: DrawPixi) {
     this.graphics = drawPixi.getNewGraphics();

--- a/frontend/src/app/module-blueprint/drawing/draw-planning-overlay.ts
+++ b/frontend/src/app/module-blueprint/drawing/draw-planning-overlay.ts
@@ -1,0 +1,64 @@
+import { BniPlanShape, CameraService } from "../../../../../lib/index";
+import { DrawPixi } from "./draw-pixi";
+
+export const PLANNING_COLORS = [
+  0x808080, 0x4169e1, 0x32cd32, 0xe5533d, 0x55d6cf, 0xcf45cf, 0x914bc7,
+  0xd99a42, 0xc8c83f, 0xd8d8d8, 0x22221c,
+] as const;
+
+const OUTLINE = 0x4a4134;
+
+export function drawPlanningShape(
+  graphics: any,
+  plan: BniPlanShape,
+  camera: CameraService,
+  alpha = 0.9,
+) {
+  const zoom = camera.currentZoom;
+  const centerX = (plan.x + camera.cameraOffset.x + 0.5) * zoom;
+  const centerY = (camera.cameraOffset.y - plan.y + 0.5) * zoom;
+  const radius = zoom * 0.39;
+
+  graphics.lineStyle(Math.max(1, zoom * 0.035), OUTLINE, alpha);
+  graphics.beginFill(PLANNING_COLORS[plan.color] ?? PLANNING_COLORS[0], alpha);
+  if (plan.shape === 1) {
+    graphics.drawCircle(centerX, centerY, radius);
+  } else if (plan.shape === 2) {
+    graphics.drawPolygon([
+      centerX,
+      centerY - radius,
+      centerX + radius,
+      centerY,
+      centerX,
+      centerY + radius,
+      centerX - radius,
+      centerY,
+    ]);
+  } else {
+    graphics.drawRoundedRect(
+      centerX - radius,
+      centerY - radius,
+      radius * 2,
+      radius * 2,
+      zoom * 0.035,
+    );
+  }
+  graphics.endFill();
+}
+
+/** Cell-sized decorative markers written by the Planning Tool mod. */
+export class DrawPlanningOverlay {
+  private graphics: any;
+
+  constructor(drawPixi: DrawPixi) {
+    this.graphics = drawPixi.getNewGraphics();
+    drawPixi.pixiApp.stage.addChild(this.graphics);
+  }
+
+  draw(plans: BniPlanShape[] | null | undefined, camera: CameraService) {
+    this.graphics.clear();
+    this.graphics.visible = plans != null && plans.length > 0;
+    if (!this.graphics.visible) return;
+    for (const plan of plans!) drawPlanningShape(this.graphics, plan, camera);
+  }
+}

--- a/frontend/src/app/module-blueprint/module-blueprint.module.ts
+++ b/frontend/src/app/module-blueprint/module-blueprint.module.ts
@@ -106,7 +106,6 @@ import { DialogFollowListComponent } from "./components/dialogs/dialog-follow-li
 import { NotificationBellComponent } from "./components/notification-bell/notification-bell.component";
 import { ToolbarButtonComponent } from "./components/toolbar-button/toolbar-button.component";
 import { SupportedModsPageComponent } from "./components/supported-mods-page/supported-mods-page.component";
-import { PlanningTool } from "./common/tools/planning-tool";
 import { PlanningToolComponent } from "./components/side-bar/planning-tool/planning-tool.component";
 
 @NgModule({
@@ -217,7 +216,6 @@ import { PlanningToolComponent } from "./components/side-bar/planning-tool/plann
     SelectTool,
     BuildTool,
     ScissorsTool,
-    PlanningTool,
     ElementReport,
     DatePipe,
     MessageService,

--- a/frontend/src/app/module-blueprint/module-blueprint.module.ts
+++ b/frontend/src/app/module-blueprint/module-blueprint.module.ts
@@ -106,6 +106,8 @@ import { DialogFollowListComponent } from "./components/dialogs/dialog-follow-li
 import { NotificationBellComponent } from "./components/notification-bell/notification-bell.component";
 import { ToolbarButtonComponent } from "./components/toolbar-button/toolbar-button.component";
 import { SupportedModsPageComponent } from "./components/supported-mods-page/supported-mods-page.component";
+import { PlanningTool } from "./common/tools/planning-tool";
+import { PlanningToolComponent } from "./components/side-bar/planning-tool/planning-tool.component";
 
 @NgModule({
   declarations: [
@@ -168,6 +170,7 @@ import { SupportedModsPageComponent } from "./components/supported-mods-page/sup
     ToolbarButtonComponent,
     NoteEditPanelComponent,
     SupportedModsPageComponent,
+    PlanningToolComponent,
   ],
   exports: [ComponentBlueprintParentComponent],
   imports: [
@@ -214,6 +217,7 @@ import { SupportedModsPageComponent } from "./components/supported-mods-page/sup
     SelectTool,
     BuildTool,
     ScissorsTool,
+    PlanningTool,
     ElementReport,
     DatePipe,
     MessageService,

--- a/frontend/src/app/module-blueprint/services/tool-service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/tool-service.spec.ts
@@ -28,18 +28,21 @@ describe("ToolService", () => {
   let mockBuild: ReturnType<typeof makeTool>;
   let mockElementReport: any;
   let mockScissors: ReturnType<typeof makeTool>;
+  let mockPlanning: ReturnType<typeof makeTool>;
 
   beforeEach(() => {
     mockSelect = makeTool(ToolType.select);
     mockBuild = makeTool(ToolType.build);
     mockElementReport = {};
     mockScissors = makeTool(ToolType.scissors);
+    mockPlanning = makeTool(ToolType.planning);
 
     service = new ToolService(
       mockSelect as any,
       mockBuild as any,
       mockElementReport,
       mockScissors as any,
+      mockPlanning as any,
     );
   });
 
@@ -54,6 +57,10 @@ describe("ToolService", () => {
 
     it("returns scissorsTool for ToolType.scissors", () => {
       expect(service.getTool(ToolType.scissors)).toBe(mockScissors);
+    });
+
+    it("returns planningTool for ToolType.planning", () => {
+      expect(service.getTool(ToolType.planning)).toBe(mockPlanning);
     });
   });
 

--- a/frontend/src/app/module-blueprint/services/tool-service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/tool-service.spec.ts
@@ -1,6 +1,7 @@
 import { ToolService } from "./tool-service";
 import { ToolType } from "../common/tools/tool";
 import { Vector2 } from "../../../../../lib/index";
+import { PlanningTool } from "../common/tools/planning-tool";
 
 const makeTool = (toolType: ToolType, toolGroup = 1) => ({
   toolType,
@@ -42,7 +43,7 @@ describe("ToolService", () => {
       mockBuild as any,
       mockElementReport,
       mockScissors as any,
-      mockPlanning as any,
+      mockPlanning as unknown as PlanningTool,
     );
   });
 

--- a/frontend/src/app/module-blueprint/services/tool-service.ts
+++ b/frontend/src/app/module-blueprint/services/tool-service.ts
@@ -10,6 +10,7 @@ import { DrawPixi } from "../drawing/draw-pixi";
 import { BuildTool } from "../common/tools/build-tool";
 import { ElementReport } from "../common/tools/element-report";
 import { ScissorsTool } from "../common/tools/scissors-tool";
+import { PlanningTool } from "../common/tools/planning-tool";
 
 @Injectable({ providedIn: "root" })
 export class ToolService implements ITool, IChangeTool {
@@ -30,6 +31,7 @@ export class ToolService implements ITool, IChangeTool {
     public buildTool: BuildTool,
     public elementReport: ElementReport,
     public scissorsTool: ScissorsTool,
+    public planningTool: PlanningTool,
   ) {
     this.observers = [];
 
@@ -39,10 +41,12 @@ export class ToolService implements ITool, IChangeTool {
     this.allTools.push(this.selectTool);
     this.allTools.push(this.buildTool);
     this.allTools.push(this.scissorsTool);
+    this.allTools.push(this.planningTool);
 
     this.buildTool.parent = this;
     this.selectTool.parent = this;
     this.scissorsTool.parent = this;
+    this.planningTool.parent = this;
   }
 
   subscribeToolChanged(observer: IObsToolChanged) {

--- a/frontend/src/assets/images/icon-planning.svg
+++ b/frontend/src/assets/images/icon-planning.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="7" y="7" width="22" height="22" rx="2" fill="#55d6cf" stroke="#40382e" stroke-width="4"/>
+  <circle cx="45" cy="19" r="11" fill="#cf45cf" stroke="#40382e" stroke-width="4"/>
+  <path d="M19 35 31 47 19 59 7 47Z" fill="#d99a42" stroke="#40382e" stroke-width="4"/>
+  <path d="M45 35 57 47 45 59 33 47Z" fill="#4169e1" stroke="#40382e" stroke-width="4"/>
+</svg>

--- a/lib/src/blueprint/blueprint.d.ts
+++ b/lib/src/blueprint/blueprint.d.ts
@@ -1,7 +1,7 @@
 import { BlueprintItem } from './blueprint-item';
 import { Vector2 } from '../vector2';
 import { OniTemplate } from '../io/oni/oni-template';
-import { BniBlueprint, BniWorldNote } from '../io/bni/bni-blueprint';
+import { BniBlueprint, BniPlanShape, BniWorldNote } from '../io/bni/bni-blueprint';
 import { MdbBlueprint } from '../io/mdb/mdb-blueprint';
 import { Overlay } from '../enums/overlay';
 import { UtilityConnectionTracker } from '../utility-connection';
@@ -12,6 +12,7 @@ export declare class Blueprint {
     unknownBuildingDefs: string[];
     bniMetadata: BniBlueprint | null;
     worldNotes: BniWorldNote[];
+    planningToolShapes: BniPlanShape[];
     utilities: UtilityConnectionTracker[][];
     innerYaml: any;
     constructor();

--- a/lib/src/blueprint/blueprint.ts
+++ b/lib/src/blueprint/blueprint.ts
@@ -6,7 +6,7 @@ import { BlueprintItemElement } from './blueprint-item-element';
 import { Vector2 } from '../vector2';
 import { OniTemplate } from '../io/oni/oni-template';
 import { OniItem } from '../oni-item';
-import { BniBlueprint, BniWorldNote } from '../io/bni/bni-blueprint';
+import { BniBlueprint, BniPlanShape, BniWorldNote } from '../io/bni/bni-blueprint';
 import { MdbBlueprint } from '../io/mdb/mdb-blueprint';
 import { BniBuilding } from '../io/bni/bni-building';
 import { Overlay } from '../enums/overlay';
@@ -33,6 +33,9 @@ export class Blueprint {
   // they survive destroyAndCopyItems into the rendered blueprint and can be
   // drawn as an editor overlay. Display-only; never part of the round-trip.
   worldNotes: BniWorldNote[] = [];
+  // Decorative cells from the separate Planning Tool mod. Unlike world notes,
+  // these are editable and therefore live in the normal MDB/undo model.
+  planningToolShapes: BniPlanShape[] = [];
 
   // We need a utility map because some objects have utilities outside of their size (HighWattageWireBridge)
   utilities: UtilityConnectionTracker[][] = [];
@@ -51,6 +54,7 @@ export class Blueprint {
     this.unknownBuildingDefs = [];
     this.bniMetadata = null;
     this.worldNotes = [];
+    this.planningToolShapes = [];
 
     // Copy the buildings
     for (let building of oniBlueprint.buildings) {
@@ -106,6 +110,9 @@ export class Blueprint {
     this.unknownBuildingDefs = [];
     this.bniMetadata = bniBlueprint;
     this.worldNotes = bniBlueprint.worldNotes ?? [];
+    this.planningToolShapes = (bniBlueprint.planningtoolmod_shapecollection ?? []).map(shape => ({
+      ...shape,
+    }));
 
     for (let building of bniBlueprint.buildings ?? []) {
       try {
@@ -132,6 +139,7 @@ export class Blueprint {
     this.unknownBuildingDefs = [];
     this.bniMetadata = null;
     this.worldNotes = [];
+    this.planningToolShapes = (mdbBlueprint.planningToolShapes ?? []).map(shape => ({ ...shape }));
 
     for (let originalTemplateItem of mdbBlueprint.blueprintItems) {
       let newTemplateItem = BlueprintHelpers.createInstance(originalTemplateItem.id);
@@ -191,6 +199,7 @@ export class Blueprint {
     // World notes live on the source (fresh import); carry them onto the
     // rendered blueprint so the editor overlay can draw them.
     this.worldNotes = source.worldNotes ?? [];
+    this.planningToolShapes = source.planningToolShapes.map(shape => ({ ...shape }));
 
     this.pauseChangeEvents();
     for (let blueprintItem of source.blueprintItems) this.addBlueprintItem(blueprintItem);
@@ -398,6 +407,9 @@ export class Blueprint {
       blueprintItems: [],
     };
 
+    if (this.planningToolShapes.length > 0)
+      returnValue.planningToolShapes = this.planningToolShapes.map(shape => ({ ...shape }));
+
     for (let originalTemplateItem of this.blueprintItems)
       returnValue.blueprintItems.push(originalTemplateItem.toMdbBuilding());
 
@@ -414,6 +426,15 @@ export class Blueprint {
     for (let originalTemplateItem of this.blueprintItems)
       if (originalTemplateItem.id != OniItem.elementId && originalTemplateItem.id != OniItem.infoId)
         returnValue.buildings.push(originalTemplateItem.toBniBuilding());
+
+    if (this.planningToolShapes.length > 0) {
+      returnValue.blueprintVersion = 3;
+      returnValue.planningtoolmod_shapecollection = this.planningToolShapes.map(shape => ({
+        ...shape,
+      }));
+      // Planning Tool shapes are represented by dig commands in BlueprintsV2.
+      returnValue.digcommands = this.planningToolShapes.map(({ x, y }) => ({ x, y }));
+    }
 
     return returnValue;
   }
@@ -439,6 +460,13 @@ export class Blueprint {
         if (bottomRight.x < position.x) bottomRight.x = position.x;
         if (bottomRight.y < position.y) bottomRight.y = position.y;
       });
+    });
+
+    this.planningToolShapes.forEach(shape => {
+      if (topLeft.x > shape.x) topLeft.x = shape.x;
+      if (topLeft.y > shape.y) topLeft.y = shape.y;
+      if (bottomRight.x < shape.x) bottomRight.x = shape.x;
+      if (bottomRight.y < shape.y) bottomRight.y = shape.y;
     });
 
     return [topLeft, bottomRight];

--- a/lib/src/io/mdb/mdb-blueprint.d.ts
+++ b/lib/src/io/mdb/mdb-blueprint.d.ts
@@ -1,5 +1,7 @@
 import { MdbBuilding } from './mdb-building';
+import { BniPlanShape } from '../bni/bni-blueprint';
 export interface MdbBlueprint {
     blueprintItems: MdbBuilding[];
+    planningToolShapes?: BniPlanShape[];
 }
 //# sourceMappingURL=mdb-blueprint.d.ts.map

--- a/lib/src/io/mdb/mdb-blueprint.ts
+++ b/lib/src/io/mdb/mdb-blueprint.ts
@@ -1,5 +1,7 @@
 import { MdbBuilding } from './mdb-building';
+import { BniPlanShape } from '../bni/bni-blueprint';
 
 export interface MdbBlueprint {
   blueprintItems: MdbBuilding[];
+  planningToolShapes?: BniPlanShape[];
 }


### PR DESCRIPTION
Adds support for Planning Tool mod notes in imported BlueprintsV2 blueprints and introduces editor controls for creating and editing them.

Planning notes support:

- 3 shapes: square, circle, and diamond
- 11 Planning Tool colors
- Importing and rendering existing notes
- Painting notes by clicking or dragging
- Replacing notes at an occupied cell
- Erasing notes
- Undo and redo
- Saving and reopening
- Game-compatible `.blueprint` export

## Implementation

- Parses `planningtoolmod_shapecollection` from BlueprintsV2 files.
- Stores planning notes in the website’s persisted blueprint model.
- Includes notes in camera bounds, including blueprints containing no buildings.
- Renders notes in the editor, thumbnails, and exported images.
- Adds a Planning Notes toolbar button and side panel for selecting shape, color, or eraser mode.
- Generates matching `digcommands` when exporting Planning Tool notes.
- Preserves notes through MDB serialization and server saves.

## Testing

- Added import, persistence, export, and camera-bound tests.
- Added Planning Tool editor behavior tests.
- Updated Tool Service coverage for the new tool.
- Verified the supplied six-note blueprint imports and exports all six notes correctly.
- Shared library, backend, and frontend TypeScript compilation pass.
- Frontend lint passes.
- Focused frontend tests pass: 25 tests.
- Full frontend test suite completed without observed failures.

## Notes

The backend Mocha suite requires the local MongoDB service and could not start without it. The Planning Tool round trip was additionally verified directly against the supplied sample blueprint.