### PR TITLE
feat(blueprint): add the element-note editor (spec phase 3)

### DIFF
--- a/frontend/src/app/module-blueprint/components/note-edit-panel/element-note-editor/element-note-editor.component.css
+++ b/frontend/src/app/module-blueprint/components/note-edit-panel/element-note-editor/element-note-editor.component.css
@@ -1,0 +1,76 @@
+.element-note-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.selected-element-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  background: #10141a;
+}
+
+.selected-element-marker {
+  width: 22px;
+  height: 22px;
+  flex: none;
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+}
+
+.selected-element-name {
+  font-size: 13px;
+}
+
+.control-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.control-icon {
+  flex: none;
+  width: 20px;
+  text-align: center;
+  color: #d9a4bf;
+}
+
+.control-slider {
+  flex: 1;
+  min-width: 0;
+}
+
+.control-title {
+  font-size: 12px;
+  margin-bottom: 2px;
+}
+
+.temperature-scale {
+  width: 100%;
+  margin-bottom: 4px;
+}
+
+.control-number {
+  width: 70px;
+  box-sizing: border-box;
+  padding: 4px 6px;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: #10141a;
+  color: #f1f1f1;
+  font-family: inherit;
+  font-size: 13px;
+}
+
+.control-unit {
+  flex: none;
+  font-size: 12px;
+  color: #d9a4bf;
+}

--- a/frontend/src/app/module-blueprint/components/note-edit-panel/element-note-editor/element-note-editor.component.css
+++ b/frontend/src/app/module-blueprint/components/note-edit-panel/element-note-editor/element-note-editor.component.css
@@ -48,6 +48,7 @@
 }
 
 .control-title {
+  display: block;
   font-size: 12px;
   margin-bottom: 2px;
 }

--- a/frontend/src/app/module-blueprint/components/note-edit-panel/element-note-editor/element-note-editor.component.html
+++ b/frontend/src/app/module-blueprint/components/note-edit-panel/element-note-editor/element-note-editor.component.html
@@ -1,0 +1,134 @@
+<div class="element-note-editor" *ngIf="note">
+  <app-cell-element-picker
+    [states]="pickerStates"
+    (selectElementCell)="onSelectElement($event)"
+  ></app-cell-element-picker>
+
+  <div class="selected-element-row">
+    <div
+      *ngIf="markerName as marker; else noElement"
+      class="selected-element-marker"
+      [style.background-color]="markerTint"
+      [style.mask-image]="'url(' + markerUrl + ')'"
+      [style.-webkit-mask-image]="'url(' + markerUrl + ')'"
+    ></div>
+    <span class="selected-element-name">
+      {{ elementName
+      }}<ng-container *ngIf="markerName">
+        ({{ elementStateLabel }})</ng-container
+      >
+    </span>
+    <ng-template #noElement></ng-template>
+  </div>
+
+  <div class="control-row">
+    <div class="control-icon" i18n-title title="Mass">
+      <span class="pi pi-box"></span>
+    </div>
+    <div class="control-slider">
+      <div class="control-title" i18n>Mass: {{ massKg }} kg</div>
+      <p-slider
+        *ngIf="hasMassRange"
+        [(ngModel)]="massKg"
+        [min]="0"
+        [max]="maxMass"
+        [step]="massStep"
+        (onSlideEnd)="commitMass()"
+      ></p-slider>
+    </div>
+    <input
+      class="control-number"
+      type="number"
+      min="0"
+      [attr.max]="hasMassRange ? maxMass : null"
+      [(ngModel)]="massKg"
+      (blur)="commitMass()"
+    />
+    <span class="control-unit" i18n>kg</span>
+  </div>
+
+  <div class="control-row">
+    <div class="control-icon" i18n-title title="Temperature">
+      <span class="pi pi-sun"></span>
+    </div>
+    <div class="control-slider">
+      <div class="control-title" i18n>Temperature: {{ tempCelsius }} °C</div>
+      <div class="temperature-scale">
+        <svg
+          version="1.1"
+          viewBox="0 0 100 20"
+          xmlns="http://www.w3.org/2000/svg"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+        >
+          <defs>
+            <linearGradient
+              id="elementNoteTemperatureGradient"
+              x2="100"
+              y1="10"
+              y2="10"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop
+                *ngFor="
+                  let threshold of temperatureThresholds;
+                  let index = index
+                "
+                [attr.stop-color]="temperatureColor(index)"
+                [attr.offset]="temperatureOffset(index)"
+              />
+            </linearGradient>
+          </defs>
+          <rect
+            width="100"
+            height="20"
+            fill="url(#elementNoteTemperatureGradient)"
+          />
+          <rect
+            *ngIf="hasTempRange"
+            x="0"
+            width="100"
+            height="20"
+            fill="#000"
+            opacity="0.55"
+            [attr.clip-path]="
+              'polygon(0 0, ' +
+              bandStartPercent +
+              '% 0, ' +
+              bandStartPercent +
+              '% 20, 0 20)'
+            "
+          />
+          <rect
+            *ngIf="hasTempRange"
+            x="0"
+            width="100"
+            height="20"
+            fill="#000"
+            opacity="0.55"
+            [attr.clip-path]="
+              'polygon(' +
+              bandEndPercent +
+              '% 0, 100% 0, 100% 20, ' +
+              bandEndPercent +
+              '% 20)'
+            "
+          />
+        </svg>
+      </div>
+      <p-slider
+        [(ngModel)]="tempScale"
+        [min]="0"
+        [max]="100"
+        [step]="0.1"
+        (onSlideEnd)="commitTemp()"
+      ></p-slider>
+    </div>
+    <input
+      class="control-number"
+      type="number"
+      [(ngModel)]="tempCelsius"
+      (blur)="commitTemp()"
+    />
+    <span class="control-unit" i18n>°C</span>
+  </div>
+</div>

