### PR TITLE
feat(blueprint): add the element-note creation tool (spec phase 4)

### DIFF
--- a/frontend/src/app/module-blueprint/common/tools/notes-tool.spec.ts
+++ b/frontend/src/app/module-blueprint/common/tools/notes-tool.spec.ts
@@ -1,0 +1,91 @@
+import { NotesTool } from "./notes-tool";
+import { ToolType } from "./tool";
+import { ShortcutAction } from "../../keybindings/shortcut-actions";
+import { BniWorldNote, Vector2 } from "../../../../../../lib/index";
+import { BlueprintService } from "../../services/blueprint-service";
+import { WorldNoteService } from "../../services/world-note.service";
+
+describe("NotesTool", () => {
+  let tool: NotesTool;
+  let blueprint: {
+    worldNotes: BniWorldNote[];
+    emitBlueprintChanged: ReturnType<typeof vi.fn>;
+  };
+  let worldNoteService: WorldNoteService;
+  let parent: { changeTool: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    blueprint = { worldNotes: [], emitBlueprintChanged: vi.fn() };
+    const blueprintService = { blueprint } as unknown as BlueprintService;
+    worldNoteService = new WorldNoteService(blueprintService);
+    tool = new NotesTool(blueprintService, worldNoteService);
+    parent = { changeTool: vi.fn() };
+    tool.parent = parent as any;
+  });
+
+  it("is an exclusive input tool", () => {
+    expect(tool.toolType).toBe(ToolType.notes);
+    expect(tool.toolGroup).toBe(1);
+    expect(tool.captureInput).toBe(true);
+    expect(tool.toggleable).toBe(false);
+  });
+
+  it("places a text note built from the pending tint", () => {
+    tool.mode = "text";
+    tool.pendingTint = "ff0000ff";
+    tool.mouseDown(new Vector2(4, 5));
+
+    expect(blueprint.worldNotes).to.have.length(1);
+    expect(blueprint.worldNotes[0]).to.deep.include({
+      x: 4,
+      y: 5,
+      type: 0,
+      tinthex: "ff0000ff",
+    });
+    expect(worldNoteService.selected).to.equal(blueprint.worldNotes[0]);
+    expect(blueprint.emitBlueprintChanged).toHaveBeenCalledOnce();
+  });
+
+  it("places an element note built from the pending template", () => {
+    tool.mode = "element";
+    tool.pendingElementNote = {
+      x: 0,
+      y: 0,
+      type: 1,
+      id: 7,
+      mass: 100,
+      temp: 300,
+    };
+    tool.mouseDown(new Vector2(1, 2));
+
+    expect(blueprint.worldNotes).to.deep.equal([
+      { x: 1, y: 2, type: 1, id: 7, mass: 100, temp: 300 },
+    ]);
+    expect(worldNoteService.selected).to.equal(blueprint.worldNotes[0]);
+  });
+
+  it("refuses a second note on an occupied cell and selects the existing one instead", () => {
+    const existing: BniWorldNote = { x: 3, y: 3, type: 0, title: "existing" };
+    blueprint.worldNotes.push(existing);
+
+    tool.mouseDown(new Vector2(3, 3));
+
+    expect(blueprint.worldNotes).to.have.length(1);
+    expect(worldNoteService.selected).to.equal(existing);
+    expect(blueprint.emitBlueprintChanged).not.toHaveBeenCalled();
+  });
+
+  it("right-click returns to the select tool", () => {
+    tool.rightClick(new Vector2(0, 0));
+    expect(parent.changeTool).toHaveBeenCalledWith(ToolType.select);
+  });
+
+  it("handles interfaceCancel by returning to the select tool", () => {
+    expect(tool.handleShortcut(ShortcutAction.interfaceCancel)).toBe(true);
+    expect(parent.changeTool).toHaveBeenCalledWith(ToolType.select);
+  });
+
+  it("declines shortcuts it does not own", () => {
+    expect(tool.handleShortcut(ShortcutAction.editDelete)).toBe(false);
+  });
+});

