### PR TITLE
feat: DLC exclusion filter, persisted on interaction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,13 +256,29 @@ content — users no longer set these manually. `multiplayerSafe` has been remov
   ID is not found; read by the save dialog to detect mods stripped during import.
 - **`?dlc=` filter** — `GET /api/getblueprints?dlc=DLC2_ID,DLC3_ID` returns blueprints requiring
   ANY of those packs (`$in`, like `rooms`; repeatable or comma-separated). Ids are validated by
-  shape (`/^[A-Z0-9_]{1,32}$/`, max 20), never against `DLC_LABELS` — a pack that ships in an
-  export before we've written its label must still be filterable. Docs with no `requiredDlcs`
-  never match. The subset test ("hide what I can't build") is a separate future `owned=` param.
+  shape (`DLC_ID_PATTERN` / `MAX_DLC_FILTER_IDS` in `lib/src/blueprint/dlc.ts`, max 20), never
+  against `DLC_LABELS` — a pack that ships in an export before we've written its label must
+  still be filterable. Docs with no `requiredDlcs` never match.
+- **`?excludeDlc=` filter** — the complement: `requiredDlcs: { $nin: [...] }`, same shape
+  validation, composes with `dlc=`/`category=`. This replaced the plan's `owned=` subset idea —
+  "I don't want Bionic blueprints" is more useful and more expressive than declaring what you
+  own. Base-game (`[]`) and never-derived docs both survive exclusion (conservative: absence of
+  DLC info is never treated as needing the excluded pack). A `$nin` on `requiredDlcs` gets no
+  help from the field's indexes (can't produce a bounded range, so the planner keeps the
+  `createdAt`-sorted index and applies the exclusion as a per-doc FETCH filter) — checked with
+  `explain()`, not a collscan, just no extra narrowing.
+- **DLC exclusion preference** — `dlcPreferences.excludedDlcs` on `User` (raw ids, `default:
+  []`), read/written via `GET`/`PATCH /api/users/me/dlc-preferences`. Applied automatically on
+  Discover load for a logged-in user *only* when the URL has no explicit `excludeDlc` param;
+  written back only on real interaction (toggle/clear), never merely from loading it, never for
+  a logged-out visitor. Private account data — never in `ProfileResponse` or any other
+  user-facing payload.
 - **Display** — the blueprint card and details page render one linked chip per required DLC
   (`dlcLabel()`, `dlcTooltip()` in `utils/chip-tooltip.ts`); `[]` renders "Base game", while an
-  absent set renders nothing. The Discover sidebar's DLC facet is multi-select and round-trips
-  through the `dlc` URL param.
+  absent set renders nothing. The Discover sidebar has two DLC facet groups — "show only" and
+  "hide" — each multi-select and round-tripping through its own URL param (`dlc` / `excludeDlc`);
+  a pack can't be in both, selecting it in one clears it from the other. Exclusion chips use the
+  danger accent (`exclude: true` on `ActiveFilterChip`) so the two read as opposite intents.
 - **Save dialog** — the DLC requirement set and `modded` are read-only, derived from blueprint
   content on open (`gameVersion` is still derived and submitted, but no longer displayed).
   `researchTier` is hidden (no tech-tree data in current export; field kept in schema for future use).

--- a/__tests__/api/blueprint-dlcs.test.ts
+++ b/__tests__/api/blueprint-dlcs.test.ts
@@ -247,6 +247,120 @@ describe('Blueprint DLC requirement derivation', function () {
     });
   });
 