--- a/frontend/src/app/module-blueprint/components/note-edit-panel/element-note-editor/element-note-editor.component.html
+++ b/frontend/src/app/module-blueprint/components/note-edit-panel/element-note-editor/element-note-editor.component.html
@@ -26,17 +26,25 @@
       <span class="pi pi-box"></span>
     </div>
     <div class="control-slider">
-      <div class="control-title" i18n>Mass: {{ massKg }} kg</div>
+      <label
+        id="element-note-mass-label"
+        for="element-note-mass-input"
+        class="control-title"
+        i18n
+        >Mass: {{ massKg }} kg</label
+      >
       <p-slider
         *ngIf="hasMassRange"
         [(ngModel)]="massKg"
         [min]="0"
         [max]="maxMass"
         [step]="massStep"
+        [ariaLabelledBy]="'element-note-mass-label'"
         (onSlideEnd)="commitMass()"
       ></p-slider>
     </div>
     <input
+      id="element-note-mass-input"
       class="control-number"
       type="number"
       min="0"
@@ -52,7 +60,13 @@
       <span class="pi pi-sun"></span>
     </div>
     <div class="control-slider">
-      <div class="control-title" i18n>Temperature: {{ tempCelsius }} °C</div>
+      <label
+        id="element-note-temperature-label"
+        for="element-note-temperature-input"
+        class="control-title"
+        i18n
+        >Temperature: {{ tempCelsius }} °C</label
+      >
       <div class="temperature-scale">
         <svg
           version="1.1"
@@ -120,10 +134,12 @@
         [min]="0"
         [max]="100"
         [step]="0.1"
+        [ariaLabelledBy]="'element-note-temperature-label'"
         (onSlideEnd)="commitTemp()"
       ></p-slider>
     </div>
     <input
+      id="element-note-temperature-input"
       class="control-number"
       type="number"
       [(ngModel)]="tempCelsius"