--- a/frontend/src/app/module-blueprint/common/tools/notes-tool.ts
+++ b/frontend/src/app/module-blueprint/common/tools/notes-tool.ts
@@ -1,0 +1,182 @@
+import { Injectable } from "@angular/core";
+import {
+  BniWorldNote,
+  BuildableElement,
+  CameraService,
+  DrawHelpers,
+  Vector2,
+} from "../../../../../../lib/index";
+import { BlueprintService } from "../../services/blueprint-service";
+import {
+  WorldNoteService,
+  findNoteAt,
+} from "../../services/world-note.service";
+import { DrawPixi } from "../../drawing/draw-pixi";
+import {
+  MARKER_URLS,
+  NOTE_ICON_TILE_FRACTION,
+  noteBadgeColor,
+  noteMarkerSprite,
+} from "../../drawing/draw-notes-overlay";
+import { ITool, ToolType } from "./tool";
+import {
+  ShortcutAction,
+  ShortcutActionId,
+} from "../../keybindings/shortcut-actions";
+import { ToolService } from "../../services/tool-service";
+
+const CURSOR_URL = "assets/images/notes/add-note.png";
+// The cursor art sits smaller than the marker preview and offset above it,
+// echoing the mod's own placement cursor rather than fully covering the pin.
+const CURSOR_TILE_FRACTION = 0.45;
+const PREVIEW_ALPHA = 0.55;
+
+// Note Creation Tool (spec/element-notes.md §6). Places text or element
+// world notes on click. Modelled on PlanningTool: single-click mutation,
+// exclusive within toolGroup 1, right-click/Escape return to Select.
+@Injectable({ providedIn: "root" })
+export class NotesTool implements ITool {
+  parent!: ToolService;
+
+  mode: "text" | "element" = "text";
+  // "RRGGBBAA" tint applied to newly placed text notes, same shape as
+  // BniWorldNote.tinthex (note-edit-panel's palette default).
+  pendingTint = "ffffffff";
+  // Shared, in place, with the reused ElementNoteEditorComponent — it
+  // mutates id/mass/temp directly via two-way bindings (spec §6, §7). x/y/
+  // type are placeholders; only id/mass/temp are read before placement.
+  pendingElementNote: BniWorldNote = { x: 0, y: 0, type: 1 };
+
+  private hoverTile: Vector2 | null = null;
+  private preview: PIXI.Sprite | null = null;
+  private cursorIcon: PIXI.Sprite | null = null;
+
+  constructor(
+    private blueprintService: BlueprintService,
+    private worldNoteService: WorldNoteService,
+  ) {}
+
+  private buildPendingNote(position: Vector2): BniWorldNote {
+    if (this.mode === "text")
+      return {
+        x: position.x,
+        y: position.y,
+        type: 0,
+        title: "",
+        text: "",
+        tinthex: this.pendingTint,
+      };
+    return {
+      x: position.x,
+      y: position.y,
+      type: 1,
+      id: this.pendingElementNote.id,
+      mass: this.pendingElementNote.mass,
+      temp: this.pendingElementNote.temp,
+    };
+  }
+
+  switchFrom() {
+    this.hoverTile = null;
+    if (this.preview != null) this.preview.visible = false;
+    if (this.cursorIcon != null) this.cursorIcon.visible = false;
+  }
+  switchTo() {}
+  mouseOut() {
+    this.hoverTile = null;
+  }
+  mouseDown(tile: Vector2) {
+    const position = DrawHelpers.getIntegerTile(tile);
+    const blueprint = this.blueprintService.blueprint;
+    const existing = findNoteAt(blueprint.worldNotes, position);
+    if (existing != null) {
+      this.worldNoteService.select(existing);
+      return;
+    }
+    const note = this.buildPendingNote(position);
+    blueprint.worldNotes.push(note);
+    this.worldNoteService.select(note);
+    this.worldNoteService.commit();
+  }
+  leftClick(_tile: Vector2) {}
+  rightClick(_tile: Vector2) {
+    this.parent.changeTool(ToolType.select);
+  }
+  hover(tile: Vector2) {
+    this.hoverTile = DrawHelpers.getIntegerTile(tile);
+  }
+  drag(_tileStart: Vector2, _tileStop: Vector2) {}
+  dragStop() {}
+  handleShortcut(action: ShortcutActionId): boolean {
+    if (action == ShortcutAction.interfaceCancel) {
+      this.parent.changeTool(ToolType.select);
+      return true;
+    }
+    return false;
+  }
+
+  private previewNote(): BniWorldNote {
+    return this.mode === "text"
+      ? { x: 0, y: 0, type: 0, tinthex: this.pendingTint }
+      : { x: 0, y: 0, type: 1, id: this.pendingElementNote.id };
+  }
+
+  private updatePreview(drawPixi: DrawPixi, camera: CameraService) {
+    let preview = this.preview;
+    if (preview == null) {
+      preview = drawPixi.getSpriteFrom(MARKER_URLS.note) as PIXI.Sprite;
+      preview.anchor.set(0.5, 0.5);
+      drawPixi.pixiApp.stage.addChild(preview);
+      this.preview = preview;
+    }
+    preview.visible = this.hoverTile != null;
+    if (!preview.visible) return;
+
+    const resolve = (tag: number) => BuildableElement.getElementByTag(tag);
+    const note = this.previewNote();
+    const marker = noteMarkerSprite(note, resolve);
+    const badge = noteBadgeColor(note, resolve);
+    preview.texture = drawPixi.getNewBaseTexture(MARKER_URLS[marker]);
+    preview.tint = badge.color;
+    preview.alpha = PREVIEW_ALPHA;
+
+    const zoom = camera.currentZoom;
+    const offset = camera.cameraOffset;
+    const size = NOTE_ICON_TILE_FRACTION * zoom;
+    preview.width = size;
+    preview.height = size;
+    preview.x = (this.hoverTile!.x + offset.x + 0.5) * zoom;
+    preview.y = (offset.y - this.hoverTile!.y + 0.5) * zoom;
+  }
+
+  private updateCursorIcon(drawPixi: DrawPixi, camera: CameraService) {
+    let icon = this.cursorIcon;
+    if (icon == null) {
+      icon = drawPixi.getSpriteFrom(CURSOR_URL) as PIXI.Sprite;
+      icon.anchor.set(0.5, 1);
+      drawPixi.pixiApp.stage.addChild(icon);
+      this.cursorIcon = icon;
+    }
+    icon.visible = this.hoverTile != null;
+    if (!icon.visible) return;
+
+    const zoom = camera.currentZoom;
+    const offset = camera.cameraOffset;
+    const markerSize = NOTE_ICON_TILE_FRACTION * zoom;
+    icon.width = CURSOR_TILE_FRACTION * zoom;
+    icon.height = CURSOR_TILE_FRACTION * zoom;
+    icon.x = (this.hoverTile!.x + offset.x + 0.5) * zoom;
+    icon.y = (offset.y - this.hoverTile!.y + 0.5) * zoom - markerSize * 0.5;
+  }
+
+  draw(drawPixi: DrawPixi, camera: CameraService) {
+    this.updatePreview(drawPixi, camera);
+    this.updateCursorIcon(drawPixi, camera);
+  }
+
+  toggleable = false;
+  visible = false;
+  captureInput = true;
+  toolType = ToolType.notes;
+  toolGroup = 1;
+}

