### PR TITLE
fix: stop conveyor logistics from deciding a blueprint's category

### DIFF
--- a/frontend/src/lib/blueprint-analyzer.spec.ts
+++ b/frontend/src/lib/blueprint-analyzer.spec.ts
@@ -217,6 +217,50 @@ describe("deriveCategory", () => {
     expect(deriveCategory(prefabIds, lookup)).toBe("automation");
   });
 
+  describe("conveyor logistics is support, not purpose", () => {
+    // The auto-sweeper and conveyor rail feed whatever build they're attached
+    // to, so they must not decide the category. Before this, transit was the
+    // largest bucket on the site and contained paku farms, boilers, ranches
+    // and geyser tamers.
+    const LOGISTICS = ["SolidTransferArm", "SolidConduit", "SolidConduitInbox"];
+
+    it("a swept ranch is ranching", () => {
+      expect(deriveCategory([...LOGISTICS, "RanchStation"], lookup)).toBe(
+        "ranching",
+      );
+    });
+
+    it("a swept steam turbine build is cooling", () => {
+      expect(deriveCategory([...LOGISTICS, "SteamTurbine2"], lookup)).toBe(
+        "cooling",
+      );
+    });
+
+    it("a swept refinery is refining", () => {
+      expect(deriveCategory([...LOGISTICS, "MetalRefinery"], lookup)).toBe(
+        "refining",
+      );
+    });
+
+    it("still tags a blueprint that is nothing but logistics", () => {
+      // The conveyance fallback survives at the capped 2, so a pure rail
+      // network is transit — it just can't outrank an appliance any more.
+      expect(deriveCategory(LOGISTICS, lookup)).toBe("transit");
+    });
+
+    it("keeps duplicant transit as a strong signal", () => {
+      // Travel tubes are the build's purpose, not plumbing for someone else's,
+      // so a tube network outranks an appliance outright rather than winning a
+      // tie on CATEGORIES order.
+      expect(
+        deriveCategory(
+          ["TravelTube", "TravelTubeEntrance", "MetalRefinery"],
+          lookup,
+        ),
+      ).toBe("transit");
+    });
+  });
+
   it("ranching signature overrides the game's food-tab placement", () => {
     // EggIncubator/FishFeeder/etc. are filed under the game's "food" build
     // tab but are unambiguously ranching buildings in blueprint terms.

--- a/lib/src/blueprint/blueprint-analyzer.ts
+++ b/lib/src/blueprint/blueprint-analyzer.ts
@@ -203,11 +203,24 @@ export const SIGNATURE_PREFABS: Record<string, SignatureVote[]> = {
   Refrigerator: [{ category: 'food', weight: 1 }],
   FarmStation: [{ category: 'food', weight: 3 }],
 
-  // transit
+  // transit — duplicant transit only.
+  //
+  // SolidTransferArm (auto-sweeper) and SolidConduit (conveyor rail) used to
+  // sit here at weight 3 and 1, and between them they turned transit into the
+  // site's junk bucket: 624 blueprints containing paku farms, boilers, ranches,
+  // research labs and geyser tamers. Conveyor logistics is a *supporting*
+  // system — a sweeper feeds a ranch, a rail carries ore out of a refinery — so
+  // its presence says nothing about what a blueprint is for, and stacked
+  // (3 + 1 + the capped conveyance fallback) it out-scored the appliance that
+  // actually defined the build.
+  //
+  // Both are still conveyance in the game's own menu, so they keep voting via
+  // FALLBACK_GAME_CATEGORY: a blueprint that is genuinely nothing but rails and
+  // sweepers reaches the capped 2 and still tags transit, but it now loses to
+  // any real appliance. Travel tubes stay at 3 — moving duplicants IS the
+  // purpose of the build that contains them.
   TravelTube: [{ category: 'transit', weight: 3 }],
   TravelTubeEntrance: [{ category: 'transit', weight: 3 }],
-  SolidConduit: [{ category: 'transit', weight: 1 }],
-  SolidTransferArm: [{ category: 'transit', weight: 3 }],
 
   // refining
   MetalRefinery: [{ category: 'refining', weight: 3 }],


### PR DESCRIPTION
Transit is the worst remaining category: 624 blueprints, containing paku farms, boilers, ranches, research labs and geyser tamers. Almost none of them are about moving things.

## Cause

Two entries in `SIGNATURE_PREFABS`:

```ts
SolidConduit:     [{ category: 'transit', weight: 1 }],  // conveyor rail
SolidTransferArm: [{ category: 'transit', weight: 3 }],  // auto-sweeper
```

Both are *supporting* infrastructure. A sweeper feeds a ranch; a rail carries ore out of a refinery. Their presence says nothing about what a blueprint is for — but stacked (3 + 1) plus the capped conveyance fallback (2) they scored **6**, against the weight-3 signature of the appliance that actually defined the build. Any modern build with logistics attached filed as transit.

This is the same bug as the uncapped fallback votes fixed in #183, one layer up: weight was being paid for infrastructure instead of for function.

## Fix

Both drop out of the signature table. They're still `conveyance` in the game's own build menu, so they keep voting through `FALLBACK_GAME_CATEGORY` at the capped 2 — a blueprint that is genuinely nothing but rails and sweepers still tags transit, it just can't outrank an appliance. `TravelTube`/`TravelTubeEntrance` stay at 3: moving duplicants is the purpose of the build that contains them.

Worked examples, all now correct:

| blueprint | before | after |
|---|---|---|
| ranch + sweepers | transit (6 vs 3) | ranching |
| steam turbine + sweepers | transit | cooling |
| refinery + rails | transit | refining |
| rails and sweepers only | transit | transit (2) |
| travel tube network | transit | transit (6) |

Expect transit to shrink substantially — that's the intent. It was absorbing blueprints that belong to the categories they'll now land in.

## Verification

- Frontend analyzer spec: 39 passing, 5 new covering each row above
- Backend 740 passing, `npm run tsc` clean

## Applying it

Existing documents only change via `npm run derive-metadata -- --recategorize`. Sample it first (`--dry-run --limit 100`) — the from -> to table will show where the 624 actually belonged.

## Known gap, not fixed here

Research labs have no category at all. Research buildings are `equipment` in the game menu, which isn't fallback-mapped, so a lab scores nothing and lands on whatever incidental building it contains. After this change they'll go untagged rather than to transit. Adding research buildings as `rooms` signatures is the obvious fix, but it's worth seeing the recategorize table first to size the problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)