### PR TITLE
feat(theme): user-built custom palette in the Appearance dialog

### DIFF
--- a/__tests__/api/theme-preference.test.ts
+++ b/__tests__/api/theme-preference.test.ts
@@ -113,6 +113,104 @@ describe('Theme preference API', function () {
       expect(response.status).to.equal(400);
     });
 
+    it('saves a custom theme with colours and round-trips them', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .patch('/api/users/me/theme-preference')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ theme: 'custom', customColors: { board: '#1B1D21', mark: '#1a9fff' } });
+
+      expect(response.status).to.equal(200);
+      expect(response.body.theme).to.equal('custom');
+      // Normalised to lowercase on the way in.
+      expect(response.body.customColors).to.deep.equal({ board: '#1b1d21', mark: '#1a9fff' });
+
+      const reread = await TestSetup.request()
+        .get('/api/users/me/theme-preference')
+        .set('Authorization', `Bearer ${token}`);
+      expect(reread.body.theme).to.equal('custom');
+      expect(reread.body.customColors).to.deep.equal({ board: '#1b1d21', mark: '#1a9fff' });
+    });
+
+    it('keeps the colour set when switching back to a prefab, and restores it on custom', async function () {
+      const token = testData.users.user1.generateJwt();
+      await TestSetup.request()
+        .patch('/api/users/me/theme-preference')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ theme: 'custom', customColors: { board: '#101f2e' } });
+
+      const prefab = await TestSetup.request()
+        .patch('/api/users/me/theme-preference')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ theme: 'film' });
+      expect(prefab.status).to.equal(200);
+      expect(prefab.body.theme).to.equal('film');
+
+      // Custom with no colours in the body is valid because a set is stored.
+      const back = await TestSetup.request()
+        .patch('/api/users/me/theme-preference')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ theme: 'custom' });
+      expect(back.status).to.equal(200);
+      expect(back.body.theme).to.equal('custom');
+      expect(back.body.customColors).to.deep.equal({ board: '#101f2e' });
+    });
+
+    it('rejects custom with no colours sent and none stored', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .patch('/api/users/me/theme-preference')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ theme: 'custom' });
+
+      expect(response.status).to.equal(400);
+      // And the account is not left pointing at a palette that doesn't exist.
+      const reread = await TestSetup.request()
+        .get('/api/users/me/theme-preference')
+        .set('Authorization', `Bearer ${token}`);
+      expect(reread.body.theme).to.equal(DEFAULT_THEME_ID);
+    });
+
+    // These values reach CSS custom properties on the client, so anything
+    // that is not a literal #rrggbb colour on a known token is refused whole.
+    it('rejects a non-hex colour value', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .patch('/api/users/me/theme-preference')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ theme: 'custom', customColors: { board: 'url(javascript:1)' } });
+      expect(response.status).to.equal(400);
+    });
+
+    it('rejects an unknown token name', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .patch('/api/users/me/theme-preference')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ theme: 'custom', customColors: { 'evil-token': '#123456' } });
+      expect(response.status).to.equal(400);
+    });
+
+    it('rejects shorthand and alpha hex forms', async function () {
+      const token = testData.users.user1.generateJwt();
+      for (const bad of ['#abc', '#aabbccdd', 'red', 'rgb(1,2,3)']) {
+        const response = await TestSetup.request()
+          .patch('/api/users/me/theme-preference')
+          .set('Authorization', `Bearer ${token}`)
+          .send({ theme: 'custom', customColors: { board: bad } });
+        expect(response.status).to.equal(400, `expected ${bad} to be rejected`);
+      }
+    });
+
+    it('rejects an empty colour object', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .patch('/api/users/me/theme-preference')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ theme: 'custom', customColors: {} });
+      expect(response.status).to.equal(400);
+    });
+
     // Cosmetic, but still private account state.
     it('does not expose the theme on the public profile', async function () {
       const token = testData.users.user1.generateJwt();
@@ -127,6 +225,7 @@ describe('Theme preference API', function () {
       if (profile.status === 200) {
         expect(profile.body).to.not.have.property('themePreference');
         expect(profile.body).to.not.have.property('theme');
+        expect(profile.body).to.not.have.property('customThemeColors');
       }
     });
   });

--- a/app/api/models/user.ts
+++ b/app/api/models/user.ts
@@ -1,4 +1,5 @@
 import mongoose, { Document, Model } from 'mongoose';
+import { CustomThemeColors } from '../../../lib/index';
 import crypto from 'crypto-js';
 import jwt from 'jsonwebtoken';
 
@@ -44,7 +45,7 @@ export interface User extends Document {
   // switching back to "custom" restores their colours. Every value is
   // validated as strict hex before it is written — it reaches a CSS custom
   // property on the client. Same privacy rule as themePreference.
-  customThemeColors?: Record<string, string>;
+  customThemeColors?: CustomThemeColors;
 
   setPassword(password: string): void;
   validPassword(password: string): boolean;

--- a/app/api/models/user.ts
+++ b/app/api/models/user.ts
@@ -39,6 +39,13 @@ export interface User extends Document {
   // Cosmetic, but still account state: not part of ProfileResponse.
   themePreference?: string;
 
+  // The user's hand-picked palette (token name → #rrggbb), present only after
+  // they save a custom theme. Kept even while a prefab is selected, so
+  // switching back to "custom" restores their colours. Every value is
+  // validated as strict hex before it is written — it reaches a CSS custom
+  // property on the client. Same privacy rule as themePreference.
+  customThemeColors?: Record<string, string>;
+
   setPassword(password: string): void;
   validPassword(password: string): boolean;
   generateJwt(role?: string): string;
@@ -87,6 +94,9 @@ export class UserModel {
         excludedDlcs: { type: [String], default: [] },
       },
       themePreference: { type: String },
+      // Written whole on every save (findByIdAndUpdate $set), validated in the
+      // controller via sanitizeCustomThemeColors — Mixed here is just storage.
+      customThemeColors: { type: mongoose.Schema.Types.Mixed },
     });
 
     // Password reset lookup: findOne({ resetToken, resetTokenExpiration: { $gt: ... } })

