### PR TITLE
feat: filter Discover by required DLC (step 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,10 +254,22 @@ content — users no longer set these manually. `multiplayerSafe` has been remov
   backfill runs.
 - **`Blueprint.hadUnknownBuildings`** — set during `importFromBni`/`importFromMdb` when a building
   ID is not found; read by the save dialog to detect mods stripped during import.
-- **Save dialog** — `gameVersion` and `modded` are read-only disabled controls populated on open.
+- **`?dlc=` filter** — `GET /api/getblueprints?dlc=DLC2_ID,DLC3_ID` returns blueprints requiring
+  ANY of those packs (`$in`, like `rooms`; repeatable or comma-separated). Ids are validated by
+  shape (`/^[A-Z0-9_]{1,32}$/`, max 20), never against `DLC_LABELS` — a pack that ships in an
+  export before we've written its label must still be filterable. Docs with no `requiredDlcs`
+  never match. The subset test ("hide what I can't build") is a separate future `owned=` param.
+- **Display** — the blueprint card and details page render one linked chip per required DLC
+  (`dlcLabel()`, `dlcTooltip()` in `utils/chip-tooltip.ts`); `[]` renders "Base game", while an
+  absent set renders nothing. The Discover sidebar's DLC facet is multi-select and round-trips
+  through the `dlc` URL param.
+- **Save dialog** — the DLC requirement set and `modded` are read-only, derived from blueprint
+  content on open (`gameVersion` is still derived and submitted, but no longer displayed).
   `researchTier` is hidden (no tech-tree data in current export; field kept in schema for future use).
 - **Backfill** — `npm run derive-metadata` re-derives `gameVersion`, `requiredDlcs`, `mods`
-  and `modded` for all existing blueprints.
+  and `modded` for all existing blueprints. **The `?dlc=` filter matches nothing until this
+  runs** — no document written before the field existed has a set at all (prod: `cd /bpni/build
+  && npm run derive-metadata`, dry-run first).
 
 ### Session Management Files
 Check these files in `agent/` directory for current status:

--- a/__tests__/api/blueprint-discovery.test.ts
+++ b/__tests__/api/blueprint-discovery.test.ts
@@ -126,6 +126,61 @@ describe('Discovery: related blueprints + trending sort', function () {
       expect(names).to.not.include(deleted.name);
     });
 
+    // Set overlap, not equality: the old single-valued gameVersion collapsed a
+    // Frosty+Bionic blueprint to one pack, so it never matched a Frosty one.
+    it('ranks blueprints sharing a required DLC above ones needing a different pack', async function () {
+      const source = await makeBlueprint(testData.users.user1._id, {
+        name: 'Related Dlc Source',
+        category: 'power',
+        requiredDlcs: ['DLC2_ID', 'DLC3_ID'],
+      });
+      // Created first, so createdAt ordering alone would put it last.
+      const sharesOnePack = await makeBlueprint(testData.users.user2._id, {
+        name: 'Related Dlc Overlap',
+        category: 'power',
+        requiredDlcs: ['DLC2_ID'],
+        createdAt: daysAgo(2),
+      });
+      const differentPack = await makeBlueprint(testData.users.user2._id, {
+        name: 'Related Dlc Disjoint',
+        category: 'power',
+        requiredDlcs: ['DLC5_ID'],
+      });
+
+      const response = await TestSetup.request().get(`/api/blueprints/${source._id}/related`);
+      expect(response.status).to.equal(200);
+      const names: string[] = response.body.blueprints.map((b: any) => b.name);
+
+      expect(names).to.include(sharesOnePack.name);
+      expect(names).to.include(differentPack.name);
+      expect(names.indexOf(sharesOnePack.name)).to.be.lessThan(names.indexOf(differentPack.name));
+    });
+
+    // Base-game-only is a shared property, not the absence of one — it is what
+    // the old gameVersion equality rewarded, and it survives the change.
+    it('ranks base-game blueprints above DLC ones for a base-game source', async function () {
+      const source = await makeBlueprint(testData.users.user1._id, {
+        name: 'Related Base Source',
+        category: 'power',
+        requiredDlcs: [],
+      });
+      const alsoBase = await makeBlueprint(testData.users.user2._id, {
+        name: 'Related Base Sibling',
+        category: 'power',
+        requiredDlcs: [],
+        createdAt: daysAgo(2),
+      });
+      const needsDlc = await makeBlueprint(testData.users.user2._id, {
+        name: 'Related Base Dlc Sibling',
+        category: 'power',
+        requiredDlcs: ['DLC3_ID'],
+      });
+
+      const response = await TestSetup.request().get(`/api/blueprints/${source._id}/related`);
+      const names: string[] = response.body.blueprints.map((b: any) => b.name);
+      expect(names.indexOf(alsoBase.name)).to.be.lessThan(names.indexOf(needsDlc.name));
+    });
+
     it('ranks same-author blueprints above signal-free ones', async function () {
       const owner = testData.users.user1._id;
       const source = await makeBlueprint(owner, { name: 'Related Author Source' });

--- a/__tests__/api/blueprint-dlcs.test.ts
+++ b/__tests__/api/blueprint-dlcs.test.ts
@@ -138,6 +138,115 @@ describe('Blueprint DLC requirement derivation', function () {
     });
   });
 
+  describe('GET /api/getblueprints?dlc=', function () {
+    let aquaticId: string;
+    let frostyId: string;
+    let baseId: string;
+
+    const list = (query: Record<string, unknown>) =>
+      TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), ...query });
+
+    const idsOf = (response: any) => response.body.blueprints.map((bp: any) => bp.id);
+
+    beforeEach(async function () {
+      this.timeout(15000);
+      aquaticId = (
+        await upload({
+          name: 'Aquatic Filter Base',
+          blueprint: blueprintData([AQUATIC_PREFAB]),
+          category: 'power',
+        })
+      ).body.id;
+      frostyId = (
+        await upload({ name: 'Frosty Filter Base', blueprint: blueprintData([FROSTY_PREFAB]) })
+      ).body.id;
+      baseId = (await upload({ name: 'Base Filter Base', blueprint: blueprintData([BASE_PREFAB]) }))
+        .body.id;
+    });
+
+    it('filters by a single DLC id', async function () {
+      const response = await list({ dlc: 'DLC5_ID' });
+      expect(response.status).to.equal(200);
+
+      const ids = idsOf(response);
+      expect(ids).to.include(aquaticId);
+      expect(ids).to.not.include(frostyId);
+      expect(ids).to.not.include(baseId);
+    });
+
+    it('matches any of a comma-separated list', async function () {
+      const response = await list({ dlc: 'DLC2_ID,DLC5_ID' });
+      expect(response.status).to.equal(200);
+
+      const ids = idsOf(response);
+      expect(ids).to.include(aquaticId);
+      expect(ids).to.include(frostyId);
+      expect(ids).to.not.include(baseId);
+    });
+
+    it('matches any of a repeated dlc param', async function () {
+      const response = await list({ dlc: ['DLC2_ID', 'DLC5_ID'] });
+      expect(response.status).to.equal(200);
+
+      const ids = idsOf(response);
+      expect(ids).to.include(aquaticId);
+      expect(ids).to.include(frostyId);
+      expect(ids).to.not.include(baseId);
+    });
+
+    it('matches a blueprint needing two packs on either of them', async function () {
+      const bothId = (
+        await upload({ name: 'Two Pack Base', blueprint: blueprintData([AND_PREFAB]) })
+      ).body.id;
+
+      expect(idsOf(await list({ dlc: 'DLC3_ID' }))).to.include(bothId);
+      expect(idsOf(await list({ dlc: 'EXPANSION1_ID' }))).to.include(bothId);
+    });
+
+    // Unknown to us, but a valid id shape — a pack released before we've
+    // written its label must be filterable rather than a 400.
+    it('accepts an unknown but well-formed id and returns nothing', async function () {
+      const response = await list({ dlc: 'DLC99_ID' });
+      expect(response.status).to.equal(200);
+      expect(response.body.blueprints).to.deep.equal([]);
+    });
+
+    it('rejects a malformed id with 400', async function () {
+      expect((await list({ dlc: 'dlc3_id' })).status).to.equal(400);
+      expect((await list({ dlc: 'DLC3_ID;drop' })).status).to.equal(400);
+      expect((await list({ dlc: ' , ' })).status).to.equal(400);
+    });
+
+    it('rejects an oversized id list with 400', async function () {
+      const many = Array.from({ length: 21 }, (_, i) => `DLC${i}_ID`).join(',');
+      expect((await list({ dlc: many })).status).to.equal(400);
+    });
+
+    it('excludes blueprints whose requiredDlcs were never derived', async function () {
+      // Seeded fixtures predate DLC derivation (field absent, not empty).
+      await BlueprintModel.model.updateOne(
+        { _id: aquaticId },
+        { $unset: { requiredDlcs: '' } }
+      );
+
+      const response = await list({ dlc: 'DLC5_ID' });
+      expect(response.status).to.equal(200);
+      expect(idsOf(response)).to.not.include(aquaticId);
+    });
+
+    it('combines with the category filter', async function () {
+      const matching = await list({ dlc: 'DLC5_ID', category: 'power' });
+      expect(matching.status).to.equal(200);
+      expect(idsOf(matching)).to.include(aquaticId);
+
+      const conflicting = await list({ dlc: 'DLC5_ID', category: 'food' });
+      expect(conflicting.status).to.equal(200);
+      expect(idsOf(conflicting)).to.not.include(aquaticId);
+    });
+  });
+
   describe('emit checks', function () {
     it('includes requiredDlcs in the list payload', async function () {
       const created = await upload({

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -47,6 +47,10 @@ import mongoose from 'mongoose';
 
 const MAX_SKIP = 10000;
 
+// Shape of a raw Klei DLC id (EXPANSION1_ID, DLC3_ID, …) — see lib/blueprint/dlc.ts
+const DLC_ID_PATTERN = /^[A-Z0-9_]{1,32}$/;
+const MAX_DLC_FILTER_IDS = 20;
+
 const SORTS = ['recent', 'popular', 'mostForked', 'mostViewed', 'mostDownloaded', 'trending'] as const;
 type BlueprintSort = (typeof SORTS)[number];
 
@@ -681,6 +685,7 @@ export class BlueprintController {
       let filterSubcategory: string | null = null;
       let filterModded: boolean | null = null;
       let filterRooms: string[] | null = null;
+      let filterDlcs: string[] | null = null;
       let filterForkedFrom: string | null = null;
       let filterRatedBy: string | null = null;
       let sort: BlueprintSort;
@@ -744,6 +749,37 @@ export class BlueprintController {
             return;
           }
           filterRooms = requested;
+        }
+
+        // ?dlc=DLC2_ID,DLC3_ID -> blueprints requiring ANY of these packs.
+        // "Show me what the Bionic pack would unlock" is a membership question,
+        // so $in (same semantics as rooms) is the right reading; the subset
+        // test ("hide what I can't build") is a separate `owned=` param.
+        //
+        // Validated by *shape*, not against DLC_LABELS: a pack that ships in an
+        // export before we've written a label for it must still be filterable,
+        // which is the same reason the schema carries no enum.
+        const rawDlc = req.query.dlc;
+        if (rawDlc != null) {
+          const requested = (Array.isArray(rawDlc) ? rawDlc : [rawDlc])
+            .flatMap(value => String(value).split(','))
+            .map(dlcId => dlcId.trim())
+            .filter(dlcId => dlcId.length > 0);
+          const invalid = requested.filter(dlcId => !DLC_ID_PATTERN.test(dlcId));
+          // The cap only bounds the $in list — there are five packs today, so
+          // anything near the limit is abuse rather than a real query.
+          if (requested.length === 0 || requested.length > MAX_DLC_FILTER_IDS || invalid.length > 0) {
+            res
+              .status(400)
+              .json(
+                apiError(
+                  400,
+                  `Invalid dlc: must be a comma-separated list of up to ${MAX_DLC_FILTER_IDS} DLC ids (A-Z, 0-9 and _)`
+                )
+              );
+            return;
+          }
+          filterDlcs = requested;
         }
 
         const rawForkedFrom = req.query.forkedFrom as string | undefined;
@@ -817,6 +853,10 @@ export class BlueprintController {
       if (filterSubcategory != null) filter.$and.push({ subcategory: filterSubcategory });
       if (filterModded != null) filter.$and.push({ modded: filterModded });
       if (filterRooms != null) filter.$and.push({ rooms: { $in: filterRooms } });
+      // Documents predating DLC derivation have no requiredDlcs at all; $in
+      // never matches a missing field, so they stay out of a dlc= result
+      // rather than reading as base-game.
+      if (filterDlcs != null) filter.$and.push({ requiredDlcs: { $in: filterDlcs } });
       if (filterForkedFrom != null) filter.$and.push({ 'forkedFrom.blueprintId': filterForkedFrom });
       if (filterRatedBy != null) {
         // Ratings live in their own collection; resolve to ids first (the

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -99,6 +99,20 @@ function sniffImageMime(bytes: Buffer): string | null {
 }
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
+// "You might also like" relevance signal for DLC requirements: sharing a pack
+// means someone who can build the blueprint they're looking at can probably
+// build this one too. Set overlap, not equality — the old single-valued
+// gameVersion could only report one pack, so a Frosty+Bionic blueprint never
+// matched a Frosty one. Both-empty counts as a match: base-game-only is a real
+// shared property (and what the old equality test rewarded), not the absence
+// of one. Documents predating derivation read as empty here, which is the
+// existing untagged-blueprint behaviour — a constant across candidates, so it
+// cannot reorder the shelf.
+function sharesDlcRequirements(sourceDlcs: string[], candidateDlcs: string[]): boolean {
+  if (sourceDlcs.length === 0) return candidateDlcs.length === 0;
+  return candidateDlcs.some(dlcId => sourceDlcs.includes(dlcId));
+}
+
 export class BlueprintController {
   public uploadBlueprint(req: Request, res: Response) {
     console.log('uploadBlueprint' + req.clientIp);
@@ -1050,7 +1064,7 @@ export class BlueprintController {
     };
   }
 
-  // "You might also like": same category/subcategory/gameVersion, or same
+  // "You might also like": same category/subcategory/DLC requirements, or same
   // author, scored simply and merged. Two cheap indexed queries + in-memory
   // scoring — plenty at this catalog's size, and avoids an aggregation with
   // no single field to sort on. Backfills with recent public blueprints so
@@ -1071,7 +1085,7 @@ export class BlueprintController {
       const viewer = optionalViewer(req);
       const source = await BlueprintModel.model
         .findOne({ _id: blueprintId, deletedAt: null })
-        .select('owner category subcategory gameVersion isPublished')
+        .select('owner category subcategory requiredDlcs isPublished')
         .lean();
       if (source == null || !canViewBlueprint(source, viewer)) {
         res.status(404).json(apiError(404, 'Blueprint not found'));
@@ -1122,11 +1136,13 @@ export class BlueprintController {
         for (const candidate of fallback) candidates.set((candidate._id as mongoose.Types.ObjectId).toString(), candidate);
       }
 
+      const sourceDlcs = source.requiredDlcs ?? [];
+
       const scored = Array.from(candidates.values()).map(candidate => {
         let score = 0;
         if (source.category != null && candidate.category === source.category) score += 3;
         if (source.subcategory != null && candidate.subcategory === source.subcategory) score += 2;
-        if (source.gameVersion != null && candidate.gameVersion === source.gameVersion) score += 1;
+        if (sharesDlcRequirements(sourceDlcs, candidate.requiredDlcs ?? [])) score += 1;
         if (sourceOwnerId != null && ownerIdOf(candidate) === sourceOwnerId) score += 2;
         return { candidate, score };
       });

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.html
@@ -62,12 +62,15 @@
         >Untagged</span
       >
       <a
-        *ngIf="item.gameVersion"
-        class="bni-chip"
+        *ngFor="let dlc of item.requiredDlcs ?? []"
+        class="bni-chip bni-chip--dlc"
         [routerLink]="['/discover']"
-        [queryParams]="{ gameVersion: item.gameVersion }"
-        [title]="gameVersionTooltip(item.gameVersion)"
-        >{{ item.gameVersion }}</a
+        [queryParams]="{ dlc: dlc }"
+        [title]="dlcTooltip(dlc)"
+        >{{ dlcLabel(dlc) }}</a
+      >
+      <span *ngIf="isBaseGame" class="bni-chip" [title]="baseGameTooltip()" i18n
+        >Base game</span
       >
       <a
         *ngIf="item.modded"

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.spec.ts
@@ -21,7 +21,7 @@ function makeItem(overrides: any = {}) {
     nbViews: 25,
     nbDownloads: 6,
     category: null,
-    gameVersion: null,
+    requiredDlcs: [],
     modded: false,
     isPublished: true,
     ...overrides,
@@ -119,10 +119,10 @@ describe("BlueprintCardComponent", () => {
     expect(fixture.nativeElement.textContent).toContain("Modded");
   });
 
-  it("links the category, gameVersion, and modded chips to filtered discover pages", () => {
+  it("links the category, DLC, and modded chips to filtered discover pages", () => {
     component.item = makeItem({
       category: "power",
-      gameVersion: "spacedOut",
+      requiredDlcs: ["EXPANSION1_ID"],
       modded: true,
     });
     fixture.detectChanges();
@@ -132,17 +132,47 @@ describe("BlueprintCardComponent", () => {
     expect(category.properties["queryParams"]).toEqual({ category: "power" });
     expect(category.properties["title"]).toContain("power");
 
-    const gameVersion = fixture.debugElement.query(
-      By.css("a.bni-chip:not(.bni-chip--cat):not(.bni-chip--modded)"),
-    );
-    expect(gameVersion.properties["routerLink"]).toEqual(["/discover"]);
-    expect(gameVersion.properties["queryParams"]).toEqual({
-      gameVersion: "spacedOut",
-    });
+    const dlc = fixture.debugElement.query(By.css("a.bni-chip--dlc"));
+    expect(dlc.properties["routerLink"]).toEqual(["/discover"]);
+    expect(dlc.properties["queryParams"]).toEqual({ dlc: "EXPANSION1_ID" });
 
     const modded = fixture.debugElement.query(By.css(".bni-chip--modded"));
     expect(modded.properties["routerLink"]).toEqual(["/discover"]);
     expect(modded.properties["queryParams"]).toEqual({ modded: "true" });
+  });
+
+  // Labels come from lib's DLC_LABELS, never from the raw id — a chip reading
+  // "DLC3_ID" would be a regression, not a cosmetic detail.
+  it("renders one chip per required DLC, labelled not raw", () => {
+    component.item = makeItem({ requiredDlcs: ["DLC2_ID", "DLC3_ID"] });
+    fixture.detectChanges();
+
+    const chips = fixture.debugElement.queryAll(By.css("a.bni-chip--dlc"));
+    expect(chips.length).toBe(2);
+    expect(chips.map((chip) => chip.nativeElement.textContent.trim())).toEqual([
+      "The Frosty Planet Pack",
+      "The Bionic Booster Pack",
+    ]);
+    expect(fixture.nativeElement.textContent).not.toContain("DLC2_ID");
+  });
+
+  it("renders an empty requirement set as a base game chip", () => {
+    component.item = makeItem({ requiredDlcs: [] });
+    fixture.detectChanges();
+
+    expect(
+      fixture.debugElement.queryAll(By.css("a.bni-chip--dlc")).length,
+    ).toBe(0);
+    expect(fixture.nativeElement.textContent).toContain("Base game");
+  });
+
+  // Absent is not the same fact as empty: a blueprint saved before DLC
+  // derivation existed must not claim to be buildable without any DLC.
+  it("says nothing when requirements were never derived", () => {
+    component.item = makeItem({ requiredDlcs: undefined });
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toContain("Base game");
   });
 
   it("renders a linked chip per detected room, using display labels", () => {

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.ts
@@ -1,11 +1,13 @@
 import { Component, Input } from "@angular/core";
 import { BlueprintListItem } from "../../../../../../lib/index";
 import {
+  baseGameTooltip,
   categoryTooltip,
-  gameVersionTooltip,
+  dlcTooltip,
   moddedTooltip,
   roomTooltip,
 } from "../../utils/chip-tooltip";
+import { dlcLabel } from "../../../../../../lib/index";
 import { roomTypeLabel } from "../../utils/room-labels";
 
 const MAX_ROOM_CHIPS = 3;
@@ -24,10 +26,18 @@ export class BlueprintCardComponent {
   @Input() linkState: Record<string, unknown> | undefined = undefined;
 
   readonly categoryTooltip = categoryTooltip;
-  readonly gameVersionTooltip = gameVersionTooltip;
+  readonly dlcTooltip = dlcTooltip;
+  readonly baseGameTooltip = baseGameTooltip;
+  readonly dlcLabel = dlcLabel;
   readonly moddedTooltip = moddedTooltip;
   readonly roomTooltip = roomTooltip;
   readonly roomTypeLabel = roomTypeLabel;
+
+  // [] is a fact ("needs no DLC"); absent is not — blueprints saved before
+  // requirements were derived must not claim to be base game.
+  get isBaseGame(): boolean {
+    return this.item.requiredDlcs?.length === 0;
+  }
 
   // Cards stay compact: at most 3 room chips, the rest collapse into "+N".
   get visibleRooms(): string[] {

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
@@ -123,12 +123,19 @@
               >{{ details.subcategory }}</a
             >
             <a
-              *ngIf="details.gameVersion"
-              class="bni-chip"
+              *ngFor="let dlc of details.requiredDlcs ?? []"
+              class="bni-chip bni-chip--dlc"
               [routerLink]="['/discover']"
-              [queryParams]="{ gameVersion: details.gameVersion }"
-              [title]="gameVersionTooltip(details.gameVersion)"
-              >{{ details.gameVersion }}</a
+              [queryParams]="{ dlc: dlc }"
+              [title]="dlcTooltip(dlc)"
+              >{{ dlcLabel(dlc) }}</a
+            >
+            <span
+              *ngIf="isBaseGame"
+              class="bni-chip"
+              [title]="baseGameTooltip()"
+              i18n
+              >Base game</span
             >
             <a
               *ngIf="details.modded"

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
@@ -26,7 +26,7 @@ function makeDetails(overrides: any = {}) {
     myRating: null,
     ownedByMe: false,
     commentCount: 3,
-    gameVersion: "spacedOut",
+    requiredDlcs: ["EXPANSION1_ID"],
     category: "power",
     subcategory: null,
     description: "A tidy coal setup",
@@ -270,7 +270,7 @@ describe("BlueprintDetailsPageComponent", () => {
     expect(el.textContent).toContain("[original removed by author]");
   });
 
-  it("links the category, subcategory, gameVersion, and modded chips to filtered discover pages", () => {
+  it("links the category, subcategory, DLC, and modded chips to filtered discover pages", () => {
     blueprintService.getBlueprintDetails.mockReturnValue(
       of(makeDetails({ subcategory: "generator", modded: true })),
     );
@@ -289,15 +289,50 @@ describe("BlueprintDetailsPageComponent", () => {
       subcategory: "generator",
     });
 
-    const gameVersion = fixture.debugElement.query(
-      By.css("a.bni-chip:not(.bni-chip--cat):not(.bni-chip--modded)"),
-    );
-    expect(gameVersion.properties["queryParams"]).toEqual({
-      gameVersion: "spacedOut",
-    });
+    const dlc = fixture.debugElement.query(By.css("a.bni-chip--dlc"));
+    expect(dlc.properties["queryParams"]).toEqual({ dlc: "EXPANSION1_ID" });
+    expect(dlc.nativeElement.textContent.trim()).toBe("Spaced Out!");
 
     const modded = fixture.debugElement.query(By.css(".bni-chip--modded"));
     expect(modded.properties["queryParams"]).toEqual({ modded: "true" });
+  });
+
+  // Labels come from lib's DLC_LABELS, never from the raw id.
+  it("renders one labelled chip per required DLC", () => {
+    blueprintService.getBlueprintDetails.mockReturnValue(
+      of(makeDetails({ requiredDlcs: ["DLC2_ID", "DLC3_ID"] })),
+    );
+    fixture.detectChanges();
+
+    const chips = fixture.debugElement.queryAll(By.css("a.bni-chip--dlc"));
+    expect(chips.map((chip) => chip.nativeElement.textContent.trim())).toEqual([
+      "The Frosty Planet Pack",
+      "The Bionic Booster Pack",
+    ]);
+    expect(fixture.nativeElement.textContent).not.toContain("DLC2_ID");
+  });
+
+  it("renders an empty requirement set as a base game chip", () => {
+    blueprintService.getBlueprintDetails.mockReturnValue(
+      of(makeDetails({ requiredDlcs: [] })),
+    );
+    fixture.detectChanges();
+
+    expect(
+      fixture.debugElement.queryAll(By.css("a.bni-chip--dlc")).length,
+    ).toBe(0);
+    expect(fixture.nativeElement.textContent).toContain("Base game");
+  });
+
+  // Absent is not the same fact as empty: a blueprint saved before DLC
+  // derivation existed must not claim to be buildable without any DLC.
+  it("says nothing when requirements were never derived", () => {
+    blueprintService.getBlueprintDetails.mockReturnValue(
+      of(makeDetails({ requiredDlcs: undefined })),
+    );
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toContain("Base game");
   });
 
   it("renders a linked chip per detected room and none when rooms is absent", () => {

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
@@ -13,13 +13,15 @@ import { BlueprintService } from "../../services/blueprint-service";
 import { AuthenticationService } from "../../services/authentification-service";
 import { VersionHistoryDialogComponent } from "../dialogs/version-history-dialog/version-history-dialog.component";
 import {
+  baseGameTooltip,
   categoryTooltip,
   subcategoryTooltip,
-  gameVersionTooltip,
+  dlcTooltip,
   moddedTooltip,
   modChipTooltip,
   roomTooltip,
 } from "../../utils/chip-tooltip";
+import { dlcLabel } from "../../../../../../lib/index";
 import { roomTypeLabel } from "../../utils/room-labels";
 import sanitize from "sanitize-filename";
 import { ModsService } from "../../services/mods-service";
@@ -49,11 +51,19 @@ export class BlueprintDetailsPageComponent implements OnInit {
 
   readonly categoryTooltip = categoryTooltip;
   readonly subcategoryTooltip = subcategoryTooltip;
-  readonly gameVersionTooltip = gameVersionTooltip;
+  readonly dlcTooltip = dlcTooltip;
+  readonly baseGameTooltip = baseGameTooltip;
+  readonly dlcLabel = dlcLabel;
   readonly moddedTooltip = moddedTooltip;
   readonly modChipTooltip = modChipTooltip;
   readonly roomTooltip = roomTooltip;
   readonly roomTypeLabel = roomTypeLabel;
+
+  // [] is a fact ("needs no DLC"); absent is not — blueprints saved before
+  // requirements were derived must not claim to be base game.
+  get isBaseGame(): boolean {
+    return this.details?.requiredDlcs?.length === 0;
+  }
 
   private pendingFragment: string | null = null;
   private readonly modTitles = new Map<string, string>();

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
@@ -116,13 +116,23 @@
         </div>
 
         <div class="bni-facet-group">
-          <h4 class="bni-facet-label" i18n>Compatibility</h4>
+          <h4 class="bni-facet-label" i18n>DLC</h4>
           <button
-            *ngFor="let opt of gameVersionOptions"
             type="button"
             class="bni-facet"
-            [class.active]="filterGameVersion === opt.value"
-            (click)="selectGameVersion(opt.value)"
+            [class.active]="filterDlcs.length === 0"
+            (click)="clearDlcFilter()"
+            i18n
+          >
+            All
+          </button>
+          <button
+            *ngFor="let opt of dlcOptions"
+            type="button"
+            class="bni-facet"
+            [class.active]="isDlcSelected(opt.value)"
+            [attr.aria-pressed]="isDlcSelected(opt.value)"
+            (click)="toggleDlc(opt.value)"
           >
             {{ opt.label }}
           </button>

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
@@ -168,6 +168,7 @@ describe("BrowsePageComponent", () => {
         null,
         null,
         null,
+        null,
       );
     });
 
@@ -184,6 +185,7 @@ describe("BrowsePageComponent", () => {
         null,
         "trending",
         0,
+        null,
         null,
         null,
         null,
@@ -209,6 +211,7 @@ describe("BrowsePageComponent", () => {
         null,
         null,
         null,
+        null,
       );
     });
 
@@ -226,6 +229,7 @@ describe("BrowsePageComponent", () => {
         "trending",
         0,
         true,
+        null,
         null,
         null,
         null,
@@ -249,6 +253,7 @@ describe("BrowsePageComponent", () => {
         "parent-1",
         null,
         null,
+        null,
       );
     });
 
@@ -269,6 +274,28 @@ describe("BrowsePageComponent", () => {
         null,
         null,
         "latrine",
+        null,
+      );
+    });
+
+    it("passes the selected DLCs to getBlueprints as a comma list", () => {
+      component.filterDlcs = ["DLC2_ID", "DLC3_ID"];
+      component.getBlueprints();
+
+      expect(blueprintService.getBlueprints).toHaveBeenCalledWith(
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        "trending",
+        0,
+        null,
+        null,
+        null,
+        null,
+        "DLC2_ID,DLC3_ID",
       );
     });
 
@@ -313,8 +340,10 @@ describe("BrowsePageComponent", () => {
       component.filterModded = true;
       component.filterForkedFrom = "parent-1";
       component.filterRooms = "latrine";
+      component.filterDlcs = ["DLC2_ID"];
       component.clearFilters();
 
+      expect(component.filterDlcs).toEqual([]);
       expect(component.filterGameVersion).toBeNull();
       expect(component.filterCategory).toBeNull();
       expect(component.filterSubcategory).toBeNull();
@@ -350,6 +379,124 @@ describe("BrowsePageComponent", () => {
       // The facetSubject fires asynchronously via debounceTime(0);
       // test that the field is cleared on the next tick
       expect(component.filterSubcategory).toBeNull();
+    });
+  });
+
+  describe("DLC filter", () => {
+    it("offers every known pack, labelled from lib rather than by raw id", () => {
+      const values = component.dlcOptions.map((o) => o.value);
+      expect(values).toContain("EXPANSION1_ID");
+      expect(values).toContain("DLC3_ID");
+      expect(
+        component.dlcOptions.find((o) => o.value === "DLC3_ID")!.label,
+      ).toBe("The Bionic Booster Pack");
+      // sorted by label, not by Klei's id numbering
+      expect(component.dlcOptions.map((o) => o.label)).toEqual(
+        [...component.dlcOptions.map((o) => o.label)].sort((a, b) =>
+          a.localeCompare(b),
+        ),
+      );
+    });
+
+    it("initializes the selection from a comma-separated URL param", () => {
+      const route = TestBed.inject(ActivatedRoute) as any;
+      route.queryParamMap = of(convertToParamMap({ dlc: "DLC2_ID,DLC3_ID" }));
+      component.ngOnInit();
+      expect(component.filterDlcs).toEqual(["DLC2_ID", "DLC3_ID"]);
+    });
+
+    it("initializes the selection from a repeated URL param", () => {
+      const route = TestBed.inject(ActivatedRoute) as any;
+      route.queryParamMap = of(
+        convertToParamMap({ dlc: ["DLC2_ID", "DLC3_ID"] }),
+      );
+      component.ngOnInit();
+      expect(component.filterDlcs).toEqual(["DLC2_ID", "DLC3_ID"]);
+    });
+
+    it("writes the selection back to the URL as a comma list", () => {
+      vi.useFakeTimers();
+      component.toggleDlc("DLC2_ID");
+      component.toggleDlc("DLC3_ID");
+      vi.advanceTimersByTime(600);
+
+      expect(router.navigate).toHaveBeenLastCalledWith([], {
+        queryParams: { dlc: "DLC2_ID,DLC3_ID" },
+        replaceUrl: true,
+      });
+    });
+
+    it("round-trips through the URL: what it writes, it reads back", () => {
+      vi.useFakeTimers();
+      component.toggleDlc("DLC2_ID");
+      component.toggleDlc("DLC3_ID");
+      vi.advanceTimersByTime(600);
+      const written = router.navigate.mock.calls.at(-1)[1].queryParams;
+      vi.useRealTimers();
+
+      const route = TestBed.inject(ActivatedRoute) as any;
+      route.queryParamMap = of(convertToParamMap(written));
+      const reopened = TestBed.createComponent(BrowsePageComponent);
+      reopened.componentInstance.ngOnInit();
+
+      expect(reopened.componentInstance.filterDlcs).toEqual([
+        "DLC2_ID",
+        "DLC3_ID",
+      ]);
+    });
+
+    it("omits the param entirely when nothing is selected", () => {
+      vi.useFakeTimers();
+      component.toggleDlc("DLC2_ID");
+      component.toggleDlc("DLC2_ID"); // toggled back off
+      vi.advanceTimersByTime(600);
+
+      expect(component.filterDlcs).toEqual([]);
+      expect(
+        router.navigate.mock.calls.at(-1)[1].queryParams,
+      ).not.toHaveProperty("dlc");
+    });
+
+    // Packs are independent: picking a second one widens the result set
+    // ("needs any of these") rather than replacing the first.
+    it("toggles selections independently instead of replacing them", () => {
+      component.toggleDlc("DLC2_ID");
+      component.toggleDlc("DLC3_ID");
+      expect(component.filterDlcs).toEqual(["DLC2_ID", "DLC3_ID"]);
+      expect(component.isDlcSelected("DLC2_ID")).toBe(true);
+
+      component.toggleDlc("DLC2_ID");
+      expect(component.filterDlcs).toEqual(["DLC3_ID"]);
+      expect(component.isDlcSelected("DLC2_ID")).toBe(false);
+    });
+
+    it("counts each selected pack as an active filter", () => {
+      component.filterDlcs = ["DLC2_ID", "DLC3_ID"];
+      expect(component.activeFilterCount).toBe(2);
+      expect(component.hasActiveFilters).toBe(true);
+    });
+
+    it("shows one chip per pack, labelled, each removable on its own", () => {
+      component.filterDlcs = ["DLC2_ID", "DLC3_ID"];
+
+      const chips = component.activeFilterChips.filter((c) =>
+        c.key.startsWith("dlc-"),
+      );
+      expect(chips.map((c) => c.label)).toEqual([
+        "The Frosty Planet Pack",
+        "The Bionic Booster Pack",
+      ]);
+
+      chips[0].remove();
+      expect(component.filterDlcs).toEqual(["DLC3_ID"]);
+    });
+
+    it("clearDlcFilter is a no-op when nothing is selected", () => {
+      const callsBefore = blueprintService.getBlueprints.mock.calls.length;
+      component.clearDlcFilter();
+      expect(blueprintService.getBlueprints.mock.calls.length).toBe(
+        callsBefore,
+      );
     });
   });
 

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
@@ -8,10 +8,11 @@ import {
 import {
   BlueprintListItem,
   BlueprintListResponse,
-  GAME_VERSIONS,
   CATEGORIES,
   SUBCATEGORIES,
   ROOM_TYPE_IDS,
+  DLC_LABELS,
+  dlcLabel,
 } from "../../../../../../lib/index";
 import { ROOM_TYPE_LABELS, roomTypeLabel } from "../../utils/room-labels";
 import {
@@ -71,7 +72,13 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   // here would make every page-1 URL unique and defeat the CDN cache.
   oldestDate: Date | null = null;
   filterName = "";
+  // Superseded by filterDlcs — no sidebar control writes it any more, but the
+  // param is still read, sent and shown as a chip so links predating the DLC
+  // filter keep working until gameVersion is dropped altogether.
   filterGameVersion: string | null = null;
+  /** Selected DLC ids; empty = no DLC restriction. Multi-select: the server
+   * matches blueprints requiring ANY of them ($in). */
+  filterDlcs: string[] = [];
   filterCategory: string | null = null;
   filterSubcategory: string | null = null;
   filterModded: boolean | null = null;
@@ -115,10 +122,14 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     },
   ];
 
-  readonly gameVersionOptions = [
-    { label: "All versions", value: null },
-    ...GAME_VERSIONS.map((v) => ({ label: v, value: v })),
-  ];
+  // Labels come from lib (checked against the game's own strings), never from
+  // pack names written out here. Ordered by label so the sidebar reads
+  // alphabetically rather than by Klei's id numbering.
+  readonly dlcOptions: { label: string; value: string }[] = Object.keys(
+    DLC_LABELS,
+  )
+    .map((id) => ({ label: dlcLabel(id), value: id }))
+    .sort((a, b) => a.label.localeCompare(b.label));
   readonly categoryOptions = [
     { label: "All categories", value: null },
     ...CATEGORIES.map((c) => ({ label: c, value: c })),
@@ -321,6 +332,13 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     // Kept as the raw param (the API accepts a comma list); the select simply
     // shows no selection for a multi-value URL, but the filter still applies.
     const rooms = params.get("rooms");
+    // Accepts both ?dlc=A&dlc=B and ?dlc=A,B — we write the CSV form, but a
+    // hand-built or shared link may use either.
+    const dlcs = params
+      .getAll("dlc")
+      .flatMap((value) => value.split(","))
+      .map((dlcId) => dlcId.trim())
+      .filter((dlcId) => dlcId.length > 0);
     const rawSort = params.get("sort");
     const sort: BlueprintSort = this.sortOptions.some(
       (option) => option.value === rawSort,
@@ -336,6 +354,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
       modded !== this.filterModded ||
       forkedFrom !== this.filterForkedFrom ||
       rooms !== this.filterRooms ||
+      dlcs.join(",") !== this.filterDlcs.join(",") ||
       sort !== this.sort;
 
     this.filterName = name;
@@ -345,6 +364,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     this.filterModded = modded;
     this.filterForkedFrom = forkedFrom;
     this.filterRooms = rooms;
+    this.filterDlcs = dlcs;
     this.sort = sort;
     return changed;
   }
@@ -369,6 +389,28 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     // game-version change must not reset it
     this.filterFacetSubject.next();
   }
+
+  isDlcSelected(dlcId: string): boolean {
+    return this.filterDlcs.includes(dlcId);
+  }
+
+  /** Multi-select: packs are independent, so picking a second one widens the
+   * result set ("needs any of these") instead of replacing the first. */
+  toggleDlc(dlcId: string) {
+    this.filterDlcs = this.isDlcSelected(dlcId)
+      ? this.filterDlcs.filter((id) => id !== dlcId)
+      : [...this.filterDlcs, dlcId];
+    // same reasoning as selectGameVersion: subcategory is scoped to category
+    this.filterFacetSubject.next();
+  }
+
+  clearDlcFilter() {
+    if (this.filterDlcs.length === 0) return;
+    this.filterDlcs = [];
+    this.filterFacetSubject.next();
+  }
+
+  readonly dlcLabel = dlcLabel;
 
   selectSubcategory(value: string | null) {
     if (this.filterSubcategory === value) return;
@@ -401,15 +443,17 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   }
 
   get activeFilterCount(): number {
-    return [
-      this.filterName,
-      this.filterGameVersion,
-      this.filterCategory,
-      this.filterSubcategory,
-      this.filterRooms,
-      this.filterForkedFrom,
-      this.filterModded !== null || null,
-    ].filter(Boolean).length;
+    return (
+      [
+        this.filterName,
+        this.filterGameVersion,
+        this.filterCategory,
+        this.filterSubcategory,
+        this.filterRooms,
+        this.filterForkedFrom,
+        this.filterModded !== null || null,
+      ].filter(Boolean).length + this.filterDlcs.length
+    );
   }
 
   get hasActiveFilters(): boolean {
@@ -464,6 +508,12 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
         this.chip("gameVersion", this.filterGameVersion, () =>
           this.selectGameVersion(null),
         ),
+      );
+    // One chip per pack, each removable on its own — unlike rooms, the sidebar
+    // control here really is multi-select, so removing one must not clear the rest.
+    for (const dlcId of this.filterDlcs)
+      chips.push(
+        this.chip(`dlc-${dlcId}`, dlcLabel(dlcId), () => this.toggleDlc(dlcId)),
       );
     if (this.filterModded != null)
       chips.push(
@@ -522,6 +572,8 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     if (this.filterForkedFrom)
       queryParams["forkedFrom"] = this.filterForkedFrom;
     if (this.filterRooms) queryParams["rooms"] = this.filterRooms;
+    if (this.filterDlcs.length > 0)
+      queryParams["dlc"] = this.filterDlcs.join(",");
     if (this.sort !== DEFAULT_SORT) queryParams["sort"] = this.sort;
     this.router.navigate([], { queryParams, replaceUrl: true });
   }
@@ -534,6 +586,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     this.filterModded = null;
     this.filterForkedFrom = null;
     this.filterRooms = null;
+    this.filterDlcs = [];
     this.applyFiltersToUrl();
     this.transitionList();
   }
@@ -572,6 +625,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
             this.filterForkedFrom,
             null,
             this.filterRooms,
+            this.filterDlcs.length > 0 ? this.filterDlcs.join(",") : null,
           );
 
     request$.subscribe({

--- a/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.css
+++ b/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.css
@@ -65,6 +65,29 @@
   align-items: end;
 }
 
+/* Read-only DLC requirement list. Styled on --p-* tokens, not the .bni-chip
+   skin: the editor deliberately keeps the stock PrimeNG look. */
+.save-dlc-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  padding-bottom: 0.55rem;
+}
+
+.save-dlc-chip {
+  font-size: 0.8rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: var(--p-content-border-radius, 6px);
+  background: var(--p-surface-700, var(--p-content-background));
+  color: var(--p-text-color);
+}
+
+.save-dlc-chip--none {
+  background: transparent;
+  border: 1px solid var(--p-content-border-color);
+  color: var(--p-text-muted-color);
+}
+
 .save-detected .metadata-checkbox {
   padding-bottom: 0.55rem;
 }

--- a/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.html
@@ -86,15 +86,18 @@
         </div>
         <div class="save-detected-fields">
           <div class="save-field">
-            <label for="save-game-version" i18n>Game version</label>
-            <p-select
-              inputId="save-game-version"
-              formControlName="gameVersion"
-              [options]="gameVersionOptions"
-              placeholder=" "
-              optionLabel="label"
-              optionValue="value"
-            ></p-select>
+            <label i18n>DLC required</label>
+            <div class="save-dlc-chips">
+              <span class="save-dlc-chip" *ngFor="let dlc of requiredDlcs">{{
+                dlcLabel(dlc)
+              }}</span>
+              <span
+                class="save-dlc-chip save-dlc-chip--none"
+                *ngIf="requiredDlcs.length === 0"
+                i18n
+                >Base game</span
+              >
+            </div>
           </div>
           <label class="metadata-checkbox">
             <p-checkbox formControlName="modded" [binary]="true"></p-checkbox>

--- a/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.html
@@ -88,12 +88,14 @@
           <div class="save-field">
             <label i18n>DLC required</label>
             <div class="save-dlc-chips">
-              <span class="save-dlc-chip" *ngFor="let dlc of requiredDlcs">{{
-                dlcLabel(dlc)
-              }}</span>
+              <span
+                class="save-dlc-chip"
+                *ngFor="let dlc of requiredDlcs ?? []"
+                >{{ dlcLabel(dlc) }}</span
+              >
               <span
                 class="save-dlc-chip save-dlc-chip--none"
-                *ngIf="requiredDlcs.length === 0"
+                *ngIf="requiredDlcs?.length === 0"
                 i18n
                 >Base game</span
               >

--- a/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.spec.ts
@@ -203,6 +203,54 @@ describe("ComponentSaveDialogComponent", () => {
     });
   });
 
+  describe("computeDerivedMetadata DLC requirements", () => {
+    afterEach(() => {
+      (OniItem as any).oniItemsMap = undefined;
+    });
+
+    function fakeBlueprint(buildingDlcIds: string[][]) {
+      return {
+        blueprintItems: buildingDlcIds.map((dlcIds) => ({
+          oniItem: { dlcIds },
+        })),
+        hadUnknownBuildings: false,
+        toMdbBlueprint: () => ({
+          blueprintItems: buildingDlcIds.map((_, i) => ({ id: `Fake${i}` })),
+        }),
+      } as any;
+    }
+
+    function showWith(buildingDlcIds: string[][]) {
+      OniItem.oniItemsMap = new Map([["Fake0", { id: "Fake0" } as any]]);
+      TestBed.inject(BlueprintService).blueprint =
+        fakeBlueprint(buildingDlcIds);
+      component.showDialog();
+    }
+
+    it("derives the union of every placed building's packs", () => {
+      showWith([["DLC3_ID"], ["DLC2_ID"], ["DLC3_ID"]]);
+      expect(component.requiredDlcs).toEqual(["DLC2_ID", "DLC3_ID"]);
+    });
+
+    it("derives [] for a base-game-only blueprint", () => {
+      showWith([[], []]);
+      expect(component.requiredDlcs).toEqual([]);
+    });
+
+    it("renders labelled chips, or Base game for an empty set", () => {
+      showWith([["DLC2_ID"]]);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toContain(
+        "The Frosty Planet Pack",
+      );
+      expect(fixture.nativeElement.textContent).not.toContain("DLC2_ID");
+
+      showWith([[]]);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toContain("Base game");
+    });
+  });
+
   describe("computeDerivedMetadata modded detection", () => {
     afterEach(() => {
       (OniItem as any).oniItemsMap = undefined;

--- a/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.spec.ts
@@ -237,6 +237,17 @@ describe("ComponentSaveDialogComponent", () => {
       expect(component.requiredDlcs).toEqual([]);
     });
 
+    // The database may not have loaded yet; an underived set must not claim
+    // the blueprint needs no DLC.
+    it("stays null and says nothing when the database is unavailable", () => {
+      (OniItem as any).oniItemsMap = undefined;
+      component.showDialog();
+      fixture.detectChanges();
+
+      expect(component.requiredDlcs).toBeNull();
+      expect(fixture.nativeElement.textContent).not.toContain("Base game");
+    });
+
     it("renders labelled chips, or Base game for an empty set", () => {
       showWith([["DLC2_ID"]]);
       fixture.detectChanges();

--- a/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.ts
@@ -38,8 +38,10 @@ export class ComponentSaveDialogComponent {
   readonly categoryOptions = CATEGORIES.map((c) => ({ label: c, value: c }));
 
   readonly dlcLabel = dlcLabel;
-  /** Derived from the blueprint's content on open; [] = base game only. */
-  requiredDlcs: string[] = [];
+  /** Derived from the blueprint's content on open; [] = base game only, null =
+   * not derivable (the database has not loaded). Same distinction the card and
+   * details page make: "needs no DLC" is a fact we must have computed. */
+  requiredDlcs: string[] | null = null;
 
   get subcategoryOptions(): { label: string; value: string }[] {
     const cat = this.saveBlueprintForm.value.category;
@@ -312,7 +314,7 @@ export class ComponentSaveDialogComponent {
   reset() {
     this.working = false;
     this.thumbnailReady = false;
-    this.requiredDlcs = [];
+    this.requiredDlcs = null;
     this.overwrite = false;
     this.pendingPublish = null;
     this._originalName = null;

--- a/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.ts
@@ -10,11 +10,12 @@ import { AuthenticationService } from "../../../services/authentification-servic
 import { BlueprintNameValidationDirective } from "src/app/module-blueprint/directives/blueprint-name-validation.directive";
 import {
   Display,
-  GAME_VERSIONS,
   CATEGORIES,
   SUBCATEGORIES,
   OniItem,
+  dlcLabel,
   deriveGameVersion,
+  deriveRequiredDlcs,
   deriveModded,
   deriveCategory,
   buildCategoryLookup,
@@ -34,11 +35,11 @@ export class ComponentSaveDialogComponent {
 
   @Output() updateThumbnail = new EventEmitter();
 
-  readonly gameVersionOptions = GAME_VERSIONS.map((v) => ({
-    label: v,
-    value: v,
-  }));
   readonly categoryOptions = CATEGORIES.map((c) => ({ label: c, value: c }));
+
+  readonly dlcLabel = dlcLabel;
+  /** Derived from the blueprint's content on open; [] = base game only. */
+  requiredDlcs: string[] = [];
 
   get subcategoryOptions(): { label: string; value: string }[] {
     const cat = this.saveBlueprintForm.value.category;
@@ -165,8 +166,9 @@ export class ComponentSaveDialogComponent {
     };
   }
 
-  // Derives gameVersion and modded from the current blueprint content and
-  // patches the disabled form controls so users see what was computed.
+  // Derives the DLC requirements, gameVersion and modded from the current
+  // blueprint content so users see what was computed. The server derives its
+  // own requiredDlcs on save — this is the preview, never the source.
   private computeDerivedMetadata() {
     const blueprint = this.blueprintService.blueprint;
     // oniItemsMap may be null in unit tests before the database loads
@@ -175,6 +177,7 @@ export class ComponentSaveDialogComponent {
     const buildingDlcIds = blueprint.blueprintItems.map(
       (item) => item.oniItem.dlcIds,
     );
+    this.requiredDlcs = deriveRequiredDlcs(buildingDlcIds);
     const gameVersion = deriveGameVersion(buildingDlcIds);
 
     const knownIds = new Set(OniItem.oniItems.map((i) => i.id));
@@ -309,6 +312,7 @@ export class ComponentSaveDialogComponent {
   reset() {
     this.working = false;
     this.thumbnailReady = false;
+    this.requiredDlcs = [];
     this.overwrite = false;
     this.pendingPublish = null;
     this._originalName = null;

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -607,6 +607,7 @@ export class BlueprintService implements IObsBlueprintChange {
     filterForkedFrom?: string | null,
     filterRatedBy?: string | null,
     filterRooms?: string | null,
+    filterDlcs?: string | null,
   ) {
     // olderthan is a cache-buster when it isn't doing real work, so send it
     // only where it is the pagination cursor: the recent sort past page 1
@@ -657,6 +658,9 @@ export class BlueprintService implements IObsBlueprintChange {
     let parameterRooms = "";
     if (filterRooms != null) parameterRooms = "&rooms=" + filterRooms;
 
+    let parameterDlcs = "";
+    if (filterDlcs != null) parameterDlcs = "&dlc=" + filterDlcs;
+
     const parameters = (
       parameterOlderThan +
       parameterFilterUserId +
@@ -668,7 +672,8 @@ export class BlueprintService implements IObsBlueprintChange {
       parameterModded +
       parameterForkedFrom +
       parameterRatedBy +
-      parameterRooms
+      parameterRooms +
+      parameterDlcs
     ).replace(/^&/, "");
 
     // General browsing is a public, viewer-independent feed — always hit the

--- a/frontend/src/app/module-blueprint/utils/chip-tooltip.ts
+++ b/frontend/src/app/module-blueprint/utils/chip-tooltip.ts
@@ -1,3 +1,16 @@
+import { dlcLabel } from "../../../../../lib/index";
+
+// Built on dlcLabel() rather than a map of its own: pack names live in lib
+// (one place, checked against the game's own strings), and an id we have no
+// label for still produces a usable tooltip instead of vanishing.
+export function dlcTooltip(dlcId: string): string {
+  return $localize`:chipTooltip.dlc:Requires the ${dlcLabel(dlcId)} DLC — browse blueprints that need it`;
+}
+
+export function baseGameTooltip(): string {
+  return $localize`:chipTooltip.baseGame:Needs no DLC — buildable in the base game`;
+}
+
 const GAME_VERSION_TOOLTIPS: Record<string, string> = {
   base: $localize`:chipTooltip.base:Base game — no DLC required`,
   spacedOut: $localize`:chipTooltip.spacedOut:Spaced Out — requires the Spaced Out! DLC`,

--- a/frontend/src/bni-skin.css
+++ b/frontend/src/bni-skin.css
@@ -445,6 +445,7 @@
 }
 
 /* Semantic hooks retain the deliberately monochrome chip treatment. */
+.bni-chip--dlc,
 .bni-chip--mod,
 .bni-chip--modded,
 .bni-chip--room {


### PR DESCRIPTION
Step 2 of `spec/dlc-requirements-plan.md`: the `dlc=` filter and the display
chips that go with it. Step 1 (#177) derives and stores `requiredDlcs`; this
makes it usable. Still additive — `gameVersion` is untouched and keeps working.

## What shipped

**`GET /api/getblueprints?dlc=…`** — comma-separated or repeated, `$in`
semantics ("show me anything from these packs"), matching the `rooms`
precedent. Ids are validated by *shape* (`/^[A-Z0-9_]{1,32}$/`, at most 20),
never against `DLC_LABELS`: a pack that ships in an export before we have
written its label must still be filterable, which is the same reason the
schema carries no enum. Documents with no `requiredDlcs` at all never match —
`$in` doesn't match a missing field, verified by test rather than assumed.

**"You might also like"** — `gameVersion` equality becomes `requiredDlcs` set
overlap. The old signal could not be honest: a Frosty+Bionic blueprint
collapsed to one pack and so never matched a Frosty one. Both-empty still
scores, because base-game-only is a shared property and it is what the old
equality test rewarded. This is its own commit (9fbed02) so it can be reverted
alone if it hurts shelf quality.

**Discover sidebar** — the single-select Compatibility facet becomes a
multi-select DLC facet; picking a second pack widens the results rather than
replacing the first. URL param `dlc`, written as CSV, read as either CSV or
repeated. Each selected pack gets its own removable chip in the active-filter
row.

**Cards, details page, save dialog** — the one `gameVersion` value becomes one
labelled chip per required pack, linking to that pack's filtered Discover page.
`[]` renders "Base game". Labels always come from lib's `dlcLabel()`; the new
`dlcTooltip()` is built on it too, so an unlabelled id still gets a usable
tooltip. `gameVersionTooltip` stays until step 4.

## The backfill — this is a rollout step, not a nice-to-have

Against prod (read-only) right now: **4,596 live blueprints, 0 with
`requiredDlcs`**. Until `derive-metadata` runs, `?dlc=` matches literally
nothing, and every card reads "Base game" (the API coerces a missing set to
`[]` — step 1's shipped behaviour, left alone here).

I can't write to prod, so this needs to run after deploy:

```
cd /bpni/build && npm run derive-metadata:dry-run   # then without :dry-run
```

Rehearsed locally against a restored prod snapshot (5,217 docs) — the script
completes and writes what it should:

| | |
|---|---|
| need ≥1 DLC | 612 (of 5,217; 505 of the 4,565 live) |
| Spaced Out / Aquatic / Frosty | 492 / 9 / 4 |
| base game (`[]`) | 4,068 live |
| still missing after run | 0 |

No Bionic or Prehistoric blueprints exist yet, so those two facets will be
empty for now — correct, not a bug.

## Decisions worth flagging

- The 20-id cap is not in the plan; it only bounds the `$in` list, since ids
  are no longer checked against a known set.
- The browse page still reads, sends and chips the `gameVersion` param even
  though no control writes it — old links keep working until step 4 removes
  the field. Same reason the save dialog still derives and submits it; it is
  just no longer displayed.
- "Base game" renders only when the set is present and empty. Absent is not
  the same fact, and a blueprint predating derivation must not claim to need
  no DLC. Our own API never sends absent (see backfill above), so this is the
  honest behaviour for any client that omits it.

## Verified

- Backend: 5 new filter tests (single id, several, repeated param, unknown
  well-formed id, malformed 400, oversized list 400, never-derived excluded,
  `dlc=` + `category=`) and 2 for the related scorer. Touched suites green
  (64 passing); full run is 696 passing with the known local WorkOS flakes,
  each green in isolation.
- Frontend: 1,005 passing (Vitest), including browse-page URL round-trip,
  independent toggling, labelled chips, and the empty/absent split on card,
  details and save dialog. `npm run lint` clean, `npm run tsc` clean.
- Browser: filtered `/discover?dlc=EXPANSION1_ID` end to end against a
  backfilled local DB — facet, chip row, card chips and details chips all
  render labels, not raw ids.

## Not in this PR

Intent 1 (`owned=`, the subset test) is step 3; dropping `gameVersion` is
step 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)