+  describe('GET /api/getblueprints?excludeDlc=', function () {
+    let aquaticId: string;
+    let frostyId: string;
+    let baseId: string;
+
+    const list = (query: Record<string, unknown>) =>
+      TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), ...query });
+
+    const idsOf = (response: any) => response.body.blueprints.map((bp: any) => bp.id);
+
+    beforeEach(async function () {
+      this.timeout(15000);
+      aquaticId = (
+        await upload({
+          name: 'Aquatic Exclude Base',
+          blueprint: blueprintData([AQUATIC_PREFAB]),
+          category: 'power',
+        })
+      ).body.id;
+      frostyId = (
+        await upload({ name: 'Frosty Exclude Base', blueprint: blueprintData([FROSTY_PREFAB]) })
+      ).body.id;
+      baseId = (
+        await upload({ name: 'Base Exclude Base', blueprint: blueprintData([BASE_PREFAB]) })
+      ).body.id;
+    });
+
+    it('hides blueprints requiring a single excluded pack', async function () {
+      const response = await list({ excludeDlc: 'DLC5_ID' });
+      expect(response.status).to.equal(200);
+
+      const ids = idsOf(response);
+      expect(ids).to.not.include(aquaticId);
+      expect(ids).to.include(frostyId);
+      expect(ids).to.include(baseId);
+    });
+
+    it('hides blueprints requiring any of a comma-separated list', async function () {
+      const response = await list({ excludeDlc: 'DLC2_ID,DLC5_ID' });
+      expect(response.status).to.equal(200);
+
+      const ids = idsOf(response);
+      expect(ids).to.not.include(aquaticId);
+      expect(ids).to.not.include(frostyId);
+      expect(ids).to.include(baseId);
+    });
+
+    it('hides a blueprint needing two packs when either is excluded', async function () {
+      const bothId = (
+        await upload({ name: 'Two Pack Exclude', blueprint: blueprintData([AND_PREFAB]) })
+      ).body.id;
+
+      expect(idsOf(await list({ excludeDlc: 'DLC3_ID' }))).to.not.include(bothId);
+      expect(idsOf(await list({ excludeDlc: 'EXPANSION1_ID' }))).to.not.include(bothId);
+    });
+
+    it('base-game blueprints always survive exclusion', async function () {
+      const response = await list({
+        excludeDlc: 'DLC2_ID,DLC3_ID,DLC4_ID,DLC5_ID,EXPANSION1_ID',
+      });
+      expect(response.status).to.equal(200);
+      expect(idsOf(response)).to.include(baseId);
+    });
+
+    it('rejects a malformed id with 400', async function () {
+      expect((await list({ excludeDlc: 'dlc3_id' })).status).to.equal(400);
+      expect((await list({ excludeDlc: 'DLC3_ID;drop' })).status).to.equal(400);
+      expect((await list({ excludeDlc: ' , ' })).status).to.equal(400);
+    });
+
+    // A never-derived doc can't be known to need the excluded pack, so it
+    // isn't hidden either — the conservative reading for a filter whose whole
+    // point is to hide things, not the "excludes from dlc=" behaviour above.
+    it('never-derived blueprints survive exclusion', async function () {
+      await BlueprintModel.model.updateOne(
+        { _id: aquaticId },
+        { $unset: { requiredDlcs: '' } }
+      );
+
+      const response = await list({ excludeDlc: 'DLC5_ID' });
+      expect(response.status).to.equal(200);
+      expect(idsOf(response)).to.include(aquaticId);
+    });
+
+    it('rejects an oversized id list with 400', async function () {
+      const many = Array.from({ length: 21 }, (_, i) => `DLC${i}_ID`).join(',');
+      expect((await list({ excludeDlc: many })).status).to.equal(400);
+    });
+
+    it('combines coherently with dlc= (membership AND NOT exclusion)', async function () {
+      const bothId = (
+        await upload({ name: 'Two Pack Combo', blueprint: blueprintData([AND_PREFAB]) })
+      ).body.id;
+
+      // Needs EXPANSION1_ID and DLC3_ID both — asking for EXPANSION1_ID while
+      // excluding DLC3_ID must exclude it, since it also needs DLC3_ID.
+      const response = await list({ dlc: 'EXPANSION1_ID', excludeDlc: 'DLC3_ID' });
+      expect(response.status).to.equal(200);
+      expect(idsOf(response)).to.not.include(bothId);
+    });
+
+    it('combines with the category filter', async function () {
+      const conflicting = await list({ excludeDlc: 'DLC5_ID', category: 'power' });
+      expect(conflicting.status).to.equal(200);
+      expect(idsOf(conflicting)).to.not.include(aquaticId);
+
+      const matching = await list({ excludeDlc: 'DLC2_ID', category: 'power' });
+      expect(matching.status).to.equal(200);
+      expect(idsOf(matching)).to.include(aquaticId);
+    });
+  });
+
   describe('emit checks', function () {
     it('includes requiredDlcs in the list payload', async function () {
       const created = await upload({

--- a/__tests__/api/dlc-preferences.test.ts
+++ b/__tests__/api/dlc-preferences.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup } from '../setup/testSetup';
+
+describe('DLC exclusion preferences API', function () {
+  let testData: any;
+
+  beforeEach(async function () {
+    this.timeout(5000);
+    testData = await TestSetup.beforeEach();
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    await TestSetup.afterEach();
+  });
+
+  describe('GET /api/users/me/dlc-preferences', function () {
+    it('returns 401 without a token', async function () {
+      const response = await TestSetup.request().get('/api/users/me/dlc-preferences');
+      expect(response.status).to.equal(401);
+    });
+
+    it('returns an empty exclusion list before the user has ever interacted', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .get('/api/users/me/dlc-preferences')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).to.equal(200);
+      expect(response.body.excludedDlcs).to.deep.equal([]);
+    });
+  });
+
+  describe('PATCH /api/users/me/dlc-preferences', function () {
+    it('returns 401 without a token', async function () {
+      const response = await TestSetup.request()
+        .patch('/api/users/me/dlc-preferences')
+        .send({ excludedDlcs: ['DLC3_ID'] });
+      expect(response.status).to.equal(401);
+    });
+
+    it('sets the exclusion list and it persists across requests', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .patch('/api/users/me/dlc-preferences')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ excludedDlcs: ['DLC3_ID', 'DLC4_ID'] });
+
+      expect(response.status).to.equal(200);
+      expect(response.body.excludedDlcs).to.deep.equal(['DLC3_ID', 'DLC4_ID']);
+
+      const reread = await TestSetup.request()
+        .get('/api/users/me/dlc-preferences')
+        .set('Authorization', `Bearer ${token}`);
+      expect(reread.body.excludedDlcs).to.deep.equal(['DLC3_ID', 'DLC4_ID']);
+    });
+
+    it('overwrites (not merges) on a second call', async function () {
+      const token = testData.users.user1.generateJwt();
+      await TestSetup.request()
+        .patch('/api/users/me/dlc-preferences')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ excludedDlcs: ['DLC3_ID'] });
+
+      const response = await TestSetup.request()
+        .patch('/api/users/me/dlc-preferences')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ excludedDlcs: ['DLC5_ID'] });
+
+      expect(response.status).to.equal(200);
+      expect(response.body.excludedDlcs).to.deep.equal(['DLC5_ID']);
+    });
+
+    it('clears the exclusion list with an empty array', async function () {
+      const token = testData.users.user1.generateJwt();
+      await TestSetup.request()
+        .patch('/api/users/me/dlc-preferences')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ excludedDlcs: ['DLC3_ID'] });
+
+      const response = await TestSetup.request()
+        .patch('/api/users/me/dlc-preferences')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ excludedDlcs: [] });
+
+      expect(response.status).to.equal(200);
+      expect(response.body.excludedDlcs).to.deep.equal([]);
+    });
+
+    it('rejects a non-array body', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .patch('/api/users/me/dlc-preferences')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ excludedDlcs: 'DLC3_ID' });
+      expect(response.status).to.equal(400);
+    });
+
+    it('rejects a malformed id', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .patch('/api/users/me/dlc-preferences')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ excludedDlcs: ['dlc3_id'] });
+      expect(response.status).to.equal(400);
+    });
+
+    it('rejects an oversized list', async function () {
+      const token = testData.users.user1.generateJwt();
+      const many = Array.from({ length: 21 }, (_, i) => `DLC${i}_ID`);
+      const response = await TestSetup.request()
+        .patch('/api/users/me/dlc-preferences')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ excludedDlcs: many });
+      expect(response.status).to.equal(400);
+    });
+
+    it("accepts an unknown but well-formed id (a pack without a label yet)", async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .patch('/api/users/me/dlc-preferences')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ excludedDlcs: ['DLC99_ID'] });
+      expect(response.status).to.equal(200);
+      expect(response.body.excludedDlcs).to.deep.equal(['DLC99_ID']);
+    });
+  });
+
+  describe('privacy: the preference never leaks into another user\'s view', function () {
+    it('is absent from the public profile response', async function () {
+      const token = testData.users.user1.generateJwt();
+      await TestSetup.request()
+        .patch('/api/users/me/dlc-preferences')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ excludedDlcs: ['DLC3_ID'] });
+
+      const profile = await TestSetup.request().get(
+        `/api/users/${testData.users.user1.username}/profile`
+      );
+      expect(profile.status).to.equal(200);
+      expect(profile.body).to.not.have.property('excludedDlcs');
+      expect(profile.body).to.not.have.property('dlcPreferences');
+    });
+
+    it('is absent from the profileSecure response seen by another logged-in user', async function () {
+      const token1 = testData.users.user1.generateJwt();
+      await TestSetup.request()
+        .patch('/api/users/me/dlc-preferences')
+        .set('Authorization', `Bearer ${token1}`)
+        .send({ excludedDlcs: ['DLC3_ID'] });
+
+      const token2 = testData.users.user2.generateJwt();
+      const profile = await TestSetup.request()
+        .get(`/api/users/${testData.users.user1.username}/profileSecure`)
+        .set('Authorization', `Bearer ${token2}`);
+
+      expect(profile.status).to.equal(200);
+      expect(profile.body).to.not.have.property('excludedDlcs');
+      expect(profile.body).to.not.have.property('dlcPreferences');
+    });
+
+    it('GET /api/users/me/dlc-preferences only ever returns the caller\'s own preference', async function () {
+      const token1 = testData.users.user1.generateJwt();
+      await TestSetup.request()
+        .patch('/api/users/me/dlc-preferences')
+        .set('Authorization', `Bearer ${token1}`)
+        .send({ excludedDlcs: ['DLC3_ID'] });
+
+      const token2 = testData.users.user2.generateJwt();
+      const response = await TestSetup.request()
+        .get('/api/users/me/dlc-preferences')
+        .set('Authorization', `Bearer ${token2}`);
+
+      expect(response.status).to.equal(200);
+      expect(response.body.excludedDlcs).to.deep.equal([]);
+    });
+  });
+});

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -20,6 +20,8 @@ import {
   ROOM_TYPE_IDS,
   RAW_SOURCE_FORMATS,
   RawSourceFormat,
+  DLC_ID_PATTERN,
+  MAX_DLC_FILTER_IDS,
 } from '../../lib/index';
 import { Blueprint as sharedBlueprint, BlueprintDetailsResponse } from '../../lib/index';
 import { computeHotScore } from '../../lib/index';
