### PR TITLE
chore: ignore impeccable scratch output, drop unused harness installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,23 @@
 
 # avatar smoke test scratch output
 avatar-smoke-test*.png
+
+# Impeccable (design skill). The durable design record IS committed — PRODUCT.md,
+# DESIGN.md and .impeccable/design.json are the project's own truth and belong in
+# review. Everything else under .impeccable/ is per-machine scratch the skill
+# regenerates: hook caches, local consent config, served decision-page logs, and
+# whatever future subdirectories it adds. Allow-list rather than deny-list so a
+# new output directory doesn't silently show up as a thousand untracked files.
+/.impeccable/*
+!/.impeccable/design.json
+!/.impeccable/config.json
+frontend/.impeccable/
+
+# The skill's own code is never vendored here: it lives at the user level
+# (~/.claude/skills) with a repo copy under the already-ignored /.claude. These
+# are the install targets for agent harnesses this project doesn't use — ignored
+# so a reinstall doesn't litter the tree again.
+/.agents/skills/impeccable/
+/.github/skills/
+/.github/hooks/
+/.codex/


### PR DESCRIPTION
## What

The impeccable design skill installed itself for four agent harnesses, leaving ~6.5M of untracked files on `master`. This sorts out what belongs in git.

**Removed** (untracked, never committed):
- `.agents/skills/impeccable/` + `.codex/hooks.json` — the Codex install
- `.github/skills/impeccable/` + `.github/hooks/impeccable.json` — the Copilot install

Neither harness is used here. The copy the detector hook actually runs is `.claude/skills/impeccable/`, which is byte-identical to `~/.claude/skills/impeccable/` and already covered by the existing `/.claude` ignore — so the skill stays a personal, user-level tool, as intended.

**Stays committed** — the durable design record, which is project truth and belongs in review:
- `PRODUCT.md`, `DESIGN.md`
- `.impeccable/design.json`

**Newly ignored** — per-machine scratch the skill regenerates:
- everything else under `.impeccable/` (hook caches, `config.local.json`, served decision-page logs under `questions/`)
- `frontend/.impeccable/`
- the harness install targets, so a reinstall can't litter the tree again

## Why an allow-list

`.impeccable/*` with `!design.json` rather than naming each output file. The skill writes `live/`, `sketches/`, `surfaces/` and `critique/` too, none of which exist yet locally — a deny-list would let the next one show up as another pile of untracked files.

The skill had written its own partial rules into `.git/info/exclude`, which is local-only (so it wouldn't survive a fresh clone) and missed `questions/` entirely. The rules now live in `.gitignore` where they're visible and versioned; the tool's marker blocks in `.git/info/exclude` are left alone since it manages them itself.

## Verification

`git status` is clean, `git check-ignore` confirms the scratch paths are ignored and `design.json` is not, and the detector hook's target (`.claude/skills/impeccable/scripts/hook.mjs`) is untouched. No source, test or build file is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)