### PR TITLE
feat: derive a DLC requirement set on every blueprint (step 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,19 +231,33 @@ Editor input goes through an action layer, never raw key comparisons.
 - **UI**: `components/dialogs/dialog-keybindings/` — Edit ▸ Keyboard shortcuts, or `Shift+/`.
 
 ### Blueprint metadata auto-derivation
-`gameVersion` and `modded` are derived deterministically from the blueprint content — users
-no longer set these manually. `multiplayerSafe` has been removed entirely.
+`requiredDlcs`, `gameVersion` and `modded` are derived deterministically from the blueprint
+content — users no longer set these manually. `multiplayerSafe` has been removed entirely.
 
 - **`lib/src/blueprint/blueprint-analyzer.ts`** — pure functions (TDD-covered):
-  - `deriveGameVersion(buildingDlcIds: string[][]): GameVersion` — highest-priority DLC in blueprint
-    (`EXPANSION1_ID`→spacedOut, `DLC2_ID`→frostyPlanet, `DLC5_ID`→bionicBooster, none→base)
+  - `deriveRequiredDlcs(buildingDlcIds: string[][]): string[]` — the union of every placed
+    building's raw Klei DLC ids, deduped and sorted; `[]` = base game only. This is the
+    current model; `deriveGameVersion` below is retained only until the frontend stops
+    importing it (step 4 of `spec/dlc-requirements-plan.md`).
+  - `deriveGameVersion(buildingDlcIds: string[][]): GameVersion` — **superseded.** Collapses
+    the set to the highest-priority DLC found, so it can't express "needs Frosty *and*
+    Bionic", and its `DLC5_ID`→bionicBooster mapping is wrong (DLC5 is the Aquatic pack).
   - `deriveModded(prefabIds: string[], knownIds: Set<string>): boolean` — true if any ID is absent
     from the loaded database
+- **`lib/src/blueprint/dlc.ts`** — `DLC_LABELS`/`dlcLabel(id)`, the one place raw ids become
+  display names (game strings `STRINGS.UI.<id>.NAME`); unknown ids fall back to the raw id.
+  Stored data is always raw ids, never labels. A contract test fails if the export ships a
+  DLC id with no label.
+- **`Blueprint.requiredDlcs`** — server-derived on every save, fork and version restore
+  (`app/api/services/dlc-derivation-service.ts`), never client-supplied; returned in the
+  list/details/editor-open responses. Absent on documents predating the field until the
+  backfill runs.
 - **`Blueprint.hadUnknownBuildings`** — set during `importFromBni`/`importFromMdb` when a building
   ID is not found; read by the save dialog to detect mods stripped during import.
 - **Save dialog** — `gameVersion` and `modded` are read-only disabled controls populated on open.
   `researchTier` is hidden (no tech-tree data in current export; field kept in schema for future use).
-- **Backfill** — `npm run derive-metadata` re-derives both fields for all existing blueprints.
+- **Backfill** — `npm run derive-metadata` re-derives `gameVersion`, `requiredDlcs`, `mods`
+  and `modded` for all existing blueprints.
 
 ### Session Management Files
 Check these files in `agent/` directory for current status:

--- a/__tests__/api/blueprint-dlcs.test.ts
+++ b/__tests__/api/blueprint-dlcs.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup } from '../setup/testSetup';
+import { BlueprintModel } from '../../app/api/models/blueprint';
+import { deriveDlcs } from '../../app/api/services/dlc-derivation-service';
+
+// The app import in TestSetup bootstraps OniItem from database-2024.json, so
+// these tests use real prefabs and their real dlcIds.
+const AQUATIC_PREFAB = 'ReefGenerator'; // DLC5_ID
+const FROSTY_PREFAB = 'Campfire'; // DLC2_ID
+const BIONIC_PREFAB = 'GunkEmptier'; // DLC3_ID
+const AND_PREFAB = 'RoboPilotModule'; // EXPANSION1_ID + DLC3_ID (needs both)
+const BASE_PREFAB = 'Tile'; // no DLC
+
+const TINY_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+const blueprintData = (prefabIds: string[]) => ({
+  blueprintItems: prefabIds.map((id, i) => ({
+    id,
+    temperature: 293.15,
+    position: { x: i, y: 0 },
+    elements: [],
+  })),
+});
+
+describe('Blueprint DLC requirement derivation', function () {
+  let authToken: string;
+  let testData: any;
+
+  const upload = (body: Record<string, unknown>) =>
+    TestSetup.request()
+      .post('/api/uploadblueprint')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ thumbnail: TINY_PNG, publish: true, ...body });
+
+  beforeEach(async function () {
+    this.timeout(15000);
+    testData = await TestSetup.beforeEach();
+    authToken = testData.users.user1.generateJwt();
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    await TestSetup.afterEach();
+  });
+
+  describe('deriveDlcs service', function () {
+    // The bug that motivated the whole change: DLC5_ID was mapped to the
+    // GameVersion 'bionicBooster', so an Aquatic Planet Pack blueprint claimed
+    // to need Bionic content. Raw ids can't be mislabelled this way.
+    it('reports the aquatic pack — and nothing bionic — for a ReefGenerator', function () {
+      const required = deriveDlcs(blueprintData([AQUATIC_PREFAB]));
+      expect(required).to.deep.equal(['DLC5_ID']);
+      expect(required).to.not.include('DLC3_ID');
+    });
+
+    it('reports [] for a base-game-only blueprint', function () {
+      expect(deriveDlcs(blueprintData([BASE_PREFAB]))).to.deep.equal([]);
+    });
+
+    // What the old single-valued gameVersion could not express: owning one pack
+    // implies nothing about the other, so both must be reported.
+    it('reports both packs for a blueprint mixing two of them', function () {
+      expect(deriveDlcs(blueprintData([AQUATIC_PREFAB, FROSTY_PREFAB]))).to.deep.equal([
+        'DLC2_ID',
+        'DLC5_ID',
+      ]);
+    });
+
+    it('keeps both ids of a building that needs two DLCs at once', function () {
+      expect(deriveDlcs(blueprintData([AND_PREFAB]))).to.deep.equal(['DLC3_ID', 'EXPANSION1_ID']);
+    });
+
+    it('dedupes repeated buildings and sorts independently of placement order', function () {
+      const a = deriveDlcs(blueprintData([BIONIC_PREFAB, FROSTY_PREFAB, BIONIC_PREFAB]));
+      const b = deriveDlcs(blueprintData([FROSTY_PREFAB, BIONIC_PREFAB]));
+      expect(a).to.deep.equal(['DLC2_ID', 'DLC3_ID']);
+      expect(a).to.deep.equal(b);
+    });
+
+    it('ignores buildings the database has never heard of', function () {
+      expect(deriveDlcs(blueprintData(['NotARealPrefabId']))).to.deep.equal([]);
+    });
+
+    it('returns [] for data without blueprintItems', function () {
+      expect(deriveDlcs({})).to.deep.equal([]);
+    });
+
+    it('returns [] for garbage data', function () {
+      expect(deriveDlcs('not an object')).to.deep.equal([]);
+      expect(deriveDlcs(null)).to.deep.equal([]);
+      expect(deriveDlcs(undefined)).to.deep.equal([]);
+    });
+  });
+
+  describe('save-path derivation', function () {
+    it('stores requiredDlcs on save', async function () {
+      const response = await upload({
+        name: 'Aquatic Save',
+        blueprint: blueprintData([AQUATIC_PREFAB, FROSTY_PREFAB]),
+      });
+
+      expect(response.status).to.equal(200);
+      const saved = await BlueprintModel.model.findById(response.body.id);
+      expect(saved!.requiredDlcs).to.deep.equal(['DLC2_ID', 'DLC5_ID']);
+    });
+
+    it('stores [] for a base-game-only save', async function () {
+      const response = await upload({
+        name: 'Base Game Save',
+        blueprint: blueprintData([BASE_PREFAB]),
+      });
+
+      expect(response.status).to.equal(200);
+      const saved = await BlueprintModel.model.findById(response.body.id);
+      expect(saved!.requiredDlcs).to.deep.equal([]);
+    });
+
+    // Requirements come from the blueprint's content, never from the client
+    // (or from what the author happens to own) — same policy as rooms/mods.
+    it('ignores a client-supplied requiredDlcs field', async function () {
+      const response = await upload({
+        name: 'Client Dlcs Ignored',
+        blueprint: blueprintData([BASE_PREFAB]),
+        requiredDlcs: ['DLC3_ID'],
+      });
+
+      expect(response.status).to.equal(200);
+      const saved = await BlueprintModel.model.findById(response.body.id);
+      expect(saved!.requiredDlcs).to.deep.equal([]);
+    });
+  });
+
+  describe('emit checks', function () {
+    it('includes requiredDlcs in the list payload', async function () {
+      const created = await upload({
+        name: 'Dlc List Emit Check',
+        blueprint: blueprintData([AQUATIC_PREFAB]),
+      });
+      expect(created.status).to.equal(200);
+
+      const list = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now() });
+
+      expect(list.status).to.equal(200);
+      const item = list.body.blueprints.find((bp: any) => bp.id === created.body.id);
+      expect(item).to.exist;
+      expect(item.requiredDlcs).to.deep.equal(['DLC5_ID']);
+    });
+
+    it('includes requiredDlcs in the details payload', async function () {
+      const created = await upload({
+        name: 'Dlc Details Emit Check',
+        blueprint: blueprintData([AND_PREFAB]),
+      });
+      expect(created.status).to.equal(200);
+
+      const details = await TestSetup.request().get(`/api/blueprints/${created.body.id}`);
+
+      expect(details.status).to.equal(200);
+      expect(details.body.requiredDlcs).to.deep.equal(['DLC3_ID', 'EXPANSION1_ID']);
+    });
+
+    it('includes requiredDlcs in the editor-open payload', async function () {
+      const created = await upload({
+        name: 'Dlc Editor Open Emit Check',
+        blueprint: blueprintData([FROSTY_PREFAB]),
+      });
+      expect(created.status).to.equal(200);
+
+      const opened = await TestSetup.request()
+        .get(`/api/getblueprint/${created.body.id}`)
+        .set('Authorization', `Bearer ${authToken}`);
+
+      expect(opened.status).to.equal(200);
+      expect(opened.body.requiredDlcs).to.deep.equal(['DLC2_ID']);
+    });
+
+    it('emits [] for a blueprint saved before the field existed', async function () {
+      const created = await upload({
+        name: 'Legacy Dlc Doc',
+        blueprint: blueprintData([AQUATIC_PREFAB]),
+      });
+      expect(created.status).to.equal(200);
+      // Simulate a document written before requiredDlcs existed: the field is
+      // absent, not empty (see the model's default: undefined).
+      await BlueprintModel.model.updateOne(
+        { _id: created.body.id },
+        { $unset: { requiredDlcs: '' } }
+      );
+
+      const details = await TestSetup.request().get(`/api/blueprints/${created.body.id}`);
+
+      expect(details.status).to.equal(200);
+      expect(details.body.requiredDlcs).to.deep.equal([]);
+    });
+  });
+});