--- a/frontend/src/app/module-blueprint/components/note-edit-panel/element-note-editor/element-note-editor.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/note-edit-panel/element-note-editor/element-note-editor.component.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  BniWorldNote,
+  BuildableElement,
+  ElementState,
+} from "../../../../../../../lib/index";
+import { ElementNoteEditorComponent } from "./element-note-editor.component";
+
+// Matches the mod screenshot cited in spec/element-notes.md: Ice at
+// 1000 kg / -41 C, maxMass 1100, lowTemp/highTemp 0/272.5 K.
+function iceLikeElement(): BuildableElement {
+  const e = new BuildableElement();
+  e.id = "Ice";
+  e.name = "Ice";
+  e.tag = 1;
+  e.state = ElementState.Solid;
+  e.uiColor = 0x66ccff;
+  e.maxMass = 1100;
+  e.defaultMass = 1000;
+  e.defaultTemperature = 232.15;
+  e.lowTemp = 0;
+  e.highTemp = 272.5;
+  return e;
+}
+
+function oxygenLikeElement(): BuildableElement {
+  const e = new BuildableElement();
+  e.id = "Oxygen";
+  e.name = "Oxygen";
+  e.tag = 2;
+  e.state = ElementState.Gas;
+  e.uiColor = 0x9be3ff;
+  e.maxMass = 1.8;
+  e.defaultMass = 1;
+  e.defaultTemperature = 293.15;
+  e.lowTemp = 0;
+  e.highTemp = 10000;
+  return e;
+}
+
+// A database predating the element-defaults export (PR #176): maxMass and
+// highTemp default to 0 rather than NaN (BuildableElement.importFrom).
+function staleElement(): BuildableElement {
+  const e = new BuildableElement();
+  e.id = "Stale";
+  e.name = "Stale";
+  e.tag = 3;
+  e.state = ElementState.Solid;
+  return e;
+}
+
+describe("ElementNoteEditorComponent", () => {
+  let component: ElementNoteEditorComponent;
+  let note: BniWorldNote;
+
+  beforeEach(() => {
+    BuildableElement.init();
+    BuildableElement.elements = [
+      iceLikeElement(),
+      oxygenLikeElement(),
+      staleElement(),
+    ];
+    component = new ElementNoteEditorComponent();
+    note = { x: 0, y: 0, type: 1, id: 1, mass: 1000, temp: 232.15 };
+    component.note = note;
+  });
+
+  it("resolves the selected element by tag and labels it", () => {
+    expect(component.element?.id).to.equal("Ice");
+    expect(component.elementName).to.equal("Ice");
+    expect(component.elementStateLabel).to.equal("Solid");
+    expect(component.markerName).to.equal("solid");
+  });
+
+  it("shows Unknown element and no marker when the tag is unresolved", () => {
+    note.id = 999;
+    expect(component.element).to.equal(undefined);
+    expect(component.elementName).to.equal("Unknown element");
+    expect(component.markerName).to.equal(null);
+  });
+
+  it("converts Kelvin to Celsius for display and back on edit", () => {
+    expect(component.tempCelsius).to.equal(-41);
+    component.tempCelsius = -41;
+    expect(note.temp).to.be.closeTo(232.15, 1e-9);
+  });
+
+  it("clamps mass to [0, maxMass] on commit", () => {
+    note.mass = 5000;
+    component.commitMass();
+    expect(note.mass).to.equal(1100);
+
+    note.mass = -10;
+    component.commitMass();
+    expect(note.mass).to.equal(0);
+  });
+
+  it("clamps temperature to [lowTemp, highTemp] (Kelvin) on commit", () => {
+    note.temp = 1000;
+    component.commitTemp();
+    expect(note.temp).to.equal(272.5);
+
+    note.temp = -50;
+    component.commitTemp();
+    expect(note.temp).to.equal(0);
+  });
+
+  it("derives a smaller mass step for a small-maxMass (gas) element than a large one (solid)", () => {
+    note.id = 2; // Oxygen, maxMass 1.8
+    expect(component.massStep).to.be.lessThan(0.01);
+    note.id = 1; // Ice, maxMass 1100
+    expect(component.massStep).to.be.at.least(1);
+  });
+
+  it("falls back to an unbounded mass input when maxMass is 0 (stale database)", () => {
+    note.id = 3;
+    expect(component.hasMassRange).to.equal(false);
+    note.mass = 99999;
+    component.commitMass();
+    expect(note.mass).to.equal(99999);
+    note.mass = -5;
+    component.commitMass();
+    expect(note.mass).to.equal(0);
+  });
+
+  it("falls back to an unclamped temperature when highTemp is 0 (stale database)", () => {
+    note.id = 3;
+    expect(component.hasTempRange).to.equal(false);
+    note.temp = 99999;
+    component.commitTemp();
+    expect(note.temp).to.equal(99999);
+  });
+
+  it("re-seeds mass and temperature from the newly selected element, always (plan Q3)", () => {
+    // Ice's values would be invalid for Oxygen (maxMass 1.8, lowTemp/highTemp 0/10000).
+    note.mass = 1840;
+    note.temp = 232.15;
+    component.onSelectElement(oxygenLikeElement());
+    expect(note.id).to.equal(2);
+    expect(note.mass).to.equal(1);
+    expect(note.temp).to.equal(293.15);
+  });
+
+  it("emits noteChange on element select, mass commit and temp commit", () => {
+    let emits = 0;
+    component.noteChange.subscribe(() => emits++);
+    component.onSelectElement(oxygenLikeElement());
+    component.commitMass();
+    component.commitTemp();
+    expect(emits).to.equal(3);
+  });
+});