--- a/frontend/src/app/module-blueprint/common/tools/tool.ts
+++ b/frontend/src/app/module-blueprint/common/tools/tool.ts
@@ -8,6 +8,7 @@ export enum ToolType {
   elementReport,
   scissors,
   planning,
+  notes,
 }
 
 export interface ITool {

--- a/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.html
+++ b/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.html
@@ -27,6 +27,9 @@
       <app-planning-tool
         [hidden]="!toolService.planningTool.visible"
       ></app-planning-tool>
+      <app-notes-tool
+        [hidden]="!toolService.notesTool.visible"
+      ></app-notes-tool>
     </div>
     <div class="side-panel-right">
       <app-element-report-tool *ngIf="showElementReport" #elementReportTool>
@@ -59,6 +62,13 @@
       [active]="toolService.scissorsTool.visible"
       [disabled]="scissorsDisabled"
       (buttonClick)="toolService.changeTool(ToolType.scissors)"
+    ></app-toolbar-button>
+    <app-toolbar-button
+      iconUrl="assets/images/notes/note.png"
+      label="Note Creation Tool"
+      i18n-label
+      [active]="toolService.notesTool.visible"
+      (buttonClick)="toolService.changeTool(ToolType.notes)"
     ></app-toolbar-button>
   </div>
 </div>

--- a/frontend/src/app/module-blueprint/components/note-edit-panel/note-edit-panel.component.ts
+++ b/frontend/src/app/module-blueprint/components/note-edit-panel/note-edit-panel.component.ts
@@ -1,6 +1,7 @@
 import { Component } from "@angular/core";
 import { BniWorldNote } from "../../../../../../lib/index";
 import { WorldNoteService } from "../../services/world-note.service";
+import { NOTE_TINT_PALETTE } from "./note-tint-palette";
 
 // Bottom-right editor for a selected BlueprintsV2 world note, modelled on the
 // mod's in-game note edit screen: text notes edit name / text / icon colour;
@@ -12,41 +13,8 @@ import { WorldNoteService } from "../../services/world-note.service";
   standalone: false,
 })
 export class NoteEditPanelComponent {
-  // Icon-colour swatches (RRGGBB); tinthex is stored RRGGBBAA.
-  readonly palette: string[] = [
-    "ffffff",
-    "c0c0c0",
-    "808080",
-    "404040",
-    "000000",
-    "7f5539",
-    "b56576",
-    "ff0000",
-    "ff8000",
-    "ffd000",
-    "ffff00",
-    "b0ff00",
-    "00ff00",
-    "00ff80",
-    "00ffff",
-    "00a0ff",
-    "0000ff",
-    "6a00ff",
-    "b000ff",
-    "ff00ff",
-    "ff0080",
-    "990000",
-    "995200",
-    "8a8a00",
-    "3d8a00",
-    "008a3d",
-    "007e8a",
-    "003d8a",
-    "1a008a",
-    "5c008a",
-    "8a008a",
-    "8a003d",
-  ];
+  // tinthex is stored RRGGBBAA.
+  readonly palette: string[] = NOTE_TINT_PALETTE;
 
   constructor(public noteService: WorldNoteService) {}
 

--- a/frontend/src/app/module-blueprint/components/note-edit-panel/note-tint-palette.ts
+++ b/frontend/src/app/module-blueprint/components/note-edit-panel/note-tint-palette.ts
@@ -1,0 +1,38 @@
+// Icon-colour swatches (RRGGBB) for a text world note's tint. Shared by the
+// bottom-right editor (note-edit-panel, editing a placed note) and the notes
+// tool's side-bar panel (notes-tool, choosing the tint for the next note
+// placed) so the two pickers never drift.
+export const NOTE_TINT_PALETTE: string[] = [
+  "ffffff",
+  "c0c0c0",
+  "808080",
+  "404040",
+  "000000",
+  "7f5539",
+  "b56576",
+  "ff0000",
+  "ff8000",
+  "ffd000",
+  "ffff00",
+  "b0ff00",
+  "00ff00",
+  "00ff80",
+  "00ffff",
+  "00a0ff",
+  "0000ff",
+  "6a00ff",
+  "b000ff",
+  "ff00ff",
+  "ff0080",
+  "990000",
+  "995200",
+  "8a8a00",
+  "3d8a00",
+  "008a3d",
+  "007e8a",
+  "003d8a",
+  "1a008a",
+  "5c008a",
+  "8a008a",
+  "8a003d",
+];

--- a/frontend/src/app/module-blueprint/components/side-bar/notes-tool/notes-tool.component.css
+++ b/frontend/src/app/module-blueprint/components/side-bar/notes-tool/notes-tool.component.css
@@ -1,0 +1,44 @@
+.notes-card {
+  padding: 12px;
+}
+.section-label {
+  margin: 12px 0 6px;
+  font-weight: 600;
+}
+.mode-tabs {
+  display: flex;
+  gap: 4px;
+}
+.mode-tab {
+  flex: 1;
+  border: 2px solid #6a6256;
+  border-radius: 4px;
+  background: #d5c5a7;
+  padding: 6px 8px;
+  cursor: pointer;
+  font-weight: 600;
+}
+.mode-tab.selected {
+  outline: 3px solid #fff;
+  box-shadow: 0 0 0 5px #3b82f6;
+}
+.color-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+.color-button {
+  width: 32px;
+  height: 32px;
+  border: 2px solid #6a6256;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.color-button.selected {
+  outline: 3px solid #fff;
+  box-shadow: 0 0 0 5px #3b82f6;
+}
+.hint {
+  margin: 12px 0 0;
+  font-size: 0.85rem;
+}

--- a/frontend/src/app/module-blueprint/components/side-bar/notes-tool/notes-tool.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/notes-tool/notes-tool.component.html
@@ -1,0 +1,52 @@
+<div class="box-card ui-widget notes-card">
+  <div class="box-card-title" i18n>Note Creation Tool</div>
+
+  <div class="mode-tabs" role="tablist">
+    <button
+      type="button"
+      class="mode-tab"
+      role="tab"
+      [class.selected]="tool.mode === 'text'"
+      [attr.aria-selected]="tool.mode === 'text'"
+      (click)="tool.mode = 'text'"
+      i18n
+    >
+      Text Notes
+    </button>
+    <button
+      type="button"
+      class="mode-tab"
+      role="tab"
+      [class.selected]="tool.mode === 'element'"
+      [attr.aria-selected]="tool.mode === 'element'"
+      (click)="tool.mode = 'element'"
+      i18n
+    >
+      Element Notes
+    </button>
+  </div>
+
+  <ng-container *ngIf="tool.mode === 'text'; else elementMode">
+    <div class="section-label" i18n>Note Icon Color</div>
+    <div class="color-grid">
+      <button
+        type="button"
+        *ngFor="let c of palette"
+        class="color-button"
+        [class.selected]="isSelectedColor(c)"
+        [style.background-color]="'#' + c"
+        [attr.aria-label]="c"
+        (click)="pickColor(c)"
+      ></button>
+    </div>
+  </ng-container>
+  <ng-template #elementMode>
+    <app-element-note-editor
+      [note]="tool.pendingElementNote"
+    ></app-element-note-editor>
+  </ng-template>
+
+  <p class="hint" i18n>
+    Click on the blueprint to place a note. Right-click to return to Select.
+  </p>
+</div>

--- a/frontend/src/app/module-blueprint/components/side-bar/notes-tool/notes-tool.component.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/notes-tool/notes-tool.component.ts
@@ -1,0 +1,28 @@
+import { Component } from "@angular/core";
+import { NotesTool } from "../../../common/tools/notes-tool";
+import { NOTE_TINT_PALETTE } from "../../note-edit-panel/note-tint-palette";
+
+// Side-bar panel for the Note Creation Tool (spec/element-notes.md §6-§7):
+// mode tabs, then the editor for the *pending* note that will be placed on
+// the next click. The element-mode editor is the same component the
+// bottom-right panel reuses for a *placed* note's element fields.
+@Component({
+  selector: "app-notes-tool",
+  templateUrl: "./notes-tool.component.html",
+  styleUrls: ["./notes-tool.component.css"],
+  standalone: false,
+})
+export class NotesToolComponent {
+  readonly palette: string[] = NOTE_TINT_PALETTE;
+
+  constructor(public tool: NotesTool) {}
+
+  isSelectedColor(hex: string): boolean {
+    return this.tool.pendingTint.slice(0, 6).toLowerCase() === hex;
+  }
+
+  pickColor(hex: string) {
+    const alpha = this.tool.pendingTint.slice(6, 8) || "ff";
+    this.tool.pendingTint = hex + alpha;
+  }
+}

--- a/frontend/src/app/module-blueprint/drawing/draw-notes-overlay.ts
+++ b/frontend/src/app/module-blueprint/drawing/draw-notes-overlay.ts
@@ -18,12 +18,15 @@ const TEXT_NOTE = 0;
 const DEFAULT_BADGE_COLOR = 0x3b82f6;
 
 // Marker art is bracket-framed and already reads as inset at full tile size,
-// so it fills most (not all) of its cell (spec §5).
-const NOTE_ICON_TILE_FRACTION = 0.9;
+// so it fills most (not all) of its cell (spec §5). Exported for NotesTool's
+// hover preview, which sizes its marker the same way.
+export const NOTE_ICON_TILE_FRACTION = 0.9;
 
 export type MarkerName = "note" | "solid" | "liquid" | "gas";
 
-const MARKER_URLS: Record<MarkerName, string> = {
+// Exported for NotesTool's hover preview, which resolves the same marker
+// name (via noteMarkerSprite) to a texture URL.
+export const MARKER_URLS: Record<MarkerName, string> = {
   note: "assets/images/notes/note.png",
   solid: "assets/images/notes/solid.png",
   liquid: "assets/images/notes/liquid.png",

--- a/frontend/src/app/module-blueprint/keybindings/shortcut-actions.spec.ts
+++ b/frontend/src/app/module-blueprint/keybindings/shortcut-actions.spec.ts
@@ -95,18 +95,20 @@ describe("shortcut action catalogue", () => {
   // the editor into a tool that edits on a single click. That reads as "the
   // select tool is broken" while quietly painting on the blueprint.
   describe("tools that edit on click", () => {
-    it.each([[ShortcutAction.toolPlanning], [ShortcutAction.toolScissors]])(
-      "ships %s unbound, since the game has no equivalent key",
-      (actionId) => {
-        expect(getShortcutAction(actionId)?.defaults).toEqual([]);
-      },
-    );
+    it.each([
+      [ShortcutAction.toolPlanning],
+      [ShortcutAction.toolScissors],
+      [ShortcutAction.toolNotes],
+    ])("ships %s unbound, since the game has no equivalent key", (actionId) => {
+      expect(getShortcutAction(actionId)?.defaults).toEqual([]);
+    });
 
     it("never binds a destructive tool to a bare letter", () => {
       const bareLetter = (chord: string) => /^Key[A-Z]$/.test(chord);
       for (const actionId of [
         ShortcutAction.toolPlanning,
         ShortcutAction.toolScissors,
+        ShortcutAction.toolNotes,
       ])
         expect(
           getShortcutAction(actionId)!.defaults.filter(bareLetter),

--- a/frontend/src/app/module-blueprint/keybindings/shortcut-actions.ts
+++ b/frontend/src/app/module-blueprint/keybindings/shortcut-actions.ts
@@ -27,6 +27,7 @@ export const ShortcutAction = {
   toolBuild: "tool.build",
   toolPlanning: "tool.planning",
   toolScissors: "tool.scissors",
+  toolNotes: "tool.notes",
 
   // Build tool
   buildRotate: "build.rotate",
@@ -171,6 +172,12 @@ export const SHORTCUT_ACTIONS: ShortcutActionDefinition[] = [
     id: ShortcutAction.toolScissors,
     category: "tools",
     label: $localize`:keyboard shortcut:Scissors tool`,
+    defaults: [],
+  },
+  {
+    id: ShortcutAction.toolNotes,
+    category: "tools",
+    label: $localize`:keyboard shortcut:Note creation tool`,
     defaults: [],
   },
 

--- a/frontend/src/app/module-blueprint/module-blueprint.module.ts
+++ b/frontend/src/app/module-blueprint/module-blueprint.module.ts
@@ -109,6 +109,7 @@ import { NotificationBellComponent } from "./components/notification-bell/notifi
 import { ToolbarButtonComponent } from "./components/toolbar-button/toolbar-button.component";
 import { SupportedModsPageComponent } from "./components/supported-mods-page/supported-mods-page.component";
 import { PlanningToolComponent } from "./components/side-bar/planning-tool/planning-tool.component";
+import { NotesToolComponent } from "./components/side-bar/notes-tool/notes-tool.component";
 
 @NgModule({
   declarations: [
@@ -174,6 +175,7 @@ import { PlanningToolComponent } from "./components/side-bar/planning-tool/plann
     ElementNoteEditorComponent,
     SupportedModsPageComponent,
     PlanningToolComponent,
+    NotesToolComponent,
   ],
   exports: [ComponentBlueprintParentComponent],
   imports: [

--- a/frontend/src/app/module-blueprint/services/tool-service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/tool-service.spec.ts
@@ -7,6 +7,7 @@ import {
   Vector2,
 } from "../../../../../lib/index";
 import { PlanningTool } from "../common/tools/planning-tool";
+import { NotesTool } from "../common/tools/notes-tool";
 import { ShortcutAction } from "../keybindings/shortcut-actions";
 
 const makeTool = (toolType: ToolType, toolGroup = 1) => ({
@@ -40,6 +41,7 @@ describe("ToolService", () => {
   let mockElementReport: any;
   let mockScissors: ReturnType<typeof makeTool>;
   let mockPlanning: ReturnType<typeof makeTool>;
+  let mockNotes: ReturnType<typeof makeTool>;
 
   beforeEach(() => {
     mockSelect = makeTool(ToolType.select);
@@ -47,6 +49,7 @@ describe("ToolService", () => {
     mockElementReport = {};
     mockScissors = makeTool(ToolType.scissors);
     mockPlanning = makeTool(ToolType.planning);
+    mockNotes = makeTool(ToolType.notes);
 
     service = new ToolService(
       mockSelect as any,
@@ -54,6 +57,7 @@ describe("ToolService", () => {
       mockElementReport,
       mockScissors as any,
       mockPlanning as unknown as PlanningTool,
+      mockNotes as unknown as NotesTool,
     );
   });
 
@@ -76,6 +80,10 @@ describe("ToolService", () => {
 
     it("returns planningTool for ToolType.planning", () => {
       expect(service.getTool(ToolType.planning)).toBe(mockPlanning);
+    });
+
+    it("returns notesTool for ToolType.notes", () => {
+      expect(service.getTool(ToolType.notes)).toBe(mockNotes);
     });
   });
 
@@ -204,6 +212,11 @@ describe("ToolService", () => {
     it("switches to the planning tool", () => {
       expect(service.handleShortcut(ShortcutAction.toolPlanning)).toBe(true);
       expect(mockPlanning.visible).toBe(true);
+    });
+
+    it("switches to the notes tool", () => {
+      expect(service.handleShortcut(ShortcutAction.toolNotes)).toBe(true);
+      expect(mockNotes.visible).toBe(true);
     });
 
     it("declines the scissors shortcut while it is unavailable", () => {

--- a/frontend/src/app/module-blueprint/services/tool-service.ts
+++ b/frontend/src/app/module-blueprint/services/tool-service.ts
@@ -17,6 +17,7 @@ import { BuildTool } from "../common/tools/build-tool";
 import { ElementReport } from "../common/tools/element-report";
 import { ScissorsTool } from "../common/tools/scissors-tool";
 import { PlanningTool } from "../common/tools/planning-tool";
+import { NotesTool } from "../common/tools/notes-tool";
 
 @Injectable({ providedIn: "root" })
 export class ToolService implements ITool, IChangeTool {
@@ -38,6 +39,7 @@ export class ToolService implements ITool, IChangeTool {
     public elementReport: ElementReport,
     public scissorsTool: ScissorsTool,
     public planningTool: PlanningTool,
+    public notesTool: NotesTool,
   ) {
     this.observers = [];
 
@@ -48,11 +50,13 @@ export class ToolService implements ITool, IChangeTool {
     this.allTools.push(this.buildTool);
     this.allTools.push(this.scissorsTool);
     this.allTools.push(this.planningTool);
+    this.allTools.push(this.notesTool);
 
     this.buildTool.parent = this;
     this.selectTool.parent = this;
     this.scissorsTool.parent = this;
     this.planningTool.parent = this;
+    this.notesTool.parent = this;
   }
 
   subscribeToolChanged(observer: IObsToolChanged) {
@@ -152,6 +156,9 @@ export class ToolService implements ITool, IChangeTool {
       case ShortcutAction.toolScissors:
         if (this.scissorsDisabled) return false;
         this.changeTool(ToolType.scissors);
+        return true;
+      case ShortcutAction.toolNotes:
+        this.changeTool(ToolType.notes);
         return true;
       default:
         return this.currentTool.handleShortcut(action);


### PR DESCRIPTION
## Summary
- Adds `NotesTool` (`common/tools/notes-tool.ts`) — a `PlanningTool`-style single-click tool that places text or element world notes. Clicking an occupied cell selects the existing note instead of creating a duplicate (via the same `findNoteAt` helper `WorldNoteService` already uses). Right-click / `interfaceCancel` return to Select.
- New side-bar panel (`components/side-bar/notes-tool/`) with Text/Element mode tabs. The element-mode tab reuses `ElementNoteEditorComponent` **unmodified** — it was built in phase 3 specifically so the pending (not-yet-placed) note could bind to it without any `WorldNoteService` coupling.
- Toolbar button added next to Planning/Scissors (`assets/images/notes/note.png`, no new art needed — the bracket-"i" glyph reads fine at toolbar size).
- New unbound keybinding `ShortcutAction.toolNotes = "tool.notes"`, following the same "ships unbound, single-click tools shouldn't claim a bare letter" precedent as Planning/Scissors.
- Small refactor: `MARKER_URLS`, `NOTE_ICON_TILE_FRACTION`, `noteMarkerSprite`, `noteBadgeColor` exported from `draw-notes-overlay.ts` so the tool's hover-preview marker reuses the overlay's own texture/tint logic instead of duplicating it. The tint-swatch palette was factored out of `note-edit-panel.component.ts` into `note-edit-panel/note-tint-palette.ts` so the tool panel's picker and the edit panel's picker can't drift apart.

This is phase 4 of `spec/element-notes.md` (spec/ is gitignored, not included in this diff). Phases 1–3 (persistence, overlay art, element-note editor) previously shipped on master.

## Design deviations
- Spec §6 describes the pending element template as "elementId, mass, temp" — implemented as a full placeholder `BniWorldNote` object instead of three loose fields, specifically so it can be passed straight into `ElementNoteEditorComponent`'s `[note]` input with zero adapter code. This is what makes reusing the editor unmodified possible.

## Test plan
- [x] `notes-tool.spec.ts` (new, 7 cases): tool exclusivity, text-note placement, element-note placement, occupied-cell reselect (no duplicate), right-click → Select, `interfaceCancel` handling, unclaimed-shortcut passthrough.
- [x] `tool-service.spec.ts` extended for the new constructor arg and `ToolType.notes` wiring/dispatch.
- [x] `shortcut-actions.spec.ts` extended: `toolNotes` added to the "ships unbound" and "never a bare letter" tables.
- [x] Full frontend suite: 1074 passed, 2 skipped (pre-existing skips, unrelated).
- [x] `ng lint`: clean. `npm run tsc` (backend/lib): clean.
- [x] Manually verified in a running dev server (Playwright): placed a text note (bottom-right editor opened on it); switched to Element Notes, picked Cobalt from the pending picker, placed a note (unresolved-fallback badge before picking an element, tinted solid marker matching Cobalt's `uiColor` after); re-clicked the first note's cell (selected the existing text note, no duplicate created); right-clicked (returned to Select tool, panel closed). Pending-panel state and map marker agreed at every step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)