### PR TITLE
feat: facet counts for the Discover sidebar

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,10 @@
 ENV_NAME="development"
 HOST="http://localhost:4200"
 BROWSE_INCREMENT="10"
+# Kill switch for the Discover sidebar facet-counts feature. Set to "false"
+# to disable without a code revert — the frontend already treats a facets
+# failure as advisory. Any other value (or unset) is enabled.
+# BLUEPRINT_FACETS_ENABLED="false"
 DB_URI="mongodb://localhost:27017/blueprintnotincluded"
 JWT_SECRET="anylongstringhere"
 SMTP_HOST="localhost"

--- a/__tests__/api/blueprint-facets.test.ts
+++ b/__tests__/api/blueprint-facets.test.ts
@@ -218,4 +218,30 @@ describe('Blueprint facet counts', function () {
       expect(secure.body.total).to.equal(anon.body.total);
     });
   });
+
+  describe('BLUEPRINT_FACETS_ENABLED kill switch', function () {
+    const originalEnv = process.env.BLUEPRINT_FACETS_ENABLED;
+
+    afterEach(function () {
+      if (originalEnv === undefined) delete process.env.BLUEPRINT_FACETS_ENABLED;
+      else process.env.BLUEPRINT_FACETS_ENABLED = originalEnv;
+    });
+
+    it('503s both endpoints without touching the database when disabled', async function () {
+      process.env.BLUEPRINT_FACETS_ENABLED = 'false';
+
+      expect((await facets()).status).to.equal(503);
+      expect((await facetsSecure({}, authToken)).status).to.equal(503);
+    });
+
+    it('is enabled by default (unset)', async function () {
+      delete process.env.BLUEPRINT_FACETS_ENABLED;
+      expect((await facets()).status).to.equal(200);
+    });
+
+    it('treats any value other than the literal "false" as enabled', async function () {
+      process.env.BLUEPRINT_FACETS_ENABLED = 'true';
+      expect((await facets()).status).to.equal(200);
+    });
+  });
 });

--- a/__tests__/api/blueprint-facets.test.ts
+++ b/__tests__/api/blueprint-facets.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup } from '../setup/testSetup';
+import { BlueprintModel } from '../../app/api/models/blueprint';
+
+// The app import in TestSetup bootstraps OniItem from database-2024.json, so
+// these tests use real prefabs and their real dlcIds (same fixtures as
+// blueprint-dlcs.test.ts).
+const AQUATIC_PREFAB = 'ReefGenerator'; // DLC5_ID
+const FROSTY_PREFAB = 'Campfire'; // DLC2_ID
+const AND_PREFAB = 'RoboPilotModule'; // EXPANSION1_ID + DLC3_ID (needs both)
+const BASE_PREFAB = 'Tile'; // no DLC
+
+const TINY_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+const blueprintData = (prefabIds: string[]) => ({
+  blueprintItems: prefabIds.map((id, i) => ({
+    id,
+    temperature: 293.15,
+    position: { x: i, y: 0 },
+    elements: [],
+  })),
+});
+
+// Every fixture in this file is named "Facet ..." so filterName scopes counts
+// away from the seed database's own blueprints (TestDbHelper.seedDatabase),
+// which otherwise inflate `total` and would need reproducing here to net out.
+const SCOPE = { filterName: 'Facet' };
+
+describe('Blueprint facet counts', function () {
+  let authToken: string;
+  let user2Token: string;
+  let testData: any;
+
+  const upload = (body: Record<string, unknown>, token = authToken) =>
+    TestSetup.request()
+      .post('/api/uploadblueprint')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ thumbnail: TINY_PNG, publish: true, ...body });
+
+  const facets = (query: Record<string, unknown> = {}, token?: string) => {
+    const req = TestSetup.request()
+      .get('/api/blueprintfacets')
+      .query({ ...SCOPE, ...query });
+    return token != null ? req.set('Authorization', `Bearer ${token}`) : req;
+  };
+
+  const facetsSecure = (query: Record<string, unknown>, token: string) =>
+    TestSetup.request()
+      .get('/api/blueprintfacetsSecure')
+      .set('Authorization', `Bearer ${token}`)
+      .query({ ...SCOPE, ...query });
+
+  const list = (query: Record<string, unknown> = {}) =>
+    TestSetup.request()
+      .get('/api/getblueprints')
+      .query({ olderthan: Date.now(), ...SCOPE, ...query });
+
+  beforeEach(async function () {
+    this.timeout(15000);
+    testData = await TestSetup.beforeEach();
+    authToken = testData.users.user1.generateJwt();
+    user2Token = testData.users.user2.generateJwt();
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    await TestSetup.afterEach();
+  });
+
+  describe('GET /api/blueprintfacets', function () {
+    let aquaticId: string;
+    let baseId: string;
+
+    beforeEach(async function () {
+      this.timeout(15000);
+      aquaticId = (
+        await upload({ name: 'Facet Aquatic', blueprint: blueprintData([AQUATIC_PREFAB]), category: 'power' })
+      ).body.id;
+      await upload({ name: 'Facet Frosty', blueprint: blueprintData([FROSTY_PREFAB]), category: 'food' });
+      baseId = (
+        await upload({ name: 'Facet Base', blueprint: blueprintData([BASE_PREFAB]), category: 'power' })
+      ).body.id;
+      await upload({ name: 'Facet Both', blueprint: blueprintData([AND_PREFAB]), category: 'food' });
+    });
+
+    it('reports total, category, requiredDlcs and baseGame counts', async function () {
+      const response = await facets();
+      expect(response.status).to.equal(200);
+
+      expect(response.body.total).to.equal(4);
+      expect(response.body.category).to.deep.equal({ power: 2, food: 2 });
+      expect(response.body.requiredDlcs.DLC5_ID).to.equal(1);
+      expect(response.body.requiredDlcs.DLC2_ID).to.equal(1);
+      // bothId needs two packs -> counted once under each, not once total.
+      expect(response.body.requiredDlcs.EXPANSION1_ID).to.equal(1);
+      expect(response.body.requiredDlcs.DLC3_ID).to.equal(1);
+      expect(response.body.baseGame).to.equal(1);
+    });
+
+    it('self-excludes: selecting a DLC leaves every DLC count unchanged', async function () {
+      const unfiltered = (await facets()).body.requiredDlcs;
+      const filtered = (await facets({ dlc: 'DLC5_ID' })).body.requiredDlcs;
+      expect(filtered).to.deep.equal(unfiltered);
+    });
+
+    it('shares one DLC count map: excludeDlc= does not move requiredDlcs counts either', async function () {
+      const unfiltered = (await facets()).body.requiredDlcs;
+      const filtered = (await facets({ excludeDlc: 'DLC5_ID' })).body.requiredDlcs;
+      expect(filtered).to.deep.equal(unfiltered);
+    });
+
+    it('cross-dimension narrowing: category= moves the DLC counts', async function () {
+      const response = await facets({ category: 'power' });
+      expect(response.status).to.equal(200);
+      // Only aquaticId + baseId are category=power.
+      expect(response.body.requiredDlcs.DLC5_ID).to.equal(1);
+      expect(response.body.requiredDlcs.DLC2_ID ?? 0).to.equal(0);
+      expect(response.body.baseGame).to.equal(1);
+    });
+
+    it('baseGame counts requiredDlcs: [] and not never-derived docs', async function () {
+      // baseId genuinely has requiredDlcs: [].
+      const withBase = await BlueprintModel.model.findById(baseId);
+      expect(withBase!.requiredDlcs).to.deep.equal([]);
+
+      // Simulate a never-derived doc (field absent, not empty).
+      await BlueprintModel.model.updateOne({ _id: aquaticId }, { $unset: { requiredDlcs: '' } });
+
+      const response = await facets();
+      expect(response.status).to.equal(200);
+      // baseId still counts; the now-undefined aquaticId does not become a
+      // second baseGame row, and it also drops out of requiredDlcs.DLC5_ID.
+      expect(response.body.baseGame).to.equal(1);
+      expect(response.body.requiredDlcs.DLC5_ID ?? 0).to.equal(0);
+    });
+
+    it('counts a blueprint needing two packs under each pack', async function () {
+      const response = await facets();
+      // bothId (RoboPilotModule) needs both EXPANSION1_ID and DLC3_ID — it
+      // shows up once in each row, not split between them.
+      expect(response.body.requiredDlcs.EXPANSION1_ID).to.equal(1);
+      expect(response.body.requiredDlcs.DLC3_ID).to.equal(1);
+    });
+
+    it('rejects malformed params with the same 400s as getblueprints', async function () {
+      expect((await facets({ category: 'not-a-category' })).status).to.equal(400);
+      expect((await facets({ dlc: 'dlc3_id' })).status).to.equal(400);
+      expect((await facets({ excludeDlc: ' , ' })).status).to.equal(400);
+      expect((await facets({ rooms: 'not-a-room' })).status).to.equal(400);
+      expect((await facets({ sort: 'not-a-sort' })).status).to.equal(400);
+    });
+
+    it('total agrees with the number of documents getblueprints returns unpaginated', async function () {
+      const query = { category: 'food' };
+      const facetsResponse = await facets(query);
+      const listResponse = await list(query);
+
+      expect(facetsResponse.status).to.equal(200);
+      expect(listResponse.status).to.equal(200);
+      expect(facetsResponse.body.total).to.equal(listResponse.body.blueprints.length);
+    });
+
+    it('sort/skip/olderthan are accepted but ignored — total is not paginated', async function () {
+      const response = await facets({ sort: 'popular', skip: 1, olderthan: 1 });
+      expect(response.status).to.equal(200);
+      expect(response.body.total).to.equal(4);
+    });
+  });
+
+  describe('draft visibility', function () {
+    it('a draft counts for its owner (via the secure route) but not for a stranger', async function () {
+      await upload({
+        name: 'Facet Draft',
+        blueprint: blueprintData([BASE_PREFAB]),
+        publish: false,
+      });
+      await upload({ name: 'Facet Published', blueprint: blueprintData([BASE_PREFAB]) });
+
+      const ownerId = testData.users.user1._id.toString();
+
+      const ownerView = await facetsSecure({ filterUserId: ownerId }, authToken);
+      expect(ownerView.status).to.equal(200);
+      expect(ownerView.body.total).to.equal(2);
+
+      const strangerView = await facetsSecure({ filterUserId: ownerId }, user2Token);
+      expect(strangerView.status).to.equal(200);
+      expect(strangerView.body.total).to.equal(1);
+
+      // Anonymous (unauthenticated) requests get the same published-only view
+      // as a stranger, regardless of filterUserId.
+      const anonView = await facets({ filterUserId: ownerId });
+      expect(anonView.status).to.equal(200);
+      expect(anonView.body.total).to.equal(1);
+    });
+  });
+
+  describe('GET /api/blueprintfacetsSecure', function () {
+    it('requires authentication', async function () {
+      const response = await TestSetup.request().get('/api/blueprintfacetsSecure');
+      expect(response.status).to.equal(401);
+    });
+
+    it('behaves like the anonymous endpoint for a logged-in viewer browsing the public feed', async function () {
+      await upload({ name: 'Facet Secure Base', blueprint: blueprintData([BASE_PREFAB]) });
+
+      const anon = await facets();
+      const secure = await facetsSecure({}, authToken);
+
+      expect(secure.status).to.equal(200);
+      expect(secure.body.total).to.equal(anon.body.total);
+    });
+  });
+});

--- a/__tests__/api/blueprints.test.ts
+++ b/__tests__/api/blueprints.test.ts
@@ -202,6 +202,17 @@ describe('Blueprint API (Mocha)', function () {
       expect(lower.body.blueprints.map((bp: any) => bp.name)).to.include('Legacy Food System');
       expect(upper.body.blueprints.map((bp: any) => bp.name)).to.include('Legacy Food System');
     });