--- a/frontend/src/app/module-blueprint/components/note-edit-panel/element-note-editor/element-note-editor.component.ts
+++ b/frontend/src/app/module-blueprint/components/note-edit-panel/element-note-editor/element-note-editor.component.ts
@@ -1,0 +1,197 @@
+import { Component, EventEmitter, Input, Output } from "@angular/core";
+import {
+  BniWorldNote,
+  BuildableElement,
+  DrawHelpers,
+  ElementState,
+} from "../../../../../../../lib/index";
+import { stripNoteMarkup } from "../../../drawing/draw-notes-overlay";
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+// Element and mass/temperature controls for a BniWorldNote (type 1), shared
+// by the bottom-right note-edit-panel (selected note) and, from phase 4, the
+// notes-tool side panel (pending note) — so it never touches WorldNoteService
+// directly. The caller owns persistence: it mutates `note` in place via
+// two-way bindings and commits (WorldNoteService.commit() or equivalent) only
+// when `noteChange` fires, matching the slider-end/blur commit rule used
+// everywhere else in the notes feature (spec/element-notes.md §3, §8).
+@Component({
+  selector: "app-element-note-editor",
+  templateUrl: "./element-note-editor.component.html",
+  styleUrls: ["./element-note-editor.component.css"],
+  standalone: false,
+})
+export class ElementNoteEditorComponent {
+  @Input() note!: BniWorldNote;
+  @Output() noteChange = new EventEmitter<void>();
+
+  readonly pickerStates: ElementState[] = [
+    ElementState.Solid,
+    ElementState.Liquid,
+    ElementState.Gas,
+  ];
+
+  readonly temperatureThresholds = DrawHelpers.temperatureThresholds;
+
+  get element(): BuildableElement | undefined {
+    return this.note?.id != null
+      ? BuildableElement.getElementByTag(this.note.id)
+      : undefined;
+  }
+
+  get elementName(): string {
+    const element = this.element;
+    return element != null
+      ? stripNoteMarkup(element.name)
+      : $localize`Unknown element`;
+  }
+
+  get elementStateLabel(): string {
+    const element = this.element;
+    if (element == null) return "";
+    switch (element.state) {
+      case ElementState.Solid:
+        return $localize`Solid`;
+      case ElementState.Liquid:
+        return $localize`Liquid`;
+      case ElementState.Gas:
+        return $localize`Gas`;
+      default:
+        return $localize`Vacuum`;
+    }
+  }
+
+  get markerName(): "solid" | "liquid" | "gas" | null {
+    const element = this.element;
+    if (element == null) return null;
+    switch (element.state) {
+      case ElementState.Solid:
+        return "solid";
+      case ElementState.Liquid:
+        return "liquid";
+      case ElementState.Gas:
+        return "gas";
+      default:
+        return null;
+    }
+  }
+
+  get markerUrl(): string {
+    return "assets/images/notes/" + (this.markerName ?? "note") + ".png";
+  }
+
+  get markerTint(): string {
+    const element = this.element;
+    return element != null
+      ? DrawHelpers.colorToHex(element.uiColor)
+      : "#3b82f6";
+  }
+
+  // Selecting a new element always re-seeds mass and temperature from that
+  // element's own defaults (spec §8.2, plan Q3 — resolved: always re-seed).
+  // Carrying over the previous element's values could easily land outside
+  // the new element's valid mass/temperature range.
+  onSelectElement(element: BuildableElement) {
+    if (this.note == null) return;
+    this.note.id = element.tag;
+    this.note.mass = element.defaultMass;
+    this.note.temp = element.defaultTemperature;
+    this.noteChange.emit();
+  }
+
+  // Mass (kg)
+  get maxMass(): number {
+    return this.element?.maxMass ?? 0;
+  }
+  get hasMassRange(): boolean {
+    return this.maxMass > 0;
+  }
+  // A step derived from the element's own range rather than one constant for
+  // every element: gases (maxMass ~1.8) land on ~0.001 kg steps, solids
+  // (maxMass ~1840) on ~1 kg steps (spec §8.2).
+  get massStep(): number {
+    const max = this.maxMass;
+    if (max <= 0) return 1;
+    const raw = max / 1000;
+    const decimals = clamp(-Math.floor(Math.log10(raw)), 0, 3);
+    const factor = Math.pow(10, decimals);
+    return Math.round(raw * factor) / factor;
+  }
+  get massKg(): number {
+    return this.note?.mass ?? 0;
+  }
+  set massKg(value: number) {
+    if (this.note != null) this.note.mass = value;
+  }
+  clampMass(value: number): number {
+    return this.hasMassRange
+      ? clamp(value, 0, this.maxMass)
+      : Math.max(0, value);
+  }
+  commitMass() {
+    if (this.note == null) return;
+    this.note.mass = this.clampMass(this.note.mass ?? 0);
+    this.noteChange.emit();
+  }
+
+  // Temperature (stored Kelvin, edited in °C on a piecewise 0-100 scale so
+  // gases with highTemp in the thousands stay usable — spec §8.3).
+  get lowTemp(): number {
+    return this.element?.lowTemp ?? 0;
+  }
+  get highTemp(): number {
+    return this.element?.highTemp ?? 0;
+  }
+  get hasTempRange(): boolean {
+    return this.highTemp > 0;
+  }
+  get tempKelvin(): number {
+    return this.note?.temp ?? 0;
+  }
+  get tempCelsius(): number {
+    return Math.round((this.tempKelvin - 273.15) * 10) / 10;
+  }
+  set tempCelsius(value: number) {
+    if (this.note != null) this.note.temp = value + 273.15;
+  }
+  get tempScale(): number {
+    return DrawHelpers.temperatureToScale(this.tempKelvin);
+  }
+  set tempScale(value: number) {
+    if (this.note != null)
+      this.note.temp = DrawHelpers.scaleToTemperature(value);
+  }
+  clampTemp(kelvin: number): number {
+    return this.hasTempRange
+      ? clamp(kelvin, this.lowTemp, this.highTemp)
+      : kelvin;
+  }
+  commitTemp() {
+    if (this.note == null) return;
+    this.note.temp = this.clampTemp(this.note.temp ?? 0);
+    this.noteChange.emit();
+  }
+  // Reachable band on the 0-100 gradient, for the highlight overlay.
+  get bandStartPercent(): number {
+    return this.hasTempRange ? DrawHelpers.temperatureToScale(this.lowTemp) : 0;
+  }
+  get bandEndPercent(): number {
+    return this.hasTempRange
+      ? DrawHelpers.temperatureToScale(this.highTemp)
+      : 100;
+  }
+
+  temperatureOffset(index: number): number {
+    return (
+      DrawHelpers.temperatureToScale(
+        this.temperatureThresholds[index].temperature,
+      ) / 100
+    );
+  }
+  temperatureColor(index: number): string {
+    return DrawHelpers.colorToHex(this.temperatureThresholds[index].color);
+  }
+}

