### PR TITLE
ci: drop Blacksmith, run all jobs on GitHub-hosted runners

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   typecheck:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -39,7 +39,7 @@ jobs:
         run: npm run tsc
 
   test:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     services:
       mongodb:

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   lint:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -35,7 +35,7 @@ jobs:
         run: cd frontend && npm run lint
 
   typecheck:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -71,7 +71,7 @@ jobs:
         run: cd frontend && npx tsc -p tsconfig.admin.json --noEmit
 
   test:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       code-quality: write
 
@@ -109,7 +109,7 @@ jobs:
           label: frontend
 
   build:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   quick-check:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -27,7 +27,7 @@ jobs:
         run: npm run tsc
 
   deploy:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: quick-check
 
     steps:
@@ -40,21 +40,25 @@ jobs:
           echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
           echo "GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
 
-      # Blacksmith sticky-disk layer cache instead of cache-from/to type=gha:
-      # on Blacksmith runners the GHA cache is a cross-provider transfer, and
-      # mode=max's ~400MB node_modules blobs kept the repo cache pinned at the
-      # 10GB cap — evictions made every build re-download blobs at <1MB/s
-      # (30+ min builds). The Blacksmith builder caches layers on local NVMe.
       - name: Set up Docker builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: docker/setup-buildx-action@v3
 
+      # type=gha is the right cache backend again now that the job runs on a
+      # GitHub-hosted runner. It was previously swapped for a Blacksmith
+      # sticky disk because from a Blacksmith runner the GHA cache is a
+      # cross-provider transfer: mode=max's ~400MB node_modules blobs pinned
+      # the repo cache at its 10GB cap and evictions re-downloaded them at
+      # <1MB/s (30+ min builds). Same-provider that transfer is local and fast,
+      # so mode=max pays off across the three npm ci stages in deploy.Dockerfile.
       - name: Build Docker image
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: deploy.Dockerfile
           tags: bni-deploy
           load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             BUILD_DATE=${{ env.BUILD_DATE }}
             GIT_COMMIT=${{ env.GIT_COMMIT }}


### PR DESCRIPTION
## Why

A surprise \$50 Blacksmith bill. Blacksmith was billing runner minutes on a repo where **GitHub Actions is free**: this repo is public, and public repos get unlimited standard-runner minutes plus a 4-core/16GB `ubuntu-latest` — the same spec as the `blacksmith-4vcpu-ubuntu-2404` class every job was pinned to.

### What the minutes actually were (July 2026, measured via the Actions API)

| Workflow | Runs | Runner-minutes |
|---|---:|---:|
| Frontend CI | 266 | 847 |
| Backend CI | 258 | 535 |
| Build and Deploy | 93 | 408 |
| **Total** | **617** | **~1,790** |

The Docker builder was the *initial* suspicion, and it is the single most expensive job (408 min, 23% of the total) — but it is not a regression. The sticky-disk switch on 2026-07-09 (3d9f92e5) cut deploy times from 350–650s to a steady ~120s and was working exactly as intended. The cost was simply that **every job in the repo** ran on paid runners, ~617 runs a month, for something GitHub gives away free here.

## What shipped

- All 8 jobs across `backend-test.yml`, `frontend-test.yml`, `publish.yml`: `blacksmith-4vcpu-ubuntu-2404` → `ubuntu-latest`.
- `useblacksmith/setup-docker-builder@v1` → `docker/setup-buildx-action@v3`
- `useblacksmith/build-push-action@v2` → `docker/build-push-action@v6`

### Layer caching decision

The sticky disk goes away with Blacksmith, so the deploy job needs a cache backend again. It goes back to `type=gha` with `mode=max`.

The existing comment explained `type=gha` had been abandoned because `mode=max`'s ~400MB `node_modules` blobs pinned the repo cache at its 10GB cap, and evictions re-downloaded them at <1MB/s (30+ min builds). That penalty was specifically **cross-provider transfer** from a Blacksmith runner to GitHub's cache. Running on GitHub's own runners removes the root cause — the transfer is local — so `mode=max` pays off again across `deploy.Dockerfile`'s three `npm ci` stages. The comment has been rewritten to record this rather than deleted, so the next person doesn't re-litigate it.

## Verification

- All three workflow files parse as valid YAML; confirmed all 8 jobs resolve to `ubuntu-latest`.
- No `blacksmith`/`useblacksmith` references remain in `.github/` except the explanatory comment above.
- The real test is this PR's own CI run — Backend CI and Frontend CI trigger on `pull_request`, so they exercise the new runners here. `publish.yml` only runs on push to `master` and will first exercise the new buildx cache path on merge; expect that first build to be slow (cold cache) and subsequent ones to warm up.

## Not done here — needs your account access

Removing the workflow references stops new usage, but **does not cancel the Blacksmith subscription or uninstall its GitHub App**. Two manual steps:

1. Uninstall the Blacksmith GitHub App: repo/org **Settings → GitHub Apps**. (I couldn't enumerate installations — the `gh` token lacks the admin scope.)
2. Cancel the plan in the Blacksmith dashboard, and take up the bill with them there — you've noted they don't have your billing details on file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)