+
+    it('treats filterName as a literal substring, not a regex', async function () {
+      // Unescaped, '(' is an invalid/unbalanced regex group and would 500;
+      // it must instead search for the literal text and simply match nothing.
+      const response = await TestSetup.request()
+        .get('/api/getblueprints')
+        .query({ olderthan: Date.now(), filterName: 'oxygen(' });
+
+      expect(response.status).to.equal(200);
+      expect(response.body.blueprints).to.deep.equal([]);
+    });
   });
 
   describe('GET /api/getblueprints?sort=popular', function () {

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -44,6 +44,8 @@ import {
   parseBlueprintFilters,
   resolveRatedByIds,
   buildBlueprintFilter,
+  buildFacetBaseFilter,
+  buildFacetDimensionMatch,
   PUBLISHED_FILTER,
 } from './services/blueprint-filter-service';
 import mongoose from 'mongoose';
@@ -729,6 +731,105 @@ export class BlueprintController {
         console.log(err);
         res.status(500).json(apiError(500, 'Failed to retrieve blueprints'));
       });
+  }
+
+  // Self-excluding ("drill-down") facet counts for the Discover sidebar: one
+  // $facet aggregation, same query params and validation as getBlueprints.
+  // Each group's count applies every active filter except that group's own
+  // (buildFacetDimensionMatch) — the outer $match (buildFacetBaseFilter)
+  // therefore carries none of the four dimension clauses, only what every
+  // branch agrees on. sort/skip/olderthan are accepted (so the client can
+  // reuse its existing query string) but never applied — counts describe the
+  // whole matching corpus, not one page of it.
+  public async getBlueprintFacets(req: Request, res: Response) {
+    console.log('getBlueprintFacets' + req.clientIp);
+    if (BlueprintModel.model == null) {
+      res.status(503).send();
+      return;
+    }
+
+    let userId = '';
+    let userJwt = req.user as UserJwt;
+    if (userJwt != null) userId = userJwt._id;
+
+    const parsed = parseBlueprintFilters(req, res, userId);
+    if (parsed == null) return;
+
+    let ratedByIds: mongoose.Types.ObjectId[] | null = null;
+    try {
+      ratedByIds = await resolveRatedByIds(parsed);
+    } catch (err) {
+      console.log('ratedBy lookup error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to retrieve blueprint facets'));
+      return;
+    }
+
+    const isAdmin = userJwt?.role === 'admin';
+    const viewer = { userId, isAdmin };
+    const outerMatch = buildFacetBaseFilter(parsed, ratedByIds, viewer);
+
+    const categoryMatch = buildFacetDimensionMatch(parsed, 'category');
+    const subcategoryMatch = buildFacetDimensionMatch(parsed, 'subcategory');
+    const roomsMatch = buildFacetDimensionMatch(parsed, 'rooms');
+    const dlcMatch = buildFacetDimensionMatch(parsed, 'dlc');
+
+    try {
+      const [result] = await BlueprintModel.model.aggregate([
+        { $match: outerMatch },
+        // Trims to the four dimension fields before $facet fans out into five
+        // branches — the list query's -data/-thumbnail/-rawSource projection
+        // for the same reason (neither is needed to count).
+        { $project: { category: 1, subcategory: 1, rooms: 1, requiredDlcs: 1 } },
+        {
+          $facet: {
+            total: [{ $count: 'n' }],
+            category: [{ $match: categoryMatch }, { $group: { _id: '$category', n: { $sum: 1 } } }],
+            subcategory: [{ $match: subcategoryMatch }, { $group: { _id: '$subcategory', n: { $sum: 1 } } }],
+            rooms: [
+              { $match: roomsMatch },
+              { $unwind: '$rooms' },
+              { $group: { _id: '$rooms', n: { $sum: 1 } } },
+            ],
+            requiredDlcs: [
+              { $match: dlcMatch },
+              { $unwind: '$requiredDlcs' },
+              { $group: { _id: '$requiredDlcs', n: { $sum: 1 } } },
+            ],
+            // Array-valued dimensions are unwound above, so a multi-pack
+            // blueprint counts once per pack — deliberately not summing to
+            // `total`. baseGame is the complementary { $size: 0 } case.
+            baseGame: [
+              { $match: { ...dlcMatch, requiredDlcs: { $size: 0 } } },
+              { $count: 'n' },
+            ],
+          },
+        },
+      ]);
+
+      const toCountMap = (rows: { _id: string | null; n: number }[]): Record<string, number> => {
+        const map: Record<string, number> = {};
+        for (const row of rows) {
+          if (row._id == null) continue;
+          map[row._id] = row.n;
+        }
+        return map;
+      };
+
+      setFeedCacheControl(req, res);
+      res.status(200).json({
+        total: result?.total?.[0]?.n ?? 0,
+        category: toCountMap(result?.category ?? []),
+        subcategory: toCountMap(result?.subcategory ?? []),
+        rooms: toCountMap(result?.rooms ?? []),
+        requiredDlcs: toCountMap(result?.requiredDlcs ?? []),
+        baseGame: result?.baseGame?.[0]?.n ?? 0,
+      });
+    } catch (err) {
+      console.log('Blueprint facets aggregation error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to retrieve blueprint facets'));
+    }
   }
 
   // Visible (non-deleted) comment counts for a page of blueprints, one aggregate.

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -71,6 +71,36 @@ function setFeedCacheControl(req: Request, res: Response) {
   res.set('Cache-Control', req.headers.authorization == null ? ANON_CACHE_CONTROL : 'no-store');
 }
 
+// Facet counts tolerate more staleness than the list itself does — a sidebar
+// number off by a few blueprints for a few minutes is imperceptible, unlike
+// a stale card. Longer TTL than ANON_CACHE_CONTROL means fewer aggregations
+// hit Mongo at all for the by-far-most-common request (no filters, the
+// Discover page load), independent of the BLUEPRINT_FACETS_ENABLED switch
+// below. Browse-page always calls the anonymous endpoint (filterUserId/
+// ratedBy are never set from Discover), so this is the path real traffic
+// takes; blueprintfacetsSecure still gets `no-store` like every other authed
+// response.
+const FACETS_CACHE_CONTROL = 'public, s-maxage=300, stale-while-revalidate=1800';
+
+function setFacetsCacheControl(req: Request, res: Response) {
+  res.set('Cache-Control', req.headers.authorization == null ? FACETS_CACHE_CONTROL : 'no-store');
+}
+
+// Kill switch for the facet-counts sidebar feature: purely cosmetic and
+// additive (the frontend already treats any facets failure as advisory and
+// renders the sidebar unfiltered/enabled), so flipping this to 'false' in the
+// environment and restarting turns it off without a code revert or deploy.
+// Read live (not cached at module load) so a restart is all it takes.
+function facetsEnabled(): boolean {
+  return process.env.BLUEPRINT_FACETS_ENABLED !== 'false';
+}
+
+// Cheap greppable signal for prod ops (`doctl apps logs <app> --type run |
+// grep facets-slow`) until real APM exists — see agent/SESSION_NOTES.md /
+// project_feed_query_perf memory: New Relic was recommended but never wired
+// up, so this is the fastest lever available today.
+const FACETS_SLOW_THRESHOLD_MS = 200;
+
 // The stored thumbnail data URI is user-supplied, so its declared mime cannot
 // be trusted: a URI claiming image/svg+xml (scriptable when opened directly)
 // or mislabeled bytes must never be echoed back as a Content-Type. Sniff the
