### PR TITLE
feat(translation): user-content translation (description + comments)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -27,3 +27,12 @@ GEMINI_API_KEY=""
 # AVATAR_CLASSIFY_MODEL="gemini-3.5-flash"
 # AVATAR_POOL_LOW_WATER="5"
 # AVATAR_POOL_REFILL="5"
+
+# User content translation (spec/user-content-translation-impl.md)
+# API key at https://console.cloud.google.com/apis/credentials, project needs
+# the Cloud Translation API enabled + billing. Leave unset to disable the
+# feature (translate endpoints answer 503).
+GOOGLE_TRANSLATE_API_KEY=""
+# Optional overrides (defaults shown)
+# MONTHLY_CHAR_BUDGET="400000"
+# MAX_TRANSLATIONS_PER_USER_PER_DAY="200"

--- a/__tests__/api/language-detection-service.test.ts
+++ b/__tests__/api/language-detection-service.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { detectLanguage } from '../../app/api/services/language-detection-service';
+
+describe('detectLanguage', function () {
+  it('detects English', function () {
+    expect(detectLanguage('This is a wonderfully well organized power generation setup.')).to.equal('en');
+  });
+
+  it('detects French and collapses region variants', function () {
+    expect(detectLanguage('Ceci est une configuration de generation electrique tres bien organisee.')).to.equal(
+      'fr'
+    );
+  });
+
+  it('detects Chinese and collapses to the zh macrolanguage code', function () {
+    expect(detectLanguage('这是一个非常好的发电站布局，管理得很整洁有序。')).to.equal('zh');
+  });
+
+  it('detects Russian', function () {
+    expect(detectLanguage('Это очень хорошо организованная схема выработки электроэнергии.')).to.equal('ru');
+  });
+
+  it('detects Korean', function () {
+    expect(detectLanguage('이것은 매우 잘 정리된 발전소 배치입니다.')).to.equal('ko');
+  });
+
+  it('returns null below the minimum significant-character threshold', function () {
+    expect(detectLanguage('nice')).to.equal(null);
+    expect(detectLanguage('ok')).to.equal(null);
+    expect(detectLanguage('')).to.equal(null);
+  });
+
+  it('returns null for pure punctuation/emoji', function () {
+    expect(detectLanguage('!!! ... ??? *** ~~~ ### @@@ ]]] [[[ >>> <<<')).to.equal(null);
+  });
+
+  it('strips reference tokens before counting significant length', function () {
+    // Only the token remains after stripping — well under the threshold
+    expect(detectLanguage('{{blueprint:507f1f77bcf86cd799439011}}')).to.equal(null);
+    expect(detectLanguage('{{user:507f1f77bcf86cd799439011}}')).to.equal(null);
+  });
+
+  it('strips URLs before detection so link-only text is not misdetected', function () {
+    expect(detectLanguage('https://example.com/some/long/path/that/is/mostly/noise')).to.equal(null);
+  });
+
+  it('still detects real content alongside a stripped token/URL', function () {
+    const result = detectLanguage(
+      'Check out {{blueprint:507f1f77bcf86cd799439011}} https://example.com — this design saves a huge amount of power and space in the base.'
+    );
+    expect(result).to.equal('en');
+  });
+
+  it('never throws on malformed input', function () {
+    expect(() => detectLanguage(null as unknown as string)).to.not.throw();
+    expect(detectLanguage(null as unknown as string)).to.equal(null);
+    expect(() => detectLanguage(undefined as unknown as string)).to.not.throw();
+  });
+});

--- a/__tests__/api/translation-controller.test.ts
+++ b/__tests__/api/translation-controller.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup } from '../setup/testSetup';
+import { BlueprintModel } from '../../app/api/models/blueprint';
+import { CommentModel } from '../../app/api/models/comment';
+import { TranslationModel } from '../../app/api/models/translation';
+import { TranslationBudgetModel } from '../../app/api/models/translation-budget';
+import { TranslationService } from '../../app/api/services/translation-service';
+import { FakeTranslationProvider } from '../helpers/fake-translation-provider';
+
+describe('Translation API', function () {
+  let testData: any;
+  let fake: FakeTranslationProvider;
+  let blueprintId: string;
+
+  beforeEach(async function () {
+    this.timeout(10000);
+    testData = await TestSetup.beforeEach();
+    await TranslationModel.model.deleteMany({});
+    await TranslationBudgetModel.model.deleteMany({});
+    fake = new FakeTranslationProvider();
+    TranslationService.setInstanceForTest(new TranslationService(fake));
+
+    blueprintId = testData.blueprints.popularBlueprint._id.toString();
+    await BlueprintModel.model.updateOne(
+      { _id: blueprintId },
+      { $set: { description: 'Bonjour le monde et bienvenue', sourceLang: 'fr' } }
+    );
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    TranslationService.setInstanceForTest(null);
+    await TranslationModel.model.deleteMany({});
+    await TranslationBudgetModel.model.deleteMany({});
+    await TestSetup.afterEach();
+  });
+
+  // ─── POST /api/blueprints/:id/translate ────────────────────────────────────
+
+  describe('POST /api/blueprints/:id/translate', function () {
+    it('requires auth', async function () {
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/translate`)
+        .send({ lang: 'en' });
+      expect(response.status).to.equal(401);
+    });
+
+    it('503s when the provider is not configured', async function () {
+      fake.configured = false;
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/translate`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ lang: 'en' });
+      expect(response.status).to.equal(503);
+    });
+
+    it('400s on an unsupported target language', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/translate`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ lang: 'fr' }); // not one of the four UI locales
+      expect(response.status).to.equal(400);
+      expect(fake.calls).to.have.length(0);
+    });
+
+    it('404s for an unknown blueprint', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .post('/api/blueprints/0123456789abcdef01234567/translate')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ lang: 'en' });
+      expect(response.status).to.equal(404);
+    });
+
+    it('404s for a draft blueprint viewed by a non-owner', async function () {
+      await BlueprintModel.model.updateOne({ _id: blueprintId }, { $set: { isPublished: false } });
+      const token = testData.users.user2.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/translate`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ lang: 'en' });
+      expect(response.status).to.equal(404);
+    });
+
+    it('translates the description and returns it', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/translate`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ lang: 'en' });
+
+      expect(response.status).to.equal(200);
+      expect(response.body.description).to.equal('[en] Bonjour le monde et bienvenue');
+      expect(response.body.sourceLang).to.equal('fr');
+      expect(response.body.cached).to.equal(false);
+      expect(fake.calls).to.have.length(1);
+    });
+
+    it('200s from cache on a second call (no second provider call)', async function () {
+      const token = testData.users.user1.generateJwt();
+      await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/translate`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ lang: 'en' });
+
+      const second = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/translate`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ lang: 'en' });
+
+      expect(second.status).to.equal(200);
+      expect(second.body.cached).to.equal(true);
+      expect(fake.calls).to.have.length(1);
+    });
+
+    it('400s when the blueprint has no description', async function () {
+      await BlueprintModel.model.updateOne({ _id: blueprintId }, { $set: { description: null } });
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/translate`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ lang: 'en' });
+      expect(response.status).to.equal(400);
+    });
+
+    it('429s with the budget-exceeded code once the monthly budget is spent', async function () {
+      process.env.MONTHLY_CHAR_BUDGET = '1';
+      await TranslationBudgetModel.model.create({
+        month: monthKey(),
+        userId: null,
+        charCount: 999999,
+        requestCount: 1,
+      });
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/translate`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ lang: 'en' });
+
+      expect(response.status).to.equal(429);
+      expect(response.body.code).to.equal('TRANSLATION_BUDGET_EXCEEDED');
+      delete process.env.MONTHLY_CHAR_BUDGET;
+    });
+  });
+
+  // ─── POST /api/blueprints/:id/comments/translate ───────────────────────────
+
+  describe('POST /api/blueprints/:id/comments/translate', function () {
+    async function makeComment(body: string, sourceLang: string | null) {
+      const comment = await CommentModel.model.create({
+        blueprintId,
+        authorId: testData.users.user2._id,
+        parentId: null,
+        body,
+        sourceLang,
+        createdAt: new Date(),
+        lastActivityAt: new Date(),
+      });
+      return (comment._id as any).toString();
+    }
+
+    it('requires auth', async function () {
+      const id = await makeComment('Bonjour tout le monde ici présent', 'fr');
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/comments/translate`)
+        .send({ lang: 'en', ids: [id] });
+      expect(response.status).to.equal(401);
+    });
+
+    it('400s on an empty or non-array ids', async function () {
+      const token = testData.users.user1.generateJwt();
+      const empty = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/comments/translate`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ lang: 'en', ids: [] });
+      expect(empty.status).to.equal(400);
+
+      const notArray = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/comments/translate`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ lang: 'en', ids: 'not-an-array' });
+      expect(notArray.status).to.equal(400);
+    });
+
+    it('400s when the batch exceeds MAX_TRANSLATE_BATCH', async function () {
+      const token = testData.users.user1.generateJwt();
+      const ids = Array.from({ length: 51 }, () => '0123456789abcdef01234567');
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/comments/translate`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ lang: 'en', ids });
+      expect(response.status).to.equal(400);
+    });
+
+    it('translates a batch of comments in one provider call and resolves reference tokens', async function () {
+      const idA = await makeComment('Bonjour tout le monde ici présent', 'fr');
+      const idB = await makeComment(
+        `Merci {{user:${testData.users.user1._id}}} pour ce beau plan génial`,
+        'fr'
+      );
+
+      const token = testData.users.user2.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/comments/translate`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ lang: 'en', ids: [idA, idB] });
+
+      expect(response.status).to.equal(200);
+      expect(response.body.translations).to.have.length(2);
+      expect(fake.calls).to.have.length(1); // one batched provider call
+
+      const first = response.body.translations.find((t: any) => t.id === idA);
+      expect(first.segments.some((s: any) => s.type === 'text' && s.text.includes('[en]'))).to.equal(true);
+
+      const second = response.body.translations.find((t: any) => t.id === idB);
+      const mentionSegment = second.segments.find((s: any) => s.type === 'user');
+      expect(mentionSegment).to.exist;
+      expect(mentionSegment.id).to.equal(String(testData.users.user1._id));
+      expect(mentionSegment.name).to.equal(testData.users.user1.username);
+    });
+
+    it('omits deleted or foreign-blueprint comments from the response', async function () {
+      const id = await makeComment('Bonjour tout le monde ici présent', 'fr');
+      await CommentModel.model.updateOne({ _id: id }, { $set: { deletedAt: new Date() } });
+
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .post(`/api/blueprints/${blueprintId}/comments/translate`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ lang: 'en', ids: [id] });
+
+      expect(response.status).to.equal(200);
+      expect(response.body.translations).to.have.length(0);
+    });
+  });
+
+  function monthKey(date = new Date()): string {
+    return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+  }
+});