--- a/frontend/src/app/module-blueprint/components/note-edit-panel/note-edit-panel.component.html
+++ b/frontend/src/app/module-blueprint/components/note-edit-panel/note-edit-panel.component.html
@@ -50,25 +50,10 @@
     </ng-container>
 
     <ng-template #elementFields>
-      <label class="note-panel-label" i18n>Element:</label>
-      <div class="note-panel-static">{{ elementName }}</div>
-
-      <label class="note-panel-label" i18n>Mass (kg):</label>
-      <input
-        class="note-panel-input"
-        type="number"
-        min="0"
-        [(ngModel)]="massKg"
-        (blur)="commit()"
-      />
-
-      <label class="note-panel-label" i18n>Temperature (°C):</label>
-      <input
-        class="note-panel-input"
-        type="number"
-        [(ngModel)]="tempCelsius"
-        (blur)="commit()"
-      />
+      <app-element-note-editor
+        [note]="n"
+        (noteChange)="commit()"
+      ></app-element-note-editor>
     </ng-template>
 
     <button type="button" class="note-panel-delete" (click)="deleteNote()" i18n>

--- a/frontend/src/app/module-blueprint/components/note-edit-panel/note-edit-panel.component.ts
+++ b/frontend/src/app/module-blueprint/components/note-edit-panel/note-edit-panel.component.ts
@@ -1,7 +1,6 @@
 import { Component } from "@angular/core";
-import { BniWorldNote, BuildableElement } from "../../../../../../lib/index";
+import { BniWorldNote } from "../../../../../../lib/index";
 import { WorldNoteService } from "../../services/world-note.service";
-import { stripNoteMarkup } from "../../drawing/draw-notes-overlay";
 
 // Bottom-right editor for a selected BlueprintsV2 world note, modelled on the
 // mod's in-game note edit screen: text notes edit name / text / icon colour;
@@ -63,14 +62,6 @@ export class NoteEditPanelComponent {
     return this.isText ? $localize`Text Note` : $localize`Element Note`;
   }
 