--- a/app/api/user-controller.ts
+++ b/app/api/user-controller.ts
@@ -14,6 +14,8 @@ import {
   MAX_DLC_FILTER_IDS,
   isThemeId,
   resolveThemeId,
+  sanitizeCustomThemeColors,
+  CUSTOM_THEME_ID,
   THEME_IDS,
 } from '../../lib/index';
 import { NotificationController } from './notification-controller';
@@ -202,7 +204,7 @@ export class UserController {
 
     UserModel.model
       .findById(user._id)
-      .select('themePreference')
+      .select('themePreference customThemeColors')
       .lean()
       .then(found => {
         if (!found) {
@@ -211,7 +213,12 @@ export class UserController {
         }
         // An account that has never chosen resolves to the current default
         // rather than reporting null, so the client has one less case.
-        res.json({ theme: resolveThemeId(found.themePreference) });
+        // Stored colours are re-sanitized on the way out — this value reaches
+        // CSS custom properties, so the read side trusts nothing either.
+        const colors = sanitizeCustomThemeColors(found.customThemeColors);
+        let theme = resolveThemeId(found.themePreference);
+        if (theme === CUSTOM_THEME_ID && !colors) theme = resolveThemeId(undefined);
+        res.json({ theme, ...(colors ? { customColors: colors } : {}) });
       })
       .catch(err => {
         console.log('getThemePreference error');
@@ -222,7 +229,7 @@ export class UserController {
 
   public updateThemePreference(req: Request, res: Response): void {
     const user = req.user as UserJwt;
-    const { theme } = req.body as { theme?: unknown };
+    const { theme, customColors } = req.body as { theme?: unknown; customColors?: unknown };
 
     // Validated against the shared id list, not free text: this value is
     // written straight into a data-palette attribute on the client.
@@ -231,14 +238,52 @@ export class UserController {
       return;
     }
 
-    UserModel.model
-      .findByIdAndUpdate(user._id, { themePreference: theme }, { new: true })
-      .then(updated => {
+    // Colours are all-or-nothing strict hex (sanitizeCustomThemeColors): they
+    // land in CSS custom properties, so nothing that isn't a literal colour is
+    // stored. Sending colours alongside a prefab id is fine — the set is kept
+    // so switching back to "custom" later restores it.
+    let colors: ReturnType<typeof sanitizeCustomThemeColors> = null;
+    if (customColors !== undefined) {
+      colors = sanitizeCustomThemeColors(customColors);
+      if (!colors) {
+        res
+          .status(400)
+          .json(apiError(400, 'customColors must map known theme tokens to #rrggbb values'));
+        return;
+      }
+    }
+
+    const update: Record<string, unknown> = { themePreference: theme };
+    if (colors) update.customThemeColors = colors;
+
+    // Selecting "custom" without sending colours is only valid when a set is
+    // already stored — checked before the write so a rejected request never
+    // leaves the account pointing at a palette that doesn't exist.
+    const guard: Promise<boolean> =
+      theme === CUSTOM_THEME_ID && !colors
+        ? UserModel.model
+            .findById(user._id)
+            .select('customThemeColors')
+            .lean()
+            .then(found => !!(found && sanitizeCustomThemeColors(found.customThemeColors)))
+        : Promise.resolve(true);
+
+    guard
+      .then(async ok => {
+        if (!ok) {
+          res.status(400).json(apiError(400, 'custom theme requires customColors'));
+          return;
+        }
+        const updated = await UserModel.model.findByIdAndUpdate(user._id, update, { new: true });
         if (!updated) {
           res.status(404).json(apiError(404, 'User not found'));
           return;
         }
-        res.json({ theme: resolveThemeId(updated.themePreference) });
+        const stored = sanitizeCustomThemeColors(updated.customThemeColors);
+        res.json({
+          theme: resolveThemeId(updated.themePreference),
+          ...(stored ? { customColors: stored } : {}),
+        });
       })
       .catch(err => {
         console.log('updateThemePreference error');

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-theme/dialog-theme.component.css
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-theme/dialog-theme.component.css
@@ -89,6 +89,153 @@
   color: var(--bni-muted);
 }
 
+/* ---- the custom palette editor ---- */
+.custom-editor {
+  margin-top: 12px;
+  padding: 12px 11px;
+  border: 1px solid var(--bni-rule);
+  background: var(--bni-inset);
+}
+
+.custom-group-label {
+  margin: 12px 0 6px;
+  font-family: var(--bni-display);
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--bni-muted);
+}
+
+.custom-group-label:first-child {
+  margin-top: 0;
+}
+
+.custom-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(215px, 1fr));
+  gap: 4px 14px;
+}
+
+.custom-token {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 0;
+  cursor: pointer;
+}
+
+/* The native colour input, dressed as a paint well. */
+.custom-well {
+  flex: none;
+  inline-size: 26px;
+  block-size: 22px;
+  padding: 0;
+  border: 1px solid var(--bni-rule-hi);
+  border-radius: 0;
+  background: none;
+  cursor: pointer;
+}
+
+.custom-well::-webkit-color-swatch-wrapper {
+  padding: 1px;
+}
+
+.custom-well::-webkit-color-swatch {
+  border: none;
+  border-radius: 0;
+}
+
+.custom-well::-moz-color-swatch {
+  border: none;
+  border-radius: 0;
+}
+
+.custom-token-name {
+  flex: 1;
+  min-width: 0;
+  font-size: 12.5px;
+  line-height: 1.3;
+  color: var(--bni-body);
+}
+
+.custom-hex {
+  flex: none;
+  width: 72px;
+  padding: 3px 5px;
+  font-family: ui-monospace, monospace;
+  font-size: 11.5px;
+  color: var(--bni-body);
+  background: var(--bni-mount);
+  border: 1px solid var(--bni-rule);
+  border-radius: 0;
+}
+
+.custom-hex:focus-visible {
+  outline: 2px solid var(--bni-mark);
+  outline-offset: -1px;
+}
+
+.custom-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 14px;
+  padding-top: 11px;
+  border-top: 1px solid var(--bni-rule);
+}
+
+.custom-reset {
+  padding: 6px 10px;
+  font-family: var(--p-font-family);
+  font-size: 12px;
+  color: var(--bni-muted);
+  background: transparent;
+  border: 1px solid var(--bni-rule);
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.custom-reset:hover {
+  color: var(--bni-ink);
+  border-color: var(--bni-rule-hi);
+}
+
+.custom-save {
+  padding: 6px 14px;
+  font-family: var(--p-font-family);
+  font-weight: 600;
+  font-size: 12.5px;
+  color: #ffffff;
+  background: var(--bni-mark);
+  border: 1px solid var(--bni-mark-dim);
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.custom-save:hover:enabled {
+  background: var(--bni-mark-hi);
+}
+
+.custom-save:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.custom-reset:focus-visible,
+.custom-save:focus-visible {
+  outline: 2px solid var(--bni-mark);
+  outline-offset: 2px;
+}
+
+.custom-hint {
+  margin: 10px 0 0;
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--bni-faint);
+}
+
 .theme-footnote {
   margin: 14px 0 0;
   padding-top: 11px;

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-theme/dialog-theme.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-theme/dialog-theme.component.html
@@ -2,6 +2,7 @@
   i18n-header
   header="Appearance"
   [(visible)]="visible"
+  (onHide)="onHide()"
   [modal]="true"
   [style]="{ width: '520px' }"
   [breakpoints]="{ '600px': '92vw' }"
@@ -55,6 +56,93 @@
         <span class="theme-note">{{ t.note }}</span>
       </span>
     </button>
+    <button
+      type="button"
+      role="radio"
+      class="theme-option"
+      [class.active]="current === 'custom'"
+      [attr.aria-checked]="current === 'custom'"
+      [attr.aria-expanded]="customOpen"
+      (click)="selectCustom()"
+    >
+      <span class="theme-swatch" aria-hidden="true">
+        <i [style.background]="customSwatch[0]"></i>
+        <i [style.background]="customSwatch[1]"></i>
+        <i [style.background]="customSwatch[2]"></i>
+      </span>
+      <span class="theme-text">
+        <span class="theme-name">
+          <ng-container i18n>Custom</ng-container>
+          <svg
+            *ngIf="current === 'custom'"
+            class="theme-check"
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="3.4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M4 12.5l5.5 5.5L20 6"></path>
+          </svg>
+        </span>
+        <span class="theme-note" *ngIf="!hasSavedCustom" i18n
+          >Pick every colour yourself, starting from the current palette.</span
+        >
+        <span class="theme-note" *ngIf="hasSavedCustom" i18n
+          >Your own palette. Click to wear it or keep tuning.</span
+        >
+      </span>
+    </button>
+  </div>
+
+  <div class="custom-editor" *ngIf="customOpen">
+    <ng-container *ngFor="let group of tokenGroups">
+      <h4 class="custom-group-label">{{ group.label }}</h4>
+      <div class="custom-grid">
+        <label class="custom-token" *ngFor="let t of group.tokens">
+          <input
+            class="custom-well"
+            type="color"
+            [value]="draftValue(t.token) || '#000000'"
+            (input)="onPick(t.token, $any($event.target).value)"
+          />
+          <span class="custom-token-name">{{ t.label }}</span>
+          <input
+            class="custom-hex"
+            type="text"
+            spellcheck="false"
+            maxlength="7"
+            [value]="draftValue(t.token)"
+            (change)="onHexTyped(t.token, $any($event.target).value)"
+            aria-label="Hex value"
+            i18n-aria-label
+          />
+        </label>
+      </div>
+    </ng-container>
+
+    <div class="custom-actions">
+      <button type="button" class="custom-reset" (click)="resetDraft()" i18n>
+        Start over from current palette
+      </button>
+      <button
+        type="button"
+        class="custom-save"
+        [disabled]="saved"
+        (click)="saveCustom()"
+      >
+        <ng-container *ngIf="!saved" i18n>Save custom theme</ng-container>
+        <ng-container *ngIf="saved" i18n>Saved</ng-container>
+      </button>
+    </div>
+    <p class="custom-hint" *ngIf="customDirty && !saved" i18n>
+      The page behind this dialog is previewing your colours. Save to keep them;
+      closing without saving puts things back.
+    </p>
   </div>
 
   <p class="theme-footnote" *ngIf="loggedIn" i18n>

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-theme/dialog-theme.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-theme/dialog-theme.component.ts
@@ -1,7 +1,69 @@
 import { Component } from "@angular/core";
 import { ThemeService, ThemeOption } from "../../../services/theme.service";
 import { AuthenticationService } from "../../../services/authentification-service";
-import { ThemeId } from "../../../../../../../lib/index";
+import {
+  ThemeId,
+  ThemeColorToken,
+  CustomThemeColors,
+  isHexColor,
+} from "../../../../../../../lib/index";
+
+interface TokenControl {
+  token: ThemeColorToken;
+  label: string;
+}
+
+interface TokenGroup {
+  label: string;
+  tokens: TokenControl[];
+}
+
+/** Every editable slot, grouped the way the skin's own token comments group them. */
+const TOKEN_GROUPS: TokenGroup[] = [
+  {
+    label: "Board & surfaces",
+    tokens: [
+      { token: "board", label: "Board (page ground)" },
+      { token: "board-deep", label: "Board, deep void" },
+      { token: "mount", label: "Card surface" },
+      { token: "mount-hi", label: "Card, hovered" },
+      { token: "inset", label: "Input fields" },
+      { token: "rule", label: "Hairline" },
+      { token: "rule-hi", label: "Hairline, strong" },
+      { token: "chip", label: "Chip" },
+      { token: "chip-hi", label: "Chip, hovered" },
+      { token: "thumbbg", label: "Thumbnail ground" },
+    ],
+  },
+  {
+    label: "Tag",
+    tokens: [
+      { token: "tag", label: "Tag stock" },
+      { token: "tag-hi", label: "Tag, hovered" },
+      { token: "tag-ink", label: "Tag ink" },
+      { token: "tag-ink-2", label: "Tag ink, secondary" },
+    ],
+  },
+  {
+    label: "Text",
+    tokens: [
+      { token: "ink", label: "Headings" },
+      { token: "body", label: "Body text" },
+      { token: "muted", label: "Secondary text" },
+      { token: "faint", label: "Faint / counts" },
+    ],
+  },
+  {
+    label: "Accent",
+    tokens: [
+      { token: "mark", label: "Mark (interaction)" },
+      { token: "mark-hi", label: "Mark, hovered" },
+      { token: "mark-dim", label: "Mark, dim" },
+      { token: "brass", label: "Brass (flagged)" },
+      { token: "danger", label: "Danger" },
+    ],
+  },
+];
 
 @Component({
   selector: "app-dialog-theme",
@@ -11,6 +73,17 @@ import { ThemeId } from "../../../../../../../lib/index";
 })
 export class DialogThemeComponent {
   visible = false;
+
+  readonly tokenGroups = TOKEN_GROUPS;
+
+  /** Whether the per-colour editor is expanded. */
+  customOpen = false;
+
+  /** Working colours while the editor is open; previewed live, saved explicitly. */
+  draft: CustomThemeColors = {};
+
+  /** True after Save until the next edit — drives the "Saved" affordance. */
+  saved = false;
 
   constructor(
     public themeService: ThemeService,
@@ -29,10 +102,83 @@ export class DialogThemeComponent {
     return this.authService.isLoggedIn();
   }
 
+  get hasSavedCustom(): boolean {
+    return this.themeService.customColors !== null;
+  }
+
+  /** The three-band swatch for the custom row: board, tag, mark. */
+  get customSwatch(): [string, string, string] {
+    const c = this.themeService.customColors ?? this.draft;
+    return [c.board ?? "#1b1d21", c.tag ?? "#d6dde4", c.mark ?? "#1a9fff"];
+  }
+
   // Applied on click, not on a Save button: the dialog sits over the page it is
   // restyling, so the preview and the commit are the same gesture.
   select(id: ThemeId): void {
+    this.customOpen = false;
     this.themeService.select(id, this.loggedIn);
+  }
+
+  /**
+   * The custom row. Re-selects the saved palette if one exists, and opens the
+   * editor either way — a first-timer starts from the palette the page is
+   * currently wearing.
+   */
+  selectCustom(): void {
+    if (this.hasSavedCustom && !this.customOpen) {
+      this.themeService.select("custom", this.loggedIn);
+    }
+    if (!this.customOpen) {
+      this.draft = {
+        ...this.themeService.seedColorsFromCurrent(),
+        ...(this.themeService.customColors ?? {}),
+      };
+      this.customOpen = true;
+      this.saved = false;
+      this.themeService.previewCustom(this.draft);
+    }
+  }
+
+  /** Template accessor: ngFor loop variables are untyped without strictTemplates. */
+  draftValue(token: ThemeColorToken): string {
+    return this.draft[token] ?? "";
+  }
+
+  /** Colour picker input — always a valid hex. */
+  onPick(token: ThemeColorToken, value: string): void {
+    this.setToken(token, value.toLowerCase());
+  }
+
+  /** Typed hex — applied only once it parses; the picker shows the last good value. */
+  onHexTyped(token: ThemeColorToken, value: string): void {
+    const v = value.trim().toLowerCase();
+    if (isHexColor(v)) this.setToken(token, v);
+  }
+
+  private setToken(token: ThemeColorToken, hex: string): void {
+    if (this.draft[token] === hex) return;
+    this.draft = { ...this.draft, [token]: hex };
+    this.saved = false;
+    this.themeService.previewCustom(this.draft);
+  }
+
+  /** Throw the draft away and start again from the live palette. */
+  resetDraft(): void {
+    this.draft = this.themeService.seedColorsFromCurrent();
+    this.saved = false;
+    this.themeService.previewCustom(this.draft);
+  }
+
+  saveCustom(): void {
+    if (this.themeService.saveCustom(this.draft, this.loggedIn)) {
+      this.saved = true;
+    }
+  }
+
+  get customDirty(): boolean {
+    const committed = this.themeService.customColors;
+    if (this.current !== "custom" || !committed) return true;
+    return JSON.stringify(committed) !== JSON.stringify(this.draft);
   }
 
   open(): void {
@@ -41,5 +187,11 @@ export class DialogThemeComponent {
 
   toggleDialog(): void {
     this.visible = !this.visible;
+  }
+
+  /** Closing the dialog abandons any unsaved preview. */
+  onHide(): void {
+    if (this.customOpen && this.customDirty) this.themeService.revertPreview();
+    this.customOpen = false;
   }
 }

--- a/frontend/src/app/module-blueprint/services/theme.service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/theme.service.spec.ts
@@ -13,6 +13,7 @@ describe("ThemeService", () => {
   beforeEach(() => {
     localStorage.clear();
     document.documentElement.removeAttribute("data-palette");
+    document.getElementById("bni-custom-theme")?.remove();
 
     TestBed.configureTestingModule({
       providers: [
@@ -108,5 +109,117 @@ describe("ThemeService", () => {
     expect(ids).toEqual(
       ["concrete", "cyanotype", "film", "sample-board", "steam"].sort(),
     );
+  });
+
+  describe("custom palette", () => {
+    const customRule = (): CSSStyleDeclaration | null => {
+      const style = document.getElementById(
+        "bni-custom-theme",
+      ) as HTMLStyleElement | null;
+      const rule = style?.sheet?.cssRules[0] as CSSStyleRule | undefined;
+      return rule?.style ?? null;
+    };
+
+    it("saves a custom palette: applies it, persists it, and PATCHes the colours", () => {
+      const ok = service.saveCustom(
+        { board: "#101010", mark: "#FF6A13" },
+        true,
+      );
+      expect(ok).toBe(true);
+
+      expect(palette()).toEqual("custom");
+      expect(localStorage.getItem(ThemeService.STORAGE_KEY)).toEqual("custom");
+      expect(
+        JSON.parse(localStorage.getItem(ThemeService.CUSTOM_STORAGE_KEY)!),
+      ).toEqual({ board: "#101010", mark: "#ff6a13" });
+
+      const rule = customRule()!;
+      expect(rule.getPropertyValue("--bni-board")).toEqual("#101010");
+      // Derived alpha tokens come from the parent hex.
+      expect(rule.getPropertyValue("--bni-mark-glow")).toEqual(
+        "rgba(255, 106, 19, 0.35)",
+      );
+
+      const req = http.expectOne("/api/users/me/theme-preference");
+      expect(req.request.method).toEqual("PATCH");
+      expect(req.request.body).toEqual({
+        theme: "custom",
+        customColors: { board: "#101010", mark: "#ff6a13" },
+      });
+      req.flush({ theme: "custom" });
+    });
+
+    it("refuses to save anything that is not strict hex on a known token", () => {
+      expect(service.saveCustom({ board: "red" } as any, false)).toBe(false);
+      expect(service.saveCustom({ nope: "#123456" } as any, false)).toBe(false);
+      expect(palette()).toBeNull();
+      http.expectNone("/api/users/me/theme-preference");
+    });
+
+    it("previews without committing, and revertPreview restores the real theme", () => {
+      service.select("film", false);
+      service.previewCustom({ board: "#222222" });
+      expect(palette()).toEqual("custom");
+      // Nothing persisted by a preview.
+      expect(localStorage.getItem(ThemeService.STORAGE_KEY)).toEqual("film");
+
+      service.revertPreview();
+      expect(palette()).toEqual("film");
+    });
+
+    it("restores a stored custom theme on init", () => {
+      localStorage.setItem(ThemeService.STORAGE_KEY, "custom");
+      localStorage.setItem(
+        ThemeService.CUSTOM_STORAGE_KEY,
+        JSON.stringify({ board: "#0a0b0c" }),
+      );
+      service.initFromLocal();
+      expect(palette()).toEqual("custom");
+      expect(customRule()!.getPropertyValue("--bni-board")).toEqual("#0a0b0c");
+    });
+
+    // A "custom" id with no colour set would render the untokenised default
+    // block anyway; resolve it honestly instead.
+    it("falls back to the default when custom is stored without colours", () => {
+      localStorage.setItem(ThemeService.STORAGE_KEY, "custom");
+      service.initFromLocal();
+      expect(palette()).toEqual("steam");
+    });
+
+    it("selecting custom without a saved set is a no-op", () => {
+      service.initFromLocal();
+      service.select("custom", true);
+      expect(palette()).toEqual("steam");
+      http.expectNone("/api/users/me/theme-preference");
+    });
+
+    it("applies the account's custom theme from loadForUser", () => {
+      service.initFromLocal();
+      service.loadForUser().subscribe();
+      http.expectOne("/api/users/me/theme-preference").flush({
+        theme: "custom",
+        customColors: { board: "#123456", mark: "#654321" },
+      });
+
+      expect(palette()).toEqual("custom");
+      expect(service.customColors).toEqual({
+        board: "#123456",
+        mark: "#654321",
+      });
+      expect(
+        JSON.parse(localStorage.getItem(ThemeService.CUSTOM_STORAGE_KEY)!),
+      ).toEqual({ board: "#123456", mark: "#654321" });
+    });
+
+    it("ignores malformed colours arriving from the account copy", () => {
+      service.initFromLocal();
+      service.loadForUser().subscribe();
+      http.expectOne("/api/users/me/theme-preference").flush({
+        theme: "custom",
+        customColors: { board: "url(javascript:1)" },
+      });
+      // Colours rejected → no set → custom resolves to the default.
+      expect(palette()).toEqual("steam");
+    });
   });
 });

--- a/frontend/src/app/module-blueprint/services/theme.service.ts
+++ b/frontend/src/app/module-blueprint/services/theme.service.ts
@@ -4,8 +4,13 @@ import { BehaviorSubject, Observable, of } from "rxjs";
 import { catchError, map, tap } from "rxjs/operators";
 import {
   ThemeId,
+  ThemeColorToken,
+  CustomThemeColors,
   DEFAULT_THEME_ID,
+  CUSTOM_THEME_ID,
+  THEME_COLOR_TOKENS,
   resolveThemeId,
+  sanitizeCustomThemeColors,
 } from "../../../../../lib/index";
 
 export interface ThemeOption {
@@ -17,8 +22,24 @@ export interface ThemeOption {
 }
 
 /**
+ * The alpha-valued tokens every palette also sets, derived here from their
+ * parent hex so a custom theme stays hex-only: [derived token, parent, alpha].
+ * Ratios match what the prefab palettes use.
+ */
+const DERIVED_ALPHA_TOKENS: readonly [string, ThemeColorToken, number][] = [
+  ["mark-glow", "mark", 0.35],
+  ["mark-tint", "mark", 0.1],
+  ["brass-tint", "brass", 0.16],
+  ["thumbgrid", "tag", 0.3],
+  ["board-light", "tag", 0.055],
+];
+
+/**
  * Applies the chosen palette by setting `data-palette` on <html>; the tokens
- * live in bni-skin.css.
+ * live in bni-skin.css. A custom palette has no CSS block: its colours are
+ * written into an injected style rule via CSSStyleDeclaration.setProperty —
+ * never by string-building CSS — after strict hex validation, because the
+ * values come from storage.
  *
  * Resolution order is preference > local > default. localStorage is written for
  * everyone, including logged-in users: it is what stops the page flashing the
@@ -29,12 +50,19 @@ export interface ThemeOption {
 @Injectable({ providedIn: "root" })
 export class ThemeService {
   static readonly STORAGE_KEY = "bpni-theme";
+  static readonly CUSTOM_STORAGE_KEY = "bpni-theme-custom";
 
   private readonly currentSubject = new BehaviorSubject<ThemeId>(
     DEFAULT_THEME_ID,
   );
   readonly current$ = this.currentSubject.asObservable();
 
+  /** The saved custom colour set, if the user has ever built one. */
+  private committedCustomColors: CustomThemeColors | null = null;
+
+  private customRule: CSSStyleDeclaration | null = null;
+
+  /** The prefab palettes; the custom option is rendered separately by the UI. */
   readonly themes: ThemeOption[] = [
     {
       id: "steam",
@@ -74,20 +102,39 @@ export class ThemeService {
     return this.currentSubject.value;
   }
 
+  get customColors(): CustomThemeColors | null {
+    return this.committedCustomColors;
+  }
+
   /** Called once at app start, before any account state is known. */
   initFromLocal(): void {
+    this.committedCustomColors = this.readCustomLocal();
     this.apply(this.readLocal() ?? DEFAULT_THEME_ID);
   }
 
   /** Called when a session is established; the account copy wins if it exists. */
   loadForUser(): Observable<ThemeId> {
     return this.http
-      .get<{ theme: string }>("/api/users/me/theme-preference")
+      .get<{ theme: string; customColors?: unknown }>(
+        "/api/users/me/theme-preference",
+      )
       .pipe(
         // A failed lookup keeps whatever local already applied rather than
         // yanking the page back to the default.
-        catchError(() => of({ theme: this.current })),
-        map((res) => resolveThemeId(res.theme)),
+        catchError(() =>
+          of({
+            theme: this.current,
+            customColors: this.committedCustomColors ?? undefined,
+          }),
+        ),
+        map((res) => {
+          const colors = sanitizeCustomThemeColors(res.customColors);
+          if (colors) {
+            this.committedCustomColors = colors;
+            this.writeCustomLocal(colors);
+          }
+          return resolveThemeId(res.theme);
+        }),
         tap((id) => {
           this.apply(id);
           this.writeLocal(id);
@@ -101,6 +148,8 @@ export class ThemeService {
    * copy, not the theme they just picked.
    */
   select(id: ThemeId, loggedIn: boolean): void {
+    // "custom" is only selectable once a colour set exists.
+    if (id === CUSTOM_THEME_ID && !this.committedCustomColors) return;
     this.apply(id);
     this.writeLocal(id);
     if (!loggedIn) return;
@@ -109,11 +158,112 @@ export class ThemeService {
       .subscribe({ error: () => {} });
   }
 
+  /**
+   * Commits a hand-picked palette: validates, applies, and persists it as the
+   * current theme. Same optimistic contract as select().
+   */
+  saveCustom(colors: CustomThemeColors, loggedIn: boolean): boolean {
+    const clean = sanitizeCustomThemeColors(colors);
+    if (!clean) return false;
+    this.committedCustomColors = clean;
+    this.writeCustomLocal(clean);
+    this.apply(CUSTOM_THEME_ID);
+    this.writeLocal(CUSTOM_THEME_ID);
+    if (loggedIn) {
+      this.http
+        .patch("/api/users/me/theme-preference", {
+          theme: CUSTOM_THEME_ID,
+          customColors: clean,
+        })
+        .subscribe({ error: () => {} });
+    }
+    return true;
+  }
+
+  /**
+   * Shows a colour set on the live page without committing anything — the
+   * editor calls this on every picker change. revertPreview() restores the
+   * committed theme (used when the dialog closes without saving).
+   */
+  previewCustom(colors: CustomThemeColors): void {
+    const clean = sanitizeCustomThemeColors(colors);
+    if (!clean) return;
+    this.writeCustomRule(clean);
+    document.documentElement.setAttribute("data-palette", CUSTOM_THEME_ID);
+  }
+
+  revertPreview(): void {
+    this.apply(this.currentSubject.value);
+  }
+
+  /**
+   * The starting point for the custom editor: the token values of whatever
+   * palette the page is currently wearing, read from the computed styles so
+   * the CSS stays the single source of truth for the prefabs.
+   */
+  seedColorsFromCurrent(): CustomThemeColors {
+    const probe = document.createElement("div");
+    probe.className = "bni-skin";
+    probe.style.display = "none";
+    document.body.appendChild(probe);
+    const computed = getComputedStyle(probe);
+    const out: CustomThemeColors = {};
+    for (const token of THEME_COLOR_TOKENS) {
+      const value = computed.getPropertyValue(`--bni-${token}`).trim();
+      if (/^#[0-9a-fA-F]{6}$/.test(value)) out[token] = value.toLowerCase();
+    }
+    probe.remove();
+    return out;
+  }
+
   private apply(id: ThemeId): void {
-    const resolved = resolveThemeId(id);
+    let resolved = resolveThemeId(id);
+    if (resolved === CUSTOM_THEME_ID) {
+      if (!this.committedCustomColors) resolved = DEFAULT_THEME_ID;
+      else this.writeCustomRule(this.committedCustomColors);
+    }
     document.documentElement.setAttribute("data-palette", resolved);
     if (resolved !== this.currentSubject.value)
       this.currentSubject.next(resolved);
+  }
+
+  /**
+   * Populates the injected `:root[data-palette="custom"] .bni-skin` rule.
+   * Values are set one property at a time on the rule's style declaration —
+   * setProperty parses, so nothing but a colour can take effect — and every
+   * value has already passed the strict hex check.
+   */
+  private writeCustomRule(colors: CustomThemeColors): void {
+    const rule = this.ensureCustomRule();
+    if (!rule) return;
+    for (const token of THEME_COLOR_TOKENS) {
+      const hex = colors[token];
+      if (hex) rule.setProperty(`--bni-${token}`, hex);
+      else rule.removeProperty(`--bni-${token}`);
+    }
+    for (const [derived, parent, alpha] of DERIVED_ALPHA_TOKENS) {
+      const hex = colors[parent];
+      if (hex) rule.setProperty(`--bni-${derived}`, hexToRgba(hex, alpha));
+      else rule.removeProperty(`--bni-${derived}`);
+    }
+  }
+
+  private ensureCustomRule(): CSSStyleDeclaration | null {
+    if (this.customRule) return this.customRule;
+    try {
+      const style = document.createElement("style");
+      style.id = "bni-custom-theme";
+      document.head.appendChild(style);
+      const sheet = style.sheet as CSSStyleSheet;
+      const index = sheet.insertRule(
+        ':root[data-palette="custom"] .bni-skin {}',
+        0,
+      );
+      this.customRule = (sheet.cssRules[index] as CSSStyleRule).style;
+      return this.customRule;
+    } catch {
+      return null;
+    }
   }
 
   private readLocal(): ThemeId | null {
@@ -132,4 +282,31 @@ export class ThemeService {
       /* private mode — the account copy still carries it */
     }
   }
+
+  private readCustomLocal(): CustomThemeColors | null {
+    try {
+      const raw = localStorage.getItem(ThemeService.CUSTOM_STORAGE_KEY);
+      return raw ? sanitizeCustomThemeColors(JSON.parse(raw)) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private writeCustomLocal(colors: CustomThemeColors): void {
+    try {
+      localStorage.setItem(
+        ThemeService.CUSTOM_STORAGE_KEY,
+        JSON.stringify(colors),
+      );
+    } catch {
+      /* private mode — the account copy still carries it */
+    }
+  }
+}
+
+function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }

--- a/lib/src/theme/theme-preference.d.ts
+++ b/lib/src/theme/theme-preference.d.ts
@@ -11,8 +11,34 @@
  * The id is the value of `data-palette` on <html>; the tokens live in
  * `frontend/src/bni-skin.css`.
  */
-export type ThemeId = 'steam' | 'sample-board' | 'film' | 'cyanotype' | 'concrete';
+export type ThemeId = 'steam' | 'sample-board' | 'film' | 'cyanotype' | 'concrete' | 'custom';
 export declare const THEME_IDS: readonly ThemeId[];
+/**
+ * The palette a user builds by hand. Its id lives in the shared list so the
+ * same validation accepts it everywhere, but unlike the prefabs it has no CSS
+ * block: the client writes the stored colours into a style rule at runtime.
+ */
+export declare const CUSTOM_THEME_ID: ThemeId;
+/**
+ * The hex-valued source tokens a palette sets — the editable slots of a custom
+ * theme. Names match the CSS custom properties minus the `--bni-` prefix.
+ * The alpha-valued tokens (mark-glow, mark-tint, brass-tint, thumbgrid,
+ * board-light) are not listed: the client derives them from their parent hex,
+ * so a custom theme is hex-only end to end.
+ */
+export declare const THEME_COLOR_TOKENS: readonly ["board", "board-deep", "mount", "mount-hi", "inset", "rule", "rule-hi", "chip", "chip-hi", "thumbbg", "tag", "tag-hi", "tag-ink", "tag-ink-2", "ink", "body", "muted", "faint", "mark", "mark-hi", "mark-dim", "brass", "danger"];
+export type ThemeColorToken = (typeof THEME_COLOR_TOKENS)[number];
+/** A full or partial set of custom colours; missing tokens fall back to the default palette. */
+export type CustomThemeColors = Partial<Record<ThemeColorToken, string>>;
+export declare function isHexColor(value: unknown): value is string;
+/**
+ * Validates a client-supplied custom colour set. Returns the normalised
+ * (lowercased) copy, or null when anything is off — an unknown token, a
+ * non-hex value, or no valid entries at all. All-or-nothing rather than
+ * best-effort: a save that silently dropped half its colours would look like
+ * data loss to the user.
+ */
+export declare function sanitizeCustomThemeColors(value: unknown): CustomThemeColors | null;
 /** Applied to logged-out visitors and to any account that has never chosen. */
 export declare const DEFAULT_THEME_ID: ThemeId;
 export declare function isThemeId(value: unknown): value is ThemeId;

--- a/lib/src/theme/theme-preference.ts
+++ b/lib/src/theme/theme-preference.ts
@@ -11,7 +11,7 @@
  * The id is the value of `data-palette` on <html>; the tokens live in
  * `frontend/src/bni-skin.css`.
  */
-export type ThemeId = 'steam' | 'sample-board' | 'film' | 'cyanotype' | 'concrete';
+export type ThemeId = 'steam' | 'sample-board' | 'film' | 'cyanotype' | 'concrete' | 'custom';
 
 export const THEME_IDS: readonly ThemeId[] = [
   'steam',
@@ -19,7 +19,84 @@ export const THEME_IDS: readonly ThemeId[] = [
   'film',
   'cyanotype',
   'concrete',
+  'custom',
 ] as const;
+
+/**
+ * The palette a user builds by hand. Its id lives in the shared list so the
+ * same validation accepts it everywhere, but unlike the prefabs it has no CSS
+ * block: the client writes the stored colours into a style rule at runtime.
+ */
+export const CUSTOM_THEME_ID: ThemeId = 'custom';
+
+/**
+ * The hex-valued source tokens a palette sets — the editable slots of a custom
+ * theme. Names match the CSS custom properties minus the `--bni-` prefix.
+ * The alpha-valued tokens (mark-glow, mark-tint, brass-tint, thumbgrid,
+ * board-light) are not listed: the client derives them from their parent hex,
+ * so a custom theme is hex-only end to end.
+ */
+export const THEME_COLOR_TOKENS = [
+  'board',
+  'board-deep',
+  'mount',
+  'mount-hi',
+  'inset',
+  'rule',
+  'rule-hi',
+  'chip',
+  'chip-hi',
+  'thumbbg',
+  'tag',
+  'tag-hi',
+  'tag-ink',
+  'tag-ink-2',
+  'ink',
+  'body',
+  'muted',
+  'faint',
+  'mark',
+  'mark-hi',
+  'mark-dim',
+  'brass',
+  'danger',
+] as const;
+
+export type ThemeColorToken = (typeof THEME_COLOR_TOKENS)[number];
+
+/** A full or partial set of custom colours; missing tokens fall back to the default palette. */
+export type CustomThemeColors = Partial<Record<ThemeColorToken, string>>;
+
+/**
+ * Strict six-digit hex only. These values end up in CSS custom properties, so
+ * the format is a security boundary, not a convenience: nothing that isn't a
+ * literal colour may pass.
+ */
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+export function isHexColor(value: unknown): value is string {
+  return typeof value === 'string' && HEX_COLOR_PATTERN.test(value);
+}
+
+/**
+ * Validates a client-supplied custom colour set. Returns the normalised
+ * (lowercased) copy, or null when anything is off — an unknown token, a
+ * non-hex value, or no valid entries at all. All-or-nothing rather than
+ * best-effort: a save that silently dropped half its colours would look like
+ * data loss to the user.
+ */
+export function sanitizeCustomThemeColors(value: unknown): CustomThemeColors | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length === 0) return null;
+  const out: CustomThemeColors = {};
+  for (const [key, colour] of entries) {
+    if (!(THEME_COLOR_TOKENS as readonly string[]).includes(key)) return null;
+    if (!isHexColor(colour)) return null;
+    out[key as ThemeColorToken] = colour.toLowerCase();
+  }
+  return out;
+}
 
 /** Applied to logged-out visitors and to any account that has never chosen. */
 export const DEFAULT_THEME_ID: ThemeId = 'steam';


### PR DESCRIPTION
## What shipped

A sixth **Custom** option in the Appearance dialog. Picking it expands an inline editor where every one of the skin's 23 hex source tokens gets a native colour well plus a typed-hex field, grouped Board & surfaces / Tag / Text / Accent. Every change previews on the live page immediately; **Save custom theme** commits it (localStorage always, the account when logged in); closing without saving reverts to the committed theme. The saved set survives switching to a prefab, so re-selecting Custom restores it.

## Design decisions

- **All 23 tokens editable, not 4 seeds + derivation.** The deferred-work note suggested deriving 26 tokens from 4 seed colours; instead the editor seeds its draft from the palette the page is currently wearing (read from computed styles, so prefab colours stay defined once in CSS) and lets the user touch any token. No derivation code to get wrong, prefabs double as starting points, and contrast is in the user's hands with a live preview. Only the 5 alpha tokens (mark-glow, mark-tint, brass-tint, thumbgrid, board-light) are derived, from their parent hex at the prefabs' ratios — a custom theme is hex-only end to end.
- **Injection surface.** Colours are validated as strict `#rrggbb` on known tokens (`sanitizeCustomThemeColors`, all-or-nothing) in the shared lib, applied on the server on **both** write and read, and on the client before any value touches the DOM. The custom palette is rendered by populating an injected `:root[data-palette="custom"] .bni-skin` rule via `CSSStyleDeclaration.setProperty` — never string-built CSS.
- **`custom` is a real ThemeId** in the shared list, so all three consumers validate it identically; unlike the prefabs it has no CSS block. Selecting `custom` with no colour set (neither sent nor stored) is a 400 server-side and resolves to the default client-side.
- **Storage**: `User.customThemeColors` (token → hex) next to `themePreference`; GET/PATCH `/api/users/me/theme-preference` gained an optional `customColors` field. Kept out of ProfileResponse like the rest.

## Verification

- Backend: 812 passing (9 new specs — round-trip, prefab↔custom switching, hex/token/shape rejection, profile privacy). The 2 workos-provision failures are the documented local flakes.
- Frontend: 1160 passing (8 new ThemeService specs — save/preview/revert, init restore, malformed account data, custom-without-colours fallback).
- `npm run tsc` clean.
- Browser-verified end to end via Playwright against the dev servers: opened the editor, changed the board colour, saw the live page repaint, saved, confirmed the PATCH stored `{theme: custom, customColors}` and a reload re-applied the custom palette (including derived alpha tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)