@@ -46,10 +48,6 @@ import { deriveDlcs } from './services/dlc-derivation-service';
 import mongoose from 'mongoose';
 
 const MAX_SKIP = 10000;
-
-// Shape of a raw Klei DLC id (EXPANSION1_ID, DLC3_ID, …) — see lib/blueprint/dlc.ts
-const DLC_ID_PATTERN = /^[A-Z0-9_]{1,32}$/;
-const MAX_DLC_FILTER_IDS = 20;
 
 const SORTS = ['recent', 'popular', 'mostForked', 'mostViewed', 'mostDownloaded', 'trending'] as const;
 type BlueprintSort = (typeof SORTS)[number];
@@ -700,6 +698,7 @@ export class BlueprintController {
       let filterModded: boolean | null = null;
       let filterRooms: string[] | null = null;
       let filterDlcs: string[] | null = null;
+      let filterExcludeDlcs: string[] | null = null;
       let filterForkedFrom: string | null = null;
       let filterRatedBy: string | null = null;
       let sort: BlueprintSort;
@@ -796,6 +795,31 @@ export class BlueprintController {
           filterDlcs = requested;
         }
 
+        // ?excludeDlc=DLC3_ID,DLC4_ID -> blueprints requiring NONE of these
+        // packs. The complement of ?dlc= (membership vs. exclusion are
+        // separate params, not a third state on one), so it composes: both can
+        // be present at once. Same shape/size validation as dlc.
+        const rawExcludeDlc = req.query.excludeDlc;
+        if (rawExcludeDlc != null) {
+          const requested = (Array.isArray(rawExcludeDlc) ? rawExcludeDlc : [rawExcludeDlc])
+            .flatMap(value => String(value).split(','))
+            .map(dlcId => dlcId.trim())
+            .filter(dlcId => dlcId.length > 0);
+          const invalid = requested.filter(dlcId => !DLC_ID_PATTERN.test(dlcId));
+          if (requested.length === 0 || requested.length > MAX_DLC_FILTER_IDS || invalid.length > 0) {
+            res
+              .status(400)
+              .json(
+                apiError(
+                  400,
+                  `Invalid excludeDlc: must be a comma-separated list of up to ${MAX_DLC_FILTER_IDS} DLC ids (A-Z, 0-9 and _)`
+                )
+              );
+            return;
+          }
+          filterExcludeDlcs = requested;
+        }
+
         const rawForkedFrom = req.query.forkedFrom as string | undefined;
         if (rawForkedFrom != null && !mongoose.Types.ObjectId.isValid(rawForkedFrom)) {
           res.status(400).json(apiError(400, 'Invalid forkedFrom: must be a valid blueprint id'));
@@ -871,6 +895,15 @@ export class BlueprintController {
       // never matches a missing field, so they stay out of a dlc= result
       // rather than reading as base-game.
       if (filterDlcs != null) filter.$and.push({ requiredDlcs: { $in: filterDlcs } });
+      // $nin over an array field matches when NONE of its elements are in the
+      // list — true for [] (base game always survives exclusion) and true for
+      // a missing field (a never-derived doc can't be known to need the
+      // excluded pack, so it isn't hidden either). Note for the planner: $nin
+      // can't produce a bounded range the way $in does, so this clause is
+      // applied as a per-document filter during FETCH rather than narrowing an
+      // index scan — the sort-driven index still bounds the query, this just
+      // adds one field check per candidate.
+      if (filterExcludeDlcs != null) filter.$and.push({ requiredDlcs: { $nin: filterExcludeDlcs } });
       if (filterForkedFrom != null) filter.$and.push({ 'forkedFrom.blueprintId': filterForkedFrom });
       if (filterRatedBy != null) {
         // Ratings live in their own collection; resolve to ids first (the

--- a/app/api/models/user.ts
+++ b/app/api/models/user.ts
@@ -24,6 +24,15 @@ export interface User extends Document {
   bio?: string;
   avatarId?: mongoose.Types.ObjectId | null;
 
+  // Packs the user doesn't want to see in Discover ("?excludeDlc="), raw Klei
+  // ids like requiredDlcs. Never set until the user interacts with the DLC
+  // filters — [] and "never touched" are the same state, so no separate flag
+  // is needed. Private account data: never include in ProfileResponse or any
+  // other response reachable by another user.
+  dlcPreferences?: {
+    excludedDlcs: string[];
+  };
+
   setPassword(password: string): void;
   validPassword(password: string): boolean;
   generateJwt(role?: string): string;
@@ -68,6 +77,9 @@ export class UserModel {
       resetTokenExpiration: Date,
       bio: { type: String, maxlength: [500, 'Bio must be 500 characters or fewer'], default: '' },
       avatarId: { type: mongoose.Schema.Types.ObjectId, ref: 'Avatar', default: null },
+      dlcPreferences: {
+        excludedDlcs: { type: [String], default: [] },
+      },
     });
 
     // Password reset lookup: findOne({ resetToken, resetTokenExpiration: { $gt: ... } })

--- a/app/api/user-controller.ts
+++ b/app/api/user-controller.ts
@@ -4,7 +4,15 @@ import { UserModel, UserJwt } from './models/user';
 import { FollowModel } from './models/follow';
 import { BlueprintModel } from './models/blueprint';
 import { BlueprintController, PUBLISHED_FILTER } from './blueprint-controller';
-import { ProfileResponse, FollowRequest, UpdateBioRequest, FollowListResponse } from '../../lib/index';
+import {
+  ProfileResponse,
+  FollowRequest,
+  UpdateBioRequest,
+  FollowListResponse,
+  UpdateDlcPreferencesRequest,
+  DLC_ID_PATTERN,
+  MAX_DLC_FILTER_IDS,
+} from '../../lib/index';
 import { NotificationController } from './notification-controller';
 import { apiError } from './utils/apiError';
 import { parseOlderThan } from './utils/pagination';
@@ -19,6 +27,8 @@ export class UserController {
     this.getProfile = this.getProfile.bind(this);
     this.follow = this.follow.bind(this);
     this.updateBio = this.updateBio.bind(this);
+    this.getDlcPreferences = this.getDlcPreferences.bind(this);
+    this.updateDlcPreferences = this.updateDlcPreferences.bind(this);
     this.getFeed = this.getFeed.bind(this);
     this.getFollowers = this.getFollowers.bind(this);
     this.getFollowing = this.getFollowing.bind(this);
@@ -156,6 +166,62 @@ export class UserController {
         console.log('updateBio error');
         console.log(err);
         res.status(500).json(apiError(500, 'Failed to update bio'));
+      });
+  }
+
+  // Private account state — never merge this into getProfile/ProfileResponse,
+  // which is reachable by other users.
+  public getDlcPreferences(req: Request, res: Response): void {
+    const user = req.user as UserJwt;
+
+    UserModel.model
+      .findById(user._id)
+      .select('dlcPreferences')
+      .lean()
+      .then(found => {
+        if (!found) {
+          res.status(404).json(apiError(404, 'User not found'));
+          return;
+        }
+        res.json({ excludedDlcs: found.dlcPreferences?.excludedDlcs ?? [] });
+      })
+      .catch(err => {
+        console.log('getDlcPreferences error');
+        console.log(err);
+        res.status(500).json(apiError(500, 'Failed to retrieve DLC preferences'));
+      });
+  }
+
+  public updateDlcPreferences(req: Request, res: Response): void {
+    const user = req.user as UserJwt;
+    const { excludedDlcs } = req.body as UpdateDlcPreferencesRequest;
+
+    if (!Array.isArray(excludedDlcs) || excludedDlcs.length > MAX_DLC_FILTER_IDS) {
+      res
+        .status(400)
+        .json(apiError(400, `excludedDlcs must be an array of up to ${MAX_DLC_FILTER_IDS} DLC ids`));
+      return;
+    }
+    if (excludedDlcs.some(id => typeof id !== 'string' || !DLC_ID_PATTERN.test(id))) {
+      res
+        .status(400)
+        .json(apiError(400, 'excludedDlcs must contain only valid DLC ids (A-Z, 0-9 and _)'));
+      return;
+    }
+
+    UserModel.model
+      .findByIdAndUpdate(user._id, { 'dlcPreferences.excludedDlcs': excludedDlcs }, { new: true })
+      .then(updated => {
+        if (!updated) {
+          res.status(404).json(apiError(404, 'User not found'));
+          return;
+        }
+        res.json({ excludedDlcs: updated.dlcPreferences?.excludedDlcs ?? [] });
+      })
+      .catch(err => {
+        console.log('updateDlcPreferences error');
+        console.log(err);
+        res.status(500).json(apiError(500, 'Failed to update DLC preferences'));
       });
   }
 

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -111,6 +111,8 @@ export class Routes {
     app.route('/api/users/:username/profileSecure').get(auth, this.userController.getProfile);
     app.route('/api/follow').post(auth, this.userController.follow);
     app.route('/api/users/me').patch(auth, this.userController.updateBio);
+    app.route('/api/users/me/dlc-preferences').get(auth, this.userController.getDlcPreferences);
+    app.route('/api/users/me/dlc-preferences').patch(auth, this.userController.updateDlcPreferences);
     // Optional seed photo arrives as a raw image/* body (no multipart in this
     // API surface); anything else falls through to random generation
     app

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.css
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.css
@@ -164,6 +164,17 @@
   opacity: 0.7;
 }
 
+/* Exclusion chips ("hide this pack") read as the opposite of every other
+   chip in the bar, which all narrow the result set toward something. */
+.active-filter-chip--exclude {
+  color: var(--bni-danger);
+}
+
+.active-filter-chip--exclude:hover {
+  background: var(--bni-chip-hi);
+  color: var(--bni-danger);
+}
+
 .clear-filters--inline {
   padding: 3px 8px;
 }

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
@@ -116,7 +116,7 @@
         </div>
 
         <div class="bni-facet-group">
-          <h4 class="bni-facet-label" i18n>DLC</h4>
+          <h4 class="bni-facet-label" i18n>DLC — show only</h4>
           <button
             type="button"
             class="bni-facet"
@@ -133,6 +133,29 @@
             [class.active]="isDlcSelected(opt.value)"
             [attr.aria-pressed]="isDlcSelected(opt.value)"
             (click)="toggleDlc(opt.value)"
+          >
+            {{ opt.label }}
+          </button>
+        </div>
+
+        <div class="bni-facet-group">
+          <h4 class="bni-facet-label" i18n>DLC — hide</h4>
+          <button
+            type="button"
+            class="bni-facet"
+            [class.active]="excludeDlcs.length === 0"
+            (click)="clearExcludeDlcFilter()"
+            i18n
+          >
+            None
+          </button>
+          <button
+            *ngFor="let opt of dlcOptions"
+            type="button"
+            class="bni-facet bni-facet--exclude"
+            [class.active]="isDlcExcluded(opt.value)"
+            [attr.aria-pressed]="isDlcExcluded(opt.value)"
+            (click)="toggleExcludeDlc(opt.value)"
           >
             {{ opt.label }}
           </button>
@@ -198,6 +221,7 @@
             *ngFor="let chip of activeFilterChips; trackBy: trackChip"
             type="button"
             class="active-filter-chip"
+            [class.active-filter-chip--exclude]="chip.exclude"
             [attr.aria-label]="chip.ariaLabel"
             (click)="chip.remove()"
           >

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
@@ -54,6 +54,8 @@ describe("BrowsePageComponent", () => {
         }),
       ),
       getFeed: vi.fn().mockReturnValue(of(makeResponse())),
+      getDlcPreferences: vi.fn().mockReturnValue(of({ excludedDlcs: [] })),
+      updateDlcPreferences: vi.fn().mockReturnValue(of({ excludedDlcs: [] })),
     };
 
     router = { navigate: vi.fn() };
@@ -169,6 +171,7 @@ describe("BrowsePageComponent", () => {
         null,
         null,
         null,
+        null,
       );
     });
 