--- a/__tests__/api/translation-controller.test.ts
+++ b/__tests__/api/translation-controller.test.ts
@@ -36,6 +36,9 @@ describe('Translation API', function () {
 
   afterEach(async function () {
     this.timeout(5000);
+    // Cleared here (not at the end of the test that sets it) so a failed
+    // assertion in that test can't leak the override into every later test.
+    delete process.env.MONTHLY_CHAR_BUDGET;
     TranslationService.setInstanceForTest(null);
     await TranslationModel.model.deleteMany({});
     await TranslationBudgetModel.model.deleteMany({});
@@ -148,7 +151,6 @@ describe('Translation API', function () {
 
       expect(response.status).to.equal(429);
       expect(response.body.code).to.equal('TRANSLATION_BUDGET_EXCEEDED');
-      delete process.env.MONTHLY_CHAR_BUDGET;
     });
   });
 

--- a/__tests__/api/translation-service.test.ts
+++ b/__tests__/api/translation-service.test.ts
@@ -224,6 +224,29 @@ describe('TranslationService', function () {
       );
       expect(otherResult.cached).to.equal(false);
     });
+
+    // Regression for the {month, userId} unique index that used to collide a
+    // user's second day of a month against their first (E11000 on upsert).
+    it('lets the same user translate again on a new day within the same month', async function () {
+      const userId = '507f1f77bcf86cd799439011';
+      await TranslationBudgetModel.model.create({
+        month: monthKey(),
+        day: `${monthKey()}-01`,
+        userId,
+        charCount: 500,
+        requestCount: 3,
+      });
+
+      const result = await service.translateOne(
+        { kind: 'blueprint', refId: '507f1f77bcf86cd799439004', sourceText: 'Une phrase du jour suivant', sourceLang: 'fr', targetLang: 'en' },
+        userId
+      );
+
+      expect(result.cached).to.equal(false);
+      expect(
+        await TranslationBudgetModel.model.countDocuments({ userId, month: monthKey() })
+      ).to.equal(2);
+    });
   });
 
   describe('batching', function () {

--- a/__tests__/api/translation-service.test.ts
+++ b/__tests__/api/translation-service.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup } from '../setup/testSetup';
+import { TranslationModel } from '../../app/api/models/translation';
+import { TranslationBudgetModel } from '../../app/api/models/translation-budget';
+import { TranslationService, TranslationBudgetExceeded } from '../../app/api/services/translation-service';
+import { FakeTranslationProvider } from '../helpers/fake-translation-provider';
+
+describe('TranslationService', function () {
+  let fake: FakeTranslationProvider;
+  let service: TranslationService;
+
+  beforeEach(async function () {
+    this.timeout(10000);
+    await TestSetup.beforeEach();
+    await TranslationModel.model.deleteMany({});
+    await TranslationBudgetModel.model.deleteMany({});
+    fake = new FakeTranslationProvider();
+    service = new TranslationService(fake);
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    delete process.env.MONTHLY_CHAR_BUDGET;
+    delete process.env.MAX_TRANSLATIONS_PER_USER_PER_DAY;
+    await TranslationModel.model.deleteMany({});
+    await TranslationBudgetModel.model.deleteMany({});
+    await TestSetup.afterEach();
+  });
+
+  describe('same-language shortcut', function () {
+    it('makes zero provider calls when sourceLang matches targetLang', async function () {
+      const result = await service.translateOne(
+        {
+          kind: 'blueprint',
+          refId: '507f1f77bcf86cd799439001',
+          sourceText: 'Hello there',
+          sourceLang: 'en',
+          targetLang: 'en',
+        },
+        null
+      );
+      expect(result).to.deep.equal({ translatedText: 'Hello there', sourceLang: 'en', cached: true, provider: 'none' });
+      expect(fake.calls).to.have.length(0);
+      expect(await TranslationModel.model.countDocuments({})).to.equal(0);
+    });
+
+    it('collapses zh-Hans to zh for the comparison', async function () {
+      const result = await service.translateOne(
+        { kind: 'blueprint', refId: '507f1f77bcf86cd799439001', sourceText: '你好', sourceLang: 'zh', targetLang: 'zh-Hans' },
+        null
+      );
+      expect(result.cached).to.equal(true);
+      expect(fake.calls).to.have.length(0);
+    });
+
+    it('skips translation for ASCII-only text with no detected source language', async function () {
+      const result = await service.translateOne(
+        { kind: 'blueprint', refId: '507f1f77bcf86cd799439001', sourceText: 'plain ascii text', sourceLang: null, targetLang: 'ru' },
+        null
+      );
+      expect(result.cached).to.equal(true);
+      expect(fake.calls).to.have.length(0);
+    });
+
+    it('still calls the provider for non-ASCII text with an unknown source language', async function () {
+      await service.translateOne(
+        { kind: 'blueprint', refId: '507f1f77bcf86cd799439001', sourceText: 'Café résumé', sourceLang: null, targetLang: 'ru' },
+        null
+      );
+      expect(fake.calls).to.have.length(1);
+    });
+  });
+
+  describe('caching', function () {
+    it('calls the provider on a miss and caches the result', async function () {
+      const result = await service.translateOne(
+        { kind: 'blueprint', refId: '507f1f77bcf86cd799439001', sourceText: 'Bonjour le monde', sourceLang: 'fr', targetLang: 'en' },
+        null
+      );
+      expect(fake.calls).to.have.length(1);
+      expect(result.cached).to.equal(false);
+      expect(result.translatedText).to.equal('[en] Bonjour le monde');
+
+      const row = await TranslationModel.model.findOne({ kind: 'blueprint', refId: '507f1f77bcf86cd799439001', targetLang: 'en' });
+      expect(row).to.not.be.null;
+      expect(row!.translatedText).to.equal('[en] Bonjour le monde');
+      expect(row!.provider).to.equal('google-v2');
+    });
+
+    it('serves a cache hit without a second provider call', async function () {
+      const input = { kind: 'blueprint' as const, refId: '507f1f77bcf86cd799439001', sourceText: 'Bonjour le monde', sourceLang: 'fr', targetLang: 'en' };
+      await service.translateOne(input, null);
+      const second = await service.translateOne(input, null);
+
+      expect(fake.calls).to.have.length(1);
+      expect(second.cached).to.equal(true);
+      expect(second.translatedText).to.equal('[en] Bonjour le monde');
+    });
+
+    it('re-translates when the source text changes (sourceHash mismatch)', async function () {
+      await service.translateOne(
+        { kind: 'blueprint', refId: '507f1f77bcf86cd799439001', sourceText: 'Bonjour le monde', sourceLang: 'fr', targetLang: 'en' },
+        null
+      );
+      const second = await service.translateOne(
+        { kind: 'blueprint', refId: '507f1f77bcf86cd799439001', sourceText: 'Bonjour tout le monde', sourceLang: 'fr', targetLang: 'en' },
+        null
+      );
+
+      expect(fake.calls).to.have.length(2);
+      expect(second.cached).to.equal(false);
+      expect(second.translatedText).to.equal('[en] Bonjour tout le monde');
+      // Same row, upserted — not a second document
+      expect(await TranslationModel.model.countDocuments({ kind: 'blueprint', refId: '507f1f77bcf86cd799439001', targetLang: 'en' })).to.equal(1);
+    });
+
+    it('a human-provided row always wins and is never overwritten by a machine translation', async function () {
+      await TranslationModel.model.create({
+        kind: 'blueprint',
+        refId: '507f1f77bcf86cd799439001',
+        targetLang: 'en',
+        sourceLang: 'fr',
+        sourceHash: 'stale-hash-does-not-matter',
+        translatedText: 'A human-corrected translation',
+        provider: 'human',
+        charCount: 30,
+      });
+
+      const result = await service.translateOne(
+        { kind: 'blueprint', refId: '507f1f77bcf86cd799439001', sourceText: 'Bonjour le monde', sourceLang: 'fr', targetLang: 'en' },
+        null
+      );
+
+      expect(fake.calls).to.have.length(0);
+      expect(result.translatedText).to.equal('A human-corrected translation');
+      expect(result.provider).to.equal('human');
+    });
+  });
+
+  describe('budget enforcement', function () {
+    it('throws before calling the provider once the monthly budget is exceeded', async function () {
+      process.env.MONTHLY_CHAR_BUDGET = '5';
+      await TranslationBudgetModel.model.create({ month: monthKey(), userId: null, charCount: 10, requestCount: 1 });
+
+      let threw = false;
+      try {
+        await service.translateOne(
+          { kind: 'blueprint', refId: '507f1f77bcf86cd799439001', sourceText: 'Bonjour le monde', sourceLang: 'fr', targetLang: 'en' },
+          null
+        );
+      } catch (err) {
+        threw = true;
+        expect(err).to.be.instanceOf(TranslationBudgetExceeded);
+      }
+      expect(threw).to.equal(true);
+      expect(fake.calls).to.have.length(0);
+    });
+
+    it('cache reads keep working even when the budget is exceeded', async function () {
+      // Populate the cache first, while under budget
+      await service.translateOne(
+        { kind: 'blueprint', refId: '507f1f77bcf86cd799439001', sourceText: 'Bonjour le monde', sourceLang: 'fr', targetLang: 'en' },
+        null
+      );
+
+      process.env.MONTHLY_CHAR_BUDGET = '1';
+      await TranslationBudgetModel.model.updateOne({ month: monthKey(), userId: null }, { $set: { charCount: 999999 } });
+
+      const result = await service.translateOne(
+        { kind: 'blueprint', refId: '507f1f77bcf86cd799439001', sourceText: 'Bonjour le monde', sourceLang: 'fr', targetLang: 'en' },
+        null
+      );
+      expect(result.cached).to.equal(true);
+      expect(fake.calls).to.have.length(1); // only the first (pre-budget-exceeded) call
+    });
+
+    it('increments both the site and per-user budget docs by the billed character count', async function () {
+      const userId = '507f1f77bcf86cd799439011';
+      await service.translateOne(
+        { kind: 'blueprint', refId: '507f1f77bcf86cd799439001', sourceText: 'Bonjour le monde', sourceLang: 'fr', targetLang: 'en' },
+        userId
+      );
+
+      const siteRow = await TranslationBudgetModel.model.findOne({ month: monthKey(), userId: null });
+      expect(siteRow!.charCount).to.equal('Bonjour le monde'.length);
+      expect(siteRow!.requestCount).to.equal(1);
+
+      const userRow = await TranslationBudgetModel.model.findOne({ userId, month: monthKey() });
+      expect(userRow!.charCount).to.equal('Bonjour le monde'.length);
+      expect(userRow!.requestCount).to.equal(1);
+    });
+
+    it('enforces the per-user daily cap independently of the site budget', async function () {
+      process.env.MAX_TRANSLATIONS_PER_USER_PER_DAY = '1';
+      const userId = '507f1f77bcf86cd799439011';
+      await service.translateOne(
+        { kind: 'blueprint', refId: '507f1f77bcf86cd799439001', sourceText: 'Bonjour le monde', sourceLang: 'fr', targetLang: 'en' },
+        userId
+      );
+
+      let threw = false;
+      try {
+        await service.translateOne(
+          { kind: 'blueprint', refId: '507f1f77bcf86cd799439002', sourceText: 'Une autre phrase ici', sourceLang: 'fr', targetLang: 'en' },
+          userId
+        );
+      } catch (err) {
+        threw = true;
+        expect(err).to.be.instanceOf(TranslationBudgetExceeded);
+      }
+      expect(threw).to.equal(true);
+
+      // A different user is unaffected
+      const otherResult = await service.translateOne(
+        { kind: 'blueprint', refId: '507f1f77bcf86cd799439003', sourceText: 'Encore une phrase', sourceLang: 'fr', targetLang: 'en' },
+        '507f1f77bcf86cd799439099'
+      );
+      expect(otherResult.cached).to.equal(false);
+    });
+  });
+
+  describe('batching', function () {
+    it('translates a batch of misses in a single provider call', async function () {
+      const results = await service.translateMany(
+        [
+          { kind: 'comment', refId: '507f1f77bcf86cd799439011', sourceText: 'Bonjour', sourceLang: 'fr', targetLang: 'en' },
+          { kind: 'comment', refId: '507f1f77bcf86cd799439012', sourceText: 'Au revoir', sourceLang: 'fr', targetLang: 'en' },
+        ],
+        null
+      );
+      expect(fake.calls).to.have.length(1);
+      expect(fake.calls[0].texts).to.deep.equal(['Bonjour', 'Au revoir']);
+      expect(results.map(r => r.translatedText)).to.deep.equal(['[en] Bonjour', '[en] Au revoir']);
+    });
+
+    it('mixes cache hits and misses in one batch without extra provider calls for the hits', async function () {
+      await service.translateOne(
+        { kind: 'comment', refId: '507f1f77bcf86cd799439011', sourceText: 'Bonjour', sourceLang: 'fr', targetLang: 'en' },
+        null
+      );
+      const results = await service.translateMany(
+        [
+          { kind: 'comment', refId: '507f1f77bcf86cd799439011', sourceText: 'Bonjour', sourceLang: 'fr', targetLang: 'en' },
+          { kind: 'comment', refId: '507f1f77bcf86cd799439012', sourceText: 'Au revoir', sourceLang: 'fr', targetLang: 'en' },
+        ],
+        null
+      );
+      expect(fake.calls).to.have.length(2); // one for the first translateOne, one for the c2 miss
+      expect(fake.calls[1].texts).to.deep.equal(['Au revoir']);
+      expect(results[0].cached).to.equal(true);
+      expect(results[1].cached).to.equal(false);
+    });
+  });
+
+  describe('reference-token safety (comments)', function () {
+    it('tokenizes references before sending to the provider and restores them after', async function () {
+      const result = await service.translateOne(
+        {
+          kind: 'comment',
+          refId: '507f1f77bcf86cd799439011',
+          sourceText: 'merci {{user:507f1f77bcf86cd799439011}} pour ce beau plan',
+          sourceLang: 'fr',
+          targetLang: 'en',
+          hasReferenceTokens: true,
+        },
+        null
+      );
+      // The provider never saw the raw token
+      expect(fake.calls[0].texts[0]).to.not.contain('{{user:');
+      // But the restored result has it back, verbatim
+      expect(result.translatedText).to.contain('{{user:507f1f77bcf86cd799439011}}');
+      expect(result.degraded).to.be.undefined;
+    });
+
+    it('discards a corrupted round-trip and returns the original text as degraded', async function () {
+      // Force the fake provider to mangle output: swallow the placeholder by
+      // stripping everything after "[en] " so the sentinel never survives.
+      fake.translate = async () => [{ text: 'a translation with no placeholder at all', detectedSourceLang: 'fr' }];
+
+      const result = await service.translateOne(
+        {
+          kind: 'comment',
+          refId: '507f1f77bcf86cd799439011',
+          sourceText: 'merci {{user:507f1f77bcf86cd799439011}} pour ce beau plan',
+          sourceLang: 'fr',
+          targetLang: 'en',
+          hasReferenceTokens: true,
+        },
+        null
+      );
+      expect(result.degraded).to.equal(true);
+      expect(result.translatedText).to.equal('merci {{user:507f1f77bcf86cd799439011}} pour ce beau plan');
+      // A degraded result must never be cached
+      expect(await TranslationModel.model.countDocuments({})).to.equal(0);
+    });
+  });
+
+  it('reports 503-worthy unconfigured state through isConfigured()', function () {
+    fake.configured = false;
+    expect(service.isConfigured()).to.equal(false);
+  });
+
+  function monthKey(date = new Date()): string {
+    return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+  }
+});

--- a/__tests__/api/translation-token-safety.test.ts
+++ b/__tests__/api/translation-token-safety.test.ts
@@ -1,0 +1,77 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { tokenizeReferences, restoreReferences } from '../../app/api/services/translation-token-safety';
+
+describe('translation-token-safety', function () {
+  describe('tokenizeReferences / restoreReferences round-trip', function () {
+    it('round-trips a single token', function () {
+      const source = 'Check out {{blueprint:507f1f77bcf86cd799439011}} for details.';
+      const { text, tokens } = tokenizeReferences(source);
+      expect(text).to.not.contain('{{blueprint:');
+      expect(restoreReferences(text, tokens)).to.equal(source);
+    });
+
+    it('round-trips multiple distinct tokens', function () {
+      const source =
+        'Thanks {{user:507f1f77bcf86cd799439011}}, see {{blueprint:507f191e810c19729de860ea}} and also {{user:5f8d0d55b54764421b7156c5}}.';
+      const { text, tokens } = tokenizeReferences(source);
+      expect(restoreReferences(text, tokens)).to.equal(source);
+    });
+
+    it('round-trips a token at the very start of the string', function () {
+      const source = '{{blueprint:507f1f77bcf86cd799439011}} is great';
+      const { text, tokens } = tokenizeReferences(source);
+      expect(restoreReferences(text, tokens)).to.equal(source);
+    });
+
+    it('round-trips adjacent tokens with no separator', function () {
+      const source = '{{blueprint:507f1f77bcf86cd799439011}}{{user:507f191e810c19729de860ea}}';
+      const { text, tokens } = tokenizeReferences(source);
+      expect(restoreReferences(text, tokens)).to.equal(source);
+    });
+
+    it('round-trips a token embedded in CJK text with no surrounding whitespace', function () {
+      const source = '请看这个蓝图{{blueprint:507f1f77bcf86cd799439011}}非常好用';
+      const { text, tokens } = tokenizeReferences(source);
+      expect(restoreReferences(text, tokens)).to.equal(source);
+    });
+
+    it('is a no-op when there are no tokens', function () {
+      const source = 'nothing to see here';
+      const { text, tokens } = tokenizeReferences(source);
+      expect(text).to.equal(source);
+      expect(tokens).to.have.length(0);
+      expect(restoreReferences(source, tokens)).to.equal(source);
+    });
+  });
+
+  describe('restoreReferences failure modes (must discard, never serve corrupted text)', function () {
+    it('fails when a placeholder is missing from the translated text', function () {
+      const { tokens } = tokenizeReferences('see {{blueprint:507f1f77bcf86cd799439011}}');
+      expect(restoreReferences('the placeholder vanished', tokens)).to.equal(null);
+    });
+
+    it('fails when a placeholder appears twice (NMT duplication)', function () {
+      const { text, tokens } = tokenizeReferences('see {{blueprint:507f1f77bcf86cd799439011}}');
+      const duplicated = `${text} ${text}`;
+      expect(restoreReferences(duplicated, tokens)).to.equal(null);
+    });
+
+    it('fails when only some of several placeholders survive', function () {
+      const { text, tokens } = tokenizeReferences(
+        'a {{user:507f1f77bcf86cd799439011}} b {{blueprint:507f191e810c19729de860ea}}'
+      );
+      // Drop the second placeholder entirely
+      const mangled = text.replace(/xxBNIREFx1xx/, 'gone');
+      expect(restoreReferences(mangled, tokens)).to.equal(null);
+    });
+
+    it('fails when the translated text contains a stray unrecognized placeholder-shaped sentinel', function () {
+      const { tokens } = tokenizeReferences('see {{blueprint:507f1f77bcf86cd799439011}}');
+      // Only one real placeholder existed (index 0); an extra index-99 sentinel
+      // appearing in the output means the round-trip cannot be trusted.
+      const withRestored = restoreReferences('see xxBNIREFx0xx and also xxBNIREFx99xx', tokens);
+      expect(withRestored).to.equal(null);
+    });
+  });
+});

--- a/__tests__/helpers/fake-translation-provider.ts
+++ b/__tests__/helpers/fake-translation-provider.ts
@@ -1,0 +1,27 @@
+import { TranslatedText, TranslationProvider } from '../../app/api/services/translation-provider';
+
+// Deterministic in-memory provider — no network in tests, ever. Prefixes each
+// input with a marker so specs can assert a translation actually happened,
+// and can optionally report a detected source language per call.
+export class FakeTranslationProvider implements TranslationProvider {
+  public configured = true;
+  public calls: { texts: string[]; targetLang: string }[] = [];
+  public detectedSourceLang: string | undefined = 'fr';
+  public failNext = false;
+
+  isConfigured(): boolean {
+    return this.configured;
+  }
+
+  async translate(texts: string[], targetLang: string): Promise<TranslatedText[]> {
+    this.calls.push({ texts, targetLang });
+    if (this.failNext) {
+      this.failNext = false;
+      throw new Error('fake provider failure');
+    }
+    return texts.map(text => ({
+      text: `[${targetLang}] ${text}`,
+      detectedSourceLang: this.detectedSourceLang,
+    }));
+  }
+}

--- a/app/api/batch/derive-language.ts
+++ b/app/api/batch/derive-language.ts
@@ -1,0 +1,111 @@
+// Backfill script: derive `sourceLang` for Blueprint.description and
+// Comment.body using the same free local detector as the save paths
+// (language-detection-service). No game database bootstrap needed — unlike
+// derive-rooms/derive-metadata, this reads only stored text.
+//
+// Usage:
+//   ts-node app/api/batch/derive-language.ts [--dry-run] [--limit N]
+//
+// --limit N reads a random sample of N documents per collection instead of
+// the whole collection (see batch-sampling.ts).
+//
+// This is step 1 of spec/user-content-translation-impl.md: detection + storage
+// only, no paid provider call. The printed language distribution is the first
+// real evidence of whether the translation feature (steps 3-5) is worth
+// building further — run this against a prod dump before committing to them.
+// In the deploy image run the compiled output instead:
+//   cd /bpni/build && node app/api/batch/derive-language.js [--dry-run]
+
+import * as mongoose from 'mongoose';
+import * as dotenv from 'dotenv';
+import { BlueprintModel } from '../models/blueprint';
+import { CommentModel } from '../models/comment';
+import { detectLanguage } from '../services/language-detection-service';
+import { parseBatchArgs, sampledCursor, describeScope } from './batch-sampling';
+
+dotenv.config();
+
+async function deriveBlueprints(dryRun: boolean, limit: number | null) {
+  const cursor = sampledCursor(
+    BlueprintModel.model,
+    { deletedAt: null, description: { $nin: [null, ''] } },
+    limit
+  );
+  let processed = 0;
+  let updated = 0;
+  const perLang = new Map<string, number>();
+  let unconfident = 0;
+
+  for await (const doc of cursor) {
+    processed++;
+    const lang = detectLanguage(doc.description as string);
+    if (lang == null) unconfident++;
+    else perLang.set(lang, (perLang.get(lang) ?? 0) + 1);
+
+    if (doc.sourceLang === (lang ?? null)) continue;
+    updated++;
+    if (!dryRun) {
+      await BlueprintModel.model.updateOne({ _id: doc._id }, { $set: { sourceLang: lang } });
+    }
+  }
+
+  console.log(`\nBlueprint descriptions — processed: ${processed}, updated: ${updated}${dryRun ? ' (dry run)' : ''}`);
+  console.log(`  not confident: ${unconfident}`);
+  reportLangs(perLang);
+}
+
+async function deriveComments(dryRun: boolean, limit: number | null) {
+  const cursor = sampledCursor(CommentModel.model, { deletedAt: null }, limit);
+  let processed = 0;
+  let updated = 0;
+  const perLang = new Map<string, number>();
+  let unconfident = 0;
+
+  for await (const doc of cursor) {
+    processed++;
+    const lang = detectLanguage(doc.body as string);
+    if (lang == null) unconfident++;
+    else perLang.set(lang, (perLang.get(lang) ?? 0) + 1);
+
+    if (doc.sourceLang === (lang ?? null)) continue;
+    updated++;
+    if (!dryRun) {
+      await CommentModel.model.updateOne({ _id: doc._id }, { $set: { sourceLang: lang } });
+    }
+  }
+
+  console.log(`\nComments — processed: ${processed}, updated: ${updated}${dryRun ? ' (dry run)' : ''}`);
+  console.log(`  not confident: ${unconfident}`);
+  reportLangs(perLang);
+}
+
+function reportLangs(perLang: Map<string, number>) {
+  const report = [...perLang.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([lang, count]) => `${lang}: ${count}`)
+    .join(', ');
+  console.log(`  by language — ${report || 'none detected'}`);
+}
+
+async function run(dryRun: boolean, limit: number | null) {
+  const mongoUri = process.env.DB_URI;
+  if (!mongoUri) throw new Error('DB_URI not set in environment');
+
+  await mongoose.connect(mongoUri);
+  BlueprintModel.init();
+  CommentModel.init();
+
+  console.log(describeScope(limit, dryRun));
+  await deriveBlueprints(dryRun, limit);
+  await deriveComments(dryRun, limit);
+
+  await mongoose.disconnect();
+}
+
+if (require.main === module) {
+  const { dryRun, limit } = parseBatchArgs(process.argv);
+  run(dryRun, limit).catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/app/api/batch/derive-language.ts
+++ b/app/api/batch/derive-language.ts
@@ -17,6 +17,7 @@
 //   cd /bpni/build && node app/api/batch/derive-language.js [--dry-run]
 
 import * as mongoose from 'mongoose';
+import { Model } from 'mongoose';
 import * as dotenv from 'dotenv';
 import { BlueprintModel } from '../models/blueprint';
 import { CommentModel } from '../models/comment';
@@ -24,6 +25,29 @@ import { detectLanguage } from '../services/language-detection-service';
 import { parseBatchArgs, sampledCursor, describeScope } from './batch-sampling';
 
 dotenv.config();
+
+// Buffers $set writes and flushes them via bulkWrite so a full-collection
+// backfill doesn't pay one round trip per changed document. Still idempotent
+// (a mid-run failure just loses the unflushed buffer, safe to restart).
+const BULK_BATCH_SIZE = 500;
+
+function batchedSourceLangWriter(model: Model<any>, dryRun: boolean) {
+  let pending: { updateOne: { filter: { _id: unknown }; update: { $set: { sourceLang: string | null } } } }[] = [];
+
+  async function flush() {
+    if (dryRun || pending.length === 0) return;
+    await model.bulkWrite(pending);
+    pending = [];
+  }
+
+  return {
+    async queue(id: unknown, sourceLang: string | null) {
+      pending.push({ updateOne: { filter: { _id: id }, update: { $set: { sourceLang } } } });
+      if (pending.length >= BULK_BATCH_SIZE) await flush();
+    },
+    flush,
+  };
+}
 
 async function deriveBlueprints(dryRun: boolean, limit: number | null) {
   const cursor = sampledCursor(
@@ -35,6 +59,7 @@ async function deriveBlueprints(dryRun: boolean, limit: number | null) {
   let updated = 0;
   const perLang = new Map<string, number>();
   let unconfident = 0;
+  const writer = batchedSourceLangWriter(BlueprintModel.model, dryRun);
 
   for await (const doc of cursor) {
     processed++;
@@ -44,10 +69,9 @@ async function deriveBlueprints(dryRun: boolean, limit: number | null) {
 
     if (doc.sourceLang === (lang ?? null)) continue;
     updated++;
-    if (!dryRun) {
-      await BlueprintModel.model.updateOne({ _id: doc._id }, { $set: { sourceLang: lang } });
-    }
+    await writer.queue(doc._id, lang);
   }
+  await writer.flush();
 
   console.log(`\nBlueprint descriptions — processed: ${processed}, updated: ${updated}${dryRun ? ' (dry run)' : ''}`);
   console.log(`  not confident: ${unconfident}`);
@@ -60,6 +84,7 @@ async function deriveComments(dryRun: boolean, limit: number | null) {
   let updated = 0;
   const perLang = new Map<string, number>();
   let unconfident = 0;
+  const writer = batchedSourceLangWriter(CommentModel.model, dryRun);
 
   for await (const doc of cursor) {
     processed++;
@@ -69,10 +94,9 @@ async function deriveComments(dryRun: boolean, limit: number | null) {
 
     if (doc.sourceLang === (lang ?? null)) continue;
     updated++;
-    if (!dryRun) {
-      await CommentModel.model.updateOne({ _id: doc._id }, { $set: { sourceLang: lang } });
-    }
+    await writer.queue(doc._id, lang);
   }
+  await writer.flush();
 
   console.log(`\nComments — processed: ${processed}, updated: ${updated}${dryRun ? ' (dry run)' : ''}`);
   console.log(`  not confident: ${unconfident}`);

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -41,6 +41,7 @@ import { PreviewImageService } from './services/preview-image-service';
 import { deriveRooms } from './services/room-derivation-service';
 import { deriveMods } from './services/mod-derivation-service';
 import { deriveDlcs } from './services/dlc-derivation-service';
+import { detectLanguage } from './services/language-detection-service';
 import {
   parseBlueprintFilters,
   resolveRatedByIds,
@@ -1297,6 +1298,7 @@ export class BlueprintController {
         category: blueprint.category ?? null,
         subcategory: blueprint.subcategory ?? null,
         description: blueprint.description ?? null,
+        sourceLang: blueprint.sourceLang ?? null,
         researchTier: blueprint.researchTier ?? null,
         modded: blueprint.modded ?? null,
         mods: blueprint.mods ?? [],
@@ -1448,6 +1450,8 @@ export class BlueprintController {
       // A blueprint using known-mod buildings is modded regardless of what the
       // client derived (protects against stale clients shipping the old heuristic).
       if (blueprint.mods.length > 0) blueprint.modded = true;
+      // Derived fact, never client-supplied (same policy as rooms/requiredDlcs).
+      blueprint.sourceLang = metadata.description ? detectLanguage(metadata.description) : null;
     }
 
     if (overwriteCreateDate || blueprint.createdAt == null) blueprint.createdAt = new Date();

--- a/app/api/comment-controller.ts
+++ b/app/api/comment-controller.ts
@@ -13,6 +13,7 @@ import {
   segmentBody,
   toEditableText,
 } from './services/comment-body';
+import { detectLanguage } from './services/language-detection-service';
 import {
   CommentDto,
   CommentThread,
@@ -57,17 +58,15 @@ interface RenderContext {
   viewer: UserJwt | null;
 }
 
-async function buildRenderContext(
-  comments: Comment[],
-  blueprintOwnerId: string,
-  viewer: UserJwt | null
-): Promise<RenderContext> {
-  const visibleBodies = comments.filter(c => c.deletedAt == null).map(c => c.body);
-  const { blueprintIds, userIds } = extractTokenIds(visibleBodies);
-  const authorIds = [...new Set(comments.map(c => c.authorId.toString()))];
-
-  const [authorDocs, blueprintDocs, userDocs] = await Promise.all([
-    UserModel.model.find({ _id: { $in: authorIds } }).select('username').lean(),
+// Shared with TranslationController: a translated body carries the same
+// {{blueprint:id}}/{{user:id}} tokens as the source (translation-token-safety
+// restores them verbatim), so it needs the same name resolution before it can
+// be rendered as segments.
+export async function resolveReferenceNames(
+  bodies: string[]
+): Promise<{ blueprints: Map<string, string>; users: Map<string, string> }> {
+  const { blueprintIds, userIds } = extractTokenIds(bodies);
+  const [blueprintDocs, userDocs] = await Promise.all([
     blueprintIds.length > 0
       ? BlueprintModel.model.find({ _id: { $in: blueprintIds }, deletedAt: null }).select('name').lean()
       : Promise.resolve([]),
@@ -75,11 +74,27 @@ async function buildRenderContext(
       ? UserModel.model.find({ _id: { $in: userIds } }).select('username').lean()
       : Promise.resolve([]),
   ]);
+  return {
+    blueprints: new Map(blueprintDocs.map(b => [b._id.toString(), b.name as string])),
+    users: new Map(userDocs.map(u => [u._id.toString(), u.username as string])),
+  };
+}
+
+async function buildRenderContext(
+  comments: Comment[],
+  blueprintOwnerId: string,
+  viewer: UserJwt | null
+): Promise<RenderContext> {
+  const visibleBodies = comments.filter(c => c.deletedAt == null).map(c => c.body);
+  const { blueprints, users } = await resolveReferenceNames(visibleBodies);
+  const authorIds = [...new Set(comments.map(c => c.authorId.toString()))];
+
+  const authorDocs = await UserModel.model.find({ _id: { $in: authorIds } }).select('username').lean();
 
   return {
     authors: new Map(authorDocs.map(u => [u._id.toString(), u.username as string])),
-    blueprints: new Map(blueprintDocs.map(b => [b._id.toString(), b.name as string])),
-    users: new Map(userDocs.map(u => [u._id.toString(), u.username as string])),
+    blueprints,
+    users,
     blueprintOwnerId,
     viewer,
   };
@@ -108,6 +123,7 @@ function toDto(comment: Comment, context: RenderContext): CommentDto {
     createdAt: comment.createdAt.toISOString(),
     lastActivityAt: comment.lastActivityAt.toISOString(),
     editedAt: comment.editedAt != null ? comment.editedAt.toISOString() : null,
+    sourceLang: comment.sourceLang ?? null,
     canDelete,
     canEdit,
     ...(canEdit ? { editSource: toEditableText(comment.body, context.users) } : {}),
@@ -254,6 +270,7 @@ export class CommentController {
         authorId: user._id,
         parentId: parentId ?? null,
         body: sanitized,
+        sourceLang: detectLanguage(sanitized),
         createdAt: now,
         lastActivityAt: now,
       });
@@ -348,6 +365,7 @@ export class CommentController {
 
       if (sanitized !== comment.body) {
         comment.body = sanitized;
+        comment.sourceLang = detectLanguage(sanitized);
         comment.editedAt = new Date();
       }
       await comment.save();

--- a/app/api/db.ts
+++ b/app/api/db.ts
@@ -12,6 +12,8 @@ import { BlueprintRatingModel } from './models/blueprint-rating';
 import { AvatarModel } from './models/avatar';
 import { AvatarSeedUploadModel } from './models/avatar-seed-upload';
 import { AvatarBatchModel } from './models/avatar-batch';
+import { TranslationModel } from './models/translation';
+import { TranslationBudgetModel } from './models/translation-budget';
 
 export class Database {
   constructor() {
@@ -40,6 +42,8 @@ export class Database {
       AvatarModel.init();
       AvatarSeedUploadModel.init();
       AvatarBatchModel.init();
+      TranslationModel.init();
+      TranslationBudgetModel.init();
     });
     mongoose.connection.on('error', err => {
       if (process.env.NODE_ENV !== 'test') {

--- a/app/api/models/blueprint.ts
+++ b/app/api/models/blueprint.ts
@@ -58,6 +58,12 @@ export interface Blueprint extends Document {
   category?: string | null;
   subcategory?: string | null;
   description?: string | null;
+  // ISO-639-1 language of `description`, server-derived on every save (never
+  // client-supplied, same nullability convention as `rooms`): null = detection
+  // ran and was not confident, absent = never derived (legacy docs, until the
+  // derive-language backfill runs). No schema default — same hydration
+  // rationale as isPublished/mods.
+  sourceLang?: string | null;
   researchTier?: string | null;
   modded?: boolean | null;
   // Workshop ids of the mods this blueprint's buildings come from. Server-derived
@@ -139,6 +145,10 @@ export class BlueprintModel {
       subcategory: { type: String, maxlength: 40 },
       description: { type: String, maxlength: 500 },
       researchTier: { type: String, enum: [...RESEARCH_TIERS, null] },
+      // No default (see field comment): a schema default would make every
+      // hydrated legacy doc read as "derived, not confident" and lose the
+      // never-derived signal.
+      sourceLang: { type: String, default: undefined },
       modded: { type: Boolean },
       // default: undefined (NOT []) — a schema default would make every hydrated
       // legacy doc appear to have mods:[] and get written back on unrelated saves,

--- a/app/api/models/comment.ts
+++ b/app/api/models/comment.ts
@@ -7,6 +7,10 @@ export interface Comment extends Document {
   parentId: mongoose.Types.ObjectId | null;
   // Sanitized plain text with internal reference tokens — never raw user input
   body: string;
+  // ISO-639-1 language of `body`, server-derived on create/edit (never
+  // client-supplied): null = detection ran and was not confident, absent =
+  // never derived (legacy docs, until the derive-language backfill runs).
+  sourceLang?: string | null;
   createdAt: Date;
   // Bumped on each reply; equals createdAt while a comment has no replies
   lastActivityAt: Date;
@@ -25,6 +29,8 @@ export class CommentModel {
       authorId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
       parentId: { type: Schema.Types.ObjectId, ref: 'Comment', default: null },
       body: { type: String, required: true, maxlength: 2000 },
+      // No default — same nullability convention as Blueprint.sourceLang
+      sourceLang: { type: String, default: undefined },
       createdAt: { type: Date, default: Date.now },
       lastActivityAt: { type: Date, default: Date.now },
       editedAt: { type: Date, default: null },

--- a/app/api/models/translation-budget.ts
+++ b/app/api/models/translation-budget.ts
@@ -1,0 +1,40 @@
+import mongoose, { Schema, Document, Model } from 'mongoose';
+
+// Character-spend accounting for the translation feature (spec/user-content-
+// translation-impl.md §5). Two row shapes share one collection, distinguished
+// by whether `userId` is set:
+//   { month, userId: null }  — the whole-site monthly budget
+//   { month, userId }        — one user's per-day usage counter (`day` set)
+// Incremented with $inc in the same code path that calls the provider, after
+// a successful call. A racy over-count of a few thousand chars is fine — the
+// budget has 20% headroom built in.
+export interface TranslationBudget extends Document {
+  month: string; // 'YYYY-MM'
+  day?: string | null; // 'YYYY-MM-DD', set only on per-user rows
+  userId?: mongoose.Types.ObjectId | null;
+  charCount: number;
+  requestCount: number;
+}
+
+export class TranslationBudgetModel {
+  static model: Model<TranslationBudget>;
+
+  public static init() {
+    const schema = new mongoose.Schema({
+      month: { type: String, required: true },
+      day: { type: String, default: null },
+      userId: { type: Schema.Types.ObjectId, ref: 'User', default: null },
+      charCount: { type: Number, default: 0 },
+      requestCount: { type: Number, default: 0 },
+    });
+
+    // Whole-site monthly row: { month, userId: null }
+    schema.index({ month: 1, userId: 1 }, { unique: true });
+    // Per-user daily cap lookup
+    schema.index({ userId: 1, day: 1 });
+
+    TranslationBudgetModel.model =
+      (mongoose.models['TranslationBudget'] as Model<TranslationBudget>) ??
+      mongoose.model<TranslationBudget>('TranslationBudget', schema);
+  }
+}

--- a/app/api/models/translation-budget.ts
+++ b/app/api/models/translation-budget.ts
@@ -28,10 +28,12 @@ export class TranslationBudgetModel {
       requestCount: { type: Number, default: 0 },
     });
 
-    // Whole-site monthly row: { month, userId: null }
-    schema.index({ month: 1, userId: 1 }, { unique: true });
-    // Per-user daily cap lookup
-    schema.index({ userId: 1, day: 1 });
+    // Site row: { month, userId: null, day: null }; per-user row: { month,
+    // userId, day }. `day` must be in the unique key — {month, userId} alone
+    // collides a user's second day of a month against their first (E11000)
+    // and also serves the per-user daily cap lookup, so the separate
+    // {userId, day} index this replaced was redundant.
+    schema.index({ month: 1, userId: 1, day: 1 }, { unique: true });
 
     TranslationBudgetModel.model =
       (mongoose.models['TranslationBudget'] as Model<TranslationBudget>) ??

--- a/app/api/models/translation.ts
+++ b/app/api/models/translation.ts
@@ -7,6 +7,11 @@ import { TRANSLATION_TARGET_LANGS } from '../../../lib/index';
 export type TranslationKind = 'blueprint' | 'comment';
 export type TranslationProviderName = 'google-v2' | 'human';
 
+// Runtime enum arrays derived from the unions above so a new kind/provider
+// added to the type can't compile while silently failing schema validation.
+const TRANSLATION_KINDS: TranslationKind[] = ['blueprint', 'comment'];
+const TRANSLATION_PROVIDERS: TranslationProviderName[] = ['google-v2', 'human'];
+
 export interface Translation extends Document {
   kind: TranslationKind;
   refId: mongoose.Types.ObjectId;
@@ -33,13 +38,13 @@ export class TranslationModel {
   public static init() {
     const translationSchema = new mongoose.Schema(
       {
-        kind: { type: String, enum: ['blueprint', 'comment'], required: true },
+        kind: { type: String, enum: TRANSLATION_KINDS, required: true },
         refId: { type: Schema.Types.ObjectId, required: true },
         targetLang: { type: String, enum: TRANSLATION_TARGET_LANGS, required: true },
         sourceLang: { type: String, default: null },
         sourceHash: { type: String, required: true },
         translatedText: { type: String, required: true },
-        provider: { type: String, enum: ['google-v2', 'human'], required: true },
+        provider: { type: String, enum: TRANSLATION_PROVIDERS, required: true },
         charCount: { type: Number, required: true },
         reviewedBy: { type: Schema.Types.ObjectId, ref: 'User', default: null },
       },

--- a/app/api/models/translation.ts
+++ b/app/api/models/translation.ts
@@ -1,0 +1,55 @@
+import mongoose, { Schema, Document, Model } from 'mongoose';
+import { TRANSLATION_TARGET_LANGS } from '../../../lib/index';
+
+// Durable cache for machine-translated user content (spec/user-content-
+// translation-impl.md §2.2). One row per (kind, refId, targetLang), upserted.
+// Rows are disposable — dropping the collection only costs money to rebuild.
+export type TranslationKind = 'blueprint' | 'comment';
+export type TranslationProviderName = 'google-v2' | 'human';
+
+export interface Translation extends Document {
+  kind: TranslationKind;
+  refId: mongoose.Types.ObjectId;
+  targetLang: string;
+  // As detected at translate time (may differ from the source doc's own
+  // sourceLang if that was recomputed since)
+  sourceLang: string | null;
+  // sha256 of the source text (first 16 hex chars) — freshness check, not an
+  // invalidation hook. A mismatch on read means "stale", not "broken": the
+  // caller re-translates and upserts over the same row.
+  sourceHash: string;
+  translatedText: string;
+  provider: TranslationProviderName;
+  charCount: number;
+  // Phase 4 (deferred): human-submitted corrections. null = machine.
+  reviewedBy?: mongoose.Types.ObjectId | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export class TranslationModel {
+  static model: Model<Translation>;
+
+  public static init() {
+    const translationSchema = new mongoose.Schema(
+      {
+        kind: { type: String, enum: ['blueprint', 'comment'], required: true },
+        refId: { type: Schema.Types.ObjectId, required: true },
+        targetLang: { type: String, enum: TRANSLATION_TARGET_LANGS, required: true },
+        sourceLang: { type: String, default: null },
+        sourceHash: { type: String, required: true },
+        translatedText: { type: String, required: true },
+        provider: { type: String, enum: ['google-v2', 'human'], required: true },
+        charCount: { type: Number, required: true },
+        reviewedBy: { type: Schema.Types.ObjectId, ref: 'User', default: null },
+      },
+      { timestamps: true }
+    );
+
+    translationSchema.index({ kind: 1, refId: 1, targetLang: 1 }, { unique: true });
+
+    TranslationModel.model =
+      (mongoose.models['Translation'] as Model<Translation>) ??
+      mongoose.model<Translation>('Translation', translationSchema);
+  }
+}

--- a/app/api/services/google-translation-provider.ts
+++ b/app/api/services/google-translation-provider.ts
@@ -9,6 +9,28 @@ interface TranslationsResponseBody {
   data?: { translations?: { translatedText: string; detectedSourceLanguage?: string }[] };
 }
 
+// The v2 client's public typings expose no per-call timeout/retry override
+// (those live on the underlying gax CallOptions, undocumented for this
+// wrapper), so a stalled request would otherwise hang indefinitely. A manual
+// race against a timer is the dependency-free way to bound it.
+const DEFAULT_TIMEOUT_MS = 15000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Translation request timed out after ${ms}ms`)), ms);
+    promise.then(
+      value => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      err => {
+        clearTimeout(timer);
+        reject(err);
+      }
+    );
+  });
+}
+
 export class GoogleTranslationProvider implements TranslationProvider {
   private client: Translate | null = null;
 
@@ -29,10 +51,11 @@ export class GoogleTranslationProvider implements TranslationProvider {
   public async translate(texts: string[], targetLang: string): Promise<TranslatedText[]> {
     if (texts.length === 0) return [];
     const client = this.getClient();
-    const [translations, apiResponse] = (await client.translate(texts, {
-      to: targetLang,
-      format: 'text',
-    })) as [string[], TranslationsResponseBody];
+    const timeoutMs = parseInt(process.env.GOOGLE_TRANSLATE_TIMEOUT_MS || '', 10) || DEFAULT_TIMEOUT_MS;
+    const [translations, apiResponse] = (await withTimeout(
+      client.translate(texts, { to: targetLang, format: 'text' }),
+      timeoutMs
+    )) as [string[], TranslationsResponseBody];
 
     const detected = apiResponse?.data?.translations ?? [];
     return translations.map((text, i) => ({

--- a/app/api/services/google-translation-provider.ts
+++ b/app/api/services/google-translation-provider.ts
@@ -1,0 +1,43 @@
+import { Translate } from '@google-cloud/translate/build/src/v2';
+import { TranslatedText, TranslationProvider } from './translation-provider';
+
+// google-translate-v2 wrapper. `key` auth (API key), matching the research
+// doc's provider choice — not a service account. format: 'text' always: HTML
+// mode would reintroduce an escaping surface the reference-token safety net
+// (translation-token-safety.ts) is specifically built to avoid.
+interface TranslationsResponseBody {
+  data?: { translations?: { translatedText: string; detectedSourceLanguage?: string }[] };
+}
+
+export class GoogleTranslationProvider implements TranslationProvider {
+  private client: Translate | null = null;
+
+  public isConfigured(): boolean {
+    return Boolean(process.env.GOOGLE_TRANSLATE_API_KEY);
+  }
+
+  private getClient(): Translate {
+    if (!this.isConfigured()) {
+      throw new Error('GOOGLE_TRANSLATE_API_KEY is not set — translation is unavailable');
+    }
+    if (this.client == null) {
+      this.client = new Translate({ key: process.env.GOOGLE_TRANSLATE_API_KEY });
+    }
+    return this.client;
+  }
+
+  public async translate(texts: string[], targetLang: string): Promise<TranslatedText[]> {
+    if (texts.length === 0) return [];
+    const client = this.getClient();
+    const [translations, apiResponse] = (await client.translate(texts, {
+      to: targetLang,
+      format: 'text',
+    })) as [string[], TranslationsResponseBody];
+
+    const detected = apiResponse?.data?.translations ?? [];
+    return translations.map((text, i) => ({
+      text,
+      detectedSourceLang: detected[i]?.detectedSourceLanguage,
+    }));
+  }
+}

--- a/app/api/services/language-detection-service.ts
+++ b/app/api/services/language-detection-service.ts
@@ -1,4 +1,4 @@
-import { detect } from 'tinyld';
+import { detectAll } from 'tinyld';
 
 // Free, local language detection for Blueprint.description / Comment.body
 // (spec/user-content-translation-impl.md §3). Pure function, no I/O, no DB —
@@ -42,14 +42,26 @@ function significantText(text: string): string {
  * when the text is too short / low-confidence / detection failed. Never
  * throws — a save must not fail because detection did.
  */
+// tinyld's `accuracy` is a relative probability spread across its full
+// language set (600+ entries including conlangs), so a real match on an
+// ambiguous Latin-script text can legitimately score as low as ~0.05-0.1 —
+// an absolute floor would reject correct French/Spanish/etc. detections
+// wholesale. A relative margin over the runner-up is the signal that
+// actually distinguishes "one clear match" from "a coin flip between two
+// candidates", without penalizing scripts (CJK/Cyrillic/Korean) that tinyld
+// is unambiguous about.
+const MIN_CONFIDENCE_MARGIN = 1.15;
+
 export function detectLanguage(text: string): string | null {
   try {
     const clean = significantText(text);
     if (clean.length < MIN_SIGNIFICANT_CHARS) return null;
 
-    const result = detect(clean);
-    if (!result) return null;
-    return normalizeLang(result);
+    const candidates = detectAll(clean);
+    if (candidates.length === 0) return null;
+    const [top, runnerUp] = candidates;
+    if (runnerUp != null && top.accuracy < runnerUp.accuracy * MIN_CONFIDENCE_MARGIN) return null;
+    return normalizeLang(top.lang);
   } catch {
     return null;
   }

--- a/app/api/services/language-detection-service.ts
+++ b/app/api/services/language-detection-service.ts
@@ -1,0 +1,56 @@
+import { detect } from 'tinyld';
+
+// Free, local language detection for Blueprint.description / Comment.body
+// (spec/user-content-translation-impl.md §3). Pure function, no I/O, no DB —
+// same shape as blueprint-analyzer. Detection failure is never fatal to a
+// save: callers wrap this, but detectLanguage itself also never throws.
+
+// Below this many significant characters, short-text detectors guess badly
+// (a two-word comment can "detect" as almost anything).
+const MIN_SIGNIFICANT_CHARS = 20;
+
+// {{blueprint:<24 hex>}} / {{user:<24 hex>}} reference tokens (comment-body.ts)
+const REFERENCE_TOKEN = /\{\{(?:blueprint|user):[0-9a-fA-F]{24}\}\}/g;
+const URL_PATTERN = /(?:https?:\/\/|www\.)[^\s)]+/gi;
+
+// tinyld returns ISO-639-1 already for most languages, but Chinese variants
+// and a few macrolanguage codes need collapsing to the site's four locales'
+// base languages.
+const LANG_ALIASES: Record<string, string> = {
+  cmn: 'zh',
+  zho: 'zh',
+  'zh-cn': 'zh',
+  'zh-tw': 'zh',
+  'zh-hans': 'zh',
+  'zh-hant': 'zh',
+};
+
+function normalizeLang(code: string): string {
+  const lower = code.toLowerCase();
+  return LANG_ALIASES[lower] ?? lower;
+}
+
+// Strips the noise that would otherwise dominate a short body (a comment that
+// is mostly a {{blueprint:...}} mention or a stripped URL remnant detects as
+// garbage), then counts what's left before bothering to run detection at all.
+function significantText(text: string): string {
+  return text.replace(REFERENCE_TOKEN, ' ').replace(URL_PATTERN, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Detects the language of user content. Returns an ISO-639-1 code, or null
+ * when the text is too short / low-confidence / detection failed. Never
+ * throws — a save must not fail because detection did.
+ */
+export function detectLanguage(text: string): string | null {
+  try {
+    const clean = significantText(text);
+    if (clean.length < MIN_SIGNIFICANT_CHARS) return null;
+
+    const result = detect(clean);
+    if (!result) return null;
+    return normalizeLang(result);
+  } catch {
+    return null;
+  }
+}

--- a/app/api/services/translation-provider.ts
+++ b/app/api/services/translation-provider.ts
@@ -1,0 +1,14 @@
+// Provider abstraction over the machine translation backend (mirrors
+// AvatarImageProvider / GeminiAvatarProvider — controllers/services never
+// call the Google SDK directly). Batch-capable by design: a comment thread
+// translation is naturally a batch of texts in one call.
+
+export interface TranslatedText {
+  text: string;
+  detectedSourceLang?: string;
+}
+
+export interface TranslationProvider {
+  isConfigured(): boolean;
+  translate(texts: string[], targetLang: string): Promise<TranslatedText[]>;
+}

--- a/app/api/services/translation-service.ts
+++ b/app/api/services/translation-service.ts
@@ -87,12 +87,19 @@ export class TranslationService {
     return `${this.monthKey(date)}-${String(date.getUTCDate()).padStart(2, '0')}`;
   }
 
+  // A malformed env value must fall back to the default, not silently disable
+  // the budget: parseInt('abc') is NaN, and NaN compares false to everything.
+  private envInt(value: string | undefined, fallback: number): number {
+    const parsed = parseInt(value ?? '', 10);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+  }
+
   private monthlyBudget(): number {
-    return parseInt(process.env.MONTHLY_CHAR_BUDGET || '400000', 10);
+    return this.envInt(process.env.MONTHLY_CHAR_BUDGET, 400000);
   }
 
   private perUserDailyCap(): number {
-    return parseInt(process.env.MAX_TRANSLATIONS_PER_USER_PER_DAY || '200', 10);
+    return this.envInt(process.env.MAX_TRANSLATIONS_PER_USER_PER_DAY, 200);
   }
 
   // Throws before any provider call is made when the site is already over its
@@ -199,12 +206,22 @@ export class TranslationService {
       await this.checkBudget(userId);
 
       // All misses in this call share targetLang (enforced by callers: one
-      // blueprint or one comment thread, one viewer locale).
+      // blueprint or one comment thread, one viewer locale) — asserted, not
+      // just assumed, since a mixed batch would cache a row translated into
+      // the wrong language under a different language's key.
       const targetLang = misses[0].input.targetLang;
+      if (misses.some(m => m.input.targetLang !== targetLang)) {
+        throw new Error('translateMany requires all inputs to share one targetLang');
+      }
       const translated = await this.provider.translate(
         misses.map(m => m.tokenized),
         providerLang(targetLang)
       );
+      if (translated.length !== misses.length) {
+        throw new Error(
+          `Translation provider returned ${translated.length} results for ${misses.length} inputs`
+        );
+      }
 
       let spentChars = 0;
       for (const text of misses.map(m => m.tokenized)) spentChars += text.length;

--- a/app/api/services/translation-service.ts
+++ b/app/api/services/translation-service.ts
@@ -1,0 +1,262 @@
+import crypto from 'crypto';
+import { Translation, TranslationModel, TranslationKind } from '../models/translation';
+import { TranslationBudgetModel } from '../models/translation-budget';
+import { TranslationProvider } from './translation-provider';
+import { GoogleTranslationProvider } from './google-translation-provider';
+import { tokenizeReferences, restoreReferences } from './translation-token-safety';
+
+// Cache + budget + provider orchestration (spec/user-content-translation-impl.md
+// §4.2). Controllers stay thin: this owns the cache lookup, budget check,
+// provider call, upsert, and accounting.
+
+export class TranslationBudgetExceeded extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TranslationBudgetExceeded';
+  }
+}
+
+export interface TranslateInput {
+  kind: TranslationKind;
+  refId: string;
+  sourceText: string;
+  sourceLang: string | null;
+  targetLang: string;
+  // Reference tokens ({{blueprint:id}}/{{user:id}}) must round-trip intact —
+  // only comment bodies carry them.
+  hasReferenceTokens?: boolean;
+}
+
+export interface TranslateResult {
+  translatedText: string;
+  sourceLang: string | null;
+  cached: boolean;
+  provider: string;
+  degraded?: boolean;
+}
+
+// zh-Hans/ru/ko/en are the site's four UI locales (lib/blueprint/translation.ts);
+// Google's target codes differ for Chinese.
+const PROVIDER_LANG_BY_TARGET: Record<string, string> = {
+  'zh-Hans': 'zh-CN',
+};
+
+function providerLang(targetLang: string): string {
+  return PROVIDER_LANG_BY_TARGET[targetLang] ?? targetLang;
+}
+
+// The site's four target locales collapse to these base languages for the
+// same-language shortcut: a Chinese description shown to a zh-Hans viewer
+// needs no translation, regardless of script variant bookkeeping.
+const BASE_LANG_BY_TARGET: Record<string, string> = {
+  'zh-Hans': 'zh',
+};
+
+function baseLangOfTarget(targetLang: string): string {
+  return BASE_LANG_BY_TARGET[targetLang] ?? targetLang;
+}
+
+function sha256(text: string): string {
+  return crypto.createHash('sha256').update(text, 'utf8').digest('hex').slice(0, 16);
+}
+
+// eslint-disable-next-line no-control-regex
+const ASCII_ONLY = /^[\x00-\x7F]*$/;
+
+export class TranslationService {
+  private static _instance: TranslationService | null = null;
+  public static get instance(): TranslationService {
+    if (this._instance == null) this._instance = new TranslationService();
+    return this._instance;
+  }
+  public static setInstanceForTest(instance: TranslationService | null) {
+    this._instance = instance;
+  }
+
+  constructor(private provider: TranslationProvider = new GoogleTranslationProvider()) {}
+
+  public isConfigured(): boolean {
+    return this.provider.isConfigured();
+  }
+
+  private monthKey(date = new Date()): string {
+    return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+  }
+
+  private dayKey(date = new Date()): string {
+    return `${this.monthKey(date)}-${String(date.getUTCDate()).padStart(2, '0')}`;
+  }
+
+  private monthlyBudget(): number {
+    return parseInt(process.env.MONTHLY_CHAR_BUDGET || '400000', 10);
+  }
+
+  private perUserDailyCap(): number {
+    return parseInt(process.env.MAX_TRANSLATIONS_PER_USER_PER_DAY || '200', 10);
+  }
+
+  // Throws before any provider call is made when the site is already over its
+  // monthly character budget, or (when userId is given) the caller has hit
+  // their daily uncached-call cap. Cache reads never go through this check.
+  private async checkBudget(userId: string | null): Promise<void> {
+    const month = this.monthKey();
+    const siteBudget = await TranslationBudgetModel.model
+      .findOne({ month, userId: null })
+      .select('charCount')
+      .lean();
+    if ((siteBudget?.charCount ?? 0) >= this.monthlyBudget()) {
+      throw new TranslationBudgetExceeded('Monthly translation budget exceeded');
+    }
+
+    if (userId != null) {
+      const day = this.dayKey();
+      const userUsage = await TranslationBudgetModel.model
+        .findOne({ month, userId, day })
+        .select('requestCount')
+        .lean();
+      if ((userUsage?.requestCount ?? 0) >= this.perUserDailyCap()) {
+        throw new TranslationBudgetExceeded('Daily translation limit exceeded for this user');
+      }
+    }
+  }
+
+  private async recordSpend(charCount: number, requestCount: number, userId: string | null): Promise<void> {
+    const month = this.monthKey();
+    await TranslationBudgetModel.model.updateOne(
+      { month, userId: null },
+      { $inc: { charCount, requestCount } },
+      { upsert: true }
+    );
+    if (userId != null) {
+      const day = this.dayKey();
+      await TranslationBudgetModel.model.updateOne(
+        { month, userId, day },
+        { $inc: { charCount, requestCount } },
+        { upsert: true }
+      );
+    }
+  }
+
+  private async findCached(
+    kind: TranslationKind,
+    refId: string,
+    targetLang: string,
+    sourceHash: string
+  ): Promise<Translation | null> {
+    const row = await TranslationModel.model.findOne({ kind, refId, targetLang });
+    if (row == null) return null;
+    // A human row always wins and is never treated as stale by a source edit
+    // (phase 4 forward-compat).
+    if (row.provider === 'human') return row;
+    if (row.sourceHash !== sourceHash) return null;
+    return row;
+  }
+
+  // Translates a batch of inputs sharing one targetLang in as few provider
+  // calls as possible (comment "translate all" is naturally a batch; a single
+  // blueprint description is a batch of one). userId drives the per-user
+  // daily cap — pass null for anonymous/system callers.
+  public async translateMany(inputs: TranslateInput[], userId: string | null): Promise<TranslateResult[]> {
+    const results: (TranslateResult | undefined)[] = new Array(inputs.length);
+    const misses: { index: number; input: TranslateInput; sourceHash: string; tokenized: string; tokens: string[] }[] = [];
+
+    for (let i = 0; i < inputs.length; i++) {
+      const input = inputs[i];
+      const { kind, refId, sourceText, sourceLang, targetLang } = input;
+
+      // Cheapest possible path — the majority case — and it needs no cache
+      // row or provider call at all.
+      if (
+        (sourceLang != null && sourceLang === baseLangOfTarget(targetLang)) ||
+        (sourceLang == null && ASCII_ONLY.test(sourceText))
+      ) {
+        results[i] = { translatedText: sourceText, sourceLang, cached: true, provider: 'none' };
+        continue;
+      }
+
+      const sourceHash = sha256(sourceText);
+      const cached = await this.findCached(kind, refId, targetLang, sourceHash);
+      if (cached != null) {
+        results[i] = {
+          translatedText: cached.translatedText,
+          sourceLang: cached.sourceLang,
+          cached: true,
+          provider: cached.provider,
+        };
+        continue;
+      }
+
+      const { text: tokenized, tokens } = input.hasReferenceTokens
+        ? tokenizeReferences(sourceText)
+        : { text: sourceText, tokens: [] as string[] };
+      misses.push({ index: i, input, sourceHash, tokenized, tokens });
+    }
+
+    if (misses.length > 0) {
+      if (!this.isConfigured()) {
+        throw new Error('Translation is not configured');
+      }
+      await this.checkBudget(userId);
+
+      // All misses in this call share targetLang (enforced by callers: one
+      // blueprint or one comment thread, one viewer locale).
+      const targetLang = misses[0].input.targetLang;
+      const translated = await this.provider.translate(
+        misses.map(m => m.tokenized),
+        providerLang(targetLang)
+      );
+
+      let spentChars = 0;
+      for (const text of misses.map(m => m.tokenized)) spentChars += text.length;
+
+      for (let m = 0; m < misses.length; m++) {
+        const { index, input, sourceHash, tokens } = misses[m];
+        const raw = translated[m];
+        const restored = tokens.length > 0 ? restoreReferences(raw.text, tokens) : raw.text;
+
+        if (restored == null) {
+          // Corrupted round-trip: never serve it, never cache it.
+          results[index] = {
+            translatedText: input.sourceText,
+            sourceLang: input.sourceLang,
+            cached: false,
+            provider: 'google-v2',
+            degraded: true,
+          };
+          continue;
+        }
+
+        const detectedSourceLang = raw.detectedSourceLang ?? input.sourceLang ?? null;
+        await TranslationModel.model.updateOne(
+          { kind: input.kind, refId: input.refId, targetLang: input.targetLang },
+          {
+            $set: {
+              sourceLang: detectedSourceLang,
+              sourceHash,
+              translatedText: restored,
+              provider: 'google-v2',
+              charCount: misses[m].tokenized.length,
+            },
+          },
+          { upsert: true }
+        );
+
+        results[index] = {
+          translatedText: restored,
+          sourceLang: detectedSourceLang,
+          cached: false,
+          provider: 'google-v2',
+        };
+      }
+
+      await this.recordSpend(spentChars, misses.length, userId);
+    }
+
+    return results as TranslateResult[];
+  }
+
+  public async translateOne(input: TranslateInput, userId: string | null): Promise<TranslateResult> {
+    const [result] = await this.translateMany([input], userId);
+    return result;
+  }
+}

--- a/app/api/services/translation-token-safety.ts
+++ b/app/api/services/translation-token-safety.ts
@@ -1,0 +1,56 @@
+// Reference-token safety for comment translation (spec/user-content-
+// translation-impl.md §4.3). Comment bodies are never raw text — they carry
+// {{blueprint:<id>}} / {{user:<id>}} tokens (comment-body.ts) that a machine
+// translator will happily mangle or reorder. Before sending: replace each
+// token with an opaque, translation-stable placeholder the NMT engine won't
+// touch; after: restore. If restoration can't find every placeholder exactly
+// once, the translation is discarded — a dropped mention is worse than an
+// untranslated comment.
+//
+// Placeholders are indexed ASCII sentinels (not the token text itself) so an
+// NMT engine has no substring resembling natural language to "helpfully"
+// translate, reorder relative to punctuation, or merge with adjacent CJK text
+// (which has no whitespace to anchor a token boundary).
+
+const REFERENCE_TOKEN = /\{\{(blueprint|user):([0-9a-fA-F]{24})\}\}/g;
+
+function placeholderFor(index: number): string {
+  // xxBNIx0xx-style: uppercase+digit runs survive NMT round-trips far better
+  // than natural-looking words, and are astronomically unlikely to occur in
+  // real user text.
+  return `xxBNIREFx${index}xx`;
+}
+
+export interface TokenizedText {
+  text: string;
+  tokens: string[]; // original {{kind:id}} strings, indexed by placeholder
+}
+
+export function tokenizeReferences(text: string): TokenizedText {
+  const tokens: string[] = [];
+  const tokenized = text.replace(REFERENCE_TOKEN, match => {
+    const placeholder = placeholderFor(tokens.length);
+    tokens.push(match);
+    return placeholder;
+  });
+  return { text: tokenized, tokens };
+}
+
+// Restores placeholders in translated text. Returns null when restoration
+// fails (missing or duplicated placeholder) — the caller must discard the
+// translation rather than serve a corrupted body.
+export function restoreReferences(translated: string, tokens: string[]): string | null {
+  if (tokens.length === 0) return translated;
+
+  let result = translated;
+  for (let i = 0; i < tokens.length; i++) {
+    const placeholder = placeholderFor(i);
+    const occurrences = result.split(placeholder).length - 1;
+    if (occurrences !== 1) return null;
+    result = result.replace(placeholder, tokens[i]);
+  }
+  // Any leftover placeholder-looking sentinel (e.g. the NMT engine duplicated
+  // or invented one) means the round-trip isn't trustworthy.
+  if (/xxBNIREFx\d+xx/.test(result)) return null;
+  return result;
+}

--- a/app/api/translation-controller.ts
+++ b/app/api/translation-controller.ts
@@ -1,0 +1,181 @@
+import { Request, Response } from 'express';
+import mongoose from 'mongoose';
+import { BlueprintModel } from './models/blueprint';
+import { CommentModel } from './models/comment';
+import { UserJwt } from './models/user';
+import { TranslationService, TranslationBudgetExceeded } from './services/translation-service';
+import { apiError } from './utils/apiError';
+import { canViewBlueprint } from './utils/blueprint-visibility';
+import { segmentBody } from './services/comment-body';
+import { resolveReferenceNames } from './comment-controller';
+import {
+  isTranslationTargetLang,
+  MAX_TRANSLATE_BATCH,
+  TranslateBlueprintRequest,
+  TranslateBlueprintResponse,
+  TranslateCommentsRequest,
+  TranslateCommentsResponse,
+  TRANSLATION_BUDGET_EXCEEDED_CODE,
+} from '../../lib/index';
+
+// Translate endpoints (spec/user-content-translation-impl.md §4.4):
+//   POST /api/blueprints/:id/translate
+//   POST /api/blueprints/:id/comments/translate
+//
+// Auth required on both — this is the only surface on the site that spends
+// real money per call, and anonymous access would make the monthly budget a
+// public resource. Method is POST despite being read-shaped: it has a spend
+// side effect and must never be cached or prefetched by Cloudflare.
+export class TranslationController {
+  constructor() {
+    this.translateBlueprint = this.translateBlueprint.bind(this);
+    this.translateComments = this.translateComments.bind(this);
+  }
+
+  private service(): TranslationService {
+    return TranslationService.instance;
+  }
+
+  public async translateBlueprint(req: Request, res: Response): Promise<void> {
+    try {
+      const service = this.service();
+      if (!service.isConfigured()) {
+        res.status(503).json(apiError(503, 'Translation is not configured'));
+        return;
+      }
+
+      const blueprintId = String(req.params.id);
+      if (!mongoose.Types.ObjectId.isValid(blueprintId)) {
+        res.status(400).json(apiError(400, 'Invalid blueprint id'));
+        return;
+      }
+
+      const { lang } = req.body as TranslateBlueprintRequest;
+      if (!isTranslationTargetLang(lang)) {
+        res.status(400).json(apiError(400, 'Unsupported target language'));
+        return;
+      }
+
+      const user = req.user as UserJwt;
+      const blueprint = await BlueprintModel.model
+        .findOne({ _id: blueprintId, deletedAt: null })
+        .select('owner isPublished description sourceLang');
+      if (!blueprint || !canViewBlueprint(blueprint, user)) {
+        res.status(404).json(apiError(404, 'Blueprint not found'));
+        return;
+      }
+
+      if (!blueprint.description) {
+        res.status(400).json(apiError(400, 'This blueprint has no description to translate'));
+        return;
+      }
+
+      const result = await service.translateOne(
+        {
+          kind: 'blueprint',
+          refId: blueprintId,
+          sourceText: blueprint.description,
+          sourceLang: blueprint.sourceLang ?? null,
+          targetLang: lang,
+        },
+        user._id
+      );
+
+      const response: TranslateBlueprintResponse = {
+        description: result.translatedText,
+        sourceLang: result.sourceLang,
+        cached: result.cached,
+        ...(result.degraded ? { degraded: true } : {}),
+      };
+      res.json(response);
+    } catch (err) {
+      this.handleError(err, res, 'translate blueprint');
+    }
+  }
+
+  public async translateComments(req: Request, res: Response): Promise<void> {
+    try {
+      const service = this.service();
+      if (!service.isConfigured()) {
+        res.status(503).json(apiError(503, 'Translation is not configured'));
+        return;
+      }
+
+      const blueprintId = String(req.params.id);
+      if (!mongoose.Types.ObjectId.isValid(blueprintId)) {
+        res.status(400).json(apiError(400, 'Invalid blueprint id'));
+        return;
+      }
+
+      const { lang, ids } = req.body as TranslateCommentsRequest;
+      if (!isTranslationTargetLang(lang)) {
+        res.status(400).json(apiError(400, 'Unsupported target language'));
+        return;
+      }
+      if (!Array.isArray(ids) || ids.length === 0 || ids.some(id => !mongoose.Types.ObjectId.isValid(id))) {
+        res.status(400).json(apiError(400, 'ids must be a non-empty array of comment ids'));
+        return;
+      }
+      if (ids.length > MAX_TRANSLATE_BATCH) {
+        res.status(400).json(apiError(400, `Cannot translate more than ${MAX_TRANSLATE_BATCH} comments at once`));
+        return;
+      }
+
+      const user = req.user as UserJwt;
+      const blueprint = await BlueprintModel.model
+        .findOne({ _id: blueprintId, deletedAt: null })
+        .select('owner isPublished')
+        .lean();
+      if (!blueprint || !canViewBlueprint(blueprint, user)) {
+        res.status(404).json(apiError(404, 'Blueprint not found'));
+        return;
+      }
+
+      const comments = await CommentModel.model.find({
+        _id: { $in: ids },
+        blueprintId,
+        deletedAt: null,
+      });
+
+      const inputs = comments.map(comment => ({
+        kind: 'comment' as const,
+        refId: (comment._id as mongoose.Types.ObjectId).toString(),
+        sourceText: comment.body,
+        sourceLang: comment.sourceLang ?? null,
+        targetLang: lang,
+        hasReferenceTokens: true,
+      }));
+
+      const results = await service.translateMany(inputs, user._id);
+
+      // Translated bodies carry the same {{blueprint:id}}/{{user:id}} tokens
+      // as the source (restored verbatim by translation-token-safety), so
+      // they need the same name resolution as an ordinary comment body
+      // before they can be rendered as segments — never expose raw tokens.
+      const names = await resolveReferenceNames(results.map(r => r.translatedText));
+
+      const response: TranslateCommentsResponse = {
+        translations: comments.map((comment, i) => ({
+          id: (comment._id as mongoose.Types.ObjectId).toString(),
+          segments: segmentBody(results[i].translatedText, names),
+          sourceLang: results[i].sourceLang,
+          cached: results[i].cached,
+          ...(results[i].degraded ? { degraded: true } : {}),
+        })),
+      };
+      res.json(response);
+    } catch (err) {
+      this.handleError(err, res, 'translate comments');
+    }
+  }
+
+  private handleError(err: unknown, res: Response, action: string): void {
+    if (err instanceof TranslationBudgetExceeded) {
+      res.status(429).json({ ...apiError(429, err.message), code: TRANSLATION_BUDGET_EXCEEDED_CODE });
+      return;
+    }
+    console.log(`${action} error`);
+    console.log(err);
+    res.status(500).json(apiError(500, `Failed to ${action}`));
+  }
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -18,6 +18,7 @@ import { NotificationController } from './api/notification-controller';
 import { PreviewController } from './api/preview-controller';
 import { AvatarController } from './api/avatar-controller';
 import { ModController } from './api/mod-controller';
+import { TranslationController } from './api/translation-controller';
 export class Routes {
   public staticController = new StaticController();
   public uploadBlueprintController = new BlueprintController();
@@ -33,6 +34,7 @@ export class Routes {
   public previewController = new PreviewController();
   public avatarController = new AvatarController();
   public modController = new ModController();
+  public translationController = new TranslationController();
 
   public routes(app: Application): void {
     // Admin-only middleware: requires role === 'admin' in the JWT (set from WorkOS platform org membership)
@@ -134,6 +136,10 @@ export class Routes {
     app.route('/api/comments/:id').patch(auth, this.commentController.edit);
     app.route('/api/comments/:id').delete(auth, this.commentController.remove);
     app.route('/api/blueprints/:id/fork').post(auth, this.blueprintVersionController.fork);
+    app.route('/api/blueprints/:id/translate').post(auth, this.translationController.translateBlueprint);
+    app
+      .route('/api/blueprints/:id/comments/translate')
+      .post(auth, this.translationController.translateComments);
     app.route('/api/notifications').get(auth, this.notificationController.list);
     app.route('/api/notifications/mark-read').post(auth, this.notificationController.markAllRead);
     app.route('/api/blueprints/:id/versions').post(auth, this.blueprintVersionController.createVersion);

--- a/app/server.ts
+++ b/app/server.ts
@@ -18,6 +18,13 @@ if (!process.env.GEMINI_API_KEY) {
   );
 }
 
+if (!process.env.GOOGLE_TRANSLATE_API_KEY) {
+  console.error(
+    '[translation] GOOGLE_TRANSLATE_API_KEY is not set — user content translation DISABLED. ' +
+      'Create a key at https://console.cloud.google.com/apis/credentials.'
+  );
+}
+
 const PORT = 3000;
 const server = app.listen(PORT, () => {
   console.log(`Example app listening on port ${PORT}!`);

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.css
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.css
@@ -130,6 +130,41 @@
   word-break: break-word;
 }
 
+.details-translate {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: -6px 0 12px;
+}
+
+.details-translate-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: var(--p-font-family);
+  font-weight: 600;
+  font-size: 12px;
+  cursor: pointer;
+  color: var(--bni-blue);
+}
+
+.details-translate-link:hover {
+  text-decoration: underline;
+  color: var(--bni-blue-hi);
+}
+
+.details-translate-link:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.details-translate-attribution,
+.details-translate-degraded {
+  font-size: 11.5px;
+  color: var(--bni-faint);
+  font-style: italic;
+}
+
 .details-actions {
   display: flex;
   align-items: center;

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
@@ -175,8 +175,49 @@
           </div>
 
           <p *ngIf="details.description" class="details-description">
-            {{ details.description }}
+            {{
+              showingTranslation && translation
+                ? translation.description
+                : details.description
+            }}
           </p>
+          <div
+            *ngIf="details.description && showTranslateButton"
+            class="details-translate"
+          >
+            <button
+              *ngIf="!showingTranslation"
+              type="button"
+              class="details-translate-link"
+              [disabled]="translating"
+              (click)="translateDescription()"
+              i18n
+            >
+              Translate
+            </button>
+            <ng-container *ngIf="showingTranslation">
+              <span
+                *ngIf="translation?.degraded"
+                class="details-translate-degraded"
+                i18n
+                >Translation unavailable</span
+              >
+              <span
+                *ngIf="!translation?.degraded"
+                class="details-translate-attribution"
+                i18n
+                >Translated by Google</span
+              >
+              <button
+                type="button"
+                class="details-translate-link"
+                (click)="showOriginalDescription()"
+                i18n
+              >
+                Show original
+              </button>
+            </ng-container>
+          </div>
 
           <div class="details-actions">
             <button

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
@@ -415,6 +415,18 @@ describe("BlueprintDetailsPageComponent", () => {
   });
 
   describe("translate description", () => {
+    it("shows no button for an anonymous viewer, even with a foreign sourceLang", () => {
+      authService.isLoggedIn.mockReturnValue(false);
+      translationService.matchesViewerLang.mockReturnValue(false);
+      blueprintService.getBlueprintDetails.mockReturnValue(
+        of(makeDetails({ sourceLang: "fr" })),
+      );
+      fixture.detectChanges();
+      expect(
+        fixture.debugElement.query(By.css(".details-translate")),
+      ).toBeNull();
+    });
+
     it("shows no button when sourceLang is absent", () => {
       fixture.detectChanges();
       expect(

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
@@ -11,6 +11,7 @@ import { BlueprintDetailsPageComponent } from "./blueprint-details-page.componen
 import { BlueprintService } from "../../services/blueprint-service";
 import { AuthenticationService } from "../../services/authentification-service";
 import { ModsService } from "../../services/mods-service";
+import { TranslationService } from "../../services/translation.service";
 
 function makeDetails(overrides: any = {}) {
   return {
@@ -30,6 +31,7 @@ function makeDetails(overrides: any = {}) {
     category: "power",
     subcategory: null,
     description: "A tidy coal setup",
+    sourceLang: null,
     researchTier: null,
     modded: false,
     isPublished: true,
@@ -49,6 +51,7 @@ describe("BlueprintDetailsPageComponent", () => {
   let messageService: any;
   let router: any;
   let modsService: any;
+  let translationService: any;
 
   beforeEach(async () => {
     blueprintService = {
@@ -71,6 +74,14 @@ describe("BlueprintDetailsPageComponent", () => {
         ]),
       ),
     };
+    translationService = {
+      matchesViewerLang: vi.fn().mockReturnValue(true),
+      translateBlueprint: vi
+        .fn()
+        .mockReturnValue(
+          of({ description: "translated", sourceLang: "fr", cached: false }),
+        ),
+    };
 
     await TestBed.configureTestingModule({
       declarations: [BlueprintDetailsPageComponent],
@@ -80,6 +91,7 @@ describe("BlueprintDetailsPageComponent", () => {
         { provide: AuthenticationService, useValue: authService },
         { provide: MessageService, useValue: messageService },
         { provide: ModsService, useValue: modsService },
+        { provide: TranslationService, useValue: translationService },
         { provide: Router, useValue: router },
         {
           provide: ActivatedRoute,
@@ -400,6 +412,98 @@ describe("BlueprintDetailsPageComponent", () => {
     expect(downloads.nativeElement.textContent).toContain("1");
     expect(downloads.nativeElement.textContent).toContain("download");
     expect(downloads.nativeElement.textContent).not.toContain("downloads");
+  });
+
+  describe("translate description", () => {
+    it("shows no button when sourceLang is absent", () => {
+      fixture.detectChanges();
+      expect(
+        fixture.debugElement.query(By.css(".details-translate")),
+      ).toBeNull();
+    });
+
+    it("shows no button when sourceLang already matches the viewer's language", () => {
+      translationService.matchesViewerLang.mockReturnValue(true);
+      blueprintService.getBlueprintDetails.mockReturnValue(
+        of(makeDetails({ sourceLang: "en" })),
+      );
+      fixture.detectChanges();
+      expect(
+        fixture.debugElement.query(By.css(".details-translate")),
+      ).toBeNull();
+    });
+
+    it("shows the button when sourceLang differs from the viewer's language", () => {
+      translationService.matchesViewerLang.mockReturnValue(false);
+      blueprintService.getBlueprintDetails.mockReturnValue(
+        of(makeDetails({ sourceLang: "fr" })),
+      );
+      fixture.detectChanges();
+      expect(
+        fixture.debugElement.query(By.css(".details-translate")),
+      ).not.toBeNull();
+    });
+
+    it("translates on click and toggles back to the original", () => {
+      translationService.matchesViewerLang.mockReturnValue(false);
+      blueprintService.getBlueprintDetails.mockReturnValue(
+        of(makeDetails({ sourceLang: "fr" })),
+      );
+      fixture.detectChanges();
+
+      component.translateDescription();
+      fixture.detectChanges();
+
+      expect(translationService.translateBlueprint).toHaveBeenCalledWith("bp1");
+      expect(fixture.nativeElement.textContent).toContain("translated");
+      expect(fixture.nativeElement.textContent).toContain(
+        "Translated by Google",
+      );
+
+      component.showOriginalDescription();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toContain("A tidy coal setup");
+    });
+
+    it("does not re-fetch on a second translate click (in-memory cache)", () => {
+      translationService.matchesViewerLang.mockReturnValue(false);
+      blueprintService.getBlueprintDetails.mockReturnValue(
+        of(makeDetails({ sourceLang: "fr" })),
+      );
+      fixture.detectChanges();
+
+      component.translateDescription();
+      component.showOriginalDescription();
+      component.translateDescription();
+
+      expect(translationService.translateBlueprint).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows a degraded note instead of an attribution when the translation is degraded", () => {
+      translationService.matchesViewerLang.mockReturnValue(false);
+      translationService.translateBlueprint.mockReturnValue(
+        of({
+          description: "A tidy coal setup",
+          sourceLang: "fr",
+          cached: false,
+          degraded: true,
+        }),
+      );
+      blueprintService.getBlueprintDetails.mockReturnValue(
+        of(makeDetails({ sourceLang: "fr" })),
+      );
+      fixture.detectChanges();
+
+      component.translateDescription();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain(
+        "Translation unavailable",
+      );
+      expect(fixture.nativeElement.textContent).not.toContain(
+        "Translated by Google",
+      );
+    });
   });
 
   describe("scrollToFragment", () => {

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
@@ -25,6 +25,8 @@ import { dlcLabel } from "../../../../../../lib/index";
 import { roomTypeLabel } from "../../utils/room-labels";
 import sanitize from "sanitize-filename";
 import { ModsService } from "../../services/mods-service";
+import { TranslationService } from "../../services/translation.service";
+import { TranslateBlueprintResponse } from "../../../../../../lib/index";
 
 const BACK_TO_DISCOVER = $localize`:blueprintDetails.backToDiscover:Back to Discover`;
 const BACK_TO_PROFILE = $localize`:blueprintDetails.backToProfile:Back to Profile`;
@@ -75,8 +77,51 @@ export class BlueprintDetailsPageComponent implements OnInit {
     private blueprintService: BlueprintService,
     private messageService: MessageService,
     private modsService: ModsService,
+    private translationService: TranslationService,
     public authService: AuthenticationService,
   ) {}
+
+  // Only shown when the description's detected language is known and differs
+  // from the viewer's own — nearly all traffic (English viewer, English
+  // description) never sees the button.
+  get showTranslateButton(): boolean {
+    const sourceLang = this.details?.sourceLang;
+    return (
+      sourceLang != null &&
+      !this.translationService.matchesViewerLang(sourceLang)
+    );
+  }
+
+  translating = false;
+  translation: TranslateBlueprintResponse | null = null;
+  showingTranslation = false;
+
+  translateDescription() {
+    if (this.details == null || this.translating) return;
+    if (this.translation != null) {
+      this.showingTranslation = true;
+      return;
+    }
+    this.translating = true;
+    this.translationService.translateBlueprint(this.details.id).subscribe({
+      next: (response) => {
+        this.translating = false;
+        this.translation = response;
+        this.showingTranslation = true;
+      },
+      error: () => {
+        this.translating = false;
+        this.messageService.add({
+          severity: "error",
+          summary: $localize`:translateError:Could not translate description`,
+        });
+      },
+    });
+  }
+
+  showOriginalDescription() {
+    this.showingTranslation = false;
+  }
 
   // Complete singular/plural messages (not a conditional suffix) so
   // translators control each form
@@ -155,6 +200,8 @@ export class BlueprintDetailsPageComponent implements OnInit {
     this.publishWorking = false;
     this.deleteWorking = false;
     this.relatedBlueprints = [];
+    this.translation = null;
+    this.showingTranslation = false;
 
     if (id == null) {
       this.loading = false;

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
@@ -81,12 +81,14 @@ export class BlueprintDetailsPageComponent implements OnInit {
     public authService: AuthenticationService,
   ) {}
 
-  // Only shown when the description's detected language is known and differs
-  // from the viewer's own — nearly all traffic (English viewer, English
-  // description) never sees the button.
+  // Only shown when logged in (the translate endpoint requires auth — an
+  // anonymous click would just fail) and when the description's detected
+  // language is known and differs from the viewer's own — nearly all traffic
+  // (English viewer, English description) never sees the button.
   get showTranslateButton(): boolean {
     const sourceLang = this.details?.sourceLang;
     return (
+      this.loggedIn &&
       sourceLang != null &&
       !this.translationService.matchesViewerLang(sourceLang)
     );
@@ -102,14 +104,20 @@ export class BlueprintDetailsPageComponent implements OnInit {
       this.showingTranslation = true;
       return;
     }
+    // Captured so a late response can't land on a blueprint the viewer has
+    // since navigated away from (switchMap cancels the details fetch, not
+    // this subscription).
+    const blueprintId = this.details.id;
     this.translating = true;
-    this.translationService.translateBlueprint(this.details.id).subscribe({
+    this.translationService.translateBlueprint(blueprintId).subscribe({
       next: (response) => {
+        if (this.details?.id !== blueprintId) return;
         this.translating = false;
         this.translation = response;
         this.showingTranslation = true;
       },
       error: () => {
+        if (this.details?.id !== blueprintId) return;
         this.translating = false;
         this.messageService.add({
           severity: "error",
@@ -200,6 +208,7 @@ export class BlueprintDetailsPageComponent implements OnInit {
     this.publishWorking = false;
     this.deleteWorking = false;
     this.relatedBlueprints = [];
+    this.translating = false;
     this.translation = null;
     this.showingTranslation = false;
 

--- a/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.css
+++ b/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.css
@@ -117,6 +117,17 @@
   color: var(--bni-danger);
 }
 
+.comments-translate-all {
+  margin-left: 14px;
+}
+
+.comment-translate-attribution,
+.comment-translate-degraded {
+  font-size: 11.5px;
+  color: var(--bni-faint);
+  font-style: italic;
+}
+
 .comment-new-form,
 .comment-reply-form {
   width: 100%;

--- a/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.html
+++ b/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.html
@@ -6,6 +6,17 @@
     >
   </h2>
 
+  <button
+    *ngIf="!loading && !loadError && showTranslateAll"
+    type="button"
+    class="comment-action-link comments-translate-all"
+    [disabled]="translateAllWorking"
+    (click)="translateAll()"
+    i18n
+  >
+    Translate all
+  </button>
+
   <p *ngIf="loading" class="comments-status" i18n>Loading comments…</p>
   <p *ngIf="loadError" class="comments-status comments-error" i18n>
     Could not load comments. Please try again.
@@ -159,35 +170,16 @@
       <em *ngIf="comment.deleted" class="comment-removed" i18n
         >[comment removed]</em
       >
-      <ng-container *ngIf="!comment.deleted">
-        <ng-container *ngFor="let segment of comment.segments">
-          <span *ngIf="segment.type === 'text'" class="comment-text">{{
-            segment.text
-          }}</span>
-          <a
-            *ngIf="segment.type === 'blueprint' && segment.name !== null"
-            [routerLink]="['/blueprint', segment.id]"
-            >{{ segment.name }}</a
-          >
-          <span
-            *ngIf="segment.type === 'blueprint' && segment.name === null"
-            class="comment-ref-deleted"
-            i18n
-            >[deleted blueprint]</span
-          >
-          <a
-            *ngIf="segment.type === 'user' && segment.name !== null"
-            [routerLink]="['/profile', segment.name]"
-            >@{{ segment.name }}</a
-          >
-          <span
-            *ngIf="segment.type === 'user' && segment.name === null"
-            class="comment-ref-deleted"
-            i18n
-            >[deleted user]</span
-          >
-        </ng-container>
-      </ng-container>
+      <ng-container
+        *ngIf="!comment.deleted"
+        [ngTemplateOutlet]="segmentsTpl"
+        [ngTemplateOutletContext]="{
+          segments:
+            showingTranslationIds.has(comment.id) && translatedSegments(comment)
+              ? translatedSegments(comment)
+              : comment.segments,
+        }"
+      ></ng-container>
     </div>
 
     <div
@@ -221,6 +213,70 @@
       >
         Delete
       </button>
+      <ng-container *ngIf="isForeignLanguage(comment)">
+        <button
+          *ngIf="!showingTranslationIds.has(comment.id)"
+          type="button"
+          class="comment-action-link"
+          [disabled]="translatingIds.has(comment.id)"
+          (click)="translateComment(comment)"
+          i18n
+        >
+          Translate
+        </button>
+        <ng-container *ngIf="showingTranslationIds.has(comment.id)">
+          <span
+            *ngIf="translationDegraded(comment)"
+            class="comment-translate-degraded"
+            i18n
+            >Translation unavailable</span
+          >
+          <span
+            *ngIf="!translationDegraded(comment)"
+            class="comment-translate-attribution"
+            i18n
+            >Translated by Google</span
+          >
+          <button
+            type="button"
+            class="comment-action-link"
+            (click)="showOriginalComment(comment)"
+            i18n
+          >
+            Show original
+          </button>
+        </ng-container>
+      </ng-container>
     </div>
   </div>
+</ng-template>
+
+<ng-template #segmentsTpl let-segments="segments">
+  <ng-container *ngFor="let segment of segments">
+    <span *ngIf="segment.type === 'text'" class="comment-text">{{
+      segment.text
+    }}</span>
+    <a
+      *ngIf="segment.type === 'blueprint' && segment.name !== null"
+      [routerLink]="['/blueprint', segment.id]"
+      >{{ segment.name }}</a
+    >
+    <span
+      *ngIf="segment.type === 'blueprint' && segment.name === null"
+      class="comment-ref-deleted"
+      i18n
+      >[deleted blueprint]</span
+    >
+    <a
+      *ngIf="segment.type === 'user' && segment.name !== null"
+      [routerLink]="['/profile', segment.name]"
+      >@{{ segment.name }}</a
+    >
+    <span
+      *ngIf="segment.type === 'user' && segment.name === null"
+      class="comment-ref-deleted"
+      i18n
+      >[deleted user]</span
+    >
+  </ng-container>
 </ng-template>

--- a/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.spec.ts
@@ -236,6 +236,15 @@ describe("CommentSectionComponent", () => {
   });
 
   describe("translation", () => {
+    it("does not offer translation to an anonymous viewer, even in a foreign language", () => {
+      authService.isLoggedIn.mockReturnValue(false);
+      translationService.matchesViewerLang.mockReturnValue(false);
+      bindBlueprint("bp1");
+      expect(
+        component.isForeignLanguage(makeComment({ sourceLang: "fr" }) as any),
+      ).toBe(false);
+    });
+
     it("does not offer translation for a comment already in the viewer's language", () => {
       translationService.matchesViewerLang.mockReturnValue(true);
       bindBlueprint("bp1");

--- a/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.spec.ts
@@ -5,6 +5,7 @@ import { of, throwError } from "rxjs";
 import { CommentSectionComponent } from "./comment-section.component";
 import { CommentService } from "../../services/comment.service";
 import { AuthenticationService } from "../../services/authentification-service";
+import { TranslationService } from "../../services/translation.service";
 
 function makeComment(overrides: any = {}) {
   return {
@@ -16,6 +17,7 @@ function makeComment(overrides: any = {}) {
     createdAt: new Date("2026-07-01").toISOString(),
     lastActivityAt: new Date("2026-07-01").toISOString(),
     editedAt: null,
+    sourceLang: null,
     canDelete: false,
     canEdit: false,
     ...overrides,
@@ -27,6 +29,7 @@ describe("CommentSectionComponent", () => {
   let fixture: ComponentFixture<CommentSectionComponent>;
   let commentService: any;
   let authService: any;
+  let translationService: any;
 
   function bindBlueprint(id: string | null) {
     component.blueprintId = id;
@@ -45,6 +48,11 @@ describe("CommentSectionComponent", () => {
       deleteComment: vi.fn().mockReturnValue(of({ delete: "OK" })),
     };
     authService = { isLoggedIn: vi.fn().mockReturnValue(true) };
+    translationService = {
+      matchesViewerLang: vi.fn().mockReturnValue(true),
+      translateComments: vi.fn().mockReturnValue(of({ translations: [] })),
+      cachedComment: vi.fn().mockReturnValue(null),
+    };
 
     await TestBed.configureTestingModule({
       declarations: [CommentSectionComponent],
@@ -52,6 +60,7 @@ describe("CommentSectionComponent", () => {
       providers: [
         { provide: CommentService, useValue: commentService },
         { provide: AuthenticationService, useValue: authService },
+        { provide: TranslationService, useValue: translationService },
       ],
     }).compileComponents();
 
@@ -223,6 +232,165 @@ describe("CommentSectionComponent", () => {
 
       expect(component.postError).toBe("Comment is empty");
       expect(component.posting).toBe(false);
+    });
+  });
+
+  describe("translation", () => {
+    it("does not offer translation for a comment already in the viewer's language", () => {
+      translationService.matchesViewerLang.mockReturnValue(true);
+      bindBlueprint("bp1");
+      expect(
+        component.isForeignLanguage(makeComment({ sourceLang: "en" }) as any),
+      ).toBe(false);
+    });
+
+    it("offers translation for a comment in a different language", () => {
+      translationService.matchesViewerLang.mockReturnValue(false);
+      bindBlueprint("bp1");
+      expect(
+        component.isForeignLanguage(makeComment({ sourceLang: "fr" }) as any),
+      ).toBe(true);
+    });
+
+    it("shows Translate all only with 2+ foreign-language comments visible", () => {
+      translationService.matchesViewerLang.mockReturnValue(false);
+      commentService.getComments.mockReturnValue(
+        of({
+          threads: [
+            {
+              comment: makeComment({ id: "c1", sourceLang: "fr" }),
+              replies: [],
+            },
+          ],
+          total: 1,
+        }),
+      );
+      bindBlueprint("bp1");
+      expect(component.showTranslateAll).toBe(false);
+
+      commentService.getComments.mockReturnValue(
+        of({
+          threads: [
+            {
+              comment: makeComment({ id: "c1", sourceLang: "fr" }),
+              replies: [],
+            },
+            {
+              comment: makeComment({ id: "c2", sourceLang: "ru" }),
+              replies: [],
+            },
+          ],
+          total: 2,
+        }),
+      );
+      bindBlueprint("bp1");
+      expect(component.showTranslateAll).toBe(true);
+      expect(component.foreignCommentIds).toEqual(["c1", "c2"]);
+    });
+
+    it("translateComment fetches once and toggles the original back into view", () => {
+      translationService.matchesViewerLang.mockReturnValue(false);
+      translationService.translateComments.mockReturnValue(
+        of({
+          translations: [
+            {
+              id: "c1",
+              segments: [{ type: "text", text: "translated" }],
+              sourceLang: "fr",
+              cached: false,
+            },
+          ],
+        }),
+      );
+      translationService.cachedComment.mockReturnValue(null);
+      bindBlueprint("bp1");
+
+      const comment = makeComment({ id: "c1", sourceLang: "fr" }) as any;
+      component.translateComment(comment);
+      expect(translationService.translateComments).toHaveBeenCalledWith("bp1", [
+        "c1",
+      ]);
+      expect(component.showingTranslationIds.has("c1")).toBe(true);
+
+      component.showOriginalComment(comment);
+      expect(component.showingTranslationIds.has("c1")).toBe(false);
+
+      translationService.cachedComment.mockReturnValue({
+        segments: [{ type: "text", text: "translated" }],
+        sourceLang: "fr",
+      });
+      component.translateComment(comment);
+      expect(translationService.translateComments).toHaveBeenCalledTimes(1);
+    });
+
+    it("translateAll issues exactly one batch request for all foreign comments", () => {
+      translationService.matchesViewerLang.mockReturnValue(false);
+      commentService.getComments.mockReturnValue(
+        of({
+          threads: [
+            {
+              comment: makeComment({ id: "c1", sourceLang: "fr" }),
+              replies: [],
+            },
+            {
+              comment: makeComment({ id: "c2", sourceLang: "ru" }),
+              replies: [],
+            },
+          ],
+          total: 2,
+        }),
+      );
+      bindBlueprint("bp1");
+
+      component.translateAll();
+      expect(translationService.translateComments).toHaveBeenCalledTimes(1);
+      expect(translationService.translateComments).toHaveBeenCalledWith("bp1", [
+        "c1",
+        "c2",
+      ]);
+    });
+
+    it("renders a degraded note instead of the attribution when a translation is degraded", () => {
+      translationService.matchesViewerLang.mockReturnValue(false);
+      translationService.translateComments.mockReturnValue(
+        of({
+          translations: [
+            {
+              id: "c1",
+              segments: [{ type: "text", text: "nice build" }],
+              sourceLang: "fr",
+              cached: false,
+              degraded: true,
+            },
+          ],
+        }),
+      );
+      commentService.getComments.mockReturnValue(
+        of({
+          threads: [
+            {
+              comment: makeComment({ id: "c1", sourceLang: "fr" }),
+              replies: [],
+            },
+          ],
+          total: 1,
+        }),
+      );
+      bindBlueprint("bp1");
+
+      component.translateComment(
+        makeComment({ id: "c1", sourceLang: "fr" }) as any,
+      );
+      translationService.cachedComment.mockReturnValue({
+        segments: [{ type: "text", text: "nice build" }],
+        sourceLang: "fr",
+        degraded: true,
+      });
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain(
+        "Translation unavailable",
+      );
     });
   });
 

--- a/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.ts
+++ b/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../../../../lib/index";
 import { CommentService } from "../../services/comment.service";
 import { AuthenticationService } from "../../services/authentification-service";
+import { TranslationService } from "../../services/translation.service";
 
 @Component({
   selector: "app-comment-section",
@@ -39,9 +40,15 @@ export class CommentSectionComponent implements OnChanges {
 
   readonly maxLength = COMMENT_MAX_LENGTH;
 
+  // Per-comment translation state, keyed by comment id
+  translatingIds = new Set<string>();
+  showingTranslationIds = new Set<string>();
+  translateAllWorking = false;
+
   constructor(
     private commentService: CommentService,
     public authService: AuthenticationService,
+    public translationService: TranslationService,
   ) {}
 
   ngOnChanges() {
@@ -52,7 +59,80 @@ export class CommentSectionComponent implements OnChanges {
     this.editText = "";
     this.editOriginalText = "";
     this.postError = null;
+    this.translatingIds = new Set();
+    this.showingTranslationIds = new Set();
+    this.translateAllWorking = false;
     this.reload();
+  }
+
+  // The button set only appears on content the viewer doesn't already read —
+  // nearly all traffic never sees it.
+  isForeignLanguage(comment: CommentDto): boolean {
+    return (
+      !comment.deleted &&
+      comment.sourceLang != null &&
+      !this.translationService.matchesViewerLang(comment.sourceLang)
+    );
+  }
+
+  get foreignCommentIds(): string[] {
+    const all = [
+      ...this.threads.map((t) => t.comment),
+      ...this.threads.flatMap((t) => t.replies),
+    ];
+    return all.filter((c) => this.isForeignLanguage(c)).map((c) => c.id);
+  }
+
+  get showTranslateAll(): boolean {
+    return this.foreignCommentIds.length >= 2;
+  }
+
+  translatedSegments(comment: CommentDto) {
+    return this.translationService.cachedComment(comment.id)?.segments ?? null;
+  }
+
+  translationDegraded(comment: CommentDto): boolean {
+    return this.translationService.cachedComment(comment.id)?.degraded === true;
+  }
+
+  translateComment(comment: CommentDto) {
+    if (this.blueprintId == null || this.translatingIds.has(comment.id)) return;
+    if (this.translationService.cachedComment(comment.id) != null) {
+      this.showingTranslationIds.add(comment.id);
+      return;
+    }
+    this.translatingIds.add(comment.id);
+    this.translationService
+      .translateComments(this.blueprintId, [comment.id])
+      .subscribe({
+        next: () => {
+          this.translatingIds.delete(comment.id);
+          this.showingTranslationIds.add(comment.id);
+        },
+        error: () => {
+          this.translatingIds.delete(comment.id);
+        },
+      });
+  }
+
+  showOriginalComment(comment: CommentDto) {
+    this.showingTranslationIds.delete(comment.id);
+  }
+
+  translateAll() {
+    if (this.blueprintId == null || this.translateAllWorking) return;
+    const ids = this.foreignCommentIds;
+    if (ids.length === 0) return;
+    this.translateAllWorking = true;
+    this.translationService.translateComments(this.blueprintId, ids).subscribe({
+      next: () => {
+        this.translateAllWorking = false;
+        for (const id of ids) this.showingTranslationIds.add(id);
+      },
+      error: () => {
+        this.translateAllWorking = false;
+      },
+    });
   }
 
   private reload() {

--- a/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.ts
+++ b/frontend/src/app/module-blueprint/components/comment-section/comment-section.component.ts
@@ -65,10 +65,12 @@ export class CommentSectionComponent implements OnChanges {
     this.reload();
   }
 
-  // The button set only appears on content the viewer doesn't already read —
-  // nearly all traffic never sees it.
+  // The button set only appears on content the viewer doesn't already read,
+  // and only when logged in — the translate endpoint requires auth, so an
+  // anonymous click would just fail. Nearly all traffic never sees it.
   isForeignLanguage(comment: CommentDto): boolean {
     return (
+      this.authService.isLoggedIn() &&
       !comment.deleted &&
       comment.sourceLang != null &&
       !this.translationService.matchesViewerLang(comment.sourceLang)
@@ -124,13 +126,21 @@ export class CommentSectionComponent implements OnChanges {
     const ids = this.foreignCommentIds;
     if (ids.length === 0) return;
     this.translateAllWorking = true;
+    // Mirrors translatingIds so a per-comment "Translate" click on one of
+    // these ids while the batch is in flight is disabled instead of firing a
+    // duplicate request.
+    for (const id of ids) this.translatingIds.add(id);
     this.translationService.translateComments(this.blueprintId, ids).subscribe({
       next: () => {
         this.translateAllWorking = false;
-        for (const id of ids) this.showingTranslationIds.add(id);
+        for (const id of ids) {
+          this.translatingIds.delete(id);
+          this.showingTranslationIds.add(id);
+        }
       },
       error: () => {
         this.translateAllWorking = false;
+        for (const id of ids) this.translatingIds.delete(id);
       },
     });
   }

--- a/frontend/src/app/module-blueprint/module-blueprint.module.ts
+++ b/frontend/src/app/module-blueprint/module-blueprint.module.ts
@@ -99,6 +99,7 @@ import { FeedbackService } from "./services/feedback.service";
 import { CommentSectionComponent } from "./components/comment-section/comment-section.component";
 import { BlueprintDetailsPageComponent } from "./components/blueprint-details-page/blueprint-details-page.component";
 import { CommentService } from "./services/comment.service";
+import { TranslationService } from "./services/translation.service";
 import { BlueprintVersionService } from "./services/blueprint-version.service";
 import { BrowsePageComponent } from "./components/browse-page/browse-page.component";
 import { DialogThemeComponent } from "./components/dialogs/dialog-theme/dialog-theme.component";
@@ -214,6 +215,7 @@ import { TerrainToolComponent } from "./components/side-bar/terrain-tool/terrain
     AuthenticationService,
     FeedbackService,
     CommentService,
+    TranslationService,
     BlueprintVersionService,
     BlueprintService,
     ToolService,

--- a/frontend/src/app/module-blueprint/services/translation.service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/translation.service.spec.ts
@@ -1,0 +1,163 @@
+import { TestBed } from "@angular/core/testing";
+import { LOCALE_ID } from "@angular/core";
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from "@angular/common/http/testing";
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from "@angular/common/http";
+
+import { TranslationService } from "./translation.service";
+import { AuthenticationService } from "./authentification-service";
+
+describe("TranslationService", () => {
+  let httpMock: HttpTestingController;
+  let mockAuth: any;
+
+  function makeService(locale: string): TranslationService {
+    TestBed.configureTestingModule({
+      providers: [
+        TranslationService,
+        { provide: AuthenticationService, useValue: mockAuth },
+        { provide: LOCALE_ID, useValue: locale },
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    });
+    const service = TestBed.inject(TranslationService);
+    httpMock = TestBed.inject(HttpTestingController);
+    return service;
+  }
+
+  beforeEach(() => {
+    mockAuth = {
+      getToken: vi.fn().mockReturnValue("test-jwt"),
+      isLoggedIn: vi.fn().mockReturnValue(true),
+    };
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe("viewerLang", () => {
+    it("maps en-US to en", () => {
+      expect(makeService("en-US").viewerLang).toBe("en");
+    });
+
+    it("passes zh-Hans, ru, ko through unchanged", () => {
+      expect(makeService("zh-Hans").viewerLang).toBe("zh-Hans");
+    });
+
+    it("falls back to en for an unrecognized locale", () => {
+      expect(makeService("fr").viewerLang).toBe("en");
+    });
+  });
+
+  describe("matchesViewerLang", () => {
+    it("collapses zh-Hans to zh for the comparison", () => {
+      const service = makeService("zh-Hans");
+      expect(service.matchesViewerLang("zh")).toBe(true);
+      expect(service.matchesViewerLang("en")).toBe(false);
+    });
+
+    it("compares directly for en/ru/ko", () => {
+      const service = makeService("ru");
+      expect(service.matchesViewerLang("ru")).toBe(true);
+      expect(service.matchesViewerLang("en")).toBe(false);
+    });
+  });
+
+  describe("translateBlueprint", () => {
+    it("posts the viewer's language and caches the result in-memory", () => {
+      const service = makeService("en-US");
+      let first: any;
+      service.translateBlueprint("bp1").subscribe((r) => (first = r));
+
+      const req = httpMock.expectOne("/api/blueprints/bp1/translate");
+      expect(req.request.method).toBe("POST");
+      expect(req.request.body).toEqual({ lang: "en" });
+      expect(req.request.headers.get("Authorization")).toBe("Bearer test-jwt");
+      req.flush({ description: "hello", sourceLang: "fr", cached: false });
+
+      expect(first).toEqual({
+        description: "hello",
+        sourceLang: "fr",
+        cached: false,
+      });
+
+      let second: any;
+      service.translateBlueprint("bp1").subscribe((r) => (second = r));
+      httpMock.expectNone("/api/blueprints/bp1/translate");
+      expect(second).toEqual(first);
+    });
+  });
+
+  describe("translateComments", () => {
+    it("only requests the ids not already cached", () => {
+      const service = makeService("en-US");
+
+      let first: any;
+      service
+        .translateComments("bp1", ["c1", "c2"])
+        .subscribe((r) => (first = r));
+      const req = httpMock.expectOne("/api/blueprints/bp1/comments/translate");
+      expect(req.request.body).toEqual({ lang: "en", ids: ["c1", "c2"] });
+      req.flush({
+        translations: [
+          {
+            id: "c1",
+            segments: [{ type: "text", text: "one" }],
+            sourceLang: "fr",
+            cached: false,
+          },
+          {
+            id: "c2",
+            segments: [{ type: "text", text: "two" }],
+            sourceLang: "fr",
+            cached: false,
+          },
+        ],
+      });
+      expect(first.translations).toHaveLength(2);
+
+      let second: any;
+      service
+        .translateComments("bp1", ["c1", "c3"])
+        .subscribe((r) => (second = r));
+      const req2 = httpMock.expectOne("/api/blueprints/bp1/comments/translate");
+      expect(req2.request.body).toEqual({ lang: "en", ids: ["c3"] });
+      req2.flush({
+        translations: [
+          {
+            id: "c3",
+            segments: [{ type: "text", text: "three" }],
+            sourceLang: "fr",
+            cached: false,
+          },
+        ],
+      });
+      expect(second.translations.map((t: any) => t.id)).toEqual(["c1", "c3"]);
+    });
+
+    it("issues no request when every id is already cached", () => {
+      const service = makeService("en-US");
+      service.translateComments("bp1", ["c1"]).subscribe();
+      httpMock.expectOne("/api/blueprints/bp1/comments/translate").flush({
+        translations: [
+          {
+            id: "c1",
+            segments: [{ type: "text", text: "one" }],
+            sourceLang: "fr",
+            cached: false,
+          },
+        ],
+      });
+
+      service.translateComments("bp1", ["c1"]).subscribe();
+      httpMock.expectNone("/api/blueprints/bp1/comments/translate");
+    });
+  });
+});

--- a/frontend/src/app/module-blueprint/services/translation.service.ts
+++ b/frontend/src/app/module-blueprint/services/translation.service.ts
@@ -1,0 +1,119 @@
+import { Inject, Injectable, LOCALE_ID } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { Observable, of } from "rxjs";
+import { map, tap } from "rxjs/operators";
+import {
+  CommentSegment,
+  TranslateBlueprintResponse,
+  TranslateCommentsResponse,
+  TranslationTargetLang,
+} from "../../../../../lib/index";
+import { AuthenticationService } from "./authentification-service";
+
+// One of the four locales the site actually builds (frontend/angular.json);
+// LOCALE_ID arrives as a full Angular locale code (en-US, zh-Hans, ru, ko).
+const TARGET_LANG_BY_LOCALE: Record<string, TranslationTargetLang> = {
+  "en-US": "en",
+  "zh-Hans": "zh-Hans",
+  ru: "ru",
+  ko: "ko",
+};
+
+@Injectable()
+export class TranslationService {
+  // In-memory per-session cache keyed `kind:id` so toggling original/translated
+  // is instant and free after the first fetch — cleared on page reload, which
+  // is fine: the durable cache is server-side.
+  private blueprintCache = new Map<string, TranslateBlueprintResponse>();
+  private commentCache = new Map<
+    string,
+    {
+      segments: CommentSegment[];
+      sourceLang: string | null;
+      cached: boolean;
+      degraded?: boolean;
+    }
+  >();
+
+  constructor(
+    private http: HttpClient,
+    private auth: AuthenticationService,
+    @Inject(LOCALE_ID) private locale: string,
+  ) {}
+
+  get viewerLang(): TranslationTargetLang {
+    return TARGET_LANG_BY_LOCALE[this.locale] ?? "en";
+  }
+
+  // Whether `sourceLang` (an ISO-639-1 code, e.g. from Blueprint.sourceLang /
+  // CommentDto.sourceLang) is already the viewer's language — the "Translate"
+  // button must not appear for content already in the viewer's own tongue.
+  matchesViewerLang(sourceLang: string): boolean {
+    const base = this.viewerLang === "zh-Hans" ? "zh" : this.viewerLang;
+    return sourceLang === base;
+  }
+
+  translateBlueprint(id: string): Observable<TranslateBlueprintResponse> {
+    const cached = this.blueprintCache.get(id);
+    if (cached) return of(cached);
+    return this.http
+      .post<TranslateBlueprintResponse>(
+        `/api/blueprints/${id}/translate`,
+        { lang: this.viewerLang },
+        { headers: this.authHeaders() },
+      )
+      .pipe(tap((response) => this.blueprintCache.set(id, response)));
+  }
+
+  translateComments(
+    blueprintId: string,
+    ids: string[],
+  ): Observable<TranslateCommentsResponse> {
+    const uncached = ids.filter((id) => !this.commentCache.has(id));
+    const fetch$: Observable<TranslateCommentsResponse> =
+      uncached.length === 0
+        ? of({ translations: [] })
+        : this.http.post<TranslateCommentsResponse>(
+            `/api/blueprints/${blueprintId}/comments/translate`,
+            { lang: this.viewerLang, ids: uncached },
+            { headers: this.authHeaders() },
+          );
+
+    return fetch$.pipe(
+      tap((response) => {
+        for (const t of response.translations) {
+          this.commentCache.set(t.id, {
+            segments: t.segments,
+            sourceLang: t.sourceLang,
+            cached: t.cached,
+            degraded: t.degraded,
+          });
+        }
+      }),
+      map(() => ({
+        translations: ids
+          .map((id) => {
+            const entry = this.commentCache.get(id);
+            return entry
+              ? {
+                  id,
+                  segments: entry.segments,
+                  sourceLang: entry.sourceLang,
+                  cached: entry.cached,
+                  degraded: entry.degraded,
+                }
+              : null;
+          })
+          .filter((t): t is NonNullable<typeof t> => t !== null),
+      })),
+    );
+  }
+
+  cachedComment(id: string) {
+    return this.commentCache.get(id) ?? null;
+  }
+
+  private authHeaders() {
+    return { Authorization: `Bearer ${this.auth.getToken()}` };
+  }
+}

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -51,6 +51,7 @@ export * from './src/blueprint/dlc';
 export * from './src/blueprint/terrain-metadata';
 export * from './src/blueprint/note-conversion';
 export * from './src/blueprint/bpv2-sanitize';
+export * from './src/blueprint/translation';
 export * from './src/blueprint/rooms';
 export * from './src/blueprint/blueprint-item';
 export * from './src/blueprint/blueprint-item-element';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -57,6 +57,7 @@ export * from './src/blueprint/dlc';
 export * from './src/blueprint/terrain-metadata';
 export * from './src/blueprint/note-conversion';
 export * from './src/blueprint/bpv2-sanitize';
+export * from './src/blueprint/translation';
 export * from './src/blueprint/rooms';
 export * from './src/blueprint/blueprint-item';
 export * from './src/blueprint/blueprint-item-element';

--- a/lib/src/blueprint/translation.d.ts
+++ b/lib/src/blueprint/translation.d.ts
@@ -1,0 +1,30 @@
+import { CommentSegment } from '../coms/comments';
+export declare const TRANSLATION_TARGET_LANGS: readonly ["en", "zh-Hans", "ru", "ko"];
+export type TranslationTargetLang = (typeof TRANSLATION_TARGET_LANGS)[number];
+export declare function isTranslationTargetLang(value: unknown): value is TranslationTargetLang;
+export declare const MAX_TRANSLATE_BATCH = 50;
+export interface TranslateBlueprintRequest {
+    lang: TranslationTargetLang;
+}
+export interface TranslateBlueprintResponse {
+    description: string;
+    sourceLang: string | null;
+    cached: boolean;
+    degraded?: boolean;
+}
+export interface TranslateCommentsRequest {
+    lang: TranslationTargetLang;
+    ids: string[];
+}
+export interface TranslatedCommentDto {
+    id: string;
+    segments: CommentSegment[];
+    sourceLang: string | null;
+    cached: boolean;
+    degraded?: boolean;
+}
+export interface TranslateCommentsResponse {
+    translations: TranslatedCommentDto[];
+}
+export declare const TRANSLATION_BUDGET_EXCEEDED_CODE = "TRANSLATION_BUDGET_EXCEEDED";
+//# sourceMappingURL=translation.d.ts.map

--- a/lib/src/blueprint/translation.ts
+++ b/lib/src/blueprint/translation.ts
@@ -1,0 +1,49 @@
+// User-content translation (spec/user-content-translation-impl.md). Shared
+// shapes for the translate endpoints — the four UI locales are a hard
+// allowlist, not a shape check: an unknown target language is money spent on
+// a page nobody can read.
+
+import { CommentSegment } from '../coms/comments';
+
+export const TRANSLATION_TARGET_LANGS = ['en', 'zh-Hans', 'ru', 'ko'] as const;
+export type TranslationTargetLang = (typeof TRANSLATION_TARGET_LANGS)[number];
+
+export function isTranslationTargetLang(value: unknown): value is TranslationTargetLang {
+  return typeof value === 'string' && (TRANSLATION_TARGET_LANGS as readonly string[]).includes(value);
+}
+
+// One comment thread visible at once is one request; caps the batch endpoint.
+export const MAX_TRANSLATE_BATCH = 50;
+
+export interface TranslateBlueprintRequest {
+  lang: TranslationTargetLang;
+}
+
+export interface TranslateBlueprintResponse {
+  description: string;
+  sourceLang: string | null;
+  cached: boolean;
+  degraded?: boolean;
+}
+
+export interface TranslateCommentsRequest {
+  lang: TranslationTargetLang;
+  ids: string[];
+}
+
+export interface TranslatedCommentDto {
+  id: string;
+  // Pre-resolved like CommentDto.segments (reference tokens restored, then
+  // rendered through the same name-resolution pipeline) — never a raw body
+  // string, so a translated {{user:id}} token never leaks to the client.
+  segments: CommentSegment[];
+  sourceLang: string | null;
+  cached: boolean;
+  degraded?: boolean;
+}
+
+export interface TranslateCommentsResponse {
+  translations: TranslatedCommentDto[];
+}
+
+export const TRANSLATION_BUDGET_EXCEEDED_CODE = 'TRANSLATION_BUDGET_EXCEEDED';

--- a/lib/src/coms/blueprint-list-response.d.ts
+++ b/lib/src/coms/blueprint-list-response.d.ts
@@ -41,6 +41,7 @@ export interface BlueprintDetailsResponse extends BlueprintListItem {
     researchTier?: string | null;
     myRating: number | null;
     ownedByMe: boolean;
+    sourceLang?: string | null;
 }
 export interface RelatedBlueprintsResponse {
     blueprints: BlueprintListItem[];

--- a/lib/src/coms/blueprint-list-response.ts
+++ b/lib/src/coms/blueprint-list-response.ts
@@ -73,6 +73,11 @@ export interface BlueprintDetailsResponse extends BlueprintListItem {
   researchTier?: string | null;
   myRating: number | null;
   ownedByMe: boolean;
+  // ISO-639-1 language of `description`, server-derived on save; null =
+  // detection ran and was not confident, absent = never derived (legacy docs).
+  // Drives the "Translate" affordance — only shown when set, non-null, and
+  // different from the viewer's locale.
+  sourceLang?: string | null;
 }
 
 // "You might also like" shelf on the details page

--- a/lib/src/coms/comments.d.ts
+++ b/lib/src/coms/comments.d.ts
@@ -17,6 +17,7 @@ export interface CommentDto {
     createdAt: string;
     lastActivityAt: string;
     editedAt: string | null;
+    sourceLang?: string | null;
     canDelete: boolean;
     canEdit: boolean;
     editSource?: string;

--- a/lib/src/coms/comments.ts
+++ b/lib/src/coms/comments.ts
@@ -28,6 +28,9 @@ export interface CommentDto {
   // hover shows this date). Distinct from any document-level updated
   // timestamp: replies and moderation never touch it.
   editedAt: string | null;
+  // ISO-639-1 language of `body`, server-derived on post/edit; null =
+  // detection ran and was not confident, absent = never derived (legacy docs).
+  sourceLang?: string | null;
   // Only meaningful when the request carried a valid token
   canDelete: boolean;
   canEdit: boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@google-cloud/translate": "^9.4.2",
         "@google/genai": "^2.12.0",
         "@workos-inc/node": "^8.11.1",
         "adm-zip": "^0.5.10",
@@ -33,7 +34,8 @@
         "passport-local": "^1.0.0",
         "pixi.js-legacy": "^5.3.0",
         "request-ip": "^3.3.0",
-        "sharp": "^0.35.3"
+        "sharp": "^0.35.3",
+        "tinyld": "^1.3.4"
       },
       "devDependencies": {
         "@types/adm-zip": "^0.5.0",
@@ -233,6 +235,70 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@google-cloud/common": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-6.1.0.tgz",
+      "integrity": "sha512-Ohjxjvusr65+SiEVBrilpyn1ir9CM8ZqWjcf7bA8ph1GCunxI6bbwtcl7iGl67A7Lr4Nz7WpNzITNETwggc7pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "^4.0.0",
+        "arrify": "^2.0.0",
+        "duplexify": "^4.1.3",
+        "extend": "^3.0.2",
+        "google-auth-library": "^10.6.2",
+        "html-entities": "^2.5.2",
+        "retry-request": "^8.0.0",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/@google-cloud/promisify": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.1.0.tgz",
+      "integrity": "sha512-G/FQx5cE/+DqBbOpA5jKsegGwdPniU6PuIEMt+qxWgFxvxuFOzVmp6zYchtYuwAWV5/8Dgs0yAmjvNZv3uXLQg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-5.1.0.tgz",
+      "integrity": "sha512-/j9zzWDxsgKg0hMuFBmLGI8ES9xj4DjXvQnDCKl0w5ed7WE3CGsgHmUoC35rvfBXshSW+5StQGnCUD+RBqITKA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/translate": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/translate/-/translate-9.4.2.tgz",
+      "integrity": "sha512-evN00jJr1PfStM0+4OQhZH4LEW8NhIF1VJUMDf3f93KGR0HptNd94a/KVpeqxrVTkCYOdXP39x52wWVcxoHmwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/common": "^6.0.0",
+        "@google-cloud/promisify": "^5.0.0",
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2",
+        "google-gax": "^5.0.0",
+        "is-html": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@google/genai": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.12.0.tgz",
@@ -255,6 +321,37 @@
         "@modelcontextprotocol/sdk": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@img/colour": {
@@ -761,7 +858,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -779,7 +875,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -792,7 +887,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -805,14 +899,12 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -830,7 +922,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -846,7 +937,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -1298,6 +1388,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -1839,7 +1939,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2405,7 +2504,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2450,6 +2548,15 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -2881,7 +2988,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -2896,7 +3002,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2909,7 +3014,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -3033,7 +3137,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3241,6 +3344,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
     "node_modules/dynamic-dedupe": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
@@ -3261,7 +3376,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -3385,7 +3499,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3650,7 +3763,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -3834,7 +3946,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -3908,7 +4019,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -3942,7 +4052,6 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -3985,6 +4094,90 @@
         "node": ">=18"
       }
     },
+    "node_modules/google-gax": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.8.tgz",
+      "integrity": "sha512-M4vpZcXQIC1gqIVGQ7eaU3jXQA6zecStyTXu514TYfThlgSurYJOxHZo9fzU6hAgwPWvuEynAVHWyaIk80VeEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "10.5.0",
+        "google-logging-utils": "1.1.3",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "3.0.4",
+        "protobufjs": "^7.5.4",
+        "retry-request": "^8.0.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/gcp-metadata": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.4.tgz",
+      "integrity": "sha512-iJ9KMsiu+xKtNRX0PmGLSaIU3bUBAyzWTyqKemKPzNPsmmsBCQYmlNg+brEbES7IHSXtdVwzBPzx1vz3FAaipw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "7.1.3",
+        "google-logging-utils": "1.1.3",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/google-logging-utils": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
@@ -4012,6 +4205,19 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4094,6 +4300,34 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/html-tags": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+      "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/http-errors": {
@@ -4287,6 +4521,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-html": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-html/-/is-html-2.0.0.tgz",
+      "integrity": "sha512-S+OpgB5i7wzIue/YSE5hg0e5ZYfG3hhpNh9KGl6ayJ38p7ED6wxQLd1TV91xHpcTvw90KMJ9EwN3F/iNflHBVg==",
+      "license": "MIT",
+      "dependencies": {
+        "html-tags": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4369,7 +4615,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ismobilejs": {
@@ -4382,7 +4627,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -4615,6 +4859,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -4849,7 +5099,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5342,6 +5591,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -5430,7 +5688,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/pako": {
@@ -5552,7 +5809,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5569,7 +5825,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -5768,6 +6023,18 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/proto3-json-serializer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.6.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
@@ -5945,7 +6212,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5990,6 +6256,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.4.tgz",
+      "integrity": "sha512-pI6/7eabUYkZxamkOq0g0uMxKLLGnjzhefY+vL8bVXag5rto4OU2YBTPytWLuHH7aEKD6fn7kJycQfid0Mwnkw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/rimraf": {
@@ -6257,7 +6536,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6270,7 +6548,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6371,7 +6648,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -6500,6 +6776,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -6528,7 +6819,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -6556,7 +6846,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6603,6 +6892,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT"
     },
     "node_modules/superagent": {
       "version": "10.3.0",
@@ -6716,11 +7011,42 @@
         "node": ">=6"
       }
     },
+    "node_modules/teeny-request": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.4.tgz",
+      "integrity": "sha512-R1Cg4Vu0UULeDfHL/kjABLaTW++9yD/B6n2g48y5dJ04hsEaxcfmAqbNDzNsbqAYJyIpZafjklLG9YxRu9uzOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
+    },
+    "node_modules/tinyld": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/tinyld/-/tinyld-1.3.4.tgz",
+      "integrity": "sha512-u26CNoaInA4XpDU+8s/6Cq8xHc2T5M4fXB3ICfXPokUQoLzmPgSZU02TAkFwFMJCWTjk53gtkS8pETTreZwCqw==",
+      "license": "MIT",
+      "bin": {
+        "tinyld": "bin/tinyld.js",
+        "tinyld-heavy": "bin/tinyld-heavy.js",
+        "tinyld-light": "bin/tinyld-light.js"
+      },
+      "engines": {
+        "node": ">= 12.10.0",
+        "npm": ">= 6.12.0",
+        "yarn": ">= 1.20.0"
+      }
     },
     "node_modules/tldts": {
       "version": "6.1.86",
@@ -7224,7 +7550,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7247,7 +7572,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -7266,7 +7590,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -7364,7 +7687,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -7374,7 +7696,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -7393,7 +7714,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "derive-metadata:dry-run": "./scripts/batch.sh derive-blueprint-metadata --dry-run",
     "derive-rooms": "./scripts/batch.sh derive-rooms",
     "derive-rooms:dry-run": "./scripts/batch.sh derive-rooms --dry-run",
+    "derive-language": "./scripts/batch.sh derive-language",
+    "derive-language:dry-run": "./scripts/batch.sh derive-language --dry-run",
     "backfill-previews": "./scripts/batch.sh backfill-preview-images",
     "backfill-previews:dry-run": "./scripts/batch.sh backfill-preview-images --dry-run",
     "avatars:seed-batch": "./scripts/batch.sh generate-avatar-batch",
@@ -52,6 +54,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@google-cloud/translate": "^9.4.2",
     "@google/genai": "^2.12.0",
     "@workos-inc/node": "^8.11.1",
     "adm-zip": "^0.5.10",
@@ -76,7 +79,8 @@
     "passport-local": "^1.0.0",
     "pixi.js-legacy": "^5.3.0",
     "request-ip": "^3.3.0",
-    "sharp": "^0.35.3"
+    "sharp": "^0.35.3",
+    "tinyld": "^1.3.4"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.0",


### PR DESCRIPTION
## Summary

Implements steps 1-5 of the user-content translation spec (detection, cache/provider service, endpoints, frontend UI). Deferred: phase 4 (human-corrected translations) and the `name`-regex relaxation, per spec.

- **Detection + storage**: `Blueprint.sourceLang` / `Comment.sourceLang`, free local detection via `tinyld`, server-derived on every save (never client-supplied, same nullability convention as `rooms`/`requiredDlcs`). `npm run derive-language[:dry-run]` backfills existing docs and reports the language distribution — the evidence for whether this feature is worth shipping further.
- **Cache + provider + budget**: `translations` collection (unique per `{kind, refId, targetLang}`, `sourceHash` freshness check, human rows always win), `TranslationProvider` abstraction (`GoogleTranslationProvider` over `@google-cloud/translate` v2, `FakeTranslationProvider` in specs — no network in tests). Monthly character budget (`MONTHLY_CHAR_BUDGET`, default 400k) + per-user daily cap (`MAX_TRANSLATIONS_PER_USER_PER_DAY`, default 200), tracked in `translationbudgets`. Cache reads keep working when the budget is exceeded — only new spend stops.
- **Reference-token safety**: comment bodies carry `{{blueprint:id}}`/`{{user:id}}` tokens that a raw NMT call would mangle. `translation-token-safety.ts` swaps them for translation-stable placeholders before the provider call and restores them after; a corrupted round-trip is discarded (never cached) and returned as `degraded: true` rather than served corrupted. Translated comment bodies are resolved through the same name-lookup pipeline as ordinary comments (`resolveReferenceNames`), so segments — never raw tokens — reach the client.
- **Endpoints**: `POST /api/blueprints/:id/translate` and `POST /api/blueprints/:id/comments/translate` (batched, capped at 50). Auth required (the only endpoint on the site that spends money per call). 503 unconfigured, 400 bad lang/oversized batch, 429 `TRANSLATION_BUDGET_EXCEEDED`.
- **Frontend**: Translate / Show original toggle on the blueprint details description and each comment, in-memory per-session cache, batched "Translate all" at the thread level, attribution / degraded-note copy.

## Test plan
- [x] `npm run tsc` clean (backend + lib)
- [x] `frontend`: `tsc --noEmit` (app + spec) clean, `npm run lint` clean
- [x] Backend: `npm run test` — 863 passing (3 pre-existing `workos-provision` local flakes, unrelated, documented as green-in-CI)
- [x] Frontend: `npm test` — 1180 passing / 2 skipped (pre-existing skips)
- [x] New backend specs: `language-detection-service`, `translation-token-safety` (adversarial round-trip cases), `translation-service` (cache/budget/human-row/batching against the fake), `translation-controller` (auth/validation/budget/segment-resolution over HTTP)
- [x] New frontend specs: `translation.service` (locale mapping, in-memory cache), details-page button visibility/toggle/degraded, comment-section per-comment + translate-all + degraded

## Deferred (per spec)
- Relaxing the blueprint `name` ASCII regex — separate decision, own blast radius
- Phase 4 human-corrected translations — schema leaves room (`provider: 'human'`, `reviewedBy`), no submission UI yet
- Running `derive-language` against the prod dump to gauge real non-English volume before further spend

🤖 Generated with [Claude Code](https://claude.com/claude-code)