### PR TITLE
feat(terrain): seed a geyser's neutronium base as element world notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,21 +297,28 @@ in the exported `buildings` array (a geyser written as a building resolves to a 
   becomes true (a box-drag selection produces no click, so the click path alone can't see it).
 - **Neutronium base** — placing an annotation seeds the row of Neutronium every geyser is
   anchored on in game: height 1, as wide as the footprint, in the row directly beneath the
-  anchor cell (`neutroniumBaseCells`). *Seeded, not owned* — these are ordinary
-  `BlueprintItemElement` cells the user then edits with the normal element tool, so deleting
+  anchor cell (`neutroniumBaseCells`). The real deposit is often a cell or two wider, but by
+  how much depends on the world seed, so only the subset that is always present is drawn.
+  Each cell is an **element world note** (`BlueprintNoteData.NoteType.Element`, i.e. `type: 1`
+  carrying `id`/`mass`/`temp`), not a website-only element cell: the mod already has a
+  first-class way to say "this cell holds this material", so the base survives the trip back
+  into the game instead of being dropped on export, and it costs no new model — world notes
+  already render, export, undo and import. It also carries no explanatory text, because the
+  mod writes only id/mass/temp for an element note and discards title/text/tint.
+  *Seeded, not owned* — the user then edits or deletes them with the note tool, so deleting
   the annotation leaves them alone rather than discarding their edits, and a cell that already
-  exists is never overwritten. The annotation and its base are one `pauseChangeEvents` batch,
-  hence one undo step. Element cells are excluded from `toBniBlueprint`'s `buildings`, so the
-  base is website-only and still costs nothing.
+  holds a note is never overwritten. The annotation and its base are one
+  `emitBlueprintChanged`, hence one undo step.
 - **Solid element cells** — `BlueprintItemElement` previously rendered only gas/liquid/vacuum;
   solids now render too (Base overlay only, tinted `element_back`, at `ZIndex.Backwall` so a
   building placed on annotated ground is never covered by it). The cell picker gained an
   opt-in **Solid** checkbox, off by default so the existing gas/liquid list is unchanged.
   Neutronium is `Unobtanium` (`NEUTRONIUM_ELEMENT_ID`); it is the one element whose exported
   `color` (white) and `uiColor` (magenta) are both sentinels — the game never renders it as a
-  material — so it gets a render-time `NEUTRONIUM_DISPLAY_COLOR`, with the database left as
-  the export wrote it. This is what makes the neutronium base above renderable, and lets the
-  user draw or extend one by hand.
+  material — so it gets a render-time `NEUTRONIUM_DISPLAY_COLOR` (`#0e0e0e`, the near-black
+  the game's own tile reads as), with the database left as the export wrote it. The override
+  applies wherever Neutronium is drawn: element cells *and* the element-note badges the
+  terrain tool seeds (`noteBadgeColor`). This lets the user draw or extend a base by hand.
 - **Active tile / area of effect** — a feature acts on exactly ONE cell, not on its whole
   footprint, and the cell differs by kind: a **volcano** erupts from the middle of its 3x3
   (`1,1`), a **geyser or vent** from the **left** of its footprint (`0,1`). The split comes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,14 @@ in the exported `buildings` array (a geyser written as a building resolves to a 
   clicking an annotation calls `selectTool.deselectAll()`, and the canvas subscribes to
   `subscribeSelectionChanged` to clear the annotation whenever `selectTool.hasSelection`
   becomes true (a box-drag selection produces no click, so the click path alone can't see it).
+- **Neutronium base** — placing an annotation seeds the row of Neutronium every geyser is
+  anchored on in game: height 1, as wide as the footprint, in the row directly beneath the
+  anchor cell (`neutroniumBaseCells`). *Seeded, not owned* — these are ordinary
+  `BlueprintItemElement` cells the user then edits with the normal element tool, so deleting
+  the annotation leaves them alone rather than discarding their edits, and a cell that already
+  exists is never overwritten. The annotation and its base are one `pauseChangeEvents` batch,
+  hence one undo step. Element cells are excluded from `toBniBlueprint`'s `buildings`, so the
+  base is website-only and still costs nothing.
 - **Solid element cells** — `BlueprintItemElement` previously rendered only gas/liquid/vacuum;
   solids now render too (Base overlay only, tinted `element_back`, at `ZIndex.Backwall` so a
   building placed on annotated ground is never covered by it). The cell picker gained an
@@ -302,9 +310,8 @@ in the exported `buildings` array (a geyser written as a building resolves to a 
   Neutronium is `Unobtanium` (`NEUTRONIUM_ELEMENT_ID`); it is the one element whose exported
   `color` (white) and `uiColor` (magenta) are both sentinels — the game never renders it as a
   material — so it gets a render-time `NEUTRONIUM_DISPLAY_COLOR`, with the database left as
-  the export wrote it. This is what makes it possible to draw the neutronium a geyser rests
-  on by hand; placing an annotation deliberately does **not** create one automatically
-  (parked on the `terrain-neutronium-base` branch — see the PR for why).
+  the export wrote it. This is what makes the neutronium base above renderable, and lets the
+  user draw or extend one by hand.
 - **Active tile / area of effect** — a feature acts on exactly ONE cell, not on its whole
   footprint, and the cell differs by kind: a **volcano** erupts from the middle of its 3x3
   (`1,1`), a **geyser or vent** from the **left** of its footprint (`0,1`). The split comes

--- a/frontend/src/app/module-blueprint/common/tools/terrain-tool.spec.ts
+++ b/frontend/src/app/module-blueprint/common/tools/terrain-tool.spec.ts
@@ -3,6 +3,7 @@ import { ToolType } from "./tool";
 import { ShortcutAction } from "../../keybindings/shortcut-actions";
 import {
   BniTerrainFeature,
+  BniWorldNote,
   BTerrainFeature,
   BuildableElement,
   TerrainFeature,
@@ -26,12 +27,8 @@ describe("TerrainTool", () => {
   let tool: TerrainTool;
   let blueprint: {
     terrainFeatures: BniTerrainFeature[];
-    items: any[];
+    worldNotes: BniWorldNote[];
     emitBlueprintChanged: ReturnType<typeof vi.fn>;
-    pauseChangeEvents: ReturnType<typeof vi.fn>;
-    resumeChangeEvents: ReturnType<typeof vi.fn>;
-    addBlueprintItem: ReturnType<typeof vi.fn>;
-    getBlueprintItemsAt: ReturnType<typeof vi.fn>;
   };
   let terrainService: TerrainAnnotationService;
   let parent: { changeTool: ReturnType<typeof vi.fn> };
@@ -44,15 +41,10 @@ describe("TerrainTool", () => {
     BuildableElement.init();
     BuildableElement.load([]);
 
-    const items: any[] = [];
     blueprint = {
       terrainFeatures: [],
-      items,
+      worldNotes: [],
       emitBlueprintChanged: vi.fn(),
-      pauseChangeEvents: vi.fn(),
-      resumeChangeEvents: vi.fn(),
-      addBlueprintItem: vi.fn((item: any) => items.push(item)),
-      getBlueprintItemsAt: vi.fn(() => []),
     };
     const blueprintService = { blueprint } as unknown as BlueprintService;
     terrainService = new TerrainAnnotationService(blueprintService);
@@ -105,17 +97,12 @@ describe("TerrainTool", () => {
     expect(blueprint.terrainFeatures[0]).toMatchObject({ x: 4, y: 6 });
   });
 
-  // The annotation itself is never a building. Placing does seed neutronium
-  // element cells beneath it, but those are `Element` pseudo-items, which
-  // toBniBlueprint excludes from the exported `buildings` array — so nothing
-  // here reaches material cost or build order either way.
-  it("never adds the annotation itself as a building", () => {
+  // Annotations are not construction. The neutronium base they seed is a world
+  // note, not a building either, so nothing a placement writes reaches material
+  // cost, build order or the exported `buildings` array.
+  it("never touches blueprintItems — annotations are not construction", () => {
     tool.mouseDown(new Vector2(0, 0));
-
-    expect(blueprint.terrainFeatures).toHaveLength(1);
-    expect(blueprint.items.some((i) => i.id === "GeyserGeneric_steam")).toBe(
-      false,
-    );
+    expect((blueprint as any).blueprintItems).toBeUndefined();
   });
 
   it("shows the layer when picked, so a placement cannot land invisibly", () => {

--- a/frontend/src/app/module-blueprint/common/tools/terrain-tool.spec.ts
+++ b/frontend/src/app/module-blueprint/common/tools/terrain-tool.spec.ts
@@ -4,6 +4,7 @@ import { ShortcutAction } from "../../keybindings/shortcut-actions";
 import {
   BniTerrainFeature,
   BTerrainFeature,
+  BuildableElement,
   TerrainFeature,
   Vector2,
 } from "../../../../../../lib/index";
@@ -25,7 +26,12 @@ describe("TerrainTool", () => {
   let tool: TerrainTool;
   let blueprint: {
     terrainFeatures: BniTerrainFeature[];
+    items: any[];
     emitBlueprintChanged: ReturnType<typeof vi.fn>;
+    pauseChangeEvents: ReturnType<typeof vi.fn>;
+    resumeChangeEvents: ReturnType<typeof vi.fn>;
+    addBlueprintItem: ReturnType<typeof vi.fn>;
+    getBlueprintItemsAt: ReturnType<typeof vi.fn>;
   };
   let terrainService: TerrainAnnotationService;
   let parent: { changeTool: ReturnType<typeof vi.fn> };
@@ -33,7 +39,21 @@ describe("TerrainTool", () => {
   beforeEach(() => {
     TerrainFeature.init();
     TerrainFeature.load(CATALOGUE);
-    blueprint = { terrainFeatures: [], emitBlueprintChanged: vi.fn() };
+    // No Neutronium loaded here, so placing seeds no base — this spec is about
+    // the tool's own behaviour; the base is covered in the service spec.
+    BuildableElement.init();
+    BuildableElement.load([]);
+
+    const items: any[] = [];
+    blueprint = {
+      terrainFeatures: [],
+      items,
+      emitBlueprintChanged: vi.fn(),
+      pauseChangeEvents: vi.fn(),
+      resumeChangeEvents: vi.fn(),
+      addBlueprintItem: vi.fn((item: any) => items.push(item)),
+      getBlueprintItemsAt: vi.fn(() => []),
+    };
     const blueprintService = { blueprint } as unknown as BlueprintService;
     terrainService = new TerrainAnnotationService(blueprintService);
     tool = new TerrainTool(blueprintService, terrainService);
@@ -85,9 +105,17 @@ describe("TerrainTool", () => {
     expect(blueprint.terrainFeatures[0]).toMatchObject({ x: 4, y: 6 });
   });
 
-  it("never touches blueprintItems — annotations are not construction", () => {
+  // The annotation itself is never a building. Placing does seed neutronium
+  // element cells beneath it, but those are `Element` pseudo-items, which
+  // toBniBlueprint excludes from the exported `buildings` array — so nothing
+  // here reaches material cost or build order either way.
+  it("never adds the annotation itself as a building", () => {
     tool.mouseDown(new Vector2(0, 0));
-    expect((blueprint as any).blueprintItems).toBeUndefined();
+
+    expect(blueprint.terrainFeatures).toHaveLength(1);
+    expect(blueprint.items.some((i) => i.id === "GeyserGeneric_steam")).toBe(
+      false,
+    );
   });
 
   it("shows the layer when picked, so a placement cannot land invisibly", () => {

--- a/frontend/src/app/module-blueprint/drawing/draw-notes-overlay.spec.ts
+++ b/frontend/src/app/module-blueprint/drawing/draw-notes-overlay.spec.ts
@@ -3,6 +3,8 @@ import {
   BniWorldNote,
   BuildableElement,
   ElementState,
+  NEUTRONIUM_DISPLAY_COLOR,
+  NEUTRONIUM_ELEMENT_ID,
 } from "../../../../../lib/index";
 import {
   MARKER_URLS,
@@ -81,6 +83,23 @@ describe("noteBadgeColor", () => {
       ).color,
     ).to.equal(0xd95e63);
     expect(noteBadgeColor(note, noElement).color).to.equal(0x3b82f6);
+  });
+
+  // Neutronium's exported uiColor is a placeholder magenta the game never
+  // shows, and the terrain tool seeds a row of these under every feature — so
+  // the badge takes the same near-black override the element's cells do.
+  it("overrides Neutronium's placeholder uiColor with its display colour", () => {
+    const note: BniWorldNote = { x: 0, y: 0, type: 1, id: 9, mass: 0, temp: 0 };
+    const neutronium = {
+      id: NEUTRONIUM_ELEMENT_ID,
+      name: "Neutronium",
+      uiColor: 0xff00ff,
+      state: ElementState.Solid,
+    } as BuildableElement;
+
+    expect(
+      noteBadgeColor(note, (t) => (t === 9 ? neutronium : undefined)),
+    ).to.deep.equal({ color: NEUTRONIUM_DISPLAY_COLOR, alpha: 1 });
   });
 });
 

--- a/frontend/src/app/module-blueprint/services/terrain-annotation.service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/terrain-annotation.service.spec.ts
@@ -1,14 +1,18 @@
 import {
   BniTerrainFeature,
   BTerrainFeature,
+  BuildableElement,
+  NEUTRONIUM_ELEMENT_ID,
   TerrainFeature,
 } from "../../../../../lib/index";
 import { BlueprintService } from "./blueprint-service";
 import {
   TerrainAnnotationService,
   findTerrainFeatureAt,
+  neutroniumBaseCells,
   terrainFootprint,
 } from "./terrain-annotation.service";
+import { BlueprintHelpers } from "../../../../../lib/index";
 
 const CATALOGUE: BTerrainFeature[] = [
   {
@@ -81,6 +85,49 @@ describe("terrain annotation geometry", () => {
     expect(findTerrainFeatureAt(null, { x: 0, y: 0 })).toBe(null);
     expect(findTerrainFeatureAt(undefined, { x: 0, y: 0 })).toBe(null);
   });
+
+  // In the game every geyser, vent and volcano is anchored on indestructible
+  // neutronium; this is that row.
+  describe("neutroniumBaseCells", () => {
+    it("is one row, as wide as the footprint, directly beneath the anchor", () => {
+      // OilWell is 4x2, anchored bottom-left at (10, 20).
+      expect(
+        neutroniumBaseCells({ id: "OilWell", x: 10, y: 20 }).map((c) => ({
+          x: c.x,
+          y: c.y,
+        })),
+      ).toEqual([
+        { x: 10, y: 19 },
+        { x: 11, y: 19 },
+        { x: 12, y: 19 },
+        { x: 13, y: 19 },
+      ]);
+    });
+
+    it("narrows with the footprint", () => {
+      // Cool Steam Vent is 2 wide.
+      expect(
+        neutroniumBaseCells({ id: "GeyserGeneric_steam", x: 0, y: 0 }),
+      ).toHaveLength(2);
+    });
+
+    it("gives an unknown feature a single cell", () => {
+      expect(
+        neutroniumBaseCells({ id: "SomeModdedGeyser", x: 5, y: 5 }),
+      ).toEqual([expect.objectContaining({ x: 5, y: 4 })]);
+    });
+
+    it("follows a feature into negative coordinates", () => {
+      expect(
+        neutroniumBaseCells({ id: "GeyserGeneric_steam", x: -3, y: -5 }).map(
+          (c) => ({ x: c.x, y: c.y }),
+        ),
+      ).toEqual([
+        { x: -3, y: -6 },
+        { x: -2, y: -6 },
+      ]);
+    });
+  });
 });
 
 describe("TerrainAnnotationService", () => {
@@ -88,12 +135,35 @@ describe("TerrainAnnotationService", () => {
   let blueprint: {
     terrainFeatures: BniTerrainFeature[];
     emitBlueprintChanged: ReturnType<typeof vi.fn>;
+    pauseChangeEvents: ReturnType<typeof vi.fn>;
+    resumeChangeEvents: ReturnType<typeof vi.fn>;
+    addBlueprintItem: ReturnType<typeof vi.fn>;
+    getBlueprintItemsAt: ReturnType<typeof vi.fn>;
+    items: any[];
   };
 
   beforeEach(() => {
     TerrainFeature.init();
     TerrainFeature.load(CATALOGUE);
-    blueprint = { terrainFeatures: [], emitBlueprintChanged: vi.fn() };
+    // No Neutronium in the element table by default, so the base-seeding tests
+    // opt in explicitly and every other test exercises the graceful no-base path.
+    BuildableElement.init();
+    BuildableElement.load([]);
+
+    const items: any[] = [];
+    blueprint = {
+      terrainFeatures: [],
+      items,
+      emitBlueprintChanged: vi.fn(),
+      pauseChangeEvents: vi.fn(),
+      // Mirrors the real Blueprint: resuming emits the batched change, which is
+      // what turns one placement into exactly one undo snapshot.
+      resumeChangeEvents: vi.fn(() => blueprint.emitBlueprintChanged()),
+      addBlueprintItem: vi.fn((item: any) => items.push(item)),
+      getBlueprintItemsAt: vi.fn((p: { x: number; y: number }) =>
+        items.filter((i) => i.position.x === p.x && i.position.y === p.y),
+      ),
+    };
     service = new TerrainAnnotationService({
       blueprint,
     } as unknown as BlueprintService);
@@ -159,6 +229,115 @@ describe("TerrainAnnotationService", () => {
     service.delete(removed);
 
     expect(service.selected).toBe(kept);
+  });
+
+  // In the game every geyser sits on neutronium, so placing one seeds that row.
+  describe("neutronium base", () => {
+    const NEUTRONIUM = {
+      id: NEUTRONIUM_ELEMENT_ID,
+      name: "Neutronium",
+      tag: 1838482828,
+      oreTags: ["Solid", "Special"],
+      state: 3,
+      maxMass: 20000,
+      defaultMass: 20000,
+      defaultTemperature: 1,
+    };
+
+    beforeEach(() => {
+      BuildableElement.init();
+      BuildableElement.load([NEUTRONIUM as never]);
+
+      // Element cells are real BlueprintItems, which need the renderer's
+      // OniItem/SpriteModifier tables — never stood up in specs. Stub the
+      // factory with the small surface seedNeutroniumBase actually touches.
+      vi.spyOn(BlueprintHelpers, "createInstance").mockImplementation(
+        (id: string) => {
+          const cell: any = {
+            id,
+            position: { x: 0, y: 0 },
+            mass: 0,
+            temperature: 0,
+            buildableElements: [],
+            setElement: (elementId: string, index: number) => {
+              cell.buildableElements[index] = { id: elementId };
+            },
+            cleanUp: () => {},
+            prepareBoundingBox: () => {},
+          };
+          return cell;
+        },
+      );
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("seeds one row, as wide as the footprint, directly beneath the anchor", () => {
+      // OilWell is 4x2, anchored bottom-left at (10, 20).
+      service.add({ id: "OilWell", x: 10, y: 20 });
+
+      expect(blueprint.items).toHaveLength(4);
+      expect(
+        blueprint.items.map((i) => ({ x: i.position.x, y: i.position.y })),
+      ).toEqual([
+        { x: 10, y: 19 },
+        { x: 11, y: 19 },
+        { x: 12, y: 19 },
+        { x: 13, y: 19 },
+      ]);
+      expect(
+        blueprint.items.every(
+          (i) => i.buildableElements[0].id === NEUTRONIUM_ELEMENT_ID,
+        ),
+      ).toBe(true);
+    });
+
+    it("matches a narrower footprint", () => {
+      // Cool Steam Vent is 2 wide.
+      service.add({ id: "GeyserGeneric_steam", x: 0, y: 0 });
+      expect(blueprint.items).toHaveLength(2);
+    });
+
+    it("gives an unknown feature a single-cell base", () => {
+      service.add({ id: "SomeModdedGeyser", x: 5, y: 5 });
+      expect(blueprint.items).toHaveLength(1);
+    });
+
+    // The user is meant to customize the base with the normal element tool, so
+    // a cell they already placed must never be replaced by the default.
+    it("never stacks a second cell where one already exists", () => {
+      service.add({ id: "OilWell", x: 10, y: 20 });
+      service.add({ id: "OilWell", x: 10, y: 20 });
+      expect(blueprint.items).toHaveLength(4);
+    });
+
+    // The annotation and its base are one edit, so they are one undo step.
+    it("batches the annotation and its base into a single change event", () => {
+      service.add({ id: "OilWell", x: 10, y: 20 });
+      expect(blueprint.pauseChangeEvents).toHaveBeenCalledTimes(1);
+      expect(blueprint.resumeChangeEvents).toHaveBeenCalledTimes(1);
+    });
+
+    // Seeded, not owned: deleting the annotation leaves cells the user may
+    // have since edited.
+    it("leaves the base behind when the annotation is deleted", () => {
+      const feature: BniTerrainFeature = { id: "OilWell", x: 10, y: 20 };
+      service.add(feature);
+      service.delete(feature);
+
+      expect(blueprint.terrainFeatures).toEqual([]);
+      expect(blueprint.items).toHaveLength(4);
+    });
+  });
+
+  // A database predating Neutronium (or any element table that lacks it) gets
+  // the annotation and no base, rather than a crash.
+  it("places no base when the database has no Neutronium", () => {
+    service.add({ id: "OilWell", x: 0, y: 0 });
+    expect(blueprint.items).toHaveLength(0);
+    expect(blueprint.terrainFeatures).toHaveLength(1);
   });
 
   // Visibility is view state only: it must never reach what is stored.

--- a/frontend/src/app/module-blueprint/services/terrain-annotation.service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/terrain-annotation.service.spec.ts
@@ -1,5 +1,6 @@
 import {
   BniTerrainFeature,
+  BniWorldNote,
   BTerrainFeature,
   BuildableElement,
   NEUTRONIUM_ELEMENT_ID,
@@ -12,7 +13,6 @@ import {
   neutroniumBaseCells,
   terrainFootprint,
 } from "./terrain-annotation.service";
-import { BlueprintHelpers } from "../../../../../lib/index";
 
 const CATALOGUE: BTerrainFeature[] = [
   {
@@ -134,12 +134,8 @@ describe("TerrainAnnotationService", () => {
   let service: TerrainAnnotationService;
   let blueprint: {
     terrainFeatures: BniTerrainFeature[];
+    worldNotes: BniWorldNote[];
     emitBlueprintChanged: ReturnType<typeof vi.fn>;
-    pauseChangeEvents: ReturnType<typeof vi.fn>;
-    resumeChangeEvents: ReturnType<typeof vi.fn>;
-    addBlueprintItem: ReturnType<typeof vi.fn>;
-    getBlueprintItemsAt: ReturnType<typeof vi.fn>;
-    items: any[];
   };
 
   beforeEach(() => {
@@ -150,19 +146,10 @@ describe("TerrainAnnotationService", () => {
     BuildableElement.init();
     BuildableElement.load([]);
 
-    const items: any[] = [];
     blueprint = {
       terrainFeatures: [],
-      items,
+      worldNotes: [],
       emitBlueprintChanged: vi.fn(),
-      pauseChangeEvents: vi.fn(),
-      // Mirrors the real Blueprint: resuming emits the batched change, which is
-      // what turns one placement into exactly one undo snapshot.
-      resumeChangeEvents: vi.fn(() => blueprint.emitBlueprintChanged()),
-      addBlueprintItem: vi.fn((item: any) => items.push(item)),
-      getBlueprintItemsAt: vi.fn((p: { x: number; y: number }) =>
-        items.filter((i) => i.position.x === p.x && i.position.y === p.y),
-      ),
     };
     service = new TerrainAnnotationService({
       blueprint,
@@ -231,7 +218,9 @@ describe("TerrainAnnotationService", () => {
     expect(service.selected).toBe(kept);
   });
 
-  // In the game every geyser sits on neutronium, so placing one seeds that row.
+  // In the game every geyser sits on neutronium, so placing one seeds that row
+  // as element world notes — the mod's own way of saying "this cell holds this
+  // material", so unlike an element cell it survives the trip back into game.
   describe("neutronium base", () => {
     const NEUTRONIUM = {
       id: NEUTRONIUM_ELEMENT_ID,
@@ -247,80 +236,79 @@ describe("TerrainAnnotationService", () => {
     beforeEach(() => {
       BuildableElement.init();
       BuildableElement.load([NEUTRONIUM as never]);
-
-      // Element cells are real BlueprintItems, which need the renderer's
-      // OniItem/SpriteModifier tables — never stood up in specs. Stub the
-      // factory with the small surface seedNeutroniumBase actually touches.
-      vi.spyOn(BlueprintHelpers, "createInstance").mockImplementation(
-        (id: string) => {
-          const cell: any = {
-            id,
-            position: { x: 0, y: 0 },
-            mass: 0,
-            temperature: 0,
-            buildableElements: [],
-            setElement: (elementId: string, index: number) => {
-              cell.buildableElements[index] = { id: elementId };
-            },
-            cleanUp: () => {},
-            prepareBoundingBox: () => {},
-          };
-          return cell;
-        },
-      );
-    });
-
-    afterEach(() => {
-      vi.restoreAllMocks();
     });
 
     it("seeds one row, as wide as the footprint, directly beneath the anchor", () => {
       // OilWell is 4x2, anchored bottom-left at (10, 20).
       service.add({ id: "OilWell", x: 10, y: 20 });
 
-      expect(blueprint.items).toHaveLength(4);
-      expect(
-        blueprint.items.map((i) => ({ x: i.position.x, y: i.position.y })),
-      ).toEqual([
+      expect(blueprint.worldNotes).toHaveLength(4);
+      expect(blueprint.worldNotes.map((n) => ({ x: n.x, y: n.y }))).toEqual([
         { x: 10, y: 19 },
         { x: 11, y: 19 },
         { x: 12, y: 19 },
         { x: 13, y: 19 },
       ]);
-      expect(
-        blueprint.items.every(
-          (i) => i.buildableElements[0].id === NEUTRONIUM_ELEMENT_ID,
-        ),
-      ).toBe(true);
+    });
+
+    // Type 1 is BlueprintNoteData.NoteType.Element; the mod writes only
+    // id/mass/temp for it, so those three are the whole payload.
+    it("writes each cell as an element note carrying Neutronium", () => {
+      service.add({ id: "GeyserGeneric_steam", x: 0, y: 0 });
+
+      expect(blueprint.worldNotes[0]).toEqual({
+        x: 0,
+        y: -1,
+        type: 1,
+        id: NEUTRONIUM.tag,
+        mass: NEUTRONIUM.defaultMass,
+        temp: NEUTRONIUM.defaultTemperature,
+      });
     });
 
     it("matches a narrower footprint", () => {
       // Cool Steam Vent is 2 wide.
       service.add({ id: "GeyserGeneric_steam", x: 0, y: 0 });
-      expect(blueprint.items).toHaveLength(2);
+      expect(blueprint.worldNotes).toHaveLength(2);
     });
 
     it("gives an unknown feature a single-cell base", () => {
       service.add({ id: "SomeModdedGeyser", x: 5, y: 5 });
-      expect(blueprint.items).toHaveLength(1);
+      expect(blueprint.worldNotes).toHaveLength(1);
     });
 
-    // The user is meant to customize the base with the normal element tool, so
-    // a cell they already placed must never be replaced by the default.
-    it("never stacks a second cell where one already exists", () => {
+    // The user is meant to customize the base with the note tool, so a note
+    // already at that cell must never be replaced by the default.
+    it("never stacks a second note where one already exists", () => {
       service.add({ id: "OilWell", x: 10, y: 20 });
       service.add({ id: "OilWell", x: 10, y: 20 });
-      expect(blueprint.items).toHaveLength(4);
+      expect(blueprint.worldNotes).toHaveLength(4);
+    });
+
+    it("leaves a note the user already placed alone", () => {
+      const theirs: BniWorldNote = { x: 10, y: 19, type: 0, text: "mine" };
+      blueprint.worldNotes = [theirs];
+      service.add({ id: "OilWell", x: 10, y: 20 });
+
+      expect(blueprint.worldNotes).toHaveLength(4);
+      expect(blueprint.worldNotes[0]).toBe(theirs);
     });
 
     // The annotation and its base are one edit, so they are one undo step.
-    it("batches the annotation and its base into a single change event", () => {
+    it("emits a single change event for the annotation and its base", () => {
       service.add({ id: "OilWell", x: 10, y: 20 });
-      expect(blueprint.pauseChangeEvents).toHaveBeenCalledTimes(1);
-      expect(blueprint.resumeChangeEvents).toHaveBeenCalledTimes(1);
+      expect(blueprint.emitBlueprintChanged).toHaveBeenCalledTimes(1);
     });
 
-    // Seeded, not owned: deleting the annotation leaves cells the user may
+    // The notes overlay caches by array identity, so a push alone would not
+    // redraw.
+    it("gives worldNotes a new array identity", () => {
+      const before = blueprint.worldNotes;
+      service.add({ id: "OilWell", x: 10, y: 20 });
+      expect(blueprint.worldNotes).not.toBe(before);
+    });
+
+    // Seeded, not owned: deleting the annotation leaves notes the user may
     // have since edited.
     it("leaves the base behind when the annotation is deleted", () => {
       const feature: BniTerrainFeature = { id: "OilWell", x: 10, y: 20 };
@@ -328,7 +316,7 @@ describe("TerrainAnnotationService", () => {
       service.delete(feature);
 
       expect(blueprint.terrainFeatures).toEqual([]);
-      expect(blueprint.items).toHaveLength(4);
+      expect(blueprint.worldNotes).toHaveLength(4);
     });
   });
 
@@ -336,7 +324,7 @@ describe("TerrainAnnotationService", () => {
   // the annotation and no base, rather than a crash.
   it("places no base when the database has no Neutronium", () => {
     service.add({ id: "OilWell", x: 0, y: 0 });
-    expect(blueprint.items).toHaveLength(0);
+    expect(blueprint.worldNotes).toHaveLength(0);
     expect(blueprint.terrainFeatures).toHaveLength(1);
   });
 

--- a/frontend/src/app/module-blueprint/services/terrain-annotation.service.ts
+++ b/frontend/src/app/module-blueprint/services/terrain-annotation.service.ts
@@ -1,5 +1,14 @@
 import { Injectable } from "@angular/core";
-import { BniTerrainFeature, TerrainFeature } from "../../../../../lib/index";
+import {
+  BlueprintHelpers,
+  BlueprintItemElement,
+  BniTerrainFeature,
+  BuildableElement,
+  NEUTRONIUM_ELEMENT_ID,
+  OniItem,
+  TerrainFeature,
+  Vector2,
+} from "../../../../../lib/index";
 import { BlueprintService } from "./blueprint-service";
 
 // Footprint of a placed annotation, in cells. The catalogue is the source of
@@ -40,6 +49,19 @@ export function findTerrainFeatureAt(
       return feature;
   }
   return null;
+}
+
+// The cells a feature's neutronium base occupies: one row, as wide as the
+// footprint, directly beneath the anchor. In the game every geyser, vent and
+// volcano is anchored on indestructible neutronium, and this is that row.
+//
+// Pure so the geometry is testable without standing up the renderer.
+export function neutroniumBaseCells(feature: BniTerrainFeature): Vector2[] {
+  const { width } = terrainFootprint(feature);
+  const cells: Vector2[] = [];
+  for (let dx = 0; dx < width; dx++)
+    cells.push(new Vector2(feature.x + dx, feature.y - 1));
+  return cells;
 }
 
 // Shared selection/visibility state for terrain annotations, modelled on
@@ -98,9 +120,52 @@ export class TerrainAnnotationService {
 
   add(feature: BniTerrainFeature) {
     const blueprint = this.blueprintService.blueprint;
+
+    // The annotation and the neutronium row it sits on are one edit, so they
+    // are one undo step: every addBlueprintItem would otherwise push its own
+    // snapshot and a single click would eat five slots of the 50-entry ring.
+    blueprint.pauseChangeEvents();
     blueprint.terrainFeatures = [...blueprint.terrainFeatures, feature];
+    this.seedNeutroniumBase(feature);
     this.select(feature);
-    blueprint.emitBlueprintChanged();
+    blueprint.resumeChangeEvents();
+  }
+
+  // Seeded, not owned. Once placed these are ordinary element cells the user
+  // edits with the normal element tool (or deletes) — which is the point, since
+  // real terrain rarely matches the default exactly. Deleting the annotation
+  // therefore leaves them alone rather than discarding edits the user made.
+  private seedNeutroniumBase(feature: BniTerrainFeature) {
+    const blueprint = this.blueprintService.blueprint;
+
+    // A database with no Neutronium simply gets no base rather than a crash.
+    const neutronium = BuildableElement.elements?.find(
+      (e) => e.id === NEUTRONIUM_ELEMENT_ID,
+    );
+    if (neutronium == null) return;
+
+    for (const position of neutroniumBaseCells(feature)) {
+      // Never stack a second cell on one that already exists: re-placing a
+      // feature over its own base must not double up, and a cell the user has
+      // already customized must win over the default.
+      const occupied = blueprint
+        .getBlueprintItemsAt(position)
+        .some((item) => item.id === OniItem.elementId);
+      if (occupied) continue;
+
+      const cell = BlueprintHelpers.createInstance(
+        OniItem.elementId,
+      ) as BlueprintItemElement | null;
+      if (cell == null) return;
+
+      cell.position = position;
+      cell.setElement(NEUTRONIUM_ELEMENT_ID, 0);
+      cell.mass = neutronium.defaultMass;
+      cell.temperature = neutronium.defaultTemperature;
+      cell.cleanUp();
+      cell.prepareBoundingBox();
+      blueprint.addBlueprintItem(cell);
+    }
   }
 
   move(feature: BniTerrainFeature, tile: { x: number; y: number }) {

--- a/frontend/src/app/module-blueprint/services/terrain-annotation.service.ts
+++ b/frontend/src/app/module-blueprint/services/terrain-annotation.service.ts
@@ -1,15 +1,20 @@
 import { Injectable } from "@angular/core";
 import {
-  BlueprintHelpers,
-  BlueprintItemElement,
   BniTerrainFeature,
+  BniWorldNote,
   BuildableElement,
   NEUTRONIUM_ELEMENT_ID,
-  OniItem,
   TerrainFeature,
   Vector2,
 } from "../../../../../lib/index";
 import { BlueprintService } from "./blueprint-service";
+import { findNoteAt } from "./world-note.service";
+
+// `BlueprintNoteData.NoteType.Element` — a note that names the element a cell
+// should hold, rather than carrying text. The mod writes only id/mass/temp for
+// this type (title, text and tint are dropped on save), which is why the base
+// carries no explanatory text: it would not survive a round-trip through game.
+const ELEMENT_NOTE = 1;
 
 // Footprint of a placed annotation, in cells. The catalogue is the source of
 // truth for size; an id this database doesn't know annotates a single cell, so
@@ -54,6 +59,10 @@ export function findTerrainFeatureAt(
 // The cells a feature's neutronium base occupies: one row, as wide as the
 // footprint, directly beneath the anchor. In the game every geyser, vent and
 // volcano is anchored on indestructible neutronium, and this is that row.
+//
+// The real deposit is often wider — a cell or two off either end, depending on
+// the world seed — but that part is unpredictable, so only the subset that is
+// always present is drawn.
 //
 // Pure so the geometry is testable without standing up the renderer.
 export function neutroniumBaseCells(feature: BniTerrainFeature): Vector2[] {
@@ -120,52 +129,56 @@ export class TerrainAnnotationService {
 
   add(feature: BniTerrainFeature) {
     const blueprint = this.blueprintService.blueprint;
-
-    // The annotation and the neutronium row it sits on are one edit, so they
-    // are one undo step: every addBlueprintItem would otherwise push its own
-    // snapshot and a single click would eat five slots of the 50-entry ring.
-    blueprint.pauseChangeEvents();
     blueprint.terrainFeatures = [...blueprint.terrainFeatures, feature];
-    this.seedNeutroniumBase(feature);
+    // Both arrays get a new identity, since the overlays cache by identity.
+    blueprint.worldNotes = [
+      ...blueprint.worldNotes,
+      ...this.neutroniumBaseNotes(feature),
+    ];
     this.select(feature);
-    blueprint.resumeChangeEvents();
+    // One emit for the annotation and its base together, so a placement costs
+    // one slot of the 50-entry undo ring rather than five.
+    blueprint.emitBlueprintChanged();
   }
 
-  // Seeded, not owned. Once placed these are ordinary element cells the user
-  // edits with the normal element tool (or deletes) — which is the point, since
-  // real terrain rarely matches the default exactly. Deleting the annotation
+  // The neutronium row a placed feature sits on, as element world notes.
+  //
+  // A note rather than an element cell, because the mod already has a
+  // first-class way to say "this cell holds this material" and it survives the
+  // round-trip into the game — an element cell is website-only and is dropped
+  // from the exported `buildings` array entirely. It also costs nothing new:
+  // world notes already render, export, undo and import.
+  //
+  // Seeded, not owned. Once placed these are ordinary world notes the user
+  // edits with the note tool (or deletes) — which is the point, since real
+  // terrain rarely matches the default exactly. Deleting the annotation
   // therefore leaves them alone rather than discarding edits the user made.
-  private seedNeutroniumBase(feature: BniTerrainFeature) {
+  private neutroniumBaseNotes(feature: BniTerrainFeature): BniWorldNote[] {
     const blueprint = this.blueprintService.blueprint;
 
     // A database with no Neutronium simply gets no base rather than a crash.
     const neutronium = BuildableElement.elements?.find(
       (e) => e.id === NEUTRONIUM_ELEMENT_ID,
     );
-    if (neutronium == null) return;
+    if (neutronium == null) return [];
 
-    for (const position of neutroniumBaseCells(feature)) {
-      // Never stack a second cell on one that already exists: re-placing a
-      // feature over its own base must not double up, and a cell the user has
+    const notes: BniWorldNote[] = [];
+    for (const cell of neutroniumBaseCells(feature)) {
+      // Never stack a second note on a cell that already has one: re-placing a
+      // feature over its own base must not double up, and a note the user has
       // already customized must win over the default.
-      const occupied = blueprint
-        .getBlueprintItemsAt(position)
-        .some((item) => item.id === OniItem.elementId);
-      if (occupied) continue;
+      if (findNoteAt(blueprint.worldNotes, cell) != null) continue;
 
-      const cell = BlueprintHelpers.createInstance(
-        OniItem.elementId,
-      ) as BlueprintItemElement | null;
-      if (cell == null) return;
-
-      cell.position = position;
-      cell.setElement(NEUTRONIUM_ELEMENT_ID, 0);
-      cell.mass = neutronium.defaultMass;
-      cell.temperature = neutronium.defaultTemperature;
-      cell.cleanUp();
-      cell.prepareBoundingBox();
-      blueprint.addBlueprintItem(cell);
+      notes.push({
+        x: cell.x,
+        y: cell.y,
+        type: ELEMENT_NOTE,
+        id: neutronium.tag,
+        mass: neutronium.defaultMass,
+        temp: neutronium.defaultTemperature,
+      });
     }
+    return notes;
   }
 
   move(feature: BniTerrainFeature, tile: { x: number; y: number }) {

--- a/lib/src/b-export/b-element.d.ts
+++ b/lib/src/b-export/b-element.d.ts
@@ -1,6 +1,6 @@
 import { ElementState } from '../enums/element-state';
 export declare const NEUTRONIUM_ELEMENT_ID = "Unobtanium";
-export declare const NEUTRONIUM_DISPLAY_COLOR = 2829104;
+export declare const NEUTRONIUM_DISPLAY_COLOR = 921102;
 export declare class BuildableElement {
     id: string;
     name: string;

--- a/lib/src/b-export/b-element.ts
+++ b/lib/src/b-export/b-element.ts
@@ -7,16 +7,17 @@ import { ElementState } from '../enums/element-state';
 // uiColor — see BlueprintItemElement's solid branch.
 export const NEUTRONIUM_ELEMENT_ID = 'Unobtanium';
 
-// Display tint for Neutronium cells.
+// Display tint for Neutronium, wherever it is drawn — element cells and the
+// element-note badges the terrain tool seeds under a feature.
 //
 // A presentational override, and the only one: Neutronium is the one element
 // whose exported colours are sentinels rather than real values — `color` is
 // pure white and `uiColor` a placeholder magenta — because the game never
 // renders it as a material or shows it in any material UI. Taking either at
 // face value paints the brightest thing on the canvas underneath every geyser.
-// In game the stuff is near-black, so that is what we draw. The database keeps
-// the export's values untouched; this is a render-time choice.
-export const NEUTRONIUM_DISPLAY_COLOR = 0x2b2b30;
+// This is the near-black the game's own tile reads as; the database keeps the
+// export's values untouched.
+export const NEUTRONIUM_DISPLAY_COLOR = 0x0e0e0e;
 
 // Elements that buildings can be made of (Exported from the game)
 // TODO we don't currently handle "exotic" elements (ie reed fibers for paintings, or bleach stone for sanitation stations)

--- a/lib/src/drawing/note-markers.d.ts
+++ b/lib/src/drawing/note-markers.d.ts
@@ -1,5 +1,5 @@
-import { BniWorldNote } from '../io/bni/bni-blueprint';
 import { BuildableElement } from '../b-export/b-element';
+import { BniWorldNote } from '../io/bni/bni-blueprint';
 export declare const NOTE_ICON_TILE_FRACTION = 0.9;
 export declare const NOTE_SYMBOLS: string[];
 export declare const DEFAULT_NOTE_SYMBOL = "note_info";

--- a/lib/src/drawing/note-markers.ts
+++ b/lib/src/drawing/note-markers.ts
@@ -1,5 +1,9 @@
+import {
+  BuildableElement,
+  NEUTRONIUM_DISPLAY_COLOR,
+  NEUTRONIUM_ELEMENT_ID,
+} from '../b-export/b-element';
 import { BniWorldNote } from '../io/bni/bni-blueprint';
-import { BuildableElement } from '../b-export/b-element';
 import { ElementState } from '../enums/element-state';
 
 // How a world note becomes a marker on the canvas: which sprite, what colour,
@@ -93,6 +97,11 @@ export function noteBadgeColor(
 ): { color: number; alpha: number } {
   if (note.type === TEXT_NOTE) return parseNoteTintHex(note.tinthex);
   const element = note.id != null ? resolveElement(note.id) : undefined;
+  // Neutronium's exported uiColor is a placeholder magenta the game never
+  // shows, and the terrain tool seeds a whole row of these under every
+  // feature — so it takes the same near-black override its cells do.
+  if (element != null && element.id === NEUTRONIUM_ELEMENT_ID)
+    return { color: NEUTRONIUM_DISPLAY_COLOR, alpha: 1 };
   return {
     color: element != null && element.uiColor ? element.uiColor : DEFAULT_BADGE_COLOR,
     alpha: 1,


### PR DESCRIPTION
Placing a terrain annotation now seeds the row of neutronium the feature is
anchored on in game, as **element world notes** — the mod's own way of saying
"this cell holds this material".

Two commits: the first adds the base seeding (previously parked on
`terrain-neutronium-base`, and its commit message still carries the "PARKED"
framing — that framing is superseded by this PR, the branch was unparked
deliberately). The second is the change that made it worth shipping.

## Why notes and not element cells

The parked version seeded `BlueprintItemElement` cells. Those are website-only:
`toBniBlueprint` drops them from the exported `buildings` array, so the
information never reached the game a blueprint came from.

`BlueprintNoteData.NoteType.Element` is a world note carrying `id`/`mass`/`temp`
— exactly "this cell holds this material", and already round-trips. Using it
means the base survives back into the game and costs no new model: world notes
already render, export, undo and import. One note per base cell.

## Design decisions

- **No explanatory text on the base.** The mod's `WriteDataJson` writes only
  `id`, `mass` and `temp` for an element note and discards `title`/`text`/
  `tinthex`, so any text would silently vanish on the next in-game save. Noted
  in code on the `ELEMENT_NOTE` constant.
- **Only the row directly beneath the anchor**, width of the footprint. The real
  deposit is often a cell or two wider, but by how much depends on the world
  seed, so the seeded shape is the subset that is always present.
- **`NEUTRONIUM_DISPLAY_COLOR` is now `#0e0e0e`** (was `0x2b2b30`) — the
  near-black the game's own tile reads as. The override now applies to note
  badges as well as element cells (`noteBadgeColor`); without it the badge would
  render the export's placeholder magenta, which the game never shows.
- **Seeded, not owned** (unchanged): deleting the annotation leaves the notes,
  and a cell that already holds a note is never overwritten — so a note the user
  customized always wins.
- Placement is a single `emitBlueprintChanged` rather than a `pauseChangeEvents`
  batch: nothing emits per item any more, so one placement is still one undo
  step.

## Verification

- Frontend: 1140 passing, 2 skipped (`cd frontend && npm test`)
- `npm run tsc` clean
- Backend: failures are confined to `workos-provision`, the WorkOS migration
  script and the version API — the documented local flakes, unrelated to this
  change and present on the base commit too.

## Deferred

The server-side preview worker still doesn't draw terrain features (documented
gap in CLAUDE.md). It does draw world notes, so the seeded base *will* appear on
blueprint cards while the geyser above it does not — worth closing, but out of
scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