@@ -185,6 +188,7 @@ describe("BrowsePageComponent", () => {
         null,
         "trending",
         0,
+        null,
         null,
         null,
         null,
@@ -212,6 +216,7 @@ describe("BrowsePageComponent", () => {
         null,
         null,
         null,
+        null,
       );
     });
 
@@ -229,6 +234,7 @@ describe("BrowsePageComponent", () => {
         "trending",
         0,
         true,
+        null,
         null,
         null,
         null,
@@ -254,6 +260,7 @@ describe("BrowsePageComponent", () => {
         null,
         null,
         null,
+        null,
       );
     });
 
@@ -274,6 +281,7 @@ describe("BrowsePageComponent", () => {
         null,
         null,
         "latrine",
+        null,
         null,
       );
     });
@@ -296,6 +304,7 @@ describe("BrowsePageComponent", () => {
         null,
         null,
         "DLC2_ID,DLC3_ID",
+        null,
       );
     });
 
@@ -497,6 +506,225 @@ describe("BrowsePageComponent", () => {
       expect(blueprintService.getBlueprints.mock.calls.length).toBe(
         callsBefore,
       );
+    });
+  });
+
+  describe("DLC exclusion filter", () => {
+    it("initializes the exclusion from a comma-separated URL param", () => {
+      const route = TestBed.inject(ActivatedRoute) as any;
+      route.queryParamMap = of(
+        convertToParamMap({ excludeDlc: "DLC3_ID,DLC4_ID" }),
+      );
+      component.ngOnInit();
+      expect(component.excludeDlcs).toEqual(["DLC3_ID", "DLC4_ID"]);
+    });
+
+    it("initializes the exclusion from a repeated URL param", () => {
+      const route = TestBed.inject(ActivatedRoute) as any;
+      route.queryParamMap = of(
+        convertToParamMap({ excludeDlc: ["DLC3_ID", "DLC4_ID"] }),
+      );
+      component.ngOnInit();
+      expect(component.excludeDlcs).toEqual(["DLC3_ID", "DLC4_ID"]);
+    });
+
+    it("writes the exclusion back to the URL as a comma list under excludeDlc", () => {
+      vi.useFakeTimers();
+      component.toggleExcludeDlc("DLC3_ID");
+      component.toggleExcludeDlc("DLC4_ID");
+      vi.advanceTimersByTime(600);
+
+      expect(router.navigate).toHaveBeenLastCalledWith([], {
+        queryParams: { excludeDlc: "DLC3_ID,DLC4_ID" },
+        replaceUrl: true,
+      });
+    });
+
+    it("round-trips through the URL: what it writes, it reads back", () => {
+      vi.useFakeTimers();
+      component.toggleExcludeDlc("DLC3_ID");
+      component.toggleExcludeDlc("DLC4_ID");
+      vi.advanceTimersByTime(600);
+      const written = router.navigate.mock.calls.at(-1)[1].queryParams;
+      vi.useRealTimers();
+
+      const route = TestBed.inject(ActivatedRoute) as any;
+      route.queryParamMap = of(convertToParamMap(written));
+      const reopened = TestBed.createComponent(BrowsePageComponent);
+      reopened.componentInstance.ngOnInit();
+
+      expect(reopened.componentInstance.excludeDlcs).toEqual([
+        "DLC3_ID",
+        "DLC4_ID",
+      ]);
+    });
+
+    it("omits the param entirely when nothing is excluded", () => {
+      vi.useFakeTimers();
+      component.toggleExcludeDlc("DLC3_ID");
+      component.toggleExcludeDlc("DLC3_ID"); // toggled back off
+      vi.advanceTimersByTime(600);
+
+      expect(component.excludeDlcs).toEqual([]);
+      expect(
+        router.navigate.mock.calls.at(-1)[1].queryParams,
+      ).not.toHaveProperty("excludeDlc");
+    });
+
+    it("toggles exclusions independently instead of replacing them", () => {
+      component.toggleExcludeDlc("DLC3_ID");
+      component.toggleExcludeDlc("DLC4_ID");
+      expect(component.excludeDlcs).toEqual(["DLC3_ID", "DLC4_ID"]);
+      expect(component.isDlcExcluded("DLC3_ID")).toBe(true);
+
+      component.toggleExcludeDlc("DLC3_ID");
+      expect(component.excludeDlcs).toEqual(["DLC4_ID"]);
+      expect(component.isDlcExcluded("DLC3_ID")).toBe(false);
+    });
+
+    it("counts each excluded pack as an active filter", () => {
+      component.excludeDlcs = ["DLC3_ID", "DLC4_ID"];
+      expect(component.activeFilterCount).toBe(2);
+      expect(component.hasActiveFilters).toBe(true);
+    });
+
+    it("shows one removable chip per excluded pack, marked as an exclusion", () => {
+      component.excludeDlcs = ["DLC3_ID"];
+
+      const chips = component.activeFilterChips.filter((c) =>
+        c.key.startsWith("exclude-dlc-"),
+      );
+      expect(chips).toHaveLength(1);
+      expect(chips[0].label).toContain("The Bionic Booster Pack");
+      expect(chips[0].exclude).toBe(true);
+
+      chips[0].remove();
+      expect(component.excludeDlcs).toEqual([]);
+    });
+
+    it("a show-only chip is not marked as an exclusion", () => {
+      component.filterDlcs = ["DLC3_ID"];
+      const chip = component.activeFilterChips.find(
+        (c) => c.key === "dlc-DLC3_ID",
+      );
+      expect(chip!.exclude).toBeFalsy();
+    });
+
+    it("clearExcludeDlcFilter is a no-op when nothing is excluded", () => {
+      const callsBefore = blueprintService.getBlueprints.mock.calls.length;
+      component.clearExcludeDlcFilter();
+      expect(blueprintService.getBlueprints.mock.calls.length).toBe(
+        callsBefore,
+      );
+      expect(userService.updateDlcPreferences).not.toHaveBeenCalled();
+    });
+
+    it("clearFilters also clears any active exclusion", () => {
+      component.excludeDlcs = ["DLC3_ID"];
+      component.clearFilters();
+      expect(component.excludeDlcs).toEqual([]);
+    });
+
+    // A pack can't be both "show only" and "hide" — whichever is chosen
+    // second wins and clears the other side.
+    it("selecting a pack as show-only clears it from the exclusion list", () => {
+      component.toggleExcludeDlc("DLC3_ID");
+      userService.updateDlcPreferences.mockClear();
+
+      component.toggleDlc("DLC3_ID");
+
+      expect(component.excludeDlcs).toEqual([]);
+      expect(component.filterDlcs).toEqual(["DLC3_ID"]);
+      expect(userService.updateDlcPreferences).toHaveBeenCalledWith([]);
+    });
+
+    it("excluding a pack clears it from the show-only list", () => {
+      component.toggleDlc("DLC3_ID");
+
+      component.toggleExcludeDlc("DLC3_ID");
+
+      expect(component.filterDlcs).toEqual([]);
+      expect(component.excludeDlcs).toEqual(["DLC3_ID"]);
+    });
+
+    it("passes the excluded DLCs to getBlueprints as a comma list", () => {
+      component.excludeDlcs = ["DLC3_ID", "DLC4_ID"];
+      component.getBlueprints();
+
+      const lastCall = blueprintService.getBlueprints.mock.calls.at(-1);
+      expect(lastCall[13]).toBe("DLC3_ID,DLC4_ID");
+    });
+  });
+
+  describe("DLC exclusion persistence", () => {
+    it("persists the exclusion list on every toggle", () => {
+      component.toggleExcludeDlc("DLC3_ID");
+      expect(userService.updateDlcPreferences).toHaveBeenLastCalledWith([
+        "DLC3_ID",
+      ]);
+
+      component.toggleExcludeDlc("DLC4_ID");
+      expect(userService.updateDlcPreferences).toHaveBeenLastCalledWith([
+        "DLC3_ID",
+        "DLC4_ID",
+      ]);
+    });
+
+    it("persists an empty list when clearing an active exclusion", () => {
+      component.excludeDlcs = ["DLC3_ID"];
+      component.clearExcludeDlcFilter();
+      expect(userService.updateDlcPreferences).toHaveBeenCalledWith([]);
+    });
+
+    it("does not persist for a logged-out visitor", () => {
+      authService.isLoggedIn.mockReturnValue(false);
+      component.toggleExcludeDlc("DLC3_ID");
+      expect(userService.updateDlcPreferences).not.toHaveBeenCalled();
+    });
+
+    it("does not fetch or apply a stored preference for a logged-out visitor", () => {
+      authService.isLoggedIn.mockReturnValue(false);
+      fixture.detectChanges();
+      expect(userService.getDlcPreferences).not.toHaveBeenCalled();
+      expect(component.excludeDlcs).toEqual([]);
+    });
+
+    it("nothing is excluded on first load when the stored preference is empty", () => {
+      fixture.detectChanges();
+      expect(userService.getDlcPreferences).toHaveBeenCalled();
+      expect(component.excludeDlcs).toEqual([]);
+      // The very first request must not have waited on the preference either.
+      const firstCall = blueprintService.getBlueprints.mock.calls[0];
+      expect(firstCall[13]).toBeNull();
+    });
+
+    it("applies a stored exclusion preference on load when the URL has no override", () => {
+      userService.getDlcPreferences.mockReturnValue(
+        of({ excludedDlcs: ["DLC3_ID"] }),
+      );
+      fixture.detectChanges();
+      expect(component.excludeDlcs).toEqual(["DLC3_ID"]);
+    });
+
+    it("merely loading the stored preference does not write it back", () => {
+      userService.getDlcPreferences.mockReturnValue(
+        of({ excludedDlcs: ["DLC3_ID"] }),
+      );
+      fixture.detectChanges();
+      expect(component.excludeDlcs).toEqual(["DLC3_ID"]);
+      expect(userService.updateDlcPreferences).not.toHaveBeenCalled();
+    });
+
+    it("an explicit excludeDlc URL param wins over the stored preference", () => {
+      const route = TestBed.inject(ActivatedRoute) as any;
+      route.queryParamMap = of(convertToParamMap({ excludeDlc: "DLC4_ID" }));
+      userService.getDlcPreferences.mockReturnValue(
+        of({ excludedDlcs: ["DLC3_ID"] }),
+      );
+      fixture.detectChanges();
+
+      expect(userService.getDlcPreferences).not.toHaveBeenCalled();
+      expect(component.excludeDlcs).toEqual(["DLC4_ID"]);
     });
   });
 

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
@@ -40,6 +40,9 @@ interface ActiveFilterChip {
   label: string;
   ariaLabel: string;
   remove: () => void;
+  /** Styles the chip as an exclusion ("hide this") rather than a restriction
+   * ("show only this") so the two read as visually distinct in the bar. */
+  exclude?: boolean;
 }
 
 /** Grid fade-out duration when the list context changes (ms); must match the
@@ -79,6 +82,15 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   /** Selected DLC ids; empty = no DLC restriction. Multi-select: the server
    * matches blueprints requiring ANY of them ($in). */
   filterDlcs: string[] = [];