-  get elementName(): string {
-    if (this.note?.id == null) return $localize`Unknown element`;
-    const element = BuildableElement.getElementByTag(this.note.id);
-    return element != null
-      ? stripNoteMarkup(element.name)
-      : $localize`Unknown element`;
-  }
-
   // Icon colour (text notes). tinthex is RRGGBBAA — keep the alpha byte.
   isSelectedColor(hex: string): boolean {
     return (this.note?.tinthex ?? "").slice(0, 6).toLowerCase() === hex;
@@ -88,22 +79,6 @@ export class NoteEditPanelComponent {
   // slider-end rule for the same reason (spec §3, §12).
   commit() {
     this.noteService.commit();
-  }
-
-  // Element mass (kg) and temperature (stored Kelvin, edited in °C).
-  get massKg(): number {
-    return this.note?.mass ?? 0;
-  }
-  set massKg(value: number) {
-    if (this.note != null) this.note.mass = value;
-  }
-
-  get tempCelsius(): number {
-    if (this.note?.temp == null) return 0;
-    return Math.round((this.note.temp - 273.15) * 100) / 100;
-  }
-  set tempCelsius(value: number) {
-    if (this.note != null) this.note.temp = value + 273.15;
   }
 
   deleteNote() {

--- a/frontend/src/app/module-blueprint/components/side-bar/cell-element-picker/cell-element-picker.component.css
+++ b/frontend/src/app/module-blueprint/components/side-bar/cell-element-picker/cell-element-picker.component.css
@@ -27,3 +27,27 @@
 .second-checkbox {
   margin-left: 10px;
 }
+
+.state-filter {
+  display: flex;
+  flex-flow: row;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.state-filter-button {
+  flex: 1;
+  padding: 4px 6px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.state-filter-button.selected {
+  background: var(--p-primary-color, #b5487a);
+  border-color: var(--p-primary-color, #b5487a);
+  color: #fff;
+}

--- a/frontend/src/app/module-blueprint/components/side-bar/cell-element-picker/cell-element-picker.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/cell-element-picker/cell-element-picker.component.html
@@ -39,6 +39,7 @@
     type="button"
     class="state-filter-button"
     [class.selected]="selectedState === null"
+    [attr.aria-pressed]="selectedState === null"
     (click)="selectState(null)"
     i18n
   >
@@ -49,6 +50,7 @@
     class="state-filter-button"
     *ngFor="let s of states"
     [class.selected]="selectedState === s"
+    [attr.aria-pressed]="selectedState === s"
     (click)="selectState(s)"
   >
     {{ stateLabel(s) }}

--- a/frontend/src/app/module-blueprint/components/side-bar/cell-element-picker/cell-element-picker.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/cell-element-picker/cell-element-picker.component.html
@@ -11,7 +11,7 @@
   />
 </div>
 
-<div *ngIf="!isForcedTag">
+<div *ngIf="!isForcedTag && !isStateFiltered">
   <p-checkbox
     name="groupTag"
     (onChange)="tagChanged($event)"
@@ -32,6 +32,27 @@
       inputId="Liquid"
     ></p-checkbox
   ></span>
+</div>
+
+<div class="state-filter" *ngIf="isStateFiltered">
+  <button
+    type="button"
+    class="state-filter-button"
+    [class.selected]="selectedState === null"
+    (click)="selectState(null)"
+    i18n
+  >
+    All
+  </button>
+  <button
+    type="button"
+    class="state-filter-button"
+    *ngFor="let s of states"
+    [class.selected]="selectedState === s"
+    (click)="selectState(s)"
+  >
+    {{ stateLabel(s) }}
+  </button>
 </div>
 
 <div class="element-list">

--- a/frontend/src/app/module-blueprint/components/side-bar/cell-element-picker/cell-element-picker.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/cell-element-picker/cell-element-picker.component.spec.ts
@@ -3,7 +3,7 @@ import { FormsModule } from "@angular/forms";
 import { CheckboxModule } from "primeng/checkbox";
 import { InputTextModule } from "primeng/inputtext";
 
-import { BuildableElement } from "../../../../../../../lib/index";
+import { BuildableElement, ElementState } from "../../../../../../../lib/index";
 import { ElementIconComponent } from "../element-icon/element-icon.component";
 import { CellElementPickerComponent } from "./cell-element-picker.component";
 
@@ -28,5 +28,83 @@ describe("CellElementPickerComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+});
+
+// The element-note picker's state filter (spec/element-notes.md §8.1): a
+// fixed `states` pool drives an All/<state>... segmented filter on
+// element.state instead of the oreTags Gas/Liquid checkboxes, and always
+// excludes None.
+describe("CellElementPickerComponent state filter", () => {
+  let component: CellElementPickerComponent;
+  let fixture: ComponentFixture<CellElementPickerComponent>;
+
+  function elementFixture(id: string, state: ElementState): BuildableElement {
+    const element = new BuildableElement();
+    element.id = id;
+    element.name = id;
+    element.state = state;
+    return element;
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CellElementPickerComponent, ElementIconComponent],
+      imports: [FormsModule, CheckboxModule, InputTextModule],
+    }).compileComponents();
+
+    BuildableElement.init();
+    BuildableElement.elements = [
+      elementFixture("Granite", ElementState.Solid),
+      elementFixture("Water", ElementState.Liquid),
+      elementFixture("Oxygen", ElementState.Gas),
+      elementFixture("Vacuum", ElementState.Vacuum),
+    ];
+    BuildableElement.elements.push(
+      Object.assign(new BuildableElement(), { id: "None", name: "None" }),
+    );
+
+    fixture = TestBed.createComponent(CellElementPickerComponent);
+    component = fixture.componentInstance;
+    component.states = [
+      ElementState.Solid,
+      ElementState.Liquid,
+      ElementState.Gas,
+    ];
+    fixture.detectChanges();
+  });
+
+  it("excludes None and Vacuum, keeping only elements in the states pool", () => {
+    const ids = component.elements.map((e) => e.id);
+    expect(ids).to.deep.equal(["Granite", "Water", "Oxygen"]);
+  });
+
+  it("segments down to a single state on selectState", () => {
+    component.selectState(ElementState.Liquid);
+    expect(component.elements.map((e) => e.id)).to.deep.equal(["Water"]);
+  });
+
+  it("selectState(null) returns to the full pool", () => {
+    component.selectState(ElementState.Gas);
+    component.selectState(null);
+    expect(component.elements.map((e) => e.id)).to.deep.equal([
+      "Granite",
+      "Water",
+      "Oxygen",
+    ]);
+  });
+
+  it("does not affect the tag-based checkbox path for existing callers", () => {
+    const forced = TestBed.createComponent(CellElementPickerComponent);
+    forced.componentInstance.selectedTags = ["Gas"];
+    // Untouched BuildableElement.elements from this describe block have no
+    // oreTags set, so the existing tag path (isStateFiltered === false)
+    // legitimately returns nothing but None — proving it wasn't switched
+    // onto the new state-based filter.
+    forced.detectChanges();
+    expect(forced.componentInstance.isStateFiltered).to.equal(false);
+    expect(forced.componentInstance.elements.map((e) => e.id)).to.deep.equal([
+      "None",
+    ]);
   });
 });

--- a/frontend/src/app/module-blueprint/components/side-bar/cell-element-picker/cell-element-picker.component.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/cell-element-picker/cell-element-picker.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Output, EventEmitter, Input } from "@angular/core";
 import { Subject } from "rxjs";
-import { BuildableElement } from "../../../../../../../lib/index";
+import { BuildableElement, ElementState } from "../../../../../../../lib/index";
 
 @Component({
   selector: "app-cell-element-picker",
@@ -22,6 +22,16 @@ export class CellElementPickerComponent implements OnInit {
     return this.forceTag != undefined;
   }
 
+  // Element-note-style filter: a fixed pool of states (e.g. [Solid, Liquid,
+  // Gas]) drives a segmented All/<state>/<state>... filter instead of the
+  // Gas/Liquid oreTags checkboxes. `None` is never selectable through this
+  // path — a note about nothing is not a thing the mod can express.
+  @Input() states?: ElementState[];
+  get isStateFiltered() {
+    return this.states != undefined;
+  }
+  selectedState: ElementState | null = null;
+
   constructor() {
     this.filterNameSubject.subscribe((_value: string) => {
       this.filter();
@@ -40,15 +50,39 @@ export class CellElementPickerComponent implements OnInit {
     this.filterElements();
   }
 
+  selectState(state: ElementState | null) {
+    this.selectedState = state;
+    this.filterElements();
+  }
+
+  stateLabel(state: ElementState): string {
+    switch (state) {
+      case ElementState.Solid:
+        return $localize`Solids`;
+      case ElementState.Liquid:
+        return $localize`Liquids`;
+      case ElementState.Gas:
+        return $localize`Gases`;
+      default:
+        return $localize`Vacuum`;
+    }
+  }
+
   filterElements() {
     this.elements = [];
-    this.elements.push(BuildableElement.getElement("None"));
+    if (!this.isStateFiltered)
+      this.elements.push(BuildableElement.getElement("None"));
     for (const element of BuildableElement.elements) {
       let filterString = false;
       let filterTag = false;
       let filterMissing = true;
 
-      if (this.forceTag == undefined) {
+      if (this.isStateFiltered) {
+        const pool = this.states!;
+        filterTag =
+          pool.indexOf(element.state) != -1 &&
+          (this.selectedState == null || element.state === this.selectedState);
+      } else if (this.forceTag == undefined) {
         for (const tag of this.selectedTags)
           if (element.hasTag(tag)) filterTag = true;
       } else if (element.hasTag(this.forceTag)) filterTag = true;

--- a/frontend/src/app/module-blueprint/components/side-bar/element-icon/element-icon.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/element-icon/element-icon.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 
-import { BuildableElement } from "../../../../../../../lib/index";
+import { BuildableElement, ElementState } from "../../../../../../../lib/index";
 import { ElementIconComponent } from "./element-icon.component";
 
 describe("ElementIconComponent", () => {
@@ -27,5 +27,52 @@ describe("ElementIconComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+});
+
+// Solid elements must render their real iconUrl, not the generic liquid/gas
+// SVG art — the state field (populated by the #176 element-defaults export)
+// is the authoritative discriminator, with hasTag kept only as a fallback
+// for a database predating that export (spec/element-notes.md §8.1).
+describe("ElementIconComponent state gating", () => {
+  function elementWith(
+    state: ElementState,
+    oreTags: string[],
+  ): BuildableElement {
+    const element = new BuildableElement();
+    element.state = state;
+    element.oreTags = oreTags;
+    return element;
+  }
+
+  it("renders a solid as an icon even if oreTags carry a stale Liquid/Gas tag", () => {
+    const component = new ElementIconComponent();
+    component.element = elementWith(ElementState.Solid, ["Solid", "Liquid"]);
+    expect(component.isLiquid).to.equal(false);
+    expect(component.isGas).to.equal(false);
+    expect(component.isIcon).to.equal(true);
+  });
+
+  it("renders a liquid/gas by state even without the matching oreTag", () => {
+    const component = new ElementIconComponent();
+    component.element = elementWith(ElementState.Liquid, []);
+    expect(component.isLiquid).to.equal(true);
+    expect(component.isIcon).to.equal(false);
+
+    component.element = elementWith(ElementState.Gas, []);
+    expect(component.isGas).to.equal(true);
+    expect(component.isIcon).to.equal(false);
+  });
+
+  it("falls back to oreTags when state is unset (Vacuum) — stale database", () => {
+    const component = new ElementIconComponent();
+    component.element = elementWith(ElementState.Vacuum, ["Liquid"]);
+    expect(component.isLiquid).to.equal(true);
+
+    component.element = elementWith(ElementState.Vacuum, ["Gas"]);
+    expect(component.isGas).to.equal(true);
+
+    component.element = elementWith(ElementState.Vacuum, []);
+    expect(component.isIcon).to.equal(true);
   });
 });

--- a/frontend/src/app/module-blueprint/components/side-bar/element-icon/element-icon.component.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/element-icon/element-icon.component.ts
@@ -1,5 +1,9 @@
 import { Component, Input } from "@angular/core";
-import { DrawHelpers, BuildableElement } from "../../../../../../../lib/index";
+import {
+  DrawHelpers,
+  BuildableElement,
+  ElementState,
+} from "../../../../../../../lib/index";
 
 @Component({
   selector: "app-element-icon",
@@ -12,17 +16,25 @@ export class ElementIconComponent {
   @Input() width!: string;
   @Input() height!: string;
 
-  // TODO boolean in export
   get isIcon() {
-    return !this.element.hasTag("Gas") && !this.element.hasTag("Liquid");
+    return !this.isGas && !this.isLiquid;
   }
   get nullIcon() {
     return this.element.icon == null || this.element.icon == "";
   }
+  // `state` (from the #176 element-defaults export) is the authoritative
+  // phase-of-matter field; fall back to the oreTags check only when it is
+  // unset (Vacuum), e.g. a database predating that export. Without this,
+  // solid elements whose oreTags happen to carry a stale/missing signal fall
+  // through to the generic "no icon" circle instead of their real iconUrl.
   get isLiquid() {
+    if (this.element.state !== ElementState.Vacuum)
+      return this.element.state === ElementState.Liquid;
     return this.element.hasTag("Liquid");
   }
   get isGas() {
+    if (this.element.state !== ElementState.Vacuum)
+      return this.element.state === ElementState.Gas;
     return this.element.hasTag("Gas");
   }
   get tint() {

--- a/frontend/src/app/module-blueprint/module-blueprint.module.ts
+++ b/frontend/src/app/module-blueprint/module-blueprint.module.ts
@@ -49,6 +49,7 @@ import { AuthenticationService } from "./services/authentification-service";
 import { BlueprintService } from "./services/blueprint-service";
 import { ToolService } from "./services/tool-service";
 import { NoteEditPanelComponent } from "./components/note-edit-panel/note-edit-panel.component";
+import { ElementNoteEditorComponent } from "./components/note-edit-panel/element-note-editor/element-note-editor.component";
 import { SelectTool } from "./common/tools/select-tool";
 import { BuildTool } from "./common/tools/build-tool";
 import { ScissorsTool } from "./common/tools/scissors-tool";
@@ -170,6 +171,7 @@ import { PlanningToolComponent } from "./components/side-bar/planning-tool/plann
     NotificationBellComponent,
     ToolbarButtonComponent,
     NoteEditPanelComponent,
+    ElementNoteEditorComponent,
     SupportedModsPageComponent,
     PlanningToolComponent,
   ],


### PR DESCRIPTION
## Summary

Implements phase 3 of `spec/element-notes.md` (element-note editor), building on the persistence + art work from phases 1–2 (`525ebdf0`, `1bcda34d`/`80f57494`).

- **`CellElementPickerComponent`** gains a `states?: ElementState[]` input: a segmented All/Solids/Liquids/Gases filter on `element.state`, alongside (not replacing) the existing `forceTag`/oreTags-checkbox path used by the cell/pipe-content pickers. `None` is excluded whenever `states` is set.
- **`ElementIconComponent`** now gates `isLiquid`/`isGas` on `element.state` first, falling back to the oreTags check only when `state` is unset (`Vacuum`) — a stale-database fallback.
- **New `components/note-edit-panel/element-note-editor/`**: element picker (reusing the extended cell picker) + tinted selected-element row ("Ice (Solid)", marker PNG masked to `uiColor` via CSS) + mass slider/input (`kg`, step derived from `maxMass`, unbounded fallback when `maxMass === 0`) + temperature slider/input reusing `temperature-picker`'s gradient markup (`°C`, reachable `[lowTemp, highTemp]` band dimmed on the gradient, unclamped fallback when `highTemp === 0`). Wired into `note-edit-panel` in place of the old plain number inputs.
- Commits go through the editor's `noteChange` output → `WorldNoteService.commit()` on slider-end/blur only (never per-frame/per-keystroke), same rule phase 1 established.
- Sign-off questions resolved per the spec's own recommendation: switching element always re-seeds *both* mass and temperature from the new element's defaults (Q3); the mod's "Common Substances" category is not reproduced, shipping `All/Solids/Liquids/Gases` only (Q4).

Phase 4 (`NotesTool` creation UI) is intentionally out of scope — the editor takes its `note` via `@Input()` and never touches `WorldNoteService` directly, so it's reusable as-is for the phase-4 side-bar panel.

## Test plan

- [x] New/updated specs: `cell-element-picker.component.spec.ts` (state filter, None exclusion, existing tag path untouched), `element-icon.component.spec.ts` (state gating + stale-db fallback), `element-note-editor.component.spec.ts` (mass/temp clamp, re-seed on element change, Kelvin↔°C, `maxMass`/`highTemp === 0` fallbacks, `noteChange` emission)
- [x] `npm test` (frontend): 85 files / 1064 passing (up from 981 baseline)
- [x] `cd frontend && npm run lint`: clean
- [x] `npm run tsc` (backend/lib): clean
- [x] Manual verification in a running dev server (Playwright): imported a BPv2 fixture with a real element note, opened the editor, exercised the state filter, switched elements (confirmed re-seed + live tinted marker update on canvas), dragged mass/temperature — screenshots below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)