--- a/__tests__/asset-processing/game-structure-contract.test.ts
+++ b/__tests__/asset-processing/game-structure-contract.test.ts
@@ -9,6 +9,7 @@ import {
   BuildMenuItem,
   CameraService,
   ConnectionType,
+  DLC_LABELS,
   SpriteInfo,
   SpriteModifier,
   ImageSource,
@@ -234,22 +235,16 @@ describe('Game structure contract (representative buildings)', () => {
       expect(unmapped, unmapped.join('; ')).to.be.empty;
     });
 
-    it('every DLC id in the database is known to the blueprint analyzer', () => {
-      // Must stay in sync with DLC_TO_GAME_VERSION in lib/src/blueprint/blueprint-analyzer.ts.
-      // A failure here means a new DLC arrived: add its GameVersion mapping there first.
-      const knownDlcIds = new Set(['EXPANSION1_ID', 'DLC2_ID', 'DLC5_ID']);
-      // Triaged, mapping deliberately deferred to its own change (see
-      // agent/TODO.md "gameVersion DLC mapping"): the U59-740622 export added
-      // these two, and wiring them up also means correcting DLC5_ID — which is
-      // currently labelled bionicBooster but is actually the aquatic pack — and
-      // re-running derive-metadata over stored blueprints. Listing them here
-      // keeps this guard live for any *other* new DLC id.
-      const pendingDlcIds = new Set(['DLC3_ID', 'DLC4_ID']);
-      const unknown = new Set<string>();
+    it('every DLC id in the database has a display label', () => {
+      // Must stay in sync with DLC_LABELS in lib/src/blueprint/dlc.ts. A failure
+      // here means a new DLC arrived in the export: add its label there (the
+      // game's own STRINGS.UI.<id>.NAME, see the frontend strings map) — the
+      // stored requiredDlcs need no change, since raw ids are what we persist.
+      const unlabelled = new Set<string>();
       for (const b of database.buildings)
         for (const dlcId of b.dlcIds ?? [])
-          if (!knownDlcIds.has(dlcId) && !pendingDlcIds.has(dlcId)) unknown.add(dlcId);
-      expect([...unknown], `unknown DLC ids: ${[...unknown].join(', ')}`).to.be.empty;
+          if (DLC_LABELS[dlcId] === undefined) unlabelled.add(dlcId);
+      expect([...unlabelled], `DLC ids without a label: ${[...unlabelled].join(', ')}`).to.be.empty;
     });
   });
 

--- a/__tests__/lib/blueprint-dlc.test.ts
+++ b/__tests__/lib/blueprint-dlc.test.ts
@@ -1,0 +1,81 @@
+import { expect } from 'chai';
+import { DLC_LABELS, deriveRequiredDlcs, dlcLabel } from '../../lib';
+
+// The DLC requirement set: an unordered union of the raw Klei ids a blueprint's
+// buildings need. Deliberately not the old ordered gameVersion — see
+// spec/dlc-requirements-plan.md for why no ordering can be correct here.
+describe('deriveRequiredDlcs (DLC requirement set)', () => {
+  it('returns [] for a blueprint with no buildings', () => {
+    expect(deriveRequiredDlcs([])).to.deep.equal([]);
+  });
+
+  it('returns [] when every building is base game', () => {
+    expect(deriveRequiredDlcs([[], [], []])).to.deep.equal([]);
+  });
+
+  it('returns the single id a one-DLC blueprint needs', () => {
+    expect(deriveRequiredDlcs([['DLC2_ID'], []])).to.deep.equal(['DLC2_ID']);
+  });
+
+  it('unions the ids across buildings', () => {
+    expect(deriveRequiredDlcs([['EXPANSION1_ID'], ['DLC2_ID'], []])).to.deep.equal([
+      'DLC2_ID',
+      'EXPANSION1_ID',
+    ]);
+  });
+
+  it('dedupes ids repeated across buildings', () => {
+    expect(deriveRequiredDlcs([['DLC3_ID'], ['DLC3_ID'], ['DLC3_ID']])).to.deep.equal(['DLC3_ID']);
+  });
+
+  it('sorts, so the stored value does not depend on building order', () => {
+    const a = deriveRequiredDlcs([['DLC5_ID'], ['DLC2_ID'], ['EXPANSION1_ID']]);
+    const b = deriveRequiredDlcs([['EXPANSION1_ID'], ['DLC5_ID'], ['DLC2_ID']]);
+    expect(a).to.deep.equal(['DLC2_ID', 'DLC5_ID', 'EXPANSION1_ID']);
+    expect(a).to.deep.equal(b);
+  });
+
+  // The case the old single-valued model could not express at all: owning the
+  // Bionic Booster Pack implies nothing about owning Frosty Planet, so a
+  // blueprint using both must report both.
+  it('reports every pack a mixed blueprint needs', () => {
+    expect(deriveRequiredDlcs([['DLC2_ID'], ['DLC3_ID']])).to.deep.equal(['DLC2_ID', 'DLC3_ID']);
+  });
+
+  // Multiple ids on one building are AND — RoboPilotModule needs Spaced Out AND
+  // the Bionic Booster Pack — which is exactly what a union preserves.
+  it('keeps both ids of an AND building', () => {
+    expect(deriveRequiredDlcs([['EXPANSION1_ID', 'DLC3_ID']])).to.deep.equal([
+      'DLC3_ID',
+      'EXPANSION1_ID',
+    ]);
+  });
+
+  // Spaced Out gets no special treatment: it is one id among the others, and a
+  // blueprint that happens to use only classic content is buildable by anyone
+  // regardless of what its author was playing.
+  it('treats EXPANSION1_ID like any other id', () => {
+    expect(deriveRequiredDlcs([['EXPANSION1_ID'], []])).to.deep.equal(['EXPANSION1_ID']);
+  });
+
+  it('passes through ids it has never heard of', () => {
+    expect(deriveRequiredDlcs([['DLC99_ID']])).to.deep.equal(['DLC99_ID']);
+  });
+});
+
+describe('dlcLabel', () => {
+  it('labels the packs with the names the game itself uses', () => {
+    expect(dlcLabel('EXPANSION1_ID')).to.equal('Spaced Out!');
+    expect(dlcLabel('DLC2_ID')).to.equal('The Frosty Planet Pack');
+    expect(dlcLabel('DLC3_ID')).to.equal('The Bionic Booster Pack');
+    expect(dlcLabel('DLC4_ID')).to.equal('The Prehistoric Planet Pack');
+    expect(dlcLabel('DLC5_ID')).to.equal('The Aquatic Planet Pack');
+  });
+
+  // A pack we don't know yet must stay visible (ugly-but-correct) rather than
+  // drop out of the UI or a filter built on these labels.
+  it('falls back to the raw id for an unknown DLC', () => {
+    expect(dlcLabel('DLC99_ID')).to.equal('DLC99_ID');
+    expect(DLC_LABELS['DLC99_ID']).to.be.undefined;
+  });
+});

--- a/agent/TODO.md
+++ b/agent/TODO.md
@@ -29,7 +29,8 @@ Open items only (import pipeline, render cutover, legacy-pipeline removal, and E
 
 ## DLC requirements: replace ordered `gameVersion` with a requirement set
 
-Designed, not implemented — full plan in `spec/dlc-requirements-plan.md`.
+**Step 1 shipped** (lib + backend + derivation, no visible change); steps 2–5 open. Full
+plan in `spec/dlc-requirements-plan.md`.
 
 DLCs are optional and unordered: anyone can own any combination, so a blueprint carries the
 *set* of DLCs it needs (`requiredDlcs: string[]`, `[]` = base game), not a single ordered
@@ -51,10 +52,20 @@ place. That removes the naming blocker entirely and makes the existing mislabel 
 Booster content is `DLC3_ID`, which arrived with the U59-740622 export alongside a
 Prehistoric pack on `DLC4_ID`.
 
-Phased in the plan; step 1 (lib + backend + derivation) lands with no visible change.
+Shipped in step 1: `deriveRequiredDlcs` + `DLC_LABELS`/`dlcLabel` in lib, `requiredDlcs` on
+the blueprint schema (indexed, server-derived on every save/fork/version-restore), emitted in
+the list/details/editor responses, derived by `derive-metadata`, and a display-label contract
+test in place of the retired `pendingDlcIds` allowlist. Labels are the game's own
+`STRINGS.UI.<id>.NAME` — `DLC5_ID` is "The Aquatic Planet Pack", `DLC4_ID` "The Prehistoric
+Planet Pack" — which settles the plan's only open naming question.
+
+Still open: step 2 (`dlc=` filter + display chips), step 3 (`owned=` subset filter, and
+whether ownership becomes a stored user preference), step 4 (drop `gameVersion` from schema,
+responses, indexes and frontend once nothing reads it), step 5 (elements).
 Element-level DLC provenance is blocked upstream: `elements.json` carries no DLC field, so
 that needs an export-side request. Backfill is not a gate — `derive-metadata` recomputes
-from stored building ids whenever we choose to run it.
+from stored building ids whenever we choose to run it; until then old blueprints have no
+`requiredDlcs` and read as base-game.
 
 ## Steam reskin follow-ups
 

--- a/app/api/batch/derive-blueprint-metadata.ts
+++ b/app/api/batch/derive-blueprint-metadata.ts
@@ -1,12 +1,14 @@
-// Backfill script: derive gameVersion, modded and category for all blueprints
-// in the database using the same logic as the save dialog.
+// Backfill script: derive gameVersion, requiredDlcs, modded and category for
+// all blueprints in the database using the same logic as the save dialog.
 //
 // Usage:
 //   ts-node app/api/batch/derive-blueprint-metadata.ts [--dry-run]
 //
 // The script loads database-2024.json to build the DLC, known-ID and category
 // maps, then iterates every blueprint document and recomputes gameVersion,
-// modded and category. modded is derived from whether any stored prefabId is
+// requiredDlcs, modded and category. requiredDlcs is the set of DLCs the
+// blueprint's buildings need; blueprints saved before it existed have no value
+// at all (they read as base-game) until this script runs. modded is derived from whether any stored prefabId is
 // absent from the current database (approximation — unknown buildings were
 // stripped before saving, so true mod detection was only possible at import
 // time). category is only ever set when currently null — a user's explicit
@@ -16,7 +18,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as mongoose from 'mongoose';
 import * as dotenv from 'dotenv';
-import { deriveGameVersion, deriveModded, deriveBlueprintMods, deriveCategory, buildCategoryLookup, CategoryLookup } from '../../../lib/index';
+import { deriveGameVersion, deriveRequiredDlcs, deriveModded, deriveBlueprintMods, deriveCategory, buildCategoryLookup, CategoryLookup } from '../../../lib/index';
 import { BlueprintModel } from '../models/blueprint';
 import { MdbBlueprint } from '../../../lib/index';
 
@@ -62,6 +64,8 @@ async function run(dryRun: boolean) {
   let leftUntagged = 0;
   let blueprintsWithMods = 0;
   const distinctMods = new Set<string>();
+  let blueprintsWithDlcs = 0;
+  const distinctDlcs = new Set<string>();
 
   for await (const doc of cursor) {
     const mdb = doc.data as MdbBlueprint;
@@ -69,6 +73,7 @@ async function run(dryRun: boolean) {
 
     const buildingDlcIds = prefabIds.map(id => dlcIdsMap.get(id) ?? []);
     const gameVersion = deriveGameVersion(buildingDlcIds);
+    const requiredDlcs = deriveRequiredDlcs(buildingDlcIds);
     // Only trust a positive modded=true: unknown buildings were stripped at import,
     // so false here means "no remaining IDs are unknown" — not "definitely vanilla".
     const derivedModded = deriveModded(prefabIds, knownIds, modByPrefabId);
@@ -85,6 +90,7 @@ async function run(dryRun: boolean) {
 
     const changed =
       doc.gameVersion !== gameVersion ||
+      JSON.stringify(doc.requiredDlcs ?? null) !== JSON.stringify(requiredDlcs) ||
       (derivedModded && doc.modded !== true) ||
       JSON.stringify(doc.mods ?? null) !== JSON.stringify(derivedMods) ||
       derivedCategory != null;
@@ -92,7 +98,7 @@ async function run(dryRun: boolean) {
     if (changed) {
       updated++;
       if (!dryRun) {
-        const $set: Record<string, unknown> = { gameVersion, mods: derivedMods };
+        const $set: Record<string, unknown> = { gameVersion, requiredDlcs, mods: derivedMods };
         if (derivedModded) $set.modded = true;
         if (derivedCategory != null) $set.category = derivedCategory;
         await BlueprintModel.model.updateOne({ _id: doc._id }, { $set });
@@ -103,11 +109,19 @@ async function run(dryRun: boolean) {
       blueprintsWithMods++;
       for (const mod of derivedMods) distinctMods.add(mod);
     }
+
+    if (requiredDlcs.length > 0) {
+      blueprintsWithDlcs++;
+      for (const dlcId of requiredDlcs) distinctDlcs.add(dlcId);
+    }
   }
 
   console.log(`Processed: ${processed}, updated: ${updated}${dryRun ? ' (dry run)' : ''}`);
   console.log(`Category — tagged: ${tagged}, left untagged: ${leftUntagged}, already set: ${alreadyTagged}`);
   console.log(`mods tagged: ${blueprintsWithMods} blueprints reference ${distinctMods.size} distinct mods`);
+  console.log(
+    `requiredDlcs: ${blueprintsWithDlcs} blueprints need at least one DLC (${[...distinctDlcs].sort().join(', ') || 'none'})`
+  );
   await mongoose.disconnect();
 }
 

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -42,6 +42,7 @@ import {
 import { PreviewImageService } from './services/preview-image-service';
 import { deriveRooms } from './services/room-derivation-service';
 import { deriveMods } from './services/mod-derivation-service';
+import { deriveDlcs } from './services/dlc-derivation-service';
 import mongoose from 'mongoose';
 
 const MAX_SKIP = 10000;
@@ -485,6 +486,7 @@ export class BlueprintController {
         rating: blueprint.ratingAverage ?? 0,
         myRating,
         gameVersion: blueprint.gameVersion ?? null,
+        requiredDlcs: blueprint.requiredDlcs ?? [],
         category: blueprint.category ?? null,
         subcategory: blueprint.subcategory ?? null,
         description: blueprint.description ?? null,
@@ -987,6 +989,7 @@ export class BlueprintController {
       rating: blueprint.ratingAverage ?? 0,
       commentCount: commentCounts.get(id) ?? 0,
       gameVersion: blueprint.gameVersion ?? null,
+      requiredDlcs: blueprint.requiredDlcs ?? [],
       category: blueprint.category ?? null,
       subcategory: blueprint.subcategory ?? null,
       description: blueprint.description ?? null,
@@ -1280,6 +1283,7 @@ export class BlueprintController {
         ownedByMe: viewerId != null && ownerId === viewerId,
         commentCount: commentCounts.get((blueprint._id as any).toString()) ?? 0,
         gameVersion: blueprint.gameVersion ?? null,
+        requiredDlcs: blueprint.requiredDlcs ?? [],
         category: blueprint.category ?? null,
         subcategory: blueprint.subcategory ?? null,
         description: blueprint.description ?? null,
@@ -1418,6 +1422,9 @@ export class BlueprintController {
     blueprint.rooms = deriveRooms(data);
     // Derived fact, never client-supplied (same policy as rooms).
     blueprint.mods = deriveMods(data);
+    // Which DLCs the placed buildings require — also derived, never
+    // client-supplied, and independent of the author's own game setup.
+    blueprint.requiredDlcs = deriveDlcs(data);
     // Set on every save: absence clears a previously stored raw so it can
     // never go stale relative to `data` (see the model field comment).
     blueprint.rawSource = rawSource?.source ?? null;

--- a/app/api/blueprint-version-controller.ts
+++ b/app/api/blueprint-version-controller.ts
@@ -9,6 +9,7 @@ import { optionalViewer } from './utils/optionalViewer';
 import { canViewBlueprint } from './utils/blueprint-visibility';
 import { BlueprintEventService } from './services/blueprint-event-service';
 import { deriveRooms } from './services/room-derivation-service';
+import { deriveDlcs } from './services/dlc-derivation-service';
 import {
   ensureCurrentVersion,
   resolveCurrentData,
@@ -92,6 +93,10 @@ export class BlueprintVersionController {
         researchTier: source.researchTier ?? null,
         modded: source.modded ?? null,
         mods: source.mods ?? [],
+        // Re-derived rather than copied: the fork's content is the source's
+        // content, so deriving is equivalent — except for sources that predate
+        // the field, where copying would leave the fork never-derived too.
+        requiredDlcs: deriveDlcs(sourceVersion.data),
         forkedFrom: {
           blueprintId: source._id,
           versionId: sourceVersion._id,
@@ -316,6 +321,8 @@ export class BlueprintVersionController {
       blueprint.modifiedAt = new Date();
       // The live content changed, so the derived room tags change with it.
       blueprint.rooms = deriveRooms(version.data);
+      // …as does which DLCs the live content requires.
+      blueprint.requiredDlcs = deriveDlcs(version.data);
       // A stored verbatim upload no longer matches the restored data — drop
       // it rather than serve an original that disagrees with the render.
       blueprint.rawSource = null;

--- a/app/api/models/blueprint.ts
+++ b/app/api/models/blueprint.ts
@@ -50,6 +50,13 @@ export interface Blueprint extends Document {
   // in blueprint-controller) so those documents stay visible until the migration runs.
   isPublished?: boolean;
   gameVersion?: string | null;
+  // Raw Klei DLC ids (EXPANSION1_ID, DLC2_ID, …) required to build this
+  // blueprint — the union of its buildings' dlcIds, server-derived on every
+  // save (never client-supplied, same policy as rooms/mods). Unordered set:
+  // [] = base game only, absent = never derived (legacy docs, until the
+  // derive-metadata backfill runs). Stored raw so a display-name change can
+  // never invalidate stored data (spec/dlc-requirements-plan.md).
+  requiredDlcs?: string[];
   category?: string | null;
   subcategory?: string | null;
   description?: string | null;
@@ -126,6 +133,11 @@ export class BlueprintModel {
       // post-deploy here). Creation sites set false explicitly instead.
       isPublished: Boolean,
       gameVersion: { type: String, enum: [...GAME_VERSIONS, null], index: true },
+      // No enum: unknown-to-us DLC ids must still round-trip (a new pack ships
+      // in an export before we know its name). default: undefined for the same
+      // reason as mods — a schema default would make legacy docs read as
+      // "derived, base game" on hydration and lose the never-derived signal.
+      requiredDlcs: { type: [String], index: true, default: undefined },
       category: { type: String, enum: [...CATEGORIES, null], index: true },
       subcategory: { type: String, maxlength: 40 },
       description: { type: String, maxlength: 500 },
@@ -177,6 +189,11 @@ export class BlueprintModel {
     blueprintSchema.index({ deletedAt: 1, isPublished: 1, gameVersion: 1, createdAt: -1 });
     blueprintSchema.index({ deletedAt: 1, isPublished: 1, category: 1, createdAt: -1 });
     blueprintSchema.index({ deletedAt: 1, isPublished: 1, gameVersion: 1, category: 1, createdAt: -1 });
+    // DLC-requirement filters on the public feed (multikey on requiredDlcs).
+    // Compound equivalents of the gameVersion pair above — one array field per
+    // compound index, and category/createdAt are scalars, so both are legal.
+    blueprintSchema.index({ deletedAt: 1, isPublished: 1, requiredDlcs: 1, createdAt: -1 });
+    blueprintSchema.index({ deletedAt: 1, isPublished: 1, requiredDlcs: 1, category: 1, createdAt: -1 });
     // Room-type filter on the public feed (multikey on rooms)
     blueprintSchema.index({ deletedAt: 1, isPublished: 1, rooms: 1, createdAt: -1 });
     // "Top rated" sort on the public feed

--- a/app/api/services/dlc-derivation-service.ts
+++ b/app/api/services/dlc-derivation-service.ts
@@ -1,0 +1,31 @@
+import { deriveRequiredDlcs, OniItem } from '../../../lib/index';
+
+// Server-side DLC-requirement derivation: the client never supplies
+// `requiredDlcs` — this is the only writer (same policy as `rooms` and `mods`).
+// Requires the game database to be loaded (OniItem.load in app.ts startup).
+// Returns the sorted distinct set of raw Klei DLC ids the blueprint's buildings
+// need; [] means base game only. Buildings unknown to the database contribute
+// nothing (they're the `modded` signal, not a DLC signal), and an unparseable
+// data blob also yields [] — such a save has bigger problems and must not fail
+// on derivation.
+let dlcIdsByPrefabId: Map<string, string[]> | null = null;
+
+function getDlcIdsByPrefabId(): Map<string, string[]> {
+  if (dlcIdsByPrefabId == null) {
+    dlcIdsByPrefabId = new Map();
+    for (const item of OniItem.oniItems)
+      if (item.dlcIds != null && item.dlcIds.length > 0) dlcIdsByPrefabId.set(item.id, item.dlcIds);
+  }
+  return dlcIdsByPrefabId;
+}
+
+export function deriveDlcs(data: unknown): string[] {
+  try {
+    const items = (data as { blueprintItems?: { id?: unknown }[] })?.blueprintItems ?? [];
+    const byPrefabId = getDlcIdsByPrefabId();
+    const buildingDlcIds = items.map(b => byPrefabId.get(String(b.id)) ?? []);
+    return deriveRequiredDlcs(buildingDlcIds);
+  } catch {
+    return [];
+  }
+}

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -44,6 +44,7 @@ export * from './src/blueprint/blueprint';
 export * from './src/blueprint/blueprint-helpers';
 export * from './src/blueprint/blueprint-metadata';
 export * from './src/blueprint/blueprint-analyzer';
+export * from './src/blueprint/dlc';
 export * from './src/blueprint/rooms';
 export * from './src/blueprint/blueprint-item';
 export * from './src/blueprint/blueprint-item-element';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -50,6 +50,7 @@ export * from './src/blueprint/blueprint';
 export * from './src/blueprint/blueprint-helpers';
 export * from './src/blueprint/blueprint-metadata';
 export * from './src/blueprint/blueprint-analyzer';
+export * from './src/blueprint/dlc';
 export * from './src/blueprint/rooms';
 export * from './src/blueprint/blueprint-item';
 export * from './src/blueprint/blueprint-item-element';

--- a/lib/src/blueprint/blueprint-analyzer.d.ts
+++ b/lib/src/blueprint/blueprint-analyzer.d.ts
@@ -1,5 +1,6 @@
 import { Category, GameVersion } from './blueprint-metadata';
-type DlcId = string;
+import { DlcId } from './dlc';
+export declare function deriveRequiredDlcs(buildingDlcIds: DlcId[][]): DlcId[];
 export declare function deriveGameVersion(buildingDlcIds: DlcId[][]): GameVersion;
 export declare function deriveBlueprintMods(prefabIds: string[], modByPrefabId: Map<string, string>): string[];
 export declare function deriveModded(prefabIds: string[], knownIds: Set<string>, modByPrefabId: Map<string, string>): boolean;

--- a/lib/src/blueprint/blueprint-analyzer.ts
+++ b/lib/src/blueprint/blueprint-analyzer.ts
@@ -1,7 +1,25 @@
 import { CATEGORIES, Category, GAME_VERSIONS, GameVersion } from './blueprint-metadata';
+import { DlcId } from './dlc';
 
-// Raw DLC ID strings as exported by OniExtract2024.
-type DlcId = string;
+// The set of DLCs a blueprint needs in order to be built: the union of every
+// placed building's dlcIds, deduped and sorted so storage and diffs are stable.
+// [] means base game only.
+//
+// Multiple ids on one building are AND ("needs all" — RoboPilotModule requires
+// both Spaced Out and the Bionic Booster Pack), which makes a plain union the
+// correct composition across buildings, with no special cases: EXPANSION1_ID is
+// treated exactly like every other id. Requirements come from the blueprint's
+// content, never from the author's own setup.
+//
+// This supersedes deriveGameVersion, which collapses the set to a single
+// highest-priority value and therefore cannot express "needs Frosty AND Bionic"
+// (owning one pack implies nothing about the other). See
+// spec/dlc-requirements-plan.md.
+export function deriveRequiredDlcs(buildingDlcIds: DlcId[][]): DlcId[] {
+  const required = new Set<DlcId>();
+  for (const dlcIds of buildingDlcIds) for (const dlcId of dlcIds) required.add(dlcId);
+  return [...required].sort();
+}
 
 const DLC_TO_GAME_VERSION: Record<string, GameVersion> = {
   EXPANSION1_ID: 'spacedOut',

--- a/lib/src/blueprint/dlc.d.ts
+++ b/lib/src/blueprint/dlc.d.ts
@@ -1,0 +1,4 @@
+export type DlcId = string;
+export declare const DLC_LABELS: Record<DlcId, string>;
+export declare function dlcLabel(id: DlcId): string;
+//# sourceMappingURL=dlc.d.ts.map

--- a/lib/src/blueprint/dlc.ts
+++ b/lib/src/blueprint/dlc.ts
@@ -1,0 +1,27 @@
+// Klei's raw DLC ids, exactly as the game exports them
+// (kPrefabID.requiredDlcIds -> BBuildingDef2024.dlcIds). Blueprints store these
+// verbatim: the id IS the identity, so a wrong display name can never turn into
+// wrong data, and a rename never costs a data rewrite.
+export type DlcId = string;
+
+// Display names, taken from the game's own strings (STRINGS.UI.<id>.NAME in the
+// export's po_string.json) rather than invented here — that's what makes them
+// checkable instead of guesswork.
+//
+// Deliberately plain strings, not $localize: lib is shared with the backend,
+// where the Angular $localize global doesn't exist at runtime. Translating pack
+// names is a frontend concern and belongs at the display site.
+export const DLC_LABELS: Record<DlcId, string> = {
+  EXPANSION1_ID: 'Spaced Out!',
+  DLC2_ID: 'The Frosty Planet Pack',
+  DLC3_ID: 'The Bionic Booster Pack',
+  DLC4_ID: 'The Prehistoric Planet Pack',
+  DLC5_ID: 'The Aquatic Planet Pack',
+};
+
+// Unknown ids fall back to the raw id, so a DLC released after this map was
+// written degrades to ugly-but-correct instead of silently vanishing from the
+// UI (or from a filter built on these labels).
+export function dlcLabel(id: DlcId): string {
+  return DLC_LABELS[id] ?? id;
+}

--- a/lib/src/coms/blueprint-list-response.d.ts
+++ b/lib/src/coms/blueprint-list-response.d.ts
@@ -17,6 +17,7 @@ export interface BlueprintListItem {
     rating: number;
     commentCount: number;
     gameVersion?: string | null;
+    requiredDlcs?: string[];
     category?: string | null;
     subcategory?: string | null;
     description?: string | null;
@@ -57,6 +58,7 @@ export interface BlueprintResponse {
     rating: number;
     myRating: number | null;
     gameVersion?: string | null;
+    requiredDlcs?: string[];
     category?: string | null;
     subcategory?: string | null;
     description?: string | null;

--- a/lib/src/coms/blueprint-list-response.ts
+++ b/lib/src/coms/blueprint-list-response.ts
@@ -25,6 +25,10 @@ export interface BlueprintListItem {
   rating: number; // average 1–5; 0 = unrated
   commentCount: number;
   gameVersion?: string | null;
+  // Raw Klei DLC ids the blueprint's buildings require (see DLC_LABELS for
+  // display names); [] = base game only, absent = never derived. Supersedes the
+  // single-valued gameVersion, which can't express needing two packs at once.
+  requiredDlcs?: string[];
   category?: string | null;
   subcategory?: string | null;
   description?: string | null;
@@ -85,6 +89,7 @@ export interface BlueprintResponse {
   rating: number;
   myRating: number | null;
   gameVersion?: string | null;
+  requiredDlcs?: string[];
   category?: string | null;
   subcategory?: string | null;
   description?: string | null;

--- a/migrations/20260725000000_blueprint-required-dlcs.js
+++ b/migrations/20260725000000_blueprint-required-dlcs.js
@@ -1,0 +1,57 @@
+'use strict';
+
+// Migration: indexes for `requiredDlcs` — the unordered set of raw Klei DLC ids
+// a blueprint's buildings require, which supersedes the single-valued
+// `gameVersion` (spec/dlc-requirements-plan.md).
+//
+// up:   create the multikey index on requiredDlcs (membership queries —
+//       "show me Bionic Booster blueprints") plus compound equivalents of the
+//       existing gameVersion discovery indexes, so the feed can filter on DLC
+//       the same way it filters on gameVersion. A compound index may contain
+//       only one array field; category/createdAt/deletedAt/isPublished are all
+//       scalars, so both compounds are legal.
+//
+// down: drop exactly those three indexes.
+//
+// No data backfill on purpose: blueprints written before the field exists have
+// no requiredDlcs at all and read as base-game until `npm run derive-metadata`
+// next runs. Every new save derives it, so there is nothing to gate on here.
+//
+// Both directions are idempotent — createIndex is a no-op for an existing
+// identical index, and dropIndex tolerates a missing one.
+
+const INDEXES = [
+  { requiredDlcs: 1 },
+  { deletedAt: 1, isPublished: 1, requiredDlcs: 1, createdAt: -1 },
+  { deletedAt: 1, isPublished: 1, requiredDlcs: 1, category: 1, createdAt: -1 },
+];
+
+function indexName(keys) {
+  return Object.entries(keys)
+    .map(([field, dir]) => `${field}_${dir}`)
+    .join('_');
+}
+
+async function dropIfExists(col, name) {
+  try {
+    await col.dropIndex(name);
+  } catch (err) {
+    if (err.codeName !== 'IndexNotFound' && err.codeName !== 'NamespaceNotFound') throw err;
+  }
+}
+
+module.exports = {
+  async up(db) {
+    const blueprints = db.collection('blueprints');
+    for (const keys of INDEXES) {
+      await blueprints.createIndex(keys, { background: true, name: indexName(keys) });
+    }
+  },
+
+  async down(db) {
+    const blueprints = db.collection('blueprints');
+    for (const keys of INDEXES) {
+      await dropIfExists(blueprints, indexName(keys));
+    }
+  },
+};


### PR DESCRIPTION
Step 1 of `spec/dlc-requirements-plan.md`: blueprints now carry **the set of DLCs they need** instead of relying on a single ordered `gameVersion`. Additive only — nothing is removed, no visible change, no frontend work.

Branched from `origin/master` after #176 merged, as the plan requires.

## What ships

**lib**
- `lib/src/blueprint/dlc.ts` — `DlcId`, `DLC_LABELS`, `dlcLabel(id)` with raw-id fallback for unknown ids.
- `deriveRequiredDlcs(buildingDlcIds)` — union across buildings, deduped, sorted. `[]` = base game only. `deriveGameVersion`/`DLC_TO_GAME_VERSION`/`GAME_VERSIONS` left untouched (step 4).
- `requiredDlcs` on `BlueprintListItem` and `BlueprintResponse`.

**backend**
- `app/api/services/dlc-derivation-service.ts` — server-side only, mirroring `mod-derivation-service`. The client never supplies `requiredDlcs`.
- `Blueprint.requiredDlcs: [String]`, indexed; derived on save, on fork, and on version restore.
- Emitted in all three response shapes (list item, details, editor-open).
- `derive-blueprint-metadata` derives it alongside `gameVersion`/`mods`/`modded`, and reports the distribution.
- Migration `20260725000000_blueprint-required-dlcs` — indexes only.

## Design decisions

- **Raw Klei ids are what's stored.** The id is the identity, so a wrong label can never become wrong data. Display names live in one map.
- **Labels come from the game, not from us.** `STRINGS.UI.<id>.NAME` in the export gives `DLC5_ID` = "The Aquatic Planet Pack" and `DLC4_ID` = "The Prehistoric Planet Pack" — so the plan's only open question (§Open questions 1) is settled with the canonical names rather than placeholders, and it confirms the mislabel that motivated the work: `DLC5_ID` was mapped to `bionicBooster`, but Bionic is `DLC3_ID`.
- **Deviation from the plan sketch:** `DLC_LABELS` uses plain strings, not `$localize`. lib is shared with the backend, where the Angular `$localize` global doesn't exist at runtime; translating pack names is a display concern for step 2.
- **Beyond the plan's file list:** fork and version-restore also derive `requiredDlcs`. Both write blueprint content, and leaving them out would mint documents missing the field. The fork path derives instead of copying so a pre-field source doesn't propagate its gap.
- **Schema shape:** no `enum` (a new DLC must round-trip before we know its name) and `default: undefined` (a schema default is applied on hydration and would make legacy docs read as "derived, base game" — the same reasoning as `mods`).
- `pendingDlcIds` allowlist retired: the contract test now asserts every `dlcIds` value in the database has a `DLC_LABELS` entry.

## Verification

- Backend suite: **689 passing**, 1 failure — the `workos-provision` local flake documented in CLAUDE.md (green in CI), unrelated to this change.
- 28 new/updated DLC tests: `deriveRequiredDlcs` (union, dedupe, stable sort, `[]`, AND-pair, unknown-id passthrough), `dlcLabel`, the `ReefGenerator` regression (reports `DLC5_ID`, reports nothing bionic), a two-pack blueprint reporting both, save round-trip, client-supplied value ignored, and all three response shapes.
- `npm run tsc` clean.
- Migration exercised locally: `up` creates all three indexes, `down` removes exactly those three, re-`up` and a second `up` are no-ops.
- No prod-dump rehearsal: the migration writes no data, and index creation over 5,252 blueprint documents (checked read-only) is not a size risk. Prod currently has 0 documents with the field, as expected.

## Deferred

Backfill is explicitly not a gate — existing blueprints have no `requiredDlcs` and read as base-game until `npm run derive-metadata` next runs. Steps 2–5 (the `dlc=` filter and chips, the `owned=` subset filter, dropping `gameVersion`, element provenance) are tracked in `agent/TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)