+  /** DLC ids to hide; empty = no exclusion. Multi-select: the server excludes
+   * blueprints requiring ANY of them ($nin). Persisted server-side as an
+   * account preference once the user actually toggles one — never applied
+   * until then, and never for a logged-out visitor. */
+  excludeDlcs: string[] = [];
+  /** True once the current URL has been read and it carried an explicit
+   * excludeDlc param (even an empty one) — an explicit param always wins over
+   * the stored account preference, so this gates whether ngOnInit applies it. */
+  private excludeDlcParamPresent = false;
   filterCategory: string | null = null;
   filterSubcategory: string | null = null;
   filterModded: boolean | null = null;
@@ -239,6 +251,23 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
           error: () => {},
         });
       }
+
+      // An explicit URL param always beats the stored preference — only
+      // fetch it when the URL didn't already decide. Never fetched at all
+      // for a logged-out visitor.
+      if (!this.excludeDlcParamPresent) {
+        this.userService.getDlcPreferences().subscribe({
+          next: (prefs) => {
+            if (this.excludeDlcParamPresent || prefs.excludedDlcs.length === 0)
+              return;
+            this.excludeDlcs = prefs.excludedDlcs.filter(
+              (id) => !this.filterDlcs.includes(id),
+            );
+            if (this.excludeDlcs.length > 0) this.transitionList();
+          },
+          error: () => {},
+        });
+      }
     }
   }
 