@@ -744,6 +774,13 @@ export class BlueprintController {
   // whole matching corpus, not one page of it.
   public async getBlueprintFacets(req: Request, res: Response) {
     console.log('getBlueprintFacets' + req.clientIp);
+    // Kill switch: the frontend already treats any non-200 here as advisory
+    // (sidebar renders unfiltered/enabled), so this is a clean off switch —
+    // no separate error handling to add, no code path to revert.
+    if (!facetsEnabled()) {
+      res.status(503).send();
+      return;
+    }
     if (BlueprintModel.model == null) {
       res.status(503).send();
       return;
@@ -778,6 +815,7 @@ export class BlueprintController {
     const roomsMatch = buildFacetDimensionMatch(parsed, 'rooms');
     const dlcMatch = buildFacetDimensionMatch(parsed, 'dlc');
 
+    const aggregationStart = Date.now();
     try {
       const [result] = await BlueprintModel.model.aggregate([
         { $match: outerMatch },
@@ -811,6 +849,11 @@ export class BlueprintController {
         },
       ]);
 
+      const aggregationMs = Date.now() - aggregationStart;
+      if (aggregationMs > FACETS_SLOW_THRESHOLD_MS) {
+        console.log(`facets-slow: ${aggregationMs}ms query=${req.originalUrl}`);
+      }
+
       const toCountMap = (rows: { _id: string | null; n: number }[]): Record<string, number> => {
         const map: Record<string, number> = {};
         for (const row of rows) {
@@ -828,7 +871,7 @@ export class BlueprintController {
         requiredDlcs: toCountMap(result?.requiredDlcs ?? []),
         baseGame: result?.baseGame?.[0]?.n ?? 0,
       };
-      setFeedCacheControl(req, res);
+      setFacetsCacheControl(req, res);
       res.status(200).json(facetsResponse);
     } catch (err) {
       console.log('Blueprint facets aggregation error');

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -5,6 +5,7 @@ import {
   BlueprintResponse,
   BlueprintListItem,
   BlueprintListResponse,
+  BlueprintFacetsResponse,
   RelatedBlueprintsResponse,
   BlueprintRate,
   BlueprintRateResponse,
@@ -769,6 +770,9 @@ export class BlueprintController {
     const viewer = { userId, isAdmin };
     const outerMatch = buildFacetBaseFilter(parsed, ratedByIds, viewer);
 
+    // total applies every active dimension filter (omits none); every other
+    // branch applies every dimension EXCEPT its own (self-excluding counts).
+    const totalMatch = buildFacetDimensionMatch(parsed, null);
     const categoryMatch = buildFacetDimensionMatch(parsed, 'category');
     const subcategoryMatch = buildFacetDimensionMatch(parsed, 'subcategory');
     const roomsMatch = buildFacetDimensionMatch(parsed, 'rooms');
@@ -783,7 +787,7 @@ export class BlueprintController {
         { $project: { category: 1, subcategory: 1, rooms: 1, requiredDlcs: 1 } },
         {
           $facet: {
-            total: [{ $count: 'n' }],
+            total: [{ $match: totalMatch }, { $count: 'n' }],
             category: [{ $match: categoryMatch }, { $group: { _id: '$category', n: { $sum: 1 } } }],
             subcategory: [{ $match: subcategoryMatch }, { $group: { _id: '$subcategory', n: { $sum: 1 } } }],
             rooms: [
@@ -816,15 +820,16 @@ export class BlueprintController {
         return map;
       };
 
-      setFeedCacheControl(req, res);
-      res.status(200).json({
+      const facetsResponse: BlueprintFacetsResponse = {
         total: result?.total?.[0]?.n ?? 0,
         category: toCountMap(result?.category ?? []),
         subcategory: toCountMap(result?.subcategory ?? []),
         rooms: toCountMap(result?.rooms ?? []),
         requiredDlcs: toCountMap(result?.requiredDlcs ?? []),
         baseGame: result?.baseGame?.[0]?.n ?? 0,
-      });
+      };
+      setFeedCacheControl(req, res);
+      res.status(200).json(facetsResponse);
     } catch (err) {
       console.log('Blueprint facets aggregation error');
       console.log(err);

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -16,11 +16,8 @@ import {
   CATEGORIES,
   SUBCATEGORIES,
   RESEARCH_TIERS,
-  ROOM_TYPE_IDS,
   RAW_SOURCE_FORMATS,
   RawSourceFormat,
-  DLC_ID_PATTERN,
-  MAX_DLC_FILTER_IDS,
 } from '../../lib/index';
 import { Blueprint as sharedBlueprint, BlueprintDetailsResponse } from '../../lib/index';
 import { computeHotScore } from '../../lib/index';
@@ -30,7 +27,6 @@ import { BlueprintRatingModel } from './models/blueprint-rating';
 import { NotificationController } from './notification-controller';
 import { BatchUtils } from './batch/batch-utils';
 import { apiError } from './utils/apiError';
-import { parseOlderThan } from './utils/pagination';
 import { optionalViewer } from './utils/optionalViewer';
 import { canViewBlueprint, ownerIdOf } from './utils/blueprint-visibility';
 import { BlueprintEventService } from './services/blueprint-event-service';
@@ -44,12 +40,15 @@ import { PreviewImageService } from './services/preview-image-service';
 import { deriveRooms } from './services/room-derivation-service';
 import { deriveMods } from './services/mod-derivation-service';
 import { deriveDlcs } from './services/dlc-derivation-service';
+import {
+  parseBlueprintFilters,
+  resolveRatedByIds,
+  buildBlueprintFilter,
+  PUBLISHED_FILTER,
+} from './services/blueprint-filter-service';
 import mongoose from 'mongoose';
 
-const MAX_SKIP = 10000;
-
-const SORTS = ['recent', 'popular', 'mostForked', 'mostViewed', 'mostDownloaded', 'trending'] as const;
-type BlueprintSort = (typeof SORTS)[number];
+export { PUBLISHED_FILTER };
 
 // How many "you might also like" cards the details page shows
 const RELATED_LIMIT = 6;
@@ -58,13 +57,6 @@ const RELATED_LIMIT = 6;
 // re-download. Real .blueprint files are tens of KB; the cap only guards the
 // 16MB Mongo document limit (data + thumbnail + rawSource share it).
 const MAX_RAW_SOURCE_BYTES = 2 * 1024 * 1024;
-
-// Public-visibility clause for feed queries. $in's null matches docs that
-// predate the isPublished backfill (deploy→migrate window), same coverage as
-// the old { $ne: false } — but $in gives the planner point bounds, so the
-// isPublished-prefixed indexes can still provide sort order for the
-// count/rating sorts instead of fetching every live doc into a blocking SORT.
-export const PUBLISHED_FILTER = { $in: [true, null] };
 
 // Anonymous feed responses are viewer-independent, so Cloudflare can cache
 // them at the edge; slightly stale lists are fine. Responses to requests
@@ -680,264 +672,63 @@ export class BlueprintController {
 
   public async getBlueprints(req: Request, res: Response) {
     console.log('getBlueprints' + req.clientIp);
-    if (BlueprintModel.model == null) res.status(503).send();
-    else {
-      let filterUserId: string;
-      let filterName: string;
-      let filterCategory: string | null = null;
-      let filterSubcategory: string | null = null;
-      let filterModded: boolean | null = null;
-      let filterRooms: string[] | null = null;
-      let filterDlcs: string[] | null = null;
-      let filterExcludeDlcs: string[] | null = null;
-      let filterForkedFrom: string | null = null;
-      let filterRatedBy: string | null = null;
-      let sort: BlueprintSort;
-      let skip = 0;
-
-      let userId = '';
-      let userJwt = req.user as UserJwt;
-      if (userJwt != null) userId = userJwt._id;
-
-      const dateFilter = parseOlderThan(req, res);
-      if (dateFilter == null) return;
-
-      try {
-        filterUserId = req.query.filterUserId as string;
-        const rawFilterName = req.query.filterName as string;
-        if (rawFilterName != null && rawFilterName.length > 60) {
-          res.status(400).json(apiError(400, 'filterName must be 60 characters or fewer'));
-          return;
-        }
-        filterName = rawFilterName;
-
-        const rawCategory = req.query.category as string | undefined;
-        if (rawCategory != null && !(CATEGORIES as readonly string[]).includes(rawCategory)) {
-          res.status(400).json(apiError(400, `Invalid category: must be one of ${CATEGORIES.join(', ')}`));
-          return;
-        }
-        filterCategory = rawCategory ?? null;
-
-        filterSubcategory = req.query.subcategory as string ?? null;
-
-        const rawModded = req.query.modded as string | undefined;
-        if (rawModded != null && rawModded !== 'true' && rawModded !== 'false') {
-          res.status(400).json(apiError(400, "Invalid modded: must be 'true' or 'false'"));
-          return;
-        }
-        filterModded = rawModded != null ? rawModded === 'true' : null;
-
-        // ?rooms=latrine,park -> blueprints containing ANY of the room types.
-        // Values validated against the shared enum (400 on garbage, consistent
-        // with category). Docs never derived (rooms null/absent) never match.
-        const rawRooms = req.query.rooms as string | undefined;
-        if (rawRooms != null) {
-          const requested = rawRooms
-            .split(',')
-            .map(room => room.trim())
-            .filter(room => room.length > 0);
-          const invalid = requested.filter(
-            room => !(ROOM_TYPE_IDS as readonly string[]).includes(room)
-          );
-          if (requested.length === 0 || invalid.length > 0) {
-            res
-              .status(400)
-              .json(apiError(400, `Invalid rooms: must be a comma-separated list of ${ROOM_TYPE_IDS.join(', ')}`));
-            return;
-          }
-          filterRooms = requested;
-        }
-
-        // ?dlc=DLC2_ID,DLC3_ID -> blueprints requiring ANY of these packs.
-        // "Show me what the Bionic pack would unlock" is a membership question,
-        // so $in (same semantics as rooms) is the right reading; the subset
-        // test ("hide what I can't build") is a separate `owned=` param.
-        //
-        // Validated by *shape*, not against DLC_LABELS: a pack that ships in an
-        // export before we've written a label for it must still be filterable,
-        // which is the same reason the schema carries no enum.
-        const rawDlc = req.query.dlc;
-        if (rawDlc != null) {
-          const requested = (Array.isArray(rawDlc) ? rawDlc : [rawDlc])
-            .flatMap(value => String(value).split(','))
-            .map(dlcId => dlcId.trim())
-            .filter(dlcId => dlcId.length > 0);
-          const invalid = requested.filter(dlcId => !DLC_ID_PATTERN.test(dlcId));
-          // The cap only bounds the $in list — there are five packs today, so
-          // anything near the limit is abuse rather than a real query.
-          if (requested.length === 0 || requested.length > MAX_DLC_FILTER_IDS || invalid.length > 0) {
-            res
-              .status(400)
-              .json(
-                apiError(
-                  400,
-                  `Invalid dlc: must be a comma-separated list of up to ${MAX_DLC_FILTER_IDS} DLC ids (A-Z, 0-9 and _)`
-                )
-              );
-            return;
-          }
-          filterDlcs = requested;
-        }
-
-        // ?excludeDlc=DLC3_ID,DLC4_ID -> blueprints requiring NONE of these
-        // packs. The complement of ?dlc= (membership vs. exclusion are
-        // separate params, not a third state on one), so it composes: both can
-        // be present at once. Same shape/size validation as dlc.
-        const rawExcludeDlc = req.query.excludeDlc;
-        if (rawExcludeDlc != null) {
-          const requested = (Array.isArray(rawExcludeDlc) ? rawExcludeDlc : [rawExcludeDlc])
-            .flatMap(value => String(value).split(','))
-            .map(dlcId => dlcId.trim())
-            .filter(dlcId => dlcId.length > 0);
-          const invalid = requested.filter(dlcId => !DLC_ID_PATTERN.test(dlcId));
-          if (requested.length === 0 || requested.length > MAX_DLC_FILTER_IDS || invalid.length > 0) {
-            res
-              .status(400)
-              .json(
-                apiError(
-                  400,
-                  `Invalid excludeDlc: must be a comma-separated list of up to ${MAX_DLC_FILTER_IDS} DLC ids (A-Z, 0-9 and _)`
-                )
-              );
-            return;
-          }
-          filterExcludeDlcs = requested;
-        }
-
-        const rawForkedFrom = req.query.forkedFrom as string | undefined;
-        if (rawForkedFrom != null && !mongoose.Types.ObjectId.isValid(rawForkedFrom)) {
-          res.status(400).json(apiError(400, 'Invalid forkedFrom: must be a valid blueprint id'));
-          return;
-        }
-        filterForkedFrom = rawForkedFrom ?? null;
-
-        const rawRatedBy = req.query.ratedBy as string | undefined;
-        if (rawRatedBy != null && !mongoose.Types.ObjectId.isValid(rawRatedBy)) {
-          res.status(400).json(apiError(400, 'Invalid ratedBy: must be a valid user id'));
-          return;
-        }
-        // Rated blueprints are private — only the owner can list their own ratings (matches
-        // the profile page's "Rated" tab, which is only ever rendered on your own profile).
-        if (rawRatedBy != null && rawRatedBy !== userId) {
-          res.status(403).json(apiError(403, 'Cannot view another user\'s rated blueprints'));
-          return;
-        }
-        filterRatedBy = rawRatedBy ?? null;
-
-        const rawSort = req.query.sort as string | undefined;
-        if (rawSort != null && !(SORTS as readonly string[]).includes(rawSort)) {
-          res.status(400).json(apiError(400, `Invalid sort: must be one of ${SORTS.join(', ')}`));
-          return;
-        }
-        sort = (rawSort as BlueprintSort) ?? 'recent';
-
-        const rawSkip = req.query.skip as string | undefined;
-        if (rawSkip != null) {
-          skip = parseInt(rawSkip);
-          // cap skip: MongoDB scans and discards skipped documents server-side,
-          // so an unbounded offset is a cheap way to force slow queries
-          if (isNaN(skip) || skip < 0 || skip > MAX_SKIP || String(skip) !== rawSkip) {
-            res.status(400).json(apiError(400, `Invalid skip parameter: must be an integer between 0 and ${MAX_SKIP}`));
-            return;
-          }
-        }
-      } catch (error) {
-        console.log(error);
-        res.status(400).json(apiError(400, 'Invalid query parameters'));
-        return;
-      }
-
-      // count-based sorts ignore the olderthan cursor (offset pagination via skip instead);
-      // the param stays accepted so the existing client call shape keeps working
-      const usesOffsetPagination = sort !== 'recent';
-      let filter: any = usesOffsetPagination
-        ? { $and: [{ deletedAt: null }] }
-        : { $and: [{ createdAt: { $lt: dateFilter } }, { deletedAt: null }] };
-
-      // Draft visibility: the general feed is published-only for every viewer.
-      // Owners see their own drafts when listing their own blueprints (the
-      // profile page always passes filterUserId), and admins see drafts when
-      // browsing a specific user's list — in both cases the owner clause below
-      // already bounds the query, so the published filter is simply dropped.
-      // Never combine the two as $or: [published, owner] — no index serves
-      // both branches under a count sort, so Mongo falls back to fetching
-      // every live 85KB doc into a blocking SORT (~16s on prod).
-      const isAdmin = userJwt?.role === 'admin';
-      const viewerOwnsList = filterUserId != null && filterUserId === userId;
-      if (!viewerOwnsList && !(isAdmin && filterUserId != null)) {
-        filter.$and.push({ isPublished: PUBLISHED_FILTER });
-      }
-
-      if (filterUserId != null) filter.$and.push({ owner: filterUserId });
-      if (filterName != null) filter.$and.push({ name: { $regex: filterName, $options: 'i' } });
-      if (filterCategory != null) filter.$and.push({ category: filterCategory });
-      if (filterSubcategory != null) filter.$and.push({ subcategory: filterSubcategory });
-      if (filterModded != null) filter.$and.push({ modded: filterModded });
-      if (filterRooms != null) filter.$and.push({ rooms: { $in: filterRooms } });
-      // Documents predating DLC derivation have no requiredDlcs at all; $in
-      // never matches a missing field, so they stay out of a dlc= result
-      // rather than reading as base-game.
-      if (filterDlcs != null) filter.$and.push({ requiredDlcs: { $in: filterDlcs } });
-      // $nin over an array field matches when NONE of its elements are in the
-      // list — true for [] (base game always survives exclusion) and true for
-      // a missing field (a never-derived doc can't be known to need the
-      // excluded pack, so it isn't hidden either). Note for the planner: $nin
-      // can't produce a bounded range the way $in does, so this clause is
-      // applied as a per-document filter during FETCH rather than narrowing an
-      // index scan — the sort-driven index still bounds the query, this just
-      // adds one field check per candidate.
-      if (filterExcludeDlcs != null) filter.$and.push({ requiredDlcs: { $nin: filterExcludeDlcs } });
-      if (filterForkedFrom != null) filter.$and.push({ 'forkedFrom.blueprintId': filterForkedFrom });
-      if (filterRatedBy != null) {
-        // Ratings live in their own collection; resolve to ids first (the
-        // {userId, updatedAt} index covers this)
-        try {
-          const ratedIds =
-            BlueprintRatingModel.model == null
-              ? []
-              : await BlueprintRatingModel.model.find({ userId: filterRatedBy }).distinct('blueprintId');
-          filter.$and.push({ _id: { $in: ratedIds } });
-        } catch (err) {
-          console.log('ratedBy lookup error');
-          console.log(err);
-          res.status(500).json(apiError(500, 'Failed to retrieve blueprints'));
-          return;
-        }
-      }
-
-      let sortSpec: Record<string, 1 | -1> = { createdAt: -1 };
-      if (sort === 'popular') sortSpec = { ratingAverage: -1, ratingCount: -1, createdAt: -1 };
-      else if (sort === 'mostForked') sortSpec = { forkCount: -1, createdAt: -1 };
-      else if (sort === 'mostViewed') sortSpec = { viewCount: -1, createdAt: -1 };
-      else if (sort === 'mostDownloaded') sortSpec = { downloadCount: -1, createdAt: -1 };
-      // Trending sorts on the materialized hotScore (lib computeHotScore),
-      // refreshed on every engagement write — so it's a plain indexed sort
-      // like every other sort, not a full-collection aggregation.
-      else if (sort === 'trending') sortSpec = { hotScore: -1, createdAt: -1 };
-
-      let browseIncrement = parseInt(process.env.BROWSE_INCREMENT as string);
-      let skipAmount = usesOffsetPagination ? skip : 0;
-      let limit = browseIncrement * 2;
-
-      // -data -thumbnail: the list renders neither blueprint contents (~85KB
-      // avg) nor the inline thumbnail data URI (~10-20KB) — together they
-      // dominate the query's fetch cost otherwise
-      BlueprintModel.model
-        .find(filter)
-        .sort(sortSpec)
-        .skip(skipAmount)
-        .limit(limit)
-        .select('-data -thumbnail -rawSource')
-        .populate('owner')
-        .then(blueprints => {
-          return BlueprintController.handleGetBlueprint(req, res, blueprints);
-        })
-        .catch(err => {
-          console.log('Blueprint find error');
-          console.log(err);
-          res.status(500).json(apiError(500, 'Failed to retrieve blueprints'));
-        });
+    if (BlueprintModel.model == null) {
+      res.status(503).send();
+      return;
     }
+
+    let userId = '';
+    let userJwt = req.user as UserJwt;
+    if (userJwt != null) userId = userJwt._id;
+
+    const parsed = parseBlueprintFilters(req, res, userId);
+    if (parsed == null) return;
+
+    let ratedByIds: mongoose.Types.ObjectId[] | null = null;
+    try {
+      ratedByIds = await resolveRatedByIds(parsed);
+    } catch (err) {
+      console.log('ratedBy lookup error');
+      console.log(err);
+      res.status(500).json(apiError(500, 'Failed to retrieve blueprints'));
+      return;
+    }
+
+    const isAdmin = userJwt?.role === 'admin';
+    const { filter, usesOffsetPagination } = buildBlueprintFilter(parsed, ratedByIds, { userId, isAdmin });
+
+    let sortSpec: Record<string, 1 | -1> = { createdAt: -1 };
+    if (parsed.sort === 'popular') sortSpec = { ratingAverage: -1, ratingCount: -1, createdAt: -1 };
+    else if (parsed.sort === 'mostForked') sortSpec = { forkCount: -1, createdAt: -1 };
+    else if (parsed.sort === 'mostViewed') sortSpec = { viewCount: -1, createdAt: -1 };
+    else if (parsed.sort === 'mostDownloaded') sortSpec = { downloadCount: -1, createdAt: -1 };
+    // Trending sorts on the materialized hotScore (lib computeHotScore),
+    // refreshed on every engagement write — so it's a plain indexed sort
+    // like every other sort, not a full-collection aggregation.
+    else if (parsed.sort === 'trending') sortSpec = { hotScore: -1, createdAt: -1 };
+
+    let browseIncrement = parseInt(process.env.BROWSE_INCREMENT as string);
+    let skipAmount = usesOffsetPagination ? parsed.skip : 0;
+    let limit = browseIncrement * 2;
+
+    // -data -thumbnail: the list renders neither blueprint contents (~85KB
+    // avg) nor the inline thumbnail data URI (~10-20KB) — together they
+    // dominate the query's fetch cost otherwise
+    BlueprintModel.model
+      .find(filter)
+      .sort(sortSpec)
+      .skip(skipAmount)
+      .limit(limit)
+      .select('-data -thumbnail -rawSource')
+      .populate('owner')
+      .then(blueprints => {
+        return BlueprintController.handleGetBlueprint(req, res, blueprints);
+      })
+      .catch(err => {
+        console.log('Blueprint find error');
+        console.log(err);
+        res.status(500).json(apiError(500, 'Failed to retrieve blueprints'));
+      });
   }
 
   // Visible (non-deleted) comment counts for a page of blueprints, one aggregate.

--- a/app/api/services/blueprint-filter-service.ts
+++ b/app/api/services/blueprint-filter-service.ts
@@ -1,0 +1,300 @@
+import { Request, Response } from 'express';
+import mongoose from 'mongoose';
+import { CATEGORIES, ROOM_TYPE_IDS, DLC_ID_PATTERN, MAX_DLC_FILTER_IDS } from '../../../lib/index';
+import { apiError } from '../utils/apiError';
+import { parseOlderThan } from '../utils/pagination';
+import { BlueprintRatingModel } from '../models/blueprint-rating';
+
+const MAX_SKIP = 10000;
+
+export const SORTS = ['recent', 'popular', 'mostForked', 'mostViewed', 'mostDownloaded', 'trending'] as const;
+export type BlueprintSort = (typeof SORTS)[number];
+
+// Public-visibility clause for feed queries. $in's null matches docs that
+// predate the isPublished backfill (deploy→migrate window), same coverage as
+// the old { $ne: false } — but $in gives the planner point bounds, so the
+// isPublished-prefixed indexes can still provide sort order for the
+// count/rating sorts instead of fetching every live doc into a blocking SORT.
+export const PUBLISHED_FILTER = { $in: [true, null] };
+
+export interface ParsedBlueprintFilters {
+  filterUserId: string | null;
+  filterName: string | null;
+  filterCategory: string | null;
+  filterSubcategory: string | null;
+  filterModded: boolean | null;
+  filterRooms: string[] | null;
+  filterDlcs: string[] | null;
+  filterExcludeDlcs: string[] | null;
+  filterForkedFrom: string | null;
+  filterRatedBy: string | null;
+  sort: BlueprintSort;
+  skip: number;
+  dateFilter: Date;
+}
+
+export interface BlueprintFilterViewer {
+  userId: string;
+  isAdmin: boolean;
+}
+
+export type FilterDimension = 'category' | 'subcategory' | 'rooms' | 'dlc';
+
+// Parses and validates the query params shared by getblueprints and
+// blueprintfacets, writing the same 400/403 responses either endpoint would
+// have written directly. Returns null once a response has been written.
+export function parseBlueprintFilters(
+  req: Request,
+  res: Response,
+  viewerUserId: string
+): ParsedBlueprintFilters | null {
+  const dateFilter = parseOlderThan(req, res);
+  if (dateFilter == null) return null;
+
+  try {
+    const filterUserId = (req.query.filterUserId as string) ?? null;
+
+    const rawFilterName = req.query.filterName as string;
+    if (rawFilterName != null && rawFilterName.length > 60) {
+      res.status(400).json(apiError(400, 'filterName must be 60 characters or fewer'));
+      return null;
+    }
+    const filterName = rawFilterName ?? null;
+
+    const rawCategory = req.query.category as string | undefined;
+    if (rawCategory != null && !(CATEGORIES as readonly string[]).includes(rawCategory)) {
+      res.status(400).json(apiError(400, `Invalid category: must be one of ${CATEGORIES.join(', ')}`));
+      return null;
+    }
+    const filterCategory = rawCategory ?? null;
+
+    const filterSubcategory = (req.query.subcategory as string) ?? null;
+
+    const rawModded = req.query.modded as string | undefined;
+    if (rawModded != null && rawModded !== 'true' && rawModded !== 'false') {
+      res.status(400).json(apiError(400, "Invalid modded: must be 'true' or 'false'"));
+      return null;
+    }
+    const filterModded = rawModded != null ? rawModded === 'true' : null;
+
+    // ?rooms=latrine,park -> blueprints containing ANY of the room types.
+    // Values validated against the shared enum (400 on garbage, consistent
+    // with category). Docs never derived (rooms null/absent) never match.
+    let filterRooms: string[] | null = null;
+    const rawRooms = req.query.rooms as string | undefined;
+    if (rawRooms != null) {
+      const requested = rawRooms
+        .split(',')
+        .map(room => room.trim())
+        .filter(room => room.length > 0);
+      const invalid = requested.filter(room => !(ROOM_TYPE_IDS as readonly string[]).includes(room));
+      if (requested.length === 0 || invalid.length > 0) {
+        res
+          .status(400)
+          .json(apiError(400, `Invalid rooms: must be a comma-separated list of ${ROOM_TYPE_IDS.join(', ')}`));
+        return null;
+      }
+      filterRooms = requested;
+    }
+
+    // ?dlc=DLC2_ID,DLC3_ID -> blueprints requiring ANY of these packs.
+    // "Show me what the Bionic pack would unlock" is a membership question,
+    // so $in (same semantics as rooms) is the right reading; the subset
+    // test ("hide what I can't build") is a separate `excludeDlc=` param.
+    //
+    // Validated by *shape*, not against DLC_LABELS: a pack that ships in an
+    // export before we've written a label for it must still be filterable,
+    // which is the same reason the schema carries no enum.
+    let filterDlcs: string[] | null = null;
+    const rawDlc = req.query.dlc;
+    if (rawDlc != null) {
+      const requested = (Array.isArray(rawDlc) ? rawDlc : [rawDlc])
+        .flatMap(value => String(value).split(','))
+        .map(dlcId => dlcId.trim())
+        .filter(dlcId => dlcId.length > 0);
+      const invalid = requested.filter(dlcId => !DLC_ID_PATTERN.test(dlcId));
+      // The cap only bounds the $in list — there are five packs today, so
+      // anything near the limit is abuse rather than a real query.
+      if (requested.length === 0 || requested.length > MAX_DLC_FILTER_IDS || invalid.length > 0) {
+        res
+          .status(400)
+          .json(
+            apiError(
+              400,
+              `Invalid dlc: must be a comma-separated list of up to ${MAX_DLC_FILTER_IDS} DLC ids (A-Z, 0-9 and _)`
+            )
+          );
+        return null;
+      }
+      filterDlcs = requested;
+    }
+
+    // ?excludeDlc=DLC3_ID,DLC4_ID -> blueprints requiring NONE of these
+    // packs. The complement of ?dlc= (membership vs. exclusion are
+    // separate params, not a third state on one), so it composes: both can
+    // be present at once. Same shape/size validation as dlc.
+    let filterExcludeDlcs: string[] | null = null;
+    const rawExcludeDlc = req.query.excludeDlc;
+    if (rawExcludeDlc != null) {
+      const requested = (Array.isArray(rawExcludeDlc) ? rawExcludeDlc : [rawExcludeDlc])
+        .flatMap(value => String(value).split(','))
+        .map(dlcId => dlcId.trim())
+        .filter(dlcId => dlcId.length > 0);
+      const invalid = requested.filter(dlcId => !DLC_ID_PATTERN.test(dlcId));
+      if (requested.length === 0 || requested.length > MAX_DLC_FILTER_IDS || invalid.length > 0) {
+        res
+          .status(400)
+          .json(
+            apiError(
+              400,
+              `Invalid excludeDlc: must be a comma-separated list of up to ${MAX_DLC_FILTER_IDS} DLC ids (A-Z, 0-9 and _)`
+            )
+          );
+        return null;
+      }
+      filterExcludeDlcs = requested;
+    }
+
+    const rawForkedFrom = req.query.forkedFrom as string | undefined;
+    if (rawForkedFrom != null && !mongoose.Types.ObjectId.isValid(rawForkedFrom)) {
+      res.status(400).json(apiError(400, 'Invalid forkedFrom: must be a valid blueprint id'));
+      return null;
+    }
+    const filterForkedFrom = rawForkedFrom ?? null;
+
+    const rawRatedBy = req.query.ratedBy as string | undefined;
+    if (rawRatedBy != null && !mongoose.Types.ObjectId.isValid(rawRatedBy)) {
+      res.status(400).json(apiError(400, 'Invalid ratedBy: must be a valid user id'));
+      return null;
+    }
+    // Rated blueprints are private — only the owner can list their own ratings (matches
+    // the profile page's "Rated" tab, which is only ever rendered on your own profile).
+    if (rawRatedBy != null && rawRatedBy !== viewerUserId) {
+      res.status(403).json(apiError(403, "Cannot view another user's rated blueprints"));
+      return null;
+    }
+    const filterRatedBy = rawRatedBy ?? null;
+
+    const rawSort = req.query.sort as string | undefined;
+    if (rawSort != null && !(SORTS as readonly string[]).includes(rawSort)) {
+      res.status(400).json(apiError(400, `Invalid sort: must be one of ${SORTS.join(', ')}`));
+      return null;
+    }
+    const sort = (rawSort as BlueprintSort) ?? 'recent';
+
+    let skip = 0;
+    const rawSkip = req.query.skip as string | undefined;
+    if (rawSkip != null) {
+      skip = parseInt(rawSkip);
+      // cap skip: MongoDB scans and discards skipped documents server-side,
+      // so an unbounded offset is a cheap way to force slow queries
+      if (isNaN(skip) || skip < 0 || skip > MAX_SKIP || String(skip) !== rawSkip) {
+        res
+          .status(400)
+          .json(apiError(400, `Invalid skip parameter: must be an integer between 0 and ${MAX_SKIP}`));
+        return null;
+      }
+    }
+
+    return {
+      filterUserId,
+      filterName,
+      filterCategory,
+      filterSubcategory,
+      filterModded,
+      filterRooms,
+      filterDlcs,
+      filterExcludeDlcs,
+      filterForkedFrom,
+      filterRatedBy,
+      sort,
+      skip,
+      dateFilter,
+    };
+  } catch (error) {
+    console.log(error);
+    res.status(400).json(apiError(400, 'Invalid query parameters'));
+    return null;
+  }
+}
+
+// Ratings live in their own collection; resolve to ids first (the
+// {userId, updatedAt} index covers this). Throws on a db error — callers
+// respond 500, matching the previous inline behaviour.
+export async function resolveRatedByIds(
+  parsed: ParsedBlueprintFilters
+): Promise<mongoose.Types.ObjectId[] | null> {
+  if (parsed.filterRatedBy == null) return null;
+  if (BlueprintRatingModel.model == null) return [];
+  return BlueprintRatingModel.model.find({ userId: parsed.filterRatedBy }).distinct('blueprintId');
+}
+
+// Builds the mongo filter shared by getblueprints and blueprintfacets.
+// `omitDimensions` drops the listed facet groups' own clauses so a $facet
+// branch can compute self-excluding ("drill-down") counts for those groups;
+// 'dlc' drops both the dlc= and excludeDlc= clauses at once, since the two
+// DLC facet groups (show-only, hide) share a single count map over one
+// dimension. The blueprintfacets outer $match omits all four at once.
+export function buildBlueprintFilter(
+  parsed: ParsedBlueprintFilters,
+  ratedByIds: mongoose.Types.ObjectId[] | null,
+  viewer: BlueprintFilterViewer,
+  omitDimensions?: FilterDimension | FilterDimension[]
+): { filter: any; usesOffsetPagination: boolean } {
+  const omitted = new Set(
+    omitDimensions == null ? [] : Array.isArray(omitDimensions) ? omitDimensions : [omitDimensions]
+  );
+  // count-based sorts ignore the olderthan cursor (offset pagination via skip instead);
+  // the param stays accepted so the existing client call shape keeps working
+  const usesOffsetPagination = parsed.sort !== 'recent';
+  const filter: any = usesOffsetPagination
+    ? { $and: [{ deletedAt: null }] }
+    : { $and: [{ createdAt: { $lt: parsed.dateFilter } }, { deletedAt: null }] };
+
+  // Draft visibility: the general feed is published-only for every viewer.
+  // Owners see their own drafts when listing their own blueprints (the
+  // profile page always passes filterUserId), and admins see drafts when
+  // browsing a specific user's list — in both cases the owner clause below
+  // already bounds the query, so the published filter is simply dropped.
+  // Never combine the two as $or: [published, owner] — no index serves
+  // both branches under a count sort, so Mongo falls back to fetching
+  // every live 85KB doc into a blocking SORT (~16s on prod).
+  const viewerOwnsList = parsed.filterUserId != null && parsed.filterUserId === viewer.userId;
+  if (!viewerOwnsList && !(viewer.isAdmin && parsed.filterUserId != null)) {
+    filter.$and.push({ isPublished: PUBLISHED_FILTER });
+  }
+
+  if (parsed.filterUserId != null) filter.$and.push({ owner: parsed.filterUserId });
+  if (parsed.filterName != null) filter.$and.push({ name: { $regex: parsed.filterName, $options: 'i' } });
+  if (!omitted.has('category') && parsed.filterCategory != null) {
+    filter.$and.push({ category: parsed.filterCategory });
+  }
+  if (!omitted.has('subcategory') && parsed.filterSubcategory != null) {
+    filter.$and.push({ subcategory: parsed.filterSubcategory });
+  }
+  if (parsed.filterModded != null) filter.$and.push({ modded: parsed.filterModded });
+  if (!omitted.has('rooms') && parsed.filterRooms != null) {
+    filter.$and.push({ rooms: { $in: parsed.filterRooms } });
+  }
+  if (!omitted.has('dlc')) {
+    // Documents predating DLC derivation have no requiredDlcs at all; $in
+    // never matches a missing field, so they stay out of a dlc= result
+    // rather than reading as base-game.
+    if (parsed.filterDlcs != null) filter.$and.push({ requiredDlcs: { $in: parsed.filterDlcs } });
+    // $nin over an array field matches when NONE of its elements are in the
+    // list — true for [] (base game always survives exclusion) and true for
+    // a missing field (a never-derived doc can't be known to need the
+    // excluded pack, so it isn't hidden either). Note for the planner: $nin
+    // can't produce a bounded range the way $in does, so this clause is
+    // applied as a per-document filter during FETCH rather than narrowing an
+    // index scan — the sort-driven index still bounds the query, this just
+    // adds one field check per candidate.
+    if (parsed.filterExcludeDlcs != null) {
+      filter.$and.push({ requiredDlcs: { $nin: parsed.filterExcludeDlcs } });
+    }
+  }
+  if (parsed.filterForkedFrom != null) filter.$and.push({ 'forkedFrom.blueprintId': parsed.filterForkedFrom });
+  if (ratedByIds != null) filter.$and.push({ _id: { $in: ratedByIds } });
+
+  return { filter, usesOffsetPagination };
+}

--- a/app/api/services/blueprint-filter-service.ts
+++ b/app/api/services/blueprint-filter-service.ts
@@ -251,6 +251,29 @@ export function buildBlueprintFilter(
     ? { $and: [{ deletedAt: null }] }
     : { $and: [{ createdAt: { $lt: parsed.dateFilter } }, { deletedAt: null }] };
 
+  filter.$and.push(...buildCommonClauses(parsed, ratedByIds, viewer));
+
+  const dims = buildDimensionClauses(parsed);
+  if (!omitted.has('category') && dims.category != null) filter.$and.push(dims.category);
+  if (!omitted.has('subcategory') && dims.subcategory != null) filter.$and.push(dims.subcategory);
+  if (!omitted.has('rooms') && dims.rooms != null) filter.$and.push(dims.rooms);
+  if (!omitted.has('dlc')) filter.$and.push(...dims.dlc);
+
+  return { filter, usesOffsetPagination };
+}
+
+// The clauses common to getblueprints and every blueprintfacets $facet
+// branch: draft visibility, owner, name, modded, forkedFrom and ratedBy.
+// Factored out once so the subtle visibility rules (viewerOwnsList, the
+// admin branch, PUBLISHED_FILTER, never $or-ing the two) can't drift between
+// the list endpoint and the facet-count aggregation.
+function buildCommonClauses(
+  parsed: ParsedBlueprintFilters,
+  ratedByIds: mongoose.Types.ObjectId[] | null,
+  viewer: BlueprintFilterViewer
+): Record<string, unknown>[] {
+  const clauses: Record<string, unknown>[] = [];
+
   // Draft visibility: the general feed is published-only for every viewer.
   // Owners see their own drafts when listing their own blueprints (the
   // profile page always passes filterUserId), and admins see drafts when
@@ -261,40 +284,75 @@ export function buildBlueprintFilter(
   // every live 85KB doc into a blocking SORT (~16s on prod).
   const viewerOwnsList = parsed.filterUserId != null && parsed.filterUserId === viewer.userId;
   if (!viewerOwnsList && !(viewer.isAdmin && parsed.filterUserId != null)) {
-    filter.$and.push({ isPublished: PUBLISHED_FILTER });
+    clauses.push({ isPublished: PUBLISHED_FILTER });
   }
 
-  if (parsed.filterUserId != null) filter.$and.push({ owner: parsed.filterUserId });
-  if (parsed.filterName != null) filter.$and.push({ name: { $regex: parsed.filterName, $options: 'i' } });
-  if (!omitted.has('category') && parsed.filterCategory != null) {
-    filter.$and.push({ category: parsed.filterCategory });
-  }
-  if (!omitted.has('subcategory') && parsed.filterSubcategory != null) {
-    filter.$and.push({ subcategory: parsed.filterSubcategory });
-  }
-  if (parsed.filterModded != null) filter.$and.push({ modded: parsed.filterModded });
-  if (!omitted.has('rooms') && parsed.filterRooms != null) {
-    filter.$and.push({ rooms: { $in: parsed.filterRooms } });
-  }
-  if (!omitted.has('dlc')) {
-    // Documents predating DLC derivation have no requiredDlcs at all; $in
-    // never matches a missing field, so they stay out of a dlc= result
-    // rather than reading as base-game.
-    if (parsed.filterDlcs != null) filter.$and.push({ requiredDlcs: { $in: parsed.filterDlcs } });
-    // $nin over an array field matches when NONE of its elements are in the
-    // list — true for [] (base game always survives exclusion) and true for
-    // a missing field (a never-derived doc can't be known to need the
-    // excluded pack, so it isn't hidden either). Note for the planner: $nin
-    // can't produce a bounded range the way $in does, so this clause is
-    // applied as a per-document filter during FETCH rather than narrowing an
-    // index scan — the sort-driven index still bounds the query, this just
-    // adds one field check per candidate.
-    if (parsed.filterExcludeDlcs != null) {
-      filter.$and.push({ requiredDlcs: { $nin: parsed.filterExcludeDlcs } });
-    }
-  }
-  if (parsed.filterForkedFrom != null) filter.$and.push({ 'forkedFrom.blueprintId': parsed.filterForkedFrom });
-  if (ratedByIds != null) filter.$and.push({ _id: { $in: ratedByIds } });
+  if (parsed.filterUserId != null) clauses.push({ owner: parsed.filterUserId });
+  if (parsed.filterName != null) clauses.push({ name: { $regex: parsed.filterName, $options: 'i' } });
+  if (parsed.filterModded != null) clauses.push({ modded: parsed.filterModded });
+  if (parsed.filterForkedFrom != null) clauses.push({ 'forkedFrom.blueprintId': parsed.filterForkedFrom });
+  if (ratedByIds != null) clauses.push({ _id: { $in: ratedByIds } });
 
-  return { filter, usesOffsetPagination };
+  return clauses;
+}
+
+interface DimensionClauses {
+  category: Record<string, unknown> | null;
+  subcategory: Record<string, unknown> | null;
+  rooms: Record<string, unknown> | null;
+  dlc: Record<string, unknown>[];
+}
+
+function buildDimensionClauses(parsed: ParsedBlueprintFilters): DimensionClauses {
+  const dlc: Record<string, unknown>[] = [];
+  // Documents predating DLC derivation have no requiredDlcs at all; $in
+  // never matches a missing field, so they stay out of a dlc= result
+  // rather than reading as base-game.
+  if (parsed.filterDlcs != null) dlc.push({ requiredDlcs: { $in: parsed.filterDlcs } });
+  // $nin over an array field matches when NONE of its elements are in the
+  // list — true for [] (base game always survives exclusion) and true for
+  // a missing field (a never-derived doc can't be known to need the
+  // excluded pack, so it isn't hidden either). Note for the planner: $nin
+  // can't produce a bounded range the way $in does, so this clause is
+  // applied as a per-document filter during FETCH rather than narrowing an
+  // index scan — the sort-driven index still bounds the query, this just
+  // adds one field check per candidate.
+  if (parsed.filterExcludeDlcs != null) dlc.push({ requiredDlcs: { $nin: parsed.filterExcludeDlcs } });
+
+  return {
+    category: parsed.filterCategory != null ? { category: parsed.filterCategory } : null,
+    subcategory: parsed.filterSubcategory != null ? { subcategory: parsed.filterSubcategory } : null,
+    rooms: parsed.filterRooms != null ? { rooms: { $in: parsed.filterRooms } } : null,
+    dlc,
+  };
+}
+
+// The blueprintfacets outer $match: every clause common to all five facet
+// branches, with NO dimension clauses at all (a $facet branch can only
+// narrow what the outer stage produced, so the outer stage must contain
+// only what every branch agrees on). Pagination (sort/skip/olderthan) is
+// deliberately never applied — counts describe the whole matching corpus,
+// not one page of it.
+export function buildFacetBaseFilter(
+  parsed: ParsedBlueprintFilters,
+  ratedByIds: mongoose.Types.ObjectId[] | null,
+  viewer: BlueprintFilterViewer
+): any {
+  return { $and: [{ deletedAt: null }, ...buildCommonClauses(parsed, ratedByIds, viewer)] };
+}
+
+// One facet group's own $match, applied inside its $facet branch on top of
+// buildFacetBaseFilter: every dimension's active clause EXCEPT `dimension`'s
+// own. This is the "drill-down" / self-excluding semantics — picking a
+// Spaced Out! filter must not zero out every other DLC's count. 'dlc' omits
+// both the dlc= and excludeDlc= clauses at once (the two DLC facet groups
+// share one count map over a single dimension).
+export function buildFacetDimensionMatch(parsed: ParsedBlueprintFilters, dimension: FilterDimension): any {
+  const dims = buildDimensionClauses(parsed);
+  const clauses: Record<string, unknown>[] = [];
+  if (dimension !== 'category' && dims.category != null) clauses.push(dims.category);
+  if (dimension !== 'subcategory' && dims.subcategory != null) clauses.push(dims.subcategory);
+  if (dimension !== 'rooms' && dims.rooms != null) clauses.push(dims.rooms);
+  if (dimension !== 'dlc') clauses.push(...dims.dlc);
+  return clauses.length > 0 ? { $and: clauses } : {};
 }

--- a/app/api/services/blueprint-filter-service.ts
+++ b/app/api/services/blueprint-filter-service.ts
@@ -229,21 +229,16 @@ export async function resolveRatedByIds(
   return BlueprintRatingModel.model.find({ userId: parsed.filterRatedBy }).distinct('blueprintId');
 }
 
-// Builds the mongo filter shared by getblueprints and blueprintfacets.
-// `omitDimensions` drops the listed facet groups' own clauses so a $facet
-// branch can compute self-excluding ("drill-down") counts for those groups;
-// 'dlc' drops both the dlc= and excludeDlc= clauses at once, since the two
-// DLC facet groups (show-only, hide) share a single count map over one
-// dimension. The blueprintfacets outer $match omits all four at once.
+// Builds the mongo filter for getblueprints. blueprintfacets does not call
+// this — its per-branch, dimension-omitting filters are built separately by
+// buildFacetBaseFilter/buildFacetDimensionMatch below, which share
+// buildCommonClauses/buildDimensionClauses with this function so the
+// draft-visibility rules can't drift between the two endpoints.
 export function buildBlueprintFilter(
   parsed: ParsedBlueprintFilters,
   ratedByIds: mongoose.Types.ObjectId[] | null,
-  viewer: BlueprintFilterViewer,
-  omitDimensions?: FilterDimension | FilterDimension[]
+  viewer: BlueprintFilterViewer
 ): { filter: any; usesOffsetPagination: boolean } {
-  const omitted = new Set(
-    omitDimensions == null ? [] : Array.isArray(omitDimensions) ? omitDimensions : [omitDimensions]
-  );
   // count-based sorts ignore the olderthan cursor (offset pagination via skip instead);
   // the param stays accepted so the existing client call shape keeps working
   const usesOffsetPagination = parsed.sort !== 'recent';
@@ -254,10 +249,10 @@ export function buildBlueprintFilter(
   filter.$and.push(...buildCommonClauses(parsed, ratedByIds, viewer));
 
   const dims = buildDimensionClauses(parsed);
-  if (!omitted.has('category') && dims.category != null) filter.$and.push(dims.category);
-  if (!omitted.has('subcategory') && dims.subcategory != null) filter.$and.push(dims.subcategory);
-  if (!omitted.has('rooms') && dims.rooms != null) filter.$and.push(dims.rooms);
-  if (!omitted.has('dlc')) filter.$and.push(...dims.dlc);
+  if (dims.category != null) filter.$and.push(dims.category);
+  if (dims.subcategory != null) filter.$and.push(dims.subcategory);
+  if (dims.rooms != null) filter.$and.push(dims.rooms);
+  filter.$and.push(...dims.dlc);
 
   return { filter, usesOffsetPagination };
 }
@@ -293,7 +288,13 @@ function buildCommonClauses(
   // via .aggregate(), which does not — a bare string here would silently
   // match nothing against the ObjectId-typed owner/forkedFrom fields.
   if (parsed.filterUserId != null) clauses.push({ owner: toObjectIdIfValid(parsed.filterUserId) });
-  if (parsed.filterName != null) clauses.push({ name: { $regex: parsed.filterName, $options: 'i' } });
+  // Escaped so filterName is a literal substring search: unescaped, a name
+  // containing regex metacharacters ('(', '*', '[', ...) either 400s on an
+  // invalid pattern or changes what it matches instead of searching for the
+  // literal text the user typed.
+  if (parsed.filterName != null) {
+    clauses.push({ name: { $regex: escapeRegExp(parsed.filterName), $options: 'i' } });
+  }
   if (parsed.filterModded != null) clauses.push({ modded: parsed.filterModded });
   if (parsed.filterForkedFrom != null) {
     clauses.push({ 'forkedFrom.blueprintId': toObjectIdIfValid(parsed.filterForkedFrom) });
@@ -305,6 +306,10 @@ function buildCommonClauses(
 
 function toObjectIdIfValid(id: string): string | mongoose.Types.ObjectId {
   return mongoose.Types.ObjectId.isValid(id) ? new mongoose.Types.ObjectId(id) : id;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 interface DimensionClauses {

--- a/app/api/services/blueprint-filter-service.ts
+++ b/app/api/services/blueprint-filter-service.ts
@@ -287,13 +287,24 @@ function buildCommonClauses(
     clauses.push({ isPublished: PUBLISHED_FILTER });
   }
 
-  if (parsed.filterUserId != null) clauses.push({ owner: parsed.filterUserId });
+  // Cast to ObjectId explicitly: buildBlueprintFilter's result goes through
+  // Mongoose's .find() (which casts query values against the schema
+  // automatically), but the facets aggregation pipeline hits the raw driver
+  // via .aggregate(), which does not — a bare string here would silently
+  // match nothing against the ObjectId-typed owner/forkedFrom fields.
+  if (parsed.filterUserId != null) clauses.push({ owner: toObjectIdIfValid(parsed.filterUserId) });
   if (parsed.filterName != null) clauses.push({ name: { $regex: parsed.filterName, $options: 'i' } });
   if (parsed.filterModded != null) clauses.push({ modded: parsed.filterModded });
-  if (parsed.filterForkedFrom != null) clauses.push({ 'forkedFrom.blueprintId': parsed.filterForkedFrom });
+  if (parsed.filterForkedFrom != null) {
+    clauses.push({ 'forkedFrom.blueprintId': toObjectIdIfValid(parsed.filterForkedFrom) });
+  }
   if (ratedByIds != null) clauses.push({ _id: { $in: ratedByIds } });
 
   return clauses;
+}
+
+function toObjectIdIfValid(id: string): string | mongoose.Types.ObjectId {
+  return mongoose.Types.ObjectId.isValid(id) ? new mongoose.Types.ObjectId(id) : id;
 }
 
 interface DimensionClauses {
@@ -346,8 +357,14 @@ export function buildFacetBaseFilter(
 // own. This is the "drill-down" / self-excluding semantics — picking a
 // Spaced Out! filter must not zero out every other DLC's count. 'dlc' omits
 // both the dlc= and excludeDlc= clauses at once (the two DLC facet groups
-// share one count map over a single dimension).
-export function buildFacetDimensionMatch(parsed: ParsedBlueprintFilters, dimension: FilterDimension): any {
+// share one count map over a single dimension). Pass `null` for the `total`
+// branch, which (unlike every facet group) must apply ALL active dimension
+// filters — it reports "docs matching every active filter", not a
+// self-excluding count.
+export function buildFacetDimensionMatch(
+  parsed: ParsedBlueprintFilters,
+  dimension: FilterDimension | null
+): any {
   const dims = buildDimensionClauses(parsed);
   const clauses: Record<string, unknown>[] = [];
   if (dimension !== 'category' && dims.category != null) clauses.push(dims.category);

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -78,6 +78,7 @@ export class Routes {
     app.route('/api/getblueprint/:id').get(this.uploadBlueprintController.getBlueprint);
     app.route('/api/getblueprintmod/:id').get(this.uploadBlueprintController.getBlueprintMod);
     app.route('/api/getblueprints').get(this.uploadBlueprintController.getBlueprints);
+    app.route('/api/blueprintfacets').get(this.uploadBlueprintController.getBlueprintFacets);
     app.route('/api/version').get(this.versionController.getVersion);
     app.route('/api/health').get(this.healthController.getHealth);
     app.route('/api/mods').get(this.modController.getMods);
@@ -102,6 +103,7 @@ export class Routes {
 
     // Logged in access
     app.route('/api/getblueprintsSecure').get(auth, this.uploadBlueprintController.getBlueprints);
+    app.route('/api/blueprintfacetsSecure').get(auth, this.uploadBlueprintController.getBlueprintFacets);
     app.route('/api/uploadblueprint').post(auth, this.uploadBlueprintController.uploadBlueprint);
     app.route('/api/rateblueprint').post(auth, this.uploadBlueprintController.rateBlueprint);
     app.route('/api/deleteblueprint').post(auth, this.uploadBlueprintController.deleteBlueprint);

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
@@ -191,6 +191,16 @@
               >{{ facetCount("dlc", opt.value) }}</span
             >
           </button>
+          <div
+            *ngIf="baseGameCount !== null"
+            class="bni-facet bni-facet--info"
+            [attr.aria-label]="baseGameAriaLabel"
+          >
+            <ng-container i18n>Base game</ng-container>
+            <span class="bni-facet-count" aria-hidden="true">{{
+              baseGameCount
+            }}</span>
+          </div>
         </div>
 
         <div class="bni-facet-group">

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.html
@@ -96,9 +96,22 @@
             type="button"
             class="bni-facet"
             [class.active]="filterCategory === opt.value"
+            [class.bni-facet--empty]="
+              isFacetEmpty('category', opt.value, filterCategory === opt.value)
+            "
+            [disabled]="
+              isFacetEmpty('category', opt.value, filterCategory === opt.value)
+            "
+            [attr.aria-label]="facetAriaLabel(opt.label, 'category', opt.value)"
             (click)="selectCategory(opt.value)"
           >
             {{ opt.label }}
+            <span
+              class="bni-facet-count"
+              *ngIf="facetCount('category', opt.value) !== null"
+              aria-hidden="true"
+              >{{ facetCount("category", opt.value) }}</span
+            >
           </button>
         </div>
 
@@ -109,9 +122,32 @@
             type="button"
             class="bni-facet"
             [class.active]="filterSubcategory === opt.value"
+            [class.bni-facet--empty]="
+              isFacetEmpty(
+                'subcategory',
+                opt.value,
+                filterSubcategory === opt.value
+              )
+            "
+            [disabled]="
+              isFacetEmpty(
+                'subcategory',
+                opt.value,
+                filterSubcategory === opt.value
+              )
+            "
+            [attr.aria-label]="
+              facetAriaLabel(opt.label, 'subcategory', opt.value)
+            "
             (click)="selectSubcategory(opt.value)"
           >
             {{ opt.label }}
+            <span
+              class="bni-facet-count"
+              *ngIf="facetCount('subcategory', opt.value) !== null"
+              aria-hidden="true"
+              >{{ facetCount("subcategory", opt.value) }}</span
+            >
           </button>
         </div>
 
@@ -121,20 +157,39 @@
             type="button"
             class="bni-facet"
             [class.active]="filterDlcs.length === 0"
+            [attr.aria-label]="dlcAllAriaLabel('All')"
             (click)="clearDlcFilter()"
-            i18n
           >
-            All
+            <ng-container i18n>All</ng-container>
+            <span
+              class="bni-facet-count"
+              *ngIf="dlcAllCount !== null"
+              aria-hidden="true"
+              >{{ dlcAllCount }}</span
+            >
           </button>
           <button
             *ngFor="let opt of dlcOptions"
             type="button"
             class="bni-facet"
             [class.active]="isDlcSelected(opt.value)"
+            [class.bni-facet--empty]="
+              isFacetEmpty('dlc', opt.value, isDlcSelected(opt.value))
+            "
+            [disabled]="
+              isFacetEmpty('dlc', opt.value, isDlcSelected(opt.value))
+            "
             [attr.aria-pressed]="isDlcSelected(opt.value)"
+            [attr.aria-label]="facetAriaLabel(opt.label, 'dlc', opt.value)"
             (click)="toggleDlc(opt.value)"
           >
             {{ opt.label }}
+            <span
+              class="bni-facet-count"
+              *ngIf="facetCount('dlc', opt.value) !== null"
+              aria-hidden="true"
+              >{{ facetCount("dlc", opt.value) }}</span
+            >
           </button>
         </div>
 
@@ -154,10 +209,23 @@
             type="button"
             class="bni-facet bni-facet--exclude"
             [class.active]="isDlcExcluded(opt.value)"
+            [class.bni-facet--empty]="
+              isFacetEmpty('dlc', opt.value, isDlcExcluded(opt.value))
+            "
+            [disabled]="
+              isFacetEmpty('dlc', opt.value, isDlcExcluded(opt.value))
+            "
             [attr.aria-pressed]="isDlcExcluded(opt.value)"
+            [attr.aria-label]="facetAriaLabel(opt.label, 'dlc', opt.value)"
             (click)="toggleExcludeDlc(opt.value)"
           >
             {{ opt.label }}
+            <span
+              class="bni-facet-count"
+              *ngIf="facetCount('dlc', opt.value) !== null"
+              aria-hidden="true"
+              >{{ facetCount("dlc", opt.value) }}</span
+            >
           </button>
         </div>
 
@@ -168,9 +236,22 @@
             type="button"
             class="bni-facet"
             [class.active]="filterRooms === opt.value"
+            [class.bni-facet--empty]="
+              isFacetEmpty('rooms', opt.value, filterRooms === opt.value)
+            "
+            [disabled]="
+              isFacetEmpty('rooms', opt.value, filterRooms === opt.value)
+            "
+            [attr.aria-label]="facetAriaLabel(opt.label, 'rooms', opt.value)"
             (click)="selectRoom(opt.value)"
           >
             {{ opt.label }}
+            <span
+              class="bni-facet-count"
+              *ngIf="facetCount('rooms', opt.value) !== null"
+              aria-hidden="true"
+              >{{ facetCount("rooms", opt.value) }}</span
+            >
           </button>
         </div>
 

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
@@ -988,6 +988,32 @@ describe("BrowsePageComponent", () => {
       expect(component.dlcAllCount).toBe(7);
     });
 
+    it("baseGameCount surfaces the read-only base-game summary row", () => {
+      expect(component.baseGameCount).toBeNull();
+
+      blueprintService.getBlueprintFacets.mockReturnValue(
+        of(makeFacets({ baseGame: 5 })),
+      );
+      fixture.detectChanges();
+
+      expect(component.baseGameCount).toBe(5);
+      expect(component.baseGameAriaLabel).toBe("Base game, 5 blueprints");
+
+      const row = fixture.debugElement.query(By.css(".bni-facet--info"));
+      expect(row).toBeTruthy();
+      expect(row.nativeElement.textContent).toContain("5");
+    });
+
+    it("hides the base-game row until counts have loaded", () => {
+      const pending = new Subject<any>();
+      blueprintService.getBlueprintFacets.mockReturnValue(pending);
+      fixture.detectChanges(); // ngOnInit — facets request now in flight
+
+      expect(component.baseGameCount).toBeNull();
+      const row = fixture.debugElement.query(By.css(".bni-facet--info"));
+      expect(row).toBeFalsy();
+    });
+
     it("wraps the count into the accessible label instead of leaving it bare", () => {
       blueprintService.getBlueprintFacets.mockReturnValue(
         of(makeFacets({ category: { power: 1 } })),

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.spec.ts
@@ -20,6 +20,18 @@ function makeResponse(blueprints: any[] = [], remaining = 0) {
   };
 }
 
+function makeFacets(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    total: 0,
+    category: {},
+    subcategory: {},
+    rooms: {},
+    requiredDlcs: {},
+    baseGame: 0,
+    ...overrides,
+  };
+}
+
 const EMPTY_PARAMS = convertToParamMap({});
 
 describe("BrowsePageComponent", () => {
@@ -33,6 +45,7 @@ describe("BrowsePageComponent", () => {
   beforeEach(async () => {
     blueprintService = {
       getBlueprints: vi.fn().mockReturnValue(of(makeResponse())),
+      getBlueprintFacets: vi.fn().mockReturnValue(of(makeFacets())),
     };
 
     authService = {
@@ -906,6 +919,111 @@ describe("BrowsePageComponent", () => {
 
       expect(component.activeFilterCount).toBe(3);
       expect(component.hasActiveFilters).toBe(true);
+    });
+  });
+
+  describe("facetCounts (sidebar facet counts)", () => {
+    it("is null before the facets request lands — every button renders unfiltered/enabled", () => {
+      expect(component.facetCounts).toBeNull();
+      expect(component.facetCount("category", "power")).toBeNull();
+      expect(component.isFacetEmpty("category", "power", false)).toBe(false);
+    });
+
+    it("fetches facet counts alongside the initial list load", () => {
+      fixture.detectChanges(); // ngOnInit
+      expect(blueprintService.getBlueprintFacets).toHaveBeenCalled();
+    });
+
+    it("populates facetCounts from the response, missing keys read as 0", () => {
+      blueprintService.getBlueprintFacets.mockReturnValue(
+        of(makeFacets({ total: 4, category: { power: 3 } })),
+      );
+      fixture.detectChanges(); // ngOnInit
+
+      expect(component.facetCounts?.total).toBe(4);
+      expect(component.facetCount("category", "power")).toBe(3);
+      expect(component.facetCount("category", "food")).toBe(0);
+    });
+
+    it("returns null for the un-scoped 'All'/'None' rows (value == null)", () => {
+      blueprintService.getBlueprintFacets.mockReturnValue(
+        of(makeFacets({ category: { power: 3 } })),
+      );
+      fixture.detectChanges();
+      expect(component.facetCount("category", null)).toBeNull();
+    });
+
+    it("zero-count facets are dimmed and disabled unless already selected", () => {
+      blueprintService.getBlueprintFacets.mockReturnValue(
+        of(makeFacets({ category: { power: 3 } })),
+      );
+      fixture.detectChanges();
+
+      // food has no docs -> disabled
+      expect(component.isFacetEmpty("category", "food", false)).toBe(true);
+      // ...unless it's the currently-selected filter, which must stay
+      // clickable so a dead-end combination can be cleared
+      expect(component.isFacetEmpty("category", "food", true)).toBe(false);
+      // power has docs -> never disabled
+      expect(component.isFacetEmpty("category", "power", false)).toBe(false);
+    });
+
+    it("a facets request failure degrades silently — facetCounts stays null, nothing disables", () => {
+      blueprintService.getBlueprintFacets.mockReturnValue(
+        throwError(() => new Error("network")),
+      );
+      fixture.detectChanges(); // ngOnInit
+
+      expect(component.facetCounts).toBeNull();
+      expect(component.isFacetEmpty("category", "power", false)).toBe(false);
+      // the list itself must still have loaded despite the facets failure
+      expect(blueprintService.getBlueprints).toHaveBeenCalled();
+    });
+
+    it("dlcAllCount mirrors total; the DLC 'hide' group's 'None' row has no equivalent", () => {
+      blueprintService.getBlueprintFacets.mockReturnValue(
+        of(makeFacets({ total: 7 })),
+      );
+      fixture.detectChanges();
+      expect(component.dlcAllCount).toBe(7);
+    });
+
+    it("wraps the count into the accessible label instead of leaving it bare", () => {
+      blueprintService.getBlueprintFacets.mockReturnValue(
+        of(makeFacets({ category: { power: 1 } })),
+      );
+      fixture.detectChanges();
+
+      expect(component.facetAriaLabel("Power", "category", "power")).toBe(
+        "Power, 1 blueprint",
+      );
+      expect(component.facetAriaLabel("Food", "category", "food")).toBe(
+        "Food, 0 blueprints",
+      );
+      // not yet loaded for a value with no counts at all -> bare label
+      expect(component.facetAriaLabel("Rooms", "rooms", null)).toBe("Rooms");
+    });
+
+    it("refetches on a filter change (transitionList) but not on loadMore (pagination)", () => {
+      fixture.detectChanges(); // ngOnInit
+      blueprintService.getBlueprintFacets.mockClear();
+
+      // selectRoom funnels straight into transitionList() (unlike
+      // selectCategory, which debounces via filterFacetSubject).
+      component.selectRoom("kitchen");
+      expect(blueprintService.getBlueprintFacets).toHaveBeenCalledTimes(1);
+
+      blueprintService.getBlueprintFacets.mockClear();
+      component.loadMore();
+      expect(blueprintService.getBlueprintFacets).not.toHaveBeenCalled();
+    });
+
+    it("is not fetched in feed view mode (no sidebar to populate)", () => {
+      fixture.detectChanges(); // ngOnInit (discover)
+      blueprintService.getBlueprintFacets.mockClear();
+
+      component.setViewMode("feed");
+      expect(blueprintService.getBlueprintFacets).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
@@ -8,6 +8,7 @@ import {
 import {
   BlueprintListItem,
   BlueprintListResponse,
+  BlueprintFacetsResponse,
   CATEGORIES,
   SUBCATEGORIES,
   ROOM_TYPE_IDS,
@@ -96,6 +97,10 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
   sort: BlueprintSort = DEFAULT_SORT;
   skipCount = 0;
   private requestId = 0;
+  /** Advisory sidebar counts; null when not yet loaded or the request
+   * failed — the sidebar renders unfiltered/enabled either way. */
+  facetCounts: BlueprintFacetsResponse | null = null;
+  private facetRequestId = 0;
 
   viewMode: "discover" | "feed" = "discover";
   followingCount = 0;
@@ -234,6 +239,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
         this.initialized = true;
         this.appendLoading();
         this.getBlueprints();
+        this.fetchFacetCounts();
       } else if (changed) {
         this.transitionList();
       }
@@ -290,6 +296,7 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
    */
   private transitionList() {
     this.resetPaging();
+    this.fetchFacetCounts();
     if (this.prefersReducedMotion()) {
       this.blueprintListItems = [];
       this.appendLoading();
@@ -716,6 +723,96 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
         if (requestId === this.requestId) this.receiveListError();
       },
     });
+  }
+
+  /** Sidebar counts, fired in parallel with getBlueprints() (never chained —
+   * the list must not wait on counts). Advisory: a failure or a still-in-
+   * flight request just leaves facetCounts as-is, so the sidebar renders
+   * unfiltered/enabled rather than erroring. Not fetched for the feed tab,
+   * which has no sidebar. */
+  private fetchFacetCounts() {
+    if (this.viewMode === "feed") return;
+    const requestId = ++this.facetRequestId;
+    this.blueprintService
+      .getBlueprintFacets({
+        filterName: this.filterName.trim() || null,
+        filterCategory: this.filterCategory,
+        filterSubcategory: this.filterSubcategory,
+        filterModded: this.filterModded,
+        filterForkedFrom: this.filterForkedFrom,
+        filterRooms: this.filterRooms,
+        filterDlcs:
+          this.filterDlcs.length > 0 ? this.filterDlcs.join(",") : null,
+        filterExcludeDlcs:
+          this.excludeDlcs.length > 0 ? this.excludeDlcs.join(",") : null,
+      })
+      .subscribe({
+        next: (counts) => {
+          if (requestId === this.facetRequestId) this.facetCounts = counts;
+        },
+        error: () => {},
+      });
+  }
+
+  /** null = counts not loaded yet (or the request failed) — every facet
+   * button then renders unfiltered/enabled. `value == null` covers the
+   * un-scoped "All"/"None" reset rows, which never show a per-item count. */
+  facetCount(
+    group: "category" | "subcategory" | "rooms" | "dlc",
+    value: string | null,
+  ): number | null {
+    if (value == null || this.facetCounts == null) return null;
+    const map =
+      group === "category"
+        ? this.facetCounts.category
+        : group === "subcategory"
+          ? this.facetCounts.subcategory
+          : group === "rooms"
+            ? this.facetCounts.rooms
+            : this.facetCounts.requiredDlcs;
+    return map[value] ?? 0;
+  }
+
+  /** Zero renders dimmed + disabled — except when already selected, so a
+   * dead-end filter combination can always be cleared. */
+  isFacetEmpty(
+    group: "category" | "subcategory" | "rooms" | "dlc",
+    value: string | null,
+    selected: boolean,
+  ): boolean {
+    if (selected) return false;
+    return this.facetCount(group, value) === 0;
+  }
+
+  /** Wraps the count into the button's accessible name ("Spaced Out!, 492
+   * blueprints") instead of leaving the bare number in it — the visible
+   * `.bni-facet-count` span stays aria-hidden. */
+  facetAriaLabel(
+    label: string,
+    group: "category" | "subcategory" | "rooms" | "dlc",
+    value: string | null,
+  ): string {
+    return this.countAriaLabel(label, this.facetCount(group, value));
+  }
+
+  /** The DLC "show only" group's "All" reset row shows `total` — the only
+   * un-scoped row with a count, since clearing the DLC filter genuinely
+   * means "everything matching the rest of the sidebar". The "hide" group's
+   * "None" row deliberately shows nothing (see dlcAllCount vs no equivalent
+   * for exclusion). */
+  get dlcAllCount(): number | null {
+    return this.facetCounts?.total ?? null;
+  }
+
+  dlcAllAriaLabel(label: string): string {
+    return this.countAriaLabel(label, this.dlcAllCount);
+  }
+
+  private countAriaLabel(label: string, count: number | null): string {
+    if (count == null) return label;
+    return count === 1
+      ? $localize`:browse.facetAriaLabelOne:${label}, 1 blueprint`
+      : $localize`:browse.facetAriaLabel:${label}, ${count} blueprints`;
   }
 
   /** Gate responses through the transition: hold them until the fade-out

--- a/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/browse-page/browse-page.component.ts
@@ -808,6 +808,20 @@ export class BrowsePageComponent implements OnInit, OnDestroy {
     return this.countAriaLabel(label, this.dlcAllCount);
   }
 
+  /** Read-only summary count under DLC — show only: how many blueprints need
+   * no pack at all. Not a clickable filter — there is no `dlc=` sentinel for
+   * "requires nothing" to toggle on. */
+  get baseGameCount(): number | null {
+    return this.facetCounts?.baseGame ?? null;
+  }
+
+  get baseGameAriaLabel(): string {
+    return this.countAriaLabel(
+      $localize`:browse.baseGame:Base game`,
+      this.baseGameCount,
+    );
+  }
+
   private countAriaLabel(label: string, count: number | null): string {
     if (count == null) return label;
     return count === 1

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -594,6 +594,43 @@ export class BlueprintService implements IObsBlueprintChange {
     );
   }
 
+  // Shared by getBlueprints and getBlueprintFacets: both endpoints accept the
+  // same filter params and validate them identically server-side, so the
+  // query-string mapping lives in one place rather than two.
+  private buildFilterQueryParams(filters: {
+    filterUserId?: string | null;
+    filterName?: string | null;
+    filterCategory?: string | null;
+    filterSubcategory?: string | null;
+    filterModded?: boolean | null;
+    filterForkedFrom?: string | null;
+    filterRatedBy?: string | null;
+    filterRooms?: string | null;
+    filterDlcs?: string | null;
+    filterExcludeDlcs?: string | null;
+  }): string {
+    const parts: string[] = [];
+    if (filters.filterUserId != null)
+      parts.push("filterUserId=" + filters.filterUserId);
+    if (filters.filterName != null)
+      parts.push("filterName=" + filters.filterName);
+    if (filters.filterCategory != null)
+      parts.push("category=" + filters.filterCategory);
+    if (filters.filterSubcategory != null)
+      parts.push("subcategory=" + filters.filterSubcategory);
+    if (filters.filterModded != null)
+      parts.push("modded=" + filters.filterModded);
+    if (filters.filterForkedFrom != null)
+      parts.push("forkedFrom=" + filters.filterForkedFrom);
+    if (filters.filterRatedBy != null)
+      parts.push("ratedBy=" + filters.filterRatedBy);
+    if (filters.filterRooms != null) parts.push("rooms=" + filters.filterRooms);
+    if (filters.filterDlcs != null) parts.push("dlc=" + filters.filterDlcs);
+    if (filters.filterExcludeDlcs != null)
+      parts.push("excludeDlc=" + filters.filterExcludeDlcs);
+    return parts.join("&");
+  }
+
   getBlueprints(
     olderThan: Date | null,
     filterUserId: string | null,
@@ -620,60 +657,29 @@ export class BlueprintService implements IObsBlueprintChange {
         ? "olderthan=" + olderThan.getTime().toString()
         : "";
 
-    let parameterFilterUserId = "";
-    if (filterUserId != null)
-      parameterFilterUserId = "&filterUserId=" + filterUserId;
-
-    let parameterFilterName = "";
-    if (filterName != null) parameterFilterName = "&filterName=" + filterName;
-
-    let parameterCategory = "";
-    if (filterCategory != null)
-      parameterCategory = "&category=" + filterCategory;
-
-    let parameterSubcategory = "";
-    if (filterSubcategory != null)
-      parameterSubcategory = "&subcategory=" + filterSubcategory;
-
     let parameterSort = "";
     if (sort != null && sort !== "recent") {
       parameterSort = "&sort=" + sort;
       if (skip != null) parameterSort += "&skip=" + skip;
     }
 
-    let parameterModded = "";
-    if (filterModded != null) parameterModded = "&modded=" + filterModded;
-
-    let parameterForkedFrom = "";
-    if (filterForkedFrom != null)
-      parameterForkedFrom = "&forkedFrom=" + filterForkedFrom;
-
-    let parameterRatedBy = "";
-    if (filterRatedBy != null) parameterRatedBy = "&ratedBy=" + filterRatedBy;
-
-    let parameterRooms = "";
-    if (filterRooms != null) parameterRooms = "&rooms=" + filterRooms;
-
-    let parameterDlcs = "";
-    if (filterDlcs != null) parameterDlcs = "&dlc=" + filterDlcs;
-
-    let parameterExcludeDlcs = "";
-    if (filterExcludeDlcs != null)
-      parameterExcludeDlcs = "&excludeDlc=" + filterExcludeDlcs;
+    const filterParams = this.buildFilterQueryParams({
+      filterUserId,
+      filterName,
+      filterCategory,
+      filterSubcategory,
+      filterModded,
+      filterForkedFrom,
+      filterRatedBy,
+      filterRooms,
+      filterDlcs,
+      filterExcludeDlcs,
+    });
 
     const parameters = (
       parameterOlderThan +
-      parameterFilterUserId +
-      parameterFilterName +
-      parameterCategory +
-      parameterSubcategory +
-      parameterSort +
-      parameterModded +
-      parameterForkedFrom +
-      parameterRatedBy +
-      parameterRooms +
-      parameterDlcs +
-      parameterExcludeDlcs
+      (filterParams.length > 0 ? "&" + filterParams : "") +
+      parameterSort
     ).replace(/^&/, "");
 
     // General browsing is a public, viewer-independent feed — always hit the
@@ -717,58 +723,7 @@ export class BlueprintService implements IObsBlueprintChange {
     filterDlcs?: string | null;
     filterExcludeDlcs?: string | null;
   }) {
-    let parameterFilterUserId = "";
-    if (options.filterUserId != null)
-      parameterFilterUserId = "&filterUserId=" + options.filterUserId;
-
-    let parameterFilterName = "";
-    if (options.filterName != null)
-      parameterFilterName = "&filterName=" + options.filterName;
-
-    let parameterCategory = "";
-    if (options.filterCategory != null)
-      parameterCategory = "&category=" + options.filterCategory;
-
-    let parameterSubcategory = "";
-    if (options.filterSubcategory != null)
-      parameterSubcategory = "&subcategory=" + options.filterSubcategory;
-
-    let parameterModded = "";
-    if (options.filterModded != null)
-      parameterModded = "&modded=" + options.filterModded;
-
-    let parameterForkedFrom = "";
-    if (options.filterForkedFrom != null)
-      parameterForkedFrom = "&forkedFrom=" + options.filterForkedFrom;
-
-    let parameterRatedBy = "";
-    if (options.filterRatedBy != null)
-      parameterRatedBy = "&ratedBy=" + options.filterRatedBy;
-
-    let parameterRooms = "";
-    if (options.filterRooms != null)
-      parameterRooms = "&rooms=" + options.filterRooms;
-
-    let parameterDlcs = "";
-    if (options.filterDlcs != null)
-      parameterDlcs = "&dlc=" + options.filterDlcs;
-
-    let parameterExcludeDlcs = "";
-    if (options.filterExcludeDlcs != null)
-      parameterExcludeDlcs = "&excludeDlc=" + options.filterExcludeDlcs;
-
-    const parameters = (
-      parameterFilterUserId +
-      parameterFilterName +
-      parameterCategory +
-      parameterSubcategory +
-      parameterModded +
-      parameterForkedFrom +
-      parameterRatedBy +
-      parameterRooms +
-      parameterDlcs +
-      parameterExcludeDlcs
-    ).replace(/^&/, "");
+    const parameters = this.buildFilterQueryParams(options);
 
     // Same viewer-dependence rule as getBlueprints: a specific user's list
     // (own/admin view includes drafts) or the private rated-by-me list needs

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -22,6 +22,7 @@ import {
   BlueprintDetailsResponse,
   RelatedBlueprintsResponse,
   BlueprintDelete,
+  BlueprintFacetsResponse,
 } from "../../../../../lib/index";
 import * as yaml from "js-yaml";
 import sanitize from "sanitize-filename";
@@ -696,6 +697,97 @@ export class BlueprintService implements IObsBlueprintChange {
     );
 
     return request;
+  }
+
+  // Self-excluding ("drill-down") facet counts for the Discover sidebar —
+  // GET /api/blueprintfacets(Secure), same params/validation as getBlueprints.
+  // Takes an options object rather than positional args: getBlueprints'
+  // thirteen-and-counting positional params are past the point a breaking
+  // shift (see the step-4 gameVersion removal) is tolerable, so this new
+  // method starts clean instead of adding a fourteenth position.
+  getBlueprintFacets(options: {
+    filterUserId?: string | null;
+    filterName?: string | null;
+    filterCategory?: string | null;
+    filterSubcategory?: string | null;
+    filterModded?: boolean | null;
+    filterForkedFrom?: string | null;
+    filterRatedBy?: string | null;
+    filterRooms?: string | null;
+    filterDlcs?: string | null;
+    filterExcludeDlcs?: string | null;
+  }) {
+    let parameterFilterUserId = "";
+    if (options.filterUserId != null)
+      parameterFilterUserId = "&filterUserId=" + options.filterUserId;
+
+    let parameterFilterName = "";
+    if (options.filterName != null)
+      parameterFilterName = "&filterName=" + options.filterName;
+
+    let parameterCategory = "";
+    if (options.filterCategory != null)
+      parameterCategory = "&category=" + options.filterCategory;
+
+    let parameterSubcategory = "";
+    if (options.filterSubcategory != null)
+      parameterSubcategory = "&subcategory=" + options.filterSubcategory;
+
+    let parameterModded = "";
+    if (options.filterModded != null)
+      parameterModded = "&modded=" + options.filterModded;
+
+    let parameterForkedFrom = "";
+    if (options.filterForkedFrom != null)
+      parameterForkedFrom = "&forkedFrom=" + options.filterForkedFrom;
+
+    let parameterRatedBy = "";
+    if (options.filterRatedBy != null)
+      parameterRatedBy = "&ratedBy=" + options.filterRatedBy;
+
+    let parameterRooms = "";
+    if (options.filterRooms != null)
+      parameterRooms = "&rooms=" + options.filterRooms;
+
+    let parameterDlcs = "";
+    if (options.filterDlcs != null)
+      parameterDlcs = "&dlc=" + options.filterDlcs;
+
+    let parameterExcludeDlcs = "";
+    if (options.filterExcludeDlcs != null)
+      parameterExcludeDlcs = "&excludeDlc=" + options.filterExcludeDlcs;
+
+    const parameters = (
+      parameterFilterUserId +
+      parameterFilterName +
+      parameterCategory +
+      parameterSubcategory +
+      parameterModded +
+      parameterForkedFrom +
+      parameterRatedBy +
+      parameterRooms +
+      parameterDlcs +
+      parameterExcludeDlcs
+    ).replace(/^&/, "");
+
+    // Same viewer-dependence rule as getBlueprints: a specific user's list
+    // (own/admin view includes drafts) or the private rated-by-me list needs
+    // the secure endpoint; general browsing stays anonymous/edge-cacheable.
+    const needsAuth =
+      options.filterUserId != null || options.filterRatedBy != null;
+    const url =
+      needsAuth && this.authService.isLoggedIn()
+        ? "/api/blueprintfacetsSecure?" + parameters
+        : "/api/blueprintfacets?" + parameters;
+
+    return this.http.get<BlueprintFacetsResponse>(
+      url,
+      needsAuth && this.authService.isLoggedIn()
+        ? {
+            headers: { Authorization: `Bearer ${this.authService.getToken()}` },
+          }
+        : {},
+    );
   }
 
   deleteBlueprint(id: string) {

--- a/frontend/src/bni-skin.css
+++ b/frontend/src/bni-skin.css
@@ -831,6 +831,18 @@
   color: var(--bni-body);
 }
 
+/* Read-only summary row (e.g. "Base game" under DLC — show only): same
+   space-between layout as a facet button, but there is nothing to click —
+   there is no `dlc=` sentinel for "requires no pack" to filter on. */
+.bni-facet--info {
+  cursor: default;
+  color: var(--bni-faint);
+}
+
+.bni-facet--info:hover {
+  color: var(--bni-faint);
+}
+
 /* ---- star rating (accent fill, display only) ---- */
 .bni-stars {
   display: inline-flex;

--- a/frontend/src/bni-skin.css
+++ b/frontend/src/bni-skin.css
@@ -814,6 +814,23 @@
   color: var(--bni-faint);
 }
 
+/* Zero-count facets stay visible (so a legitimately-empty pack/room is
+   discoverable, not silently hidden) but read as unavailable — dimmed and
+   non-interactive. Never applied to the active/selected row: a dead-end
+   filter combination must stay clickable so it can be cleared. */
+.bni-facet--empty {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.bni-facet--empty:hover {
+  color: var(--bni-body);
+}
+
+.bni-facet--exclude.bni-facet--empty:hover {
+  color: var(--bni-body);
+}
+
 /* ---- star rating (accent fill, display only) ---- */
 .bni-stars {
   display: inline-flex;

--- a/lib/src/coms/blueprint-list-response.d.ts
+++ b/lib/src/coms/blueprint-list-response.d.ts
@@ -29,6 +29,14 @@ export interface BlueprintListItem {
     nbDownloads: number;
     forkedFrom?: ForkedFromDto | null;
 }
+export interface BlueprintFacetsResponse {
+    total: number;
+    category: Record<string, number>;
+    subcategory: Record<string, number>;
+    rooms: Record<string, number>;
+    requiredDlcs: Record<string, number>;
+    baseGame: number;
+}
 export interface BlueprintDetailsResponse extends BlueprintListItem {
     researchTier?: string | null;
     myRating: number | null;

--- a/lib/src/coms/blueprint-list-response.ts
+++ b/lib/src/coms/blueprint-list-response.ts
@@ -47,6 +47,23 @@ export interface BlueprintListItem {
   forkedFrom?: ForkedFromDto | null;
 }
 
+// Self-excluding ("drill-down") facet counts for the Discover sidebar —
+// GET /api/blueprintfacets(Secure), same query params as getblueprints.
+// Each group's counts apply every OTHER active filter but not its own
+// (picking a DLC must not zero out the rest of the DLC list); requiredDlcs
+// and baseGame share one count map with the excludeDlc= "hide" group, since
+// show-only/hide are two controls over a single dimension. Array-valued
+// dimensions (rooms, requiredDlcs) don't sum to `total`: a blueprint needing
+// two packs counts once under each. Omitting a key from a map means 0.
+export interface BlueprintFacetsResponse {
+  total: number;
+  category: Record<string, number>;
+  subcategory: Record<string, number>;
+  rooms: Record<string, number>;
+  requiredDlcs: Record<string, number>;
+  baseGame: number;
+}
+
 // Meta-only view for the blueprint details page — everything the list item
 // carries, without the heavy `data` payload the editor loads separately.
 // Per-viewer fields (myRating/ownedByMe) live only here: list responses are


### PR DESCRIPTION
## Summary
Implements step 5 of `spec/dlc-resume.md` — self-excluding ("drill-down") facet counts for the Discover sidebar, e.g. "Spaced Out! (492)".

- **Refactor (no behaviour change):** extracted the ~150 lines of query parsing + `$and` filter assembly out of `BlueprintController.getBlueprints` into `app/api/services/blueprint-filter-service.ts` (`parseBlueprintFilters` + `buildBlueprintFilter`, with an `omitDimensions` option), so the facets aggregation can reuse the exact same draft-visibility/owner/name rules instead of reimplementing them.
- **Backend:** `GET /api/blueprintfacets` (+ `blueprintfacetsSecure`), one `$facet` aggregation returning `{ total, category, subcategory, rooms, requiredDlcs, baseGame }`. Each group's counts apply every other active filter but not its own; `dlc=`/`excludeDlc=` share one count map (two controls over one dimension). `sort`/`skip`/`olderthan` are accepted (so the client can reuse its existing query string) but never applied — counts describe the whole matching corpus, not one page.
  - Found and fixed two bugs while writing tests: the aggregate pipeline doesn't cast query values the way Mongoose's `.find()` does, so `owner`/`forkedFrom` string comparisons silently matched nothing; and the `total` branch needs its own full-dimension `$match` since (unlike every other group) it isn't self-excluding.
- **Frontend:** `BlueprintService.getBlueprintFacets()` (options object, not positional — the existing `getBlueprints` is past the point a 14th positional arg is tolerable; converting it was left out of scope per the spec's open call). `browse-page.component` fetches counts in parallel with the list (never chained) from the same `transitionList()` choke point every filter change already goes through; `loadMore()` (pagination) and the feed tab don't refetch. Counts are advisory — a facets failure leaves the sidebar fully enabled. Zero-count facets render dimmed + disabled unless already selected. Counts are wrapped into `aria-label` so screen readers get "Spaced Out!, 492 blueprints" instead of a bare number.

## Verification
- Backend: 728/728 passing (3 pre-existing WorkOS-provision/migration flakes unrelated to this change, documented as CI-green/locally-flaky).
- Frontend: 1028/1028 passing (2 pre-existing skips), new `facetCounts` describe block covers render/zero-disabled/selected-stays-clickable/failure-degrades-silently.
- New `__tests__/api/blueprint-facets.test.ts`: self-exclusion, shared DLC count map, cross-dimension narrowing, `baseGame` vs never-derived docs, multi-pack counted under each pack, draft visibility (secure vs anonymous vs stranger), same 400s as `getblueprints`, and the list-vs-facets `total` agreement test.
- `explain()` against a restored prod dump (~4565 published docs): outer `$match` served by the existing `deletedAt_1_isPublished_1_createdAt_-1` index (FETCH stage, no collscan); wall time 34–50ms across unfiltered and filtered combinations — well under the ~50ms budget, no `$project`-before-`$facet` tuning needed beyond what's already there.

## Deferred (per spec)
- Converting `getBlueprints` itself to an options object — flagged as optional scope, left alone.