@@ -339,6 +368,12 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
       .flatMap((value) => value.split(","))
       .map((dlcId) => dlcId.trim())
       .filter((dlcId) => dlcId.length > 0);
+    const excludeDlcParamPresent = params.has("excludeDlc");
+    const excludeDlcs = params
+      .getAll("excludeDlc")
+      .flatMap((value) => value.split(","))
+      .map((dlcId) => dlcId.trim())
+      .filter((dlcId) => dlcId.length > 0);
     const rawSort = params.get("sort");
     const sort: BlueprintSort = this.sortOptions.some(
       (option) => option.value === rawSort,
@@ -355,6 +390,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
       forkedFrom !== this.filterForkedFrom ||
       rooms !== this.filterRooms ||
       dlcs.join(",") !== this.filterDlcs.join(",") ||
+      excludeDlcs.join(",") !== this.excludeDlcs.join(",") ||
       sort !== this.sort;
 
     this.filterName = name;
@@ -365,6 +401,10 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     this.filterForkedFrom = forkedFrom;
     this.filterRooms = rooms;
     this.filterDlcs = dlcs;
+    this.excludeDlcParamPresent = excludeDlcParamPresent;
+    // An explicit param always wins: only overwrite the (possibly
+    // preference-loaded) state when the URL actually carried one.
+    if (excludeDlcParamPresent) this.excludeDlcs = excludeDlcs;
     this.sort = sort;
     return changed;
   }
@@ -397,9 +437,16 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   /** Multi-select: packs are independent, so picking a second one widens the
    * result set ("needs any of these") instead of replacing the first. */
   toggleDlc(dlcId: string) {
-    this.filterDlcs = this.isDlcSelected(dlcId)
+    const wasSelected = this.isDlcSelected(dlcId);
+    this.filterDlcs = wasSelected
       ? this.filterDlcs.filter((id) => id !== dlcId)
       : [...this.filterDlcs, dlcId];
+    // A pack can't be both "show only" and "hide" at once — selecting it here
+    // wins and drops it from the exclusion side, persisting that change.
+    if (!wasSelected && this.isDlcExcluded(dlcId)) {
+      this.excludeDlcs = this.excludeDlcs.filter((id) => id !== dlcId);
+      this.persistDlcExclusionPreference();
+    }
     // same reasoning as selectGameVersion: subcategory is scoped to category
     this.filterFacetSubject.next();
   }
@@ -411,6 +458,39 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   }
 
   readonly dlcLabel = dlcLabel;
+
+  isDlcExcluded(dlcId: string): boolean {
+    return this.excludeDlcs.includes(dlcId);
+  }
+
+  /** Multi-select, symmetric to toggleDlc. Every call is a real interaction
+   * with the exclusion filter, so every call persists the resulting list as
+   * the user's account preference (a no-op for a logged-out visitor). */
+  toggleExcludeDlc(dlcId: string) {
+    const wasExcluded = this.isDlcExcluded(dlcId);
+    this.excludeDlcs = wasExcluded
+      ? this.excludeDlcs.filter((id) => id !== dlcId)
+      : [...this.excludeDlcs, dlcId];
+    if (!wasExcluded && this.isDlcSelected(dlcId)) {
+      this.filterDlcs = this.filterDlcs.filter((id) => id !== dlcId);
+    }
+    this.persistDlcExclusionPreference();
+    this.filterFacetSubject.next();
+  }
+
+  clearExcludeDlcFilter() {
+    if (this.excludeDlcs.length === 0) return;
+    this.excludeDlcs = [];
+    this.persistDlcExclusionPreference();
+    this.filterFacetSubject.next();
+  }
+
+  private persistDlcExclusionPreference() {
+    if (!this.loggedIn) return;
+    this.userService.updateDlcPreferences(this.excludeDlcs).subscribe({
+      error: () => {},
+    });
+  }
 
   selectSubcategory(value: string | null) {
     if (this.filterSubcategory === value) return;
@@ -452,7 +532,9 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
         this.filterRooms,
         this.filterForkedFrom,
         this.filterModded !== null || null,
-      ].filter(Boolean).length + this.filterDlcs.length
+      ].filter(Boolean).length +
+      this.filterDlcs.length +
+      this.excludeDlcs.length
     );
   }
 
@@ -468,8 +550,15 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     key: string,
     label: string,
     remove: () => void,
+    exclude?: boolean,
   ): ActiveFilterChip {
-    return { key, label, ariaLabel: this.removeChipAriaLabel(label), remove };
+    return {
+      key,
+      label,
+      ariaLabel: this.removeChipAriaLabel(label),
+      remove,
+      exclude,
+    };
   }
 
   // Pinned above the grid (not the sidebar) so an active filter combination
@@ -514,6 +603,17 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     for (const dlcId of this.filterDlcs)
       chips.push(
         this.chip(`dlc-${dlcId}`, dlcLabel(dlcId), () => this.toggleDlc(dlcId)),
+      );
+    // Same one-chip-per-pack shape as the "show only" chips above, styled
+    // distinctly (exclude: true) so the two read as opposite intents.
+    for (const dlcId of this.excludeDlcs)
+      chips.push(
+        this.chip(
+          `exclude-dlc-${dlcId}`,
+          $localize`:browse filter chip:No ${dlcLabel(dlcId)}`,
+          () => this.toggleExcludeDlc(dlcId),
+          true,
+        ),
       );
     if (this.filterModded != null)
       chips.push(
@@ -574,6 +674,8 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     if (this.filterRooms) queryParams["rooms"] = this.filterRooms;
     if (this.filterDlcs.length > 0)
       queryParams["dlc"] = this.filterDlcs.join(",");
+    if (this.excludeDlcs.length > 0)
+      queryParams["excludeDlc"] = this.excludeDlcs.join(",");
     if (this.sort !== DEFAULT_SORT) queryParams["sort"] = this.sort;
     this.router.navigate([], { queryParams, replaceUrl: true });
   }
@@ -587,6 +689,9 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     this.filterForkedFrom = null;
     this.filterRooms = null;
     this.filterDlcs = [];
+    const hadExclusions = this.excludeDlcs.length > 0;
+    this.excludeDlcs = [];
+    if (hadExclusions) this.persistDlcExclusionPreference();
     this.applyFiltersToUrl();
     this.transitionList();
   }
@@ -626,6 +731,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
             null,
             this.filterRooms,
             this.filterDlcs.length > 0 ? this.filterDlcs.join(",") : null,
+            this.excludeDlcs.length > 0 ? this.excludeDlcs.join(",") : null,
           );
 
     request$.subscribe({

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -608,6 +608,7 @@ export class BlueprintService implements IObsBlueprintChange {
     filterRatedBy?: string | null,
     filterRooms?: string | null,
     filterDlcs?: string | null,
+    filterExcludeDlcs?: string | null,
   ) {
     // olderthan is a cache-buster when it isn't doing real work, so send it
     // only where it is the pagination cursor: the recent sort past page 1
@@ -661,6 +662,10 @@ export class BlueprintService implements IObsBlueprintChange {
     let parameterDlcs = "";
     if (filterDlcs != null) parameterDlcs = "&dlc=" + filterDlcs;
 
+    let parameterExcludeDlcs = "";
+    if (filterExcludeDlcs != null)
+      parameterExcludeDlcs = "&excludeDlc=" + filterExcludeDlcs;
+
     const parameters = (
       parameterOlderThan +
       parameterFilterUserId +
@@ -673,7 +678,8 @@ export class BlueprintService implements IObsBlueprintChange {
       parameterForkedFrom +
       parameterRatedBy +
       parameterRooms +
-      parameterDlcs
+      parameterDlcs +
+      parameterExcludeDlcs
     ).replace(/^&/, "");
 
     // General browsing is a public, viewer-independent feed — always hit the

--- a/frontend/src/app/module-blueprint/services/user-service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/user-service.spec.ts
@@ -83,6 +83,31 @@ describe("UserService", () => {
     });
   });
 
+  describe("getDlcPreferences", () => {
+    it("requests the stored exclusion preference with an auth header", () => {
+      service.getDlcPreferences().subscribe();
+      expect(mockHttp.get).toHaveBeenCalledWith(
+        "/api/users/me/dlc-preferences",
+        expect.objectContaining({
+          headers: { Authorization: "Bearer token123" },
+        }),
+      );
+    });
+  });
+
+  describe("updateDlcPreferences", () => {
+    it("patches the exclusion list with an auth header", () => {
+      service.updateDlcPreferences(["DLC3_ID", "DLC4_ID"]).subscribe();
+      expect(mockHttp.patch).toHaveBeenCalledWith(
+        "/api/users/me/dlc-preferences",
+        { excludedDlcs: ["DLC3_ID", "DLC4_ID"] },
+        expect.objectContaining({
+          headers: { Authorization: "Bearer token123" },
+        }),
+      );
+    });
+  });
+
   describe("getFeed", () => {
     it("requests the feed with an olderthan cursor", () => {
       const date = new Date("2024-01-01");

--- a/frontend/src/app/module-blueprint/services/user-service.ts
+++ b/frontend/src/app/module-blueprint/services/user-service.ts
@@ -12,6 +12,8 @@ import {
   AvatarStatusResponse,
   AvailableAvatarsResponse,
   AvatarSelectRequest,
+  DlcPreferencesResponse,
+  UpdateDlcPreferencesRequest,
 } from "../../../../../lib/index";
 
 @Injectable({ providedIn: "root" })
@@ -55,6 +57,26 @@ export class UserService {
 
   private authHeaders(): { [header: string]: string } {
     return { Authorization: `Bearer ${this.authService.getToken()}` };
+  }
+
+  // Private account state — which DLC packs the user wants hidden from
+  // Discover. Never fetched or written for a logged-out visitor.
+  getDlcPreferences(): Observable<DlcPreferencesResponse> {
+    return this.http.get<DlcPreferencesResponse>(
+      "/api/users/me/dlc-preferences",
+      { headers: this.authHeaders() },
+    );
+  }
+
+  updateDlcPreferences(
+    excludedDlcs: string[],
+  ): Observable<DlcPreferencesResponse> {
+    const body: UpdateDlcPreferencesRequest = { excludedDlcs };
+    return this.http.patch<DlcPreferencesResponse>(
+      "/api/users/me/dlc-preferences",
+      body,
+      { headers: this.authHeaders() },
+    );
   }
 
   getAvatarStatus(): Observable<AvatarStatusResponse> {

--- a/frontend/src/app/module-blueprint/utils/chip-tooltip.ts
+++ b/frontend/src/app/module-blueprint/utils/chip-tooltip.ts
@@ -11,6 +11,10 @@ export function baseGameTooltip(): string {
   return $localize`:chipTooltip.baseGame:Needs no DLC — buildable in the base game`;
 }
 
+export function excludeDlcTooltip(dlcId: string): string {
+  return $localize`:chipTooltip.excludeDlc:Hides blueprints that need the ${dlcLabel(dlcId)} DLC`;
+}
+
 const GAME_VERSION_TOOLTIPS: Record<string, string> = {
   base: $localize`:chipTooltip.base:Base game — no DLC required`,
   spacedOut: $localize`:chipTooltip.spacedOut:Spaced Out — requires the Spaced Out! DLC`,

--- a/frontend/src/bni-skin.css
+++ b/frontend/src/bni-skin.css
@@ -796,6 +796,19 @@
   box-shadow: inset 2px 0 0 var(--bni-accent);
 }
 
+/* Exclusion ("hide this") facets use the danger accent instead of the
+   regular one, so "show only" and "hide" read as opposite intents rather
+   than two identical-looking button groups. */
+.bni-facet--exclude:hover {
+  color: var(--bni-danger);
+}
+
+.bni-facet--exclude.active {
+  background: var(--bni-panel2);
+  color: var(--bni-ink);
+  box-shadow: inset 2px 0 0 var(--bni-danger);
+}
+
 .bni-facet-count {
   font-size: 12px;
   color: var(--bni-faint);

--- a/lib/src/blueprint/dlc.d.ts
+++ b/lib/src/blueprint/dlc.d.ts
@@ -1,4 +1,6 @@
 export type DlcId = string;
 export declare const DLC_LABELS: Record<DlcId, string>;
 export declare function dlcLabel(id: DlcId): string;
+export declare const DLC_ID_PATTERN: RegExp;
+export declare const MAX_DLC_FILTER_IDS = 20;
 //# sourceMappingURL=dlc.d.ts.map

--- a/lib/src/blueprint/dlc.ts
+++ b/lib/src/blueprint/dlc.ts
@@ -25,3 +25,13 @@ export const DLC_LABELS: Record<DlcId, string> = {
 export function dlcLabel(id: DlcId): string {
   return DLC_LABELS[id] ?? id;
 }
+
+// Shape of a raw Klei DLC id (EXPANSION1_ID, DLC3_ID, …). Shared by every place
+// that accepts a set of ids from a client — `?dlc=`, `?excludeDlc=`, and the
+// stored exclusion preference — validated by shape rather than against
+// DLC_LABELS, so a pack that ships in an export before we've written its label
+// stays usable everywhere.
+export const DLC_ID_PATTERN = /^[A-Z0-9_]{1,32}$/;
+
+// There are five packs today; this only bounds abuse, not real usage.
+export const MAX_DLC_FILTER_IDS = 20;

--- a/lib/src/coms/social.d.ts
+++ b/lib/src/coms/social.d.ts
@@ -16,6 +16,12 @@ export interface FollowRequest {
 export interface UpdateBioRequest {
     bio: string;
 }
+export interface DlcPreferencesResponse {
+    excludedDlcs: string[];
+}
+export interface UpdateDlcPreferencesRequest {
+    excludedDlcs: string[];
+}
 export interface FollowListEntry {
     id: string;
     username: string;

--- a/lib/src/coms/social.ts
+++ b/lib/src/coms/social.ts
@@ -21,6 +21,17 @@ export interface UpdateBioRequest {
   bio: string;
 }
 
+// Private account data — which DLC packs the user doesn't want to see in
+// Discover. Never part of ProfileResponse; only reachable by the owner via
+// /api/users/me/dlc-preferences.
+export interface DlcPreferencesResponse {
+  excludedDlcs: string[];
+}
+
+export interface UpdateDlcPreferencesRequest {
+  excludedDlcs: string[];
+}
+
 export interface FollowListEntry {
   id: string;
   username: string;


### PR DESCRIPTION
## Summary

Step 3 of the DLC requirements plan (see `spec/dlc-resume.md` / `spec/dlc-requirements-plan.md`, local-only): an exclusion filter for Discover — "hide blueprints needing this DLC" — as the complement of the existing `?dlc=` membership filter, persisted server-side once a user actually interacts with it.

This replaces the plan's earlier `owned=` subset-test idea. Exclusion is strictly more expressive than declared ownership: owning a pack doesn't mean you want to see it in every search, and a subset test can't express "hide this pack I own but am not playing right now."

**Design decisions, settled with Kevin before writing code (via AskUserQuestion):**
- **Interaction model:** two separate facet groups in the sidebar — "DLC — show only" and "DLC — hide" — rather than a tri-state toggle on one control or a secondary hide-icon per row. Clearest mental model, every button stays single-purpose (accessible), each group maps to its own chip type.
- **Persistence scope:** DLC filters only, not sticky filter state generally (sticky category/sort was flagged as a past "why is Discover broken" bug).
- **Logged out:** resets every visit — no fetch, no write, no localStorage. The `excludeDlc` URL param still works and is shareable.

### Backend
- `GET /api/getblueprints?excludeDlc=DLC3_ID,DLC4_ID` — `requiredDlcs: { $nin: [...] }`, same shape/size validation as `dlc=`, composes with `dlc=` and `category=`. Base-game (`[]`) and never-derived blueprints always survive exclusion (conservative: absence of DLC info is never treated as needing the excluded pack).
- Checked with `explain()` against local data: a `$nin` on `requiredDlcs` gets no help from that field's indexes — bounding it breaks the `createdAt` sort, so the planner keeps the plain `deletedAt_1_isPublished_1_createdAt_-1` index and applies the exclusion as a per-document FETCH filter instead. Not a collscan, just no extra narrowing — expected planner behavior for a negation.
- `User.dlcPreferences.excludedDlcs` (raw Klei ids, `default: []`) + `GET`/`PATCH /api/users/me/dlc-preferences`, auth'd. Verified it never leaks into `ProfileResponse` or any other user-facing payload.
- Shared `DLC_ID_PATTERN`/`MAX_DLC_FILTER_IDS` moved from `blueprint-controller.ts` into `lib/blueprint/dlc.ts` so both the query filter and the preference endpoint validate ids identically.

### Frontend
- `browse-page.component.ts`/`.html`/`.css`: `excludeDlcs` state, `toggleExcludeDlc`/`clearExcludeDlcFilter`, URL round-trip via `excludeDlc`, removable chips styled with the danger accent (`exclude: true` on `ActiveFilterChip`). A pack can't be in both lists — selecting it in one clears it from the other.
- An explicit `excludeDlc` URL param (even empty) always wins over the stored preference. The preference is applied automatically on load for a logged-in user only when the URL has no override, and is written back only from a real toggle/clear interaction — never merely from loading it.

## Test plan
- [x] Backend: `npm run test` — 711 passing (12 pre-existing local-only WorkOS timeout flakes, unrelated to this change, green in CI per repo notes)
- [x] Frontend: `cd frontend && npm test` — 1030 passing
- [x] `cd frontend && npm run lint` — clean
- [x] `npm run build` (backend + frontend + lib) — clean
- [x] New backend tests: `excludeDlc` filter (single/list/either-of-two-required, base-game/never-derived survive, malformed/oversized → 400, composes with `dlc=`/`category=`) and the preference endpoints (get/patch, overwrite-not-merge, validation, and leak checks against public profile / another user's `profileSecure` / another user's own GET)
- [x] New frontend tests: URL round-trip, mutual exclusion between show-only/hide, chip removal, and the three persistence invariants (nothing applied when the stored preference is empty, loading it never writes it back, an explicit URL param wins over it)
- [ ] Manual click-through in a browser — not done this session (see note below)

**Note on manual verification:** I confirmed the feature end-to-end by inspecting the live `ng serve` dev server's recompiled bundle (it already contained the new "DLC — show only"/"DLC — hide" facet labels and `excludeDlc` param, confirming HMR picked up the change cleanly), but did not click through it in an actual browser — the shared Playwright browser profile was locked by another active session at the time. Worth a manual pass before merge.

## Deferred
- Step 4 (drop `gameVersion` entirely) — tracked in `spec/dlc-resume.md`, unaffected by this PR.
- Facet counts ("Spaced Out! (492)") — separate follow-up, not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)