### PR TITLE
feat(names): allow Unicode blueprint titles (search plan phase 3a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,9 +421,39 @@ on download. `Info` now survives as an *input* format only.
   "Group identical copies" toggle appears only while a search is active, and the card shows a
   `+N copies` chip). **Facet counts never collapse** — a category count describes the corpus,
   not the view, so the sidebar can legitimately read 4 where the list shows 1.
-- **Not built yet** (later phases of the plan): the `name` regex relaxation + title
-  translation pivot, query translation + `searchqueries` telemetry, IDF weighting for
-  structural matches, semantic retrieval.
+- **Not built yet** (later phases of the plan): the title translation pivot, query translation
+  + `searchqueries` telemetry, IDF weighting for structural matches, semantic retrieval.
+
+### Blueprint titles are Unicode
+`Blueprint.name` was `/^[a-zA-Z0-9_ -]+$/`, which 400'd every non-English title at save. The
+policy is now one shared module, `lib/src/blueprint/blueprint-name.ts`, used by the save
+dialog (`blueprint-name-validation.directive.ts`), the upload endpoint and the Mongoose
+schema — three surfaces that must not be able to disagree, since the failure mode is a form
+that accepts what the server rejects.
+- **Allowed**: every script, punctuation, emoji. **Rejected**: control characters, `\p{Cf}`
+  format characters (bidi overrides and the rest) *except* ZWNJ/ZWJ, unassigned/private-use/
+  surrogate code points, runs of more than 4 combining marks, and Latin mixed with Cyrillic or
+  Greek **inside one word** — the "Rоdriguez" homoglyph spoof. The confusable rule is per-word
+  and only those scripts on purpose: mixing across words is ordinary (`Ферма SPOM v2`,
+  `SPOM 电解 v3`), and a broader UTS #39 restriction would reject the very titles this exists
+  to allow. The endpoint returns the specific rule broken; the dialog renders a translated
+  message per `reason` (never the policy's English string).
+- **`normalizeBlueprintName`** (NFC + whitespace collapsed to U+0020 + trim) runs at ingress
+  and only there. It is load-bearing for the `{owner, name}` duplicate check, which is an
+  exact string match: without it, a title typed on macOS (decomposed) and on Windows
+  (composed) are two documents with identical-looking names and the author cannot overwrite
+  their own blueprint from their other machine. The schema validator
+  (`isCanonicalBlueprintName`) demands the already-normalized form rather than normalizing
+  again, so a non-canonical name reaching a model write fails instead of being silently
+  repaired. **Not case-folded** — the check has always been case-sensitive and folding it
+  would newly collide existing ASCII titles. Length stays 60 UTF-16 code units, the unit
+  `maxlength` counts.
+- **Download filenames**: `attachmentDisposition` (`app/api/utils/content-disposition.ts`)
+  emits RFC 6266's pair — an ASCII fallback plus `filename*=UTF-8''` — because an HTTP header
+  is ISO-8859-1 and a title containing `"` would otherwise escape the quoted string. The
+  client-side path uses `sanitize-filename`, which already preserves non-ASCII.
+- Search needs no special handling: `normalizeText` already applies NFC and keeps non-Latin
+  letters, and search rows are derived on save (covered end-to-end in `search.test.ts`).
 
 ### Blueprint metadata auto-derivation
 `requiredDlcs`, `gameVersion` and `modded` are derived deterministically from the blueprint

--- a/__tests__/api/blueprint-raw-source.test.ts
+++ b/__tests__/api/blueprint-raw-source.test.ts
@@ -74,6 +74,29 @@ describe('Blueprint raw source round-trip API', function () {
     expect(raw.text).to.equal('SGVsbG8gd29ybGQ=');
   });
 
+  it('serves a non-ASCII title as an ASCII filename plus an RFC 5987 filename*', async function () {
+    // Titles are Unicode; an HTTP header is not. The name is never
+    // interpolated raw — a Korean title must still yield a header a client can
+    // parse, and a title with a quote must not break out of the quoted string.
+    const saved = await upload({
+      name: '산소 "발생기"',
+      rawSource: FIXTURE_TEXT,
+      rawSourceFormat: 'bpv2-json',
+    });
+    expect(saved.status).to.equal(200);
+
+    const raw = await TestSetup.request().get(`/api/blueprints/${saved.body.id}/raw`);
+    expect(raw.status).to.equal(200);
+    const disposition = raw.headers['content-disposition'];
+    // The whole ASCII title transliterates to nothing, so the fallback stem is
+    // used rather than a nameless ".blueprint".
+    expect(disposition).to.contain('filename="blueprint.blueprint"');
+    expect(disposition).to.contain(
+      `filename*=UTF-8''${encodeURIComponent('산소 발생기.blueprint')}`
+    );
+    expect(raw.text).to.equal(FIXTURE_TEXT);
+  });
+
   it('404s when the blueprint has no stored raw source', async function () {
     const saved = await upload({ name: 'No Raw' });
     expect(saved.status).to.equal(200);

--- a/__tests__/api/blueprint-validation.test.ts
+++ b/__tests__/api/blueprint-validation.test.ts
@@ -23,21 +23,49 @@ describe('Blueprint Validation API (Mocha)', function () {
     await TestSetup.afterEach();
   });
 
+  // Character-class coverage lives in the pure policy spec
+  // (__tests__/lib/blueprint-name.test.ts); these assert that the endpoint
+  // applies that policy and stores the normalized form.
   describe('Blueprint name validation', function () {
-    it('should reject blueprint names with invalid characters', async function () {
-      const response = await TestSetup.request()
+    const upload = (name: string, extra: Record<string, unknown> = {}) =>
+      TestSetup.request()
         .post('/api/uploadblueprint')
         .set('Authorization', `Bearer ${authToken}`)
         .send({
-          name: 'Invalid@Name#123',
+          name,
           blueprint: { test: 'data' },
           thumbnail: 'base64thumbnail',
           overwrite: false,
+          ...extra,
         });
 
+    it('should accept non-Latin blueprint names', async function () {
+      // The phase-3a fix: each of these was a 400 under the old ASCII regex,
+      // which meant a non-English build could not be saved at all.
+      for (const name of ['电解制氧系统', 'Ферма для слизи', '산소 발생기', 'Máy lọc nước']) {
+        const response = await upload(name);
+        expect(response.status, name).to.equal(200);
+        expect(response.body.id, name).to.exist;
+      }
+    });
+
+    it('should accept punctuation the old ASCII regex rejected', async function () {
+      const response = await upload('Invalid@Name#123');
+      expect(response.status).to.equal(200);
+    });
+
+    it('should reject a name with invisible or direction-changing characters', async function () {
+      // U+202E right-to-left override, written as an escape so it is visible here.
+      const response = await upload('Base\u202eOne');
       expect(response.status).to.equal(400);
       expect(response.body.errors).to.be.an('array');
       expect(response.body.errors[0].status).to.equal('400');
+    });
+
+    it('should reject Latin/Cyrillic homoglyph mixing inside one word', async function () {
+      // U+043E Cyrillic small o, indistinguishable from ASCII 'o'.
+      const response = await upload('R\u043edriguez');
+      expect(response.status).to.equal(400);
     });
 
     it('should reject blueprint names longer than 60 characters', async function () {
@@ -116,6 +144,69 @@ describe('Blueprint Validation API (Mocha)', function () {
 
       expect(response.status).to.equal(200);
       expect(response.body.overwrite).to.be.true;
+    });
+
+    it('should treat differently-normalized spellings of one name as the same blueprint', async function () {
+      // macOS hands over decomposed text, Windows composed. Without NFC at
+      // ingress these are two documents with visually identical titles, and
+      // the author cannot overwrite their own blueprint from the other
+      // machine — the {owner, name} check is an exact string match.
+      const composed = 'M\u00e1y l\u1ecdc';
+      const decomposed = 'Ma\u0301y lo\u0323c';
+
+      const first = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({
+          name: composed,
+          blueprint: { test: 'data' },
+          thumbnail: 'base64thumbnail',
+          overwrite: false,
+        });
+      expect(first.status).to.equal(200);
+
+      const second = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({
+          name: decomposed,
+          blueprint: { test: 'data' },
+          thumbnail: 'base64thumbnail',
+          overwrite: false,
+        });
+      expect(second.body.overwrite).to.be.true;
+
+      const overwritten = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({
+          name: decomposed,
+          blueprint: { test: 'other data' },
+          thumbnail: 'base64thumbnail',
+          overwrite: true,
+        });
+      expect(overwritten.status).to.equal(200);
+      expect(overwritten.body.id).to.equal(first.body.id);
+    });
+
+    it('should store the name in normalized form', async function () {
+      const response = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({
+          name: '  Padded   Name  ',
+          blueprint: { test: 'data' },
+          thumbnail: 'base64thumbnail',
+          overwrite: false,
+        });
+      expect(response.status).to.equal(200);
+
+      // Owner token: a fresh upload is a draft, invisible to anonymous readers.
+      const details = await TestSetup.request()
+        .get(`/api/blueprints/${response.body.id}`)
+        .set('Authorization', `Bearer ${authToken}`);
+      expect(details.status).to.equal(200);
+      expect(details.body.name).to.equal('Padded Name');
     });
 
     it('should allow overwriting when overwrite flag is true', async function () {

--- a/__tests__/api/blueprints.test.ts
+++ b/__tests__/api/blueprints.test.ts
@@ -212,7 +212,9 @@ describe('Blueprint API (Mocha)', function () {
         .query({ olderthan: Date.now(), filterName: 'oxygen(' });
 
       expect(response.status).to.equal(200);
-      expect(response.body.blueprints.map((bp: any) => bp.name)).to.include('Oxygen Production Line');
+      expect(response.body.blueprints.map((bp: any) => bp.name)).to.include(
+        'Oxygen Production Line'
+      );
     });
   });
 
@@ -249,9 +251,7 @@ describe('Blueprint API (Mocha)', function () {
 
       expect(response.status).to.equal(200);
       const names = response.body.blueprints.map((bp: any) => bp.name);
-      expect(names.indexOf('Fresh Unrated')).to.be.lessThan(
-        names.indexOf('Legacy Food System')
-      );
+      expect(names.indexOf('Fresh Unrated')).to.be.lessThan(names.indexOf('Legacy Food System'));
     });
 
     it('should paginate with skip', async function () {
@@ -370,9 +370,7 @@ describe('Blueprint API (Mocha)', function () {
       const id = testData.blueprints.popularBlueprint._id.toString();
       const userId = testData.users.user2._id.toString(); // user2 rated it 5 (seeded)
 
-      const response = await TestSetup.request()
-        .get(`/api/getblueprint/${id}`)
-        .query({ userId });
+      const response = await TestSetup.request().get(`/api/getblueprint/${id}`).query({ userId });
 
       expect(response.status).to.equal(200);
       expect(response.body.myRating).to.equal(null);
@@ -459,13 +457,33 @@ describe('Blueprint API (Mocha)', function () {
       expect(second.body.id).to.equal(first.body.id); // same record, same id
     });
 
-    it('should reject a name with special characters', async function () {
+    it('should accept punctuation and non-Latin scripts in a name', async function () {
+      // Titles are Unicode as of phase 3a — punctuation and every script are
+      // ordinary. Only the deceptive/unrenderable classes are rejected, which
+      // the policy spec covers character by character.
       const token = testData.users.user1.generateJwt();
 
       const response = await TestSetup.request()
         .post('/api/uploadblueprint')
         .set('Authorization', `Bearer ${token}`)
         .send({ name: 'Bad! <Name>', blueprint: SAMPLE_BLUEPRINT_DATA, thumbnail: TINY_PNG });
+
+      expect(response.status).to.equal(200);
+    });
+
+    it('should reject a name containing a bidi override', async function () {
+      const token = testData.users.user1.generateJwt();
+
+      const response = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          // U+202E right-to-left override, as an escape: the whole point of
+          // the character is that a literal would be invisible in review.
+          name: 'Base\u202eOne',
+          blueprint: SAMPLE_BLUEPRINT_DATA,
+          thumbnail: TINY_PNG,
+        });
 
       expect(response.status).to.equal(400);
       expect(response.body.errors).to.be.an('array');
@@ -509,16 +527,20 @@ describe('Blueprint API (Mocha)', function () {
 
       const blueprintWithOffsets = {
         blueprintItems: [
-          { id: 'Generator', position: { x: 10000, y: 0 } },   // x > 8000 → 10000 - 9999 = 1
-          { id: 'Battery',   position: { x: 0,     y: -9000 } }, // y < -8000 → -9000 + 9999 = 999
-          { id: 'Wire',      position: { x: 100,   y: -100 } },  // in bounds, unchanged
+          { id: 'Generator', position: { x: 10000, y: 0 } }, // x > 8000 → 10000 - 9999 = 1
+          { id: 'Battery', position: { x: 0, y: -9000 } }, // y < -8000 → -9000 + 9999 = 999
+          { id: 'Wire', position: { x: 100, y: -100 } }, // in bounds, unchanged
         ],
       };
 
       const upload = await TestSetup.request()
         .post('/api/uploadblueprint')
         .set('Authorization', `Bearer ${token}`)
-        .send({ name: 'Position Correction Test', blueprint: blueprintWithOffsets, thumbnail: TINY_PNG });
+        .send({
+          name: 'Position Correction Test',
+          blueprint: blueprintWithOffsets,
+          thumbnail: TINY_PNG,
+        });
 
       expect(upload.status).to.equal(200);
       const id = upload.body.id;
@@ -667,7 +689,7 @@ describe('Blueprint API (Mocha)', function () {
       expect(updated!.deletedAt).to.be.instanceOf(Date);
     });
 
-    it('should not allow deleting another user\'s blueprint', async function () {
+    it("should not allow deleting another user's blueprint", async function () {
       const token = testData.users.user2.generateJwt(); // user2 does not own popularBlueprint
       const id = testData.blueprints.popularBlueprint._id.toString();
 
@@ -703,7 +725,9 @@ describe('Blueprint API (Mocha)', function () {
         .get('/api/getblueprints')
         .query({ olderthan: Date.now() });
       expect(before.status).to.equal(200);
-      expect(before.body.blueprints.map((bp: any) => bp.name)).to.include('Super Coal Generator Setup');
+      expect(before.body.blueprints.map((bp: any) => bp.name)).to.include(
+        'Super Coal Generator Setup'
+      );
 
       await TestSetup.request()
         .post('/api/deleteblueprint')

--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -209,7 +209,9 @@ describe('Search (blueprintsearch)', function () {
       const substring = await TestSetup.request()
         .get('/api/getblueprints')
         .query({ olderthan: Date.now(), filterName: 'oxygen' });
-      expect(substring.body.blueprints.map((bp: any) => bp.name)).to.include('Oxygen Production Line');
+      expect(substring.body.blueprints.map((bp: any) => bp.name)).to.include(
+        'Oxygen Production Line'
+      );
     });
   });
 
@@ -281,7 +283,11 @@ describe('Search (blueprintsearch)', function () {
     it('collapses under an explicit count sort too, not just relevance order', async function () {
       // The site's default sort is trending, so a collapse that only covered
       // the relevance path would never fire in the actual UI.
-      const copies = await saveCopies(['Ranch Sorted One', 'Ranch Sorted Two', 'Ranch Sorted Three']);
+      const copies = await saveCopies([
+        'Ranch Sorted One',
+        'Ranch Sorted Two',
+        'Ranch Sorted Three',
+      ]);
       const copyIds = copies.map(doc => (doc._id as Types.ObjectId).toString());
 
       const response = await TestSetup.request()
@@ -306,7 +312,10 @@ describe('Search (blueprintsearch)', function () {
       const visibleId = (copies[1]._id as Types.ObjectId).toString();
       // Make the first copy (earliest createdAt, so the elected canonical) a
       // draft. The visible copy must still be the result, not a hole.
-      await BlueprintModel.model.updateOne({ _id: copies[0]._id }, { $set: { isPublished: false } });
+      await BlueprintModel.model.updateOne(
+        { _id: copies[0]._id },
+        { $set: { isPublished: false } }
+      );
 
       const response = await TestSetup.request()
         .get('/api/getblueprints')
@@ -367,6 +376,42 @@ describe('Search (blueprintsearch)', function () {
       // An actual Date, not merely "not null" — undefined must fail too if
       // the sync never landed before the poll gave up.
       expect(row!.deletedAt).to.be.an.instanceOf(Date);
+    });
+
+    it('saves a non-ASCII title through the upload endpoint and finds it again', async function () {
+      // End-to-end for the phase-3a name relaxation: a Vietnamese title is
+      // storable (it was a 400 before), its search row is derived on save, and
+      // it is retrievable by a query typed in either Unicode normalization —
+      // normalizeText applies NFC on both sides, and the stored title is
+      // canonical, so the two can never disagree.
+      const token = testData.users.user1.generateJwt();
+      const title = 'M\u00e1y l\u1ecdc n\u01b0\u1edbc'; // "water filter", composed
+      const decomposedQuery = 'ma\u0301y lo\u0323c'; // same words, decomposed
+
+      const saved = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          name: title,
+          blueprint: bpData(['WaterPurifier']),
+          thumbnail: 'base64thumbnail',
+          publish: true,
+        });
+      expect(saved.status).to.equal(200);
+
+      const row = await BlueprintSearchModel.model.findOne({ blueprintId: saved.body.id });
+      expect(row!.title).to.equal(title);
+
+      for (const query of [title, decomposedQuery]) {
+        const response = await TestSetup.request()
+          .get('/api/getblueprints')
+          .query({ filterName: query });
+        expect(response.status, query).to.equal(200);
+        expect(
+          response.body.blueprints.map((bp: any) => bp.id),
+          query
+        ).to.include(saved.body.id);
+      }
     });
   });
 });

--- a/__tests__/api/website-meta.test.ts
+++ b/__tests__/api/website-meta.test.ts
@@ -1,0 +1,32 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+
+import { htmlMetaTag, WebsiteMeta } from '../../app/websiteMeta';
+
+// These tags are rendered raw by index-robots.ejs (`<%- metaTags %>`), and
+// og:title carries a user-supplied blueprint name. The old ASCII-only name
+// regex made injection unreachable; Unicode titles allow `"` and `<`.
+describe('websiteMeta', function () {
+  it('escapes quotes and angle brackets in tag content', function () {
+    const tag = htmlMetaTag('og:title' as any, 'x" /><script>alert(1)</script>');
+    expect(tag).to.equal(
+      '<meta property="og:title" content="x&quot; /&gt;&lt;script&gt;alert(1)&lt;/script&gt;" />'
+    );
+    expect(tag).to.not.contain('<script>');
+  });
+
+  it('escapes ampersands without double-escaping the entities it emits', function () {
+    expect(htmlMetaTag('og:title' as any, 'Coal & Water')).to.contain('content="Coal &amp; Water"');
+  });
+
+  it('passes a non-ASCII title through unchanged — only markup is escaped', function () {
+    const title = '산소 발생기'; // Korean, no markup characters
+    expect(htmlMetaTag('og:title' as any, title)).to.contain(`content="${title}"`);
+  });
+
+  it('escapes a hostile title reached through WebsiteMeta.getHtmlTags', function () {
+    const tags = new WebsiteMeta({ 'og:title': 'Base"><img src=x onerror=alert(1)>' }).getHtmlTags();
+    expect(tags).to.not.contain('<img');
+    expect(tags).to.contain('&lt;img');
+  });
+});

--- a/__tests__/lib/blueprint-name.test.ts
+++ b/__tests__/lib/blueprint-name.test.ts
@@ -1,0 +1,131 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import {
+  BlueprintNameRejection,
+  MAX_BLUEPRINT_NAME_LENGTH,
+  isCanonicalBlueprintName,
+  normalizeBlueprintName,
+  validateBlueprintName,
+} from '../../lib/index';
+
+// Blueprint title policy (spec/multilingual-search-plan.md phase 3a). Every
+// character class below is written as an escape: the whole point of the
+// rejected ones is that they are invisible in a file read, so a literal in this
+// file would be unreviewable and could be silently normalized by an editor.
+const RLO = '\u202e'; // right-to-left override
+const ZWSP = '\u200b'; // zero-width space
+const ZWNJ = '\u200c'; // zero-width non-joiner
+const ZWJ = '\u200d'; // zero-width joiner
+const BOM = '\ufeff'; // byte-order mark
+const NBSP = '\u00a0'; // no-break space
+const IDEOGRAPHIC_SPACE = '\u3000';
+const CYRILLIC_O = '\u043e'; // looks exactly like ASCII 'o'
+
+function reasonFor(name: string): BlueprintNameRejection | 'accepted' {
+  const result = validateBlueprintName(name);
+  return result.ok ? 'accepted' : result.reason;
+}
+
+describe('blueprint-name policy', function () {
+  describe('accepts real titles', function () {
+    // The regression this whole change exists to fix: each of these was a 400
+    // under the old /^[a-zA-Z0-9_ -]+$/.
+    const titles: [string, string][] = [
+      ['English', 'Rodriguez SPOM v2'],
+      ['Vietnamese', 'Máy lọc nước tự động'],
+      ['Chinese', '电解制氧系统'],
+      ['Russian', 'Ферма для слизи'],
+      ['Korean', '산소 발생기 설계'],
+      ['Japanese, Han + Kana in one word', '酸素発生装置のせっけい'],
+      ['mixed Latin and Han across words', 'SPOM 电解 v3'],
+      ['emoji', 'Cool base 🚀'],
+      ['punctuation the old regex rejected', 'Base #1 (v2.5): "final"'],
+    ];
+    for (const [label, title] of titles) {
+      it(label, function () {
+        expect(reasonFor(title), title).to.equal('accepted');
+      });
+    }
+  });
+
+  describe('normalization', function () {
+    it('composes decomposed diacritics (NFC)', function () {
+      const decomposed = 'Ma\u0301y lo\u0323c';
+      const composed = 'M\u00e1y l\u1ecdc';
+      expect(normalizeBlueprintName(decomposed)).to.equal(composed);
+    });
+
+    it('collapses every kind of whitespace to single spaces and trims', function () {
+      const raw = `  Base${NBSP}One${IDEOGRAPHIC_SPACE}Two\t\tThree \n`;
+      expect(normalizeBlueprintName(raw)).to.equal('Base One Two Three');
+    });
+
+    it('is idempotent, which is what lets the schema demand canonical form', function () {
+      const once = normalizeBlueprintName(`  Máy${NBSP}lọc  `);
+      expect(normalizeBlueprintName(once)).to.equal(once);
+      expect(isCanonicalBlueprintName(once)).to.equal(true);
+    });
+
+    it('rejects a non-canonical string as a stored value even when it would validate', function () {
+      // The decomposed form is a perfectly legal title, but not the form the
+      // model may store — normalization happens at ingress, not in the schema.
+      expect(validateBlueprintName('Ma\u0301y').ok).to.equal(true);
+      expect(isCanonicalBlueprintName('Ma\u0301y')).to.equal(false);
+      expect(isCanonicalBlueprintName('  padded  ')).to.equal(false);
+    });
+  });
+
+  describe('rejections', function () {
+    it('rejects an empty or whitespace-only name', function () {
+      expect(reasonFor('')).to.equal('empty');
+      expect(reasonFor(`  ${NBSP}\t `)).to.equal('empty');
+    });
+
+    it('rejects control characters', function () {
+      expect(reasonFor('Base\u0000One')).to.equal('control');
+      expect(reasonFor('Base\u0007One')).to.equal('control');
+    });
+
+    it('rejects bidi overrides and zero-width characters', function () {
+      expect(reasonFor(`Base${RLO}One`)).to.equal('invisible');
+      expect(reasonFor(`Base${ZWSP}One`)).to.equal('invisible');
+      // Mid-string: a leading BOM is stripped by String.trim, which is fine —
+      // it leaves a clean title rather than a rejected one.
+      expect(reasonFor(`Base${BOM}One`)).to.equal('invisible');
+      expect(reasonFor(`${BOM}Base`)).to.equal('accepted');
+    });
+
+    it('allows ZWNJ/ZWJ, which real scripts and emoji sequences need', function () {
+      expect(reasonFor(`Base${ZWNJ}One`)).to.equal('accepted');
+      // Family emoji: a ZWJ sequence.
+      expect(reasonFor(`Base \u{1f468}${ZWJ}\u{1f469}${ZWJ}\u{1f466}`)).to.equal('accepted');
+    });
+
+    it('rejects stacked combining marks but not Vietnamese', function () {
+      expect(reasonFor('Base' + '\u0301'.repeat(8))).to.equal('stacked-marks');
+      // Vietnamese stacks at most two marks on a base letter.
+      expect(reasonFor('Nứớc')).to.equal('accepted');
+    });
+
+    it('rejects Latin/Cyrillic homoglyph mixing inside one word', function () {
+      expect(reasonFor(`R${CYRILLIC_O}driguez`)).to.equal('mixed-script');
+    });
+
+    it('allows Latin and Cyrillic in separate words', function () {
+      // The narrowness that matters: a Russian title with an English model
+      // number is ordinary, and must not be caught by the homoglyph rule.
+      expect(reasonFor('Ферма SPOM v2')).to.equal('accepted');
+    });
+
+    it('rejects a name over the length limit, counted after normalization', function () {
+      expect(reasonFor('a'.repeat(MAX_BLUEPRINT_NAME_LENGTH))).to.equal('accepted');
+      expect(reasonFor('a'.repeat(MAX_BLUEPRINT_NAME_LENGTH + 1))).to.equal('too-long');
+      // Trailing whitespace is normalized away, so it does not push a name over.
+      expect(reasonFor('a'.repeat(MAX_BLUEPRINT_NAME_LENGTH) + '   ')).to.equal('accepted');
+    });
+
+    it('rejects a non-string', function () {
+      expect(reasonFor(undefined as unknown as string)).to.equal('empty');
+    });
+  });
+});

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -9,16 +9,17 @@ import {
   RelatedBlueprintsResponse,
   BlueprintRate,
   BlueprintRateResponse,
-//   Vector2,
-//   CameraService,
-//   Overlay,
-//   ImageSource,
+  //   Vector2,
+  //   CameraService,
+  //   Overlay,
+  //   ImageSource,
   BlueprintDelete,
   CATEGORIES,
   SUBCATEGORIES,
   RESEARCH_TIERS,
   RAW_SOURCE_FORMATS,
   RawSourceFormat,
+  validateBlueprintName,
 } from '../../lib/index';
 import { Blueprint as sharedBlueprint, BlueprintDetailsResponse } from '../../lib/index';
 import { computeHotScore } from '../../lib/index';
@@ -30,6 +31,7 @@ import { BatchUtils } from './batch/batch-utils';
 import { apiError } from './utils/apiError';
 import { optionalViewer } from './utils/optionalViewer';
 import { canViewBlueprint, ownerIdOf } from './utils/blueprint-visibility';
+import { attachmentDisposition } from './utils/content-disposition';
 import { BlueprintEventService } from './services/blueprint-event-service';
 import { BlueprintCounterService, CounterKind } from './services/blueprint-counter-service';
 import {
@@ -44,7 +46,12 @@ import { deriveDlcs } from './services/dlc-derivation-service';
 import { detectLanguageCode } from './services/language-detection-service';
 import { TranslationService } from './services/translation-service';
 import { upsertSearchRow, syncSearchRowStatus } from './services/search-index-service';
-import { collapseClusters, SearchMatch, searchBlueprints, searchV2Enabled } from './services/search-service';
+import {
+  collapseClusters,
+  SearchMatch,
+  searchBlueprints,
+  searchV2Enabled,
+} from './services/search-service';
 import {
   parseBlueprintFilters,
   resolveRatedByIds,
@@ -148,26 +155,33 @@ export class BlueprintController {
 
       let user = req.user as UserJwt;
       let ownerId = user._id;
-      let name = req.body.name;
+      let rawName = req.body.name;
       let data = req.body.blueprint;
       let thumbnail = req.body.thumbnail;
       let overwrite = req.body.overwrite;
 
-      if (!name) {
+      if (!rawName) {
         res.status(400).json(apiError(400, 'Blueprint name is required'));
         return;
       }
 
-      let regexp = /^[a-zA-Z0-9-_ ]+$/;
-      if (name.search(regexp) == -1 || name.length > 60) {
-        console.log('Blueprint name too long or with weird characters');
-        res.status(400).json(apiError(400, 'Blueprint name must be 1–60 alphanumeric characters (hyphens, underscores, and spaces allowed)'));
+      // Unicode titles, normalized here and only here: everything downstream —
+      // the {owner, name} duplicate lookup, the stored document, the search row
+      // — uses the canonical form, so "Máy lọc" typed on macOS (decomposed) and
+      // on Windows (composed) are the same blueprint rather than two.
+      const nameCheck = validateBlueprintName(rawName);
+      if (!nameCheck.ok) {
+        console.log(`Blueprint name rejected: ${nameCheck.reason}`);
+        res.status(400).json(apiError(400, nameCheck.message));
         return;
       }
+      const name = nameCheck.name;
 
       const category = req.body.category ?? null;
       if (category != null && !(CATEGORIES as readonly string[]).includes(category)) {
-        res.status(400).json(apiError(400, `Invalid category: must be one of ${CATEGORIES.join(', ')}`));
+        res
+          .status(400)
+          .json(apiError(400, `Invalid category: must be one of ${CATEGORIES.join(', ')}`));
         return;
       }
 
@@ -186,7 +200,9 @@ export class BlueprintController {
 
       const researchTier = req.body.researchTier ?? null;
       if (researchTier != null && !(RESEARCH_TIERS as readonly string[]).includes(researchTier)) {
-        res.status(400).json(apiError(400, `Invalid researchTier: must be one of ${RESEARCH_TIERS.join(', ')}`));
+        res
+          .status(400)
+          .json(apiError(400, `Invalid researchTier: must be one of ${RESEARCH_TIERS.join(', ')}`));
         return;
       }
 
@@ -212,12 +228,17 @@ export class BlueprintController {
       if (req.body.rawSource != null) {
         const source = req.body.rawSource;
         const format = req.body.rawSourceFormat;
-        if (typeof source !== 'string' || Buffer.byteLength(source, 'utf8') > MAX_RAW_SOURCE_BYTES) {
+        if (
+          typeof source !== 'string' ||
+          Buffer.byteLength(source, 'utf8') > MAX_RAW_SOURCE_BYTES
+        ) {
           res.status(400).json(apiError(400, 'rawSource must be a string of at most 2MB'));
           return;
         }
         if (!(RAW_SOURCE_FORMATS as readonly string[]).includes(format)) {
-          res.status(400).json(apiError(400, `rawSourceFormat must be one of ${RAW_SOURCE_FORMATS.join(', ')}`));
+          res
+            .status(400)
+            .json(apiError(400, `rawSourceFormat must be one of ${RAW_SOURCE_FORMATS.join(', ')}`));
           return;
         }
         rawSource = { source, format };
@@ -257,10 +278,7 @@ export class BlueprintController {
           } else {
             // Blueprints start unrated — authors can't rate their own work
             let blueprint = new BlueprintModel.model();
-            const forkSource = await BlueprintController.resolveForkSource(
-              sourceBlueprintId,
-              user
-            );
+            const forkSource = await BlueprintController.resolveForkSource(sourceBlueprintId, user);
             BlueprintController.saveBlueprint(
               req,
               res,
@@ -471,7 +489,8 @@ export class BlueprintController {
     blueprintIds: mongoose.Types.ObjectId[],
     userId: string
   ): Promise<Map<string, number>> {
-    if (userId === '' || blueprintIds.length === 0 || BlueprintRatingModel.model == null) return new Map();
+    if (userId === '' || blueprintIds.length === 0 || BlueprintRatingModel.model == null)
+      return new Map();
     const rows = await BlueprintRatingModel.model
       .find({ blueprintId: { $in: blueprintIds }, userId })
       .select('blueprintId value')
@@ -565,7 +584,7 @@ export class BlueprintController {
     }
     // TODO checks here
     let id = String(req.params.id);
-//       let _userId = req.query.userId;
+    //       let _userId = req.query.userId;
 
     try {
       const blueprint = await BlueprintModel.model.findOne({ _id: id });
@@ -625,8 +644,8 @@ export class BlueprintController {
       // Fetching the original file is a download
       BlueprintController.recordCounter('download', req, blueprint);
 
-      // Blueprint names are schema-restricted to [a-zA-Z0-9-_ ], safe to
-      // embed in the disposition header as-is.
+      // Titles are Unicode, so the name is never interpolated into the header
+      // raw — see attachmentDisposition for the ASCII + RFC 5987 pair.
       const isShareString = blueprint.rawSourceFormat === 'bpv2-sharestring';
       res.set(
         'Content-Type',
@@ -634,7 +653,7 @@ export class BlueprintController {
       );
       res.set(
         'Content-Disposition',
-        `attachment; filename="${blueprint.name}${isShareString ? '.txt' : '.blueprint'}"`
+        attachmentDisposition(blueprint.name, isShareString ? '.txt' : '.blueprint')
       );
       res.send(blueprint.rawSource);
     } catch (err) {
@@ -764,7 +783,8 @@ export class BlueprintController {
       // The probe saw every copy; the page must only see the canonicals.
       visibleSearchIds = new Set(searchIds.map(id => id.toString()));
       for (const entry of collapsed) {
-        if (entry.duplicateCount > 0) duplicateCounts.set(entry.id.toString(), entry.duplicateCount);
+        if (entry.duplicateCount > 0)
+          duplicateCounts.set(entry.id.toString(), entry.duplicateCount);
       }
     }
 
@@ -830,7 +850,9 @@ export class BlueprintController {
   // Resolves filterName through the search service when v2 is enabled.
   // null = no search clause (no query, kill switch off, or the search layer
   // errored — in which case the caller falls back to the legacy name regex).
-  private static async resolveSearchMatches(filterName: string | null): Promise<SearchMatch[] | null> {
+  private static async resolveSearchMatches(
+    filterName: string | null
+  ): Promise<SearchMatch[] | null> {
     if (filterName == null || !searchV2Enabled()) return null;
     try {
       return await searchBlueprints(filterName);
@@ -929,7 +951,8 @@ export class BlueprintController {
     // "how many blueprints are in this category" must not depend on a view
     // setting).
     const searchIds =
-      (await BlueprintController.resolveSearchMatches(parsed.filterName))?.map(match => match.id) ?? null;
+      (await BlueprintController.resolveSearchMatches(parsed.filterName))?.map(match => match.id) ??
+      null;
 
     const isAdmin = userJwt?.role === 'admin';
     const viewer = { userId, isAdmin };
@@ -955,7 +978,10 @@ export class BlueprintController {
           $facet: {
             total: [{ $match: totalMatch }, { $count: 'n' }],
             category: [{ $match: categoryMatch }, { $group: { _id: '$category', n: { $sum: 1 } } }],
-            subcategory: [{ $match: subcategoryMatch }, { $group: { _id: '$subcategory', n: { $sum: 1 } } }],
+            subcategory: [
+              { $match: subcategoryMatch },
+              { $group: { _id: '$subcategory', n: { $sum: 1 } } },
+            ],
             rooms: [
               { $match: roomsMatch },
               { $unwind: '$rooms' },
@@ -969,10 +995,7 @@ export class BlueprintController {
             // Array-valued dimensions are unwound above, so a multi-pack
             // blueprint counts once per pack — deliberately not summing to
             // `total`. baseGame is the complementary { $size: 0 } case.
-            baseGame: [
-              { $match: { ...dlcMatch, requiredDlcs: { $size: 0 } } },
-              { $count: 'n' },
-            ],
+            baseGame: [{ $match: { ...dlcMatch, requiredDlcs: { $size: 0 } } }, { $count: 'n' }],
           },
         },
       ]);
@@ -1014,10 +1037,11 @@ export class BlueprintController {
     blueprintIds: mongoose.Types.ObjectId[]
   ): Promise<Map<string, number>> {
     if (blueprintIds.length === 0 || CommentModel.model == null) return new Map();
-    const rows: { _id: mongoose.Types.ObjectId; count: number }[] = await CommentModel.model.aggregate([
-      { $match: { blueprintId: { $in: blueprintIds }, deletedAt: null } },
-      { $group: { _id: '$blueprintId', count: { $sum: 1 } } },
-    ]);
+    const rows: { _id: mongoose.Types.ObjectId; count: number }[] =
+      await CommentModel.model.aggregate([
+        { $match: { blueprintId: { $in: blueprintIds }, deletedAt: null } },
+        { $group: { _id: '$blueprintId', count: { $sum: 1 } } },
+      ]);
     return new Map(rows.map(row => [row._id.toString(), row.count]));
   }
 
@@ -1091,7 +1115,12 @@ export class BlueprintController {
       for (const blueprint of page) {
         if (blueprint.createdAt < returnValue.oldest) returnValue.oldest = blueprint.createdAt;
         returnValue.blueprints.push(
-          BlueprintController.buildListItem(blueprint, commentCounts, forkedFromNames, duplicateCounts)
+          BlueprintController.buildListItem(
+            blueprint,
+            commentCounts,
+            forkedFromNames,
+            duplicateCounts
+          )
         );
       }
 
@@ -1152,7 +1181,8 @@ export class BlueprintController {
         blueprint.forkedFrom != null
           ? {
               blueprintId: blueprint.forkedFrom.blueprintId.toString(),
-              blueprintName: forkedFromNames.get(blueprint.forkedFrom.blueprintId.toString()) ?? null,
+              blueprintName:
+                forkedFromNames.get(blueprint.forkedFrom.blueprintId.toString()) ?? null,
             }
           : null,
     };
@@ -1217,7 +1247,8 @@ export class BlueprintController {
 
       const candidates = new Map<string, Blueprint>();
       for (const pool of pools) {
-        for (const candidate of pool) candidates.set((candidate._id as mongoose.Types.ObjectId).toString(), candidate);
+        for (const candidate of pool)
+          candidates.set((candidate._id as mongoose.Types.ObjectId).toString(), candidate);
       }
 
       if (candidates.size < RELATED_LIMIT) {
@@ -1227,7 +1258,8 @@ export class BlueprintController {
           .limit(RELATED_LIMIT * 4)
           .select('-data -thumbnail -rawSource')
           .populate('owner');
-        for (const candidate of fallback) candidates.set((candidate._id as mongoose.Types.ObjectId).toString(), candidate);
+        for (const candidate of fallback)
+          candidates.set((candidate._id as mongoose.Types.ObjectId).toString(), candidate);
       }
 
       const sourceDlcs = source.requiredDlcs ?? [];
@@ -1263,7 +1295,9 @@ export class BlueprintController {
       let forkedFromNames = new Map<string, string | null>();
       try {
         forkedFromNames = await BlueprintController.getForkedFromNames(
-          page.filter(blueprint => blueprint.forkedFrom != null).map(blueprint => blueprint.forkedFrom!.blueprintId)
+          page
+            .filter(blueprint => blueprint.forkedFrom != null)
+            .map(blueprint => blueprint.forkedFrom!.blueprintId)
         );
       } catch (err) {
         console.log('related forkedFrom name lookup error');
@@ -1398,7 +1432,9 @@ export class BlueprintController {
       let forkedFromName: string | null = null;
       if (blueprint.forkedFrom != null) {
         try {
-          const names = await BlueprintController.getForkedFromNames([blueprint.forkedFrom.blueprintId]);
+          const names = await BlueprintController.getForkedFromNames([
+            blueprint.forkedFrom.blueprintId,
+          ]);
           forkedFromName = names.get(blueprint.forkedFrom.blueprintId.toString()) ?? null;
         } catch (err) {
           console.log('forkedFrom name lookup error');
@@ -1449,7 +1485,10 @@ export class BlueprintController {
         nbDownloads: blueprint.downloadCount ?? 0,
         forkedFrom:
           blueprint.forkedFrom != null
-            ? { blueprintId: blueprint.forkedFrom.blueprintId.toString(), blueprintName: forkedFromName }
+            ? {
+                blueprintId: blueprint.forkedFrom.blueprintId.toString(),
+                blueprintName: forkedFromName,
+              }
             : null,
       };
 
@@ -1639,7 +1678,11 @@ export class BlueprintController {
       type: overwriteCreateDate ? 'created' : 'updated',
     });
     if (publish === true && !wasPublished) {
-      BlueprintEventService.log({ blueprintId: newBlueprint.id, actorId: ownerId, type: 'published' });
+      BlueprintEventService.log({
+        blueprintId: newBlueprint.id,
+        actorId: ownerId,
+        type: 'published',
+      });
     }
 
     // Copy-as-fork bookkeeping — mirrors POST /api/blueprints/:id/fork
@@ -1673,7 +1716,11 @@ export class BlueprintController {
 
     // Render-on-write: warm the preview cache so the first browse view of
     // this save doesn't pay the render (preview-images-perf-2.md Phase 2).
-    PreviewImageService.instance.prerender(newBlueprint.id, newBlueprint.modifiedAt, async () => data);
+    PreviewImageService.instance.prerender(
+      newBlueprint.id,
+      newBlueprint.modifiedAt,
+      async () => data
+    );
 
     try {
       BatchUtils.UpdatePositionCorrection(newBlueprint);

--- a/app/api/models/blueprint.ts
+++ b/app/api/models/blueprint.ts
@@ -5,6 +5,8 @@ import {
   ROOM_TYPE_IDS,
   RAW_SOURCE_FORMATS,
   RawSourceFormat,
+  MAX_BLUEPRINT_NAME_LENGTH,
+  isCanonicalBlueprintName,
 } from '../../../lib/index';
 
 // Discriminator for the stored thumbnail: 'real' = data-URI image, the other
@@ -114,8 +116,20 @@ export class BlueprintModel {
       name: {
         type: String,
         required: true,
-        match: [/^[a-zA-Z0-9_ -]+$/, 'Blueprint name may only contain letters, numbers, hyphens, underscores, and spaces'],
-        maxlength: [60, 'Blueprint name must be 60 characters or fewer'],
+        // Titles are Unicode (spec/multilingual-search-plan.md phase 3a); the
+        // policy lives in lib so the save dialog, the upload endpoint and this
+        // schema cannot disagree. The schema deliberately demands the
+        // *canonical* form (NFC, collapsed whitespace) rather than normalizing
+        // here: normalization belongs at ingress, and a non-canonical name
+        // reaching a model write means some path skipped it.
+        validate: {
+          validator: isCanonicalBlueprintName,
+          message: 'Blueprint name is not a valid, normalized title',
+        },
+        maxlength: [
+          MAX_BLUEPRINT_NAME_LENGTH,
+          `Blueprint name must be ${MAX_BLUEPRINT_NAME_LENGTH} characters or fewer`,
+        ],
         minlength: [1, 'Blueprint name is required'],
       },
       ratingCount: { type: Number, default: 0 },
@@ -197,7 +211,13 @@ export class BlueprintModel {
     // DLC-requirement filters on the public feed (multikey on requiredDlcs;
     // one array field per compound index, category/createdAt are scalars).
     blueprintSchema.index({ deletedAt: 1, isPublished: 1, requiredDlcs: 1, createdAt: -1 });
-    blueprintSchema.index({ deletedAt: 1, isPublished: 1, requiredDlcs: 1, category: 1, createdAt: -1 });
+    blueprintSchema.index({
+      deletedAt: 1,
+      isPublished: 1,
+      requiredDlcs: 1,
+      category: 1,
+      createdAt: -1,
+    });
     // Room-type filter on the public feed (multikey on rooms)
     blueprintSchema.index({ deletedAt: 1, isPublished: 1, rooms: 1, createdAt: -1 });
     // "Top rated" sort on the public feed

--- a/app/api/utils/content-disposition.ts
+++ b/app/api/utils/content-disposition.ts
@@ -1,0 +1,46 @@
+// Content-Disposition for blueprint downloads.
+//
+// Titles are Unicode as of the phase-3a name relaxation, so the old
+// `filename="${blueprint.name}.blueprint"` is no longer safe on two counts: an
+// HTTP header field is ISO-8859-1 by the spec (a Korean title emits bytes a
+// client may render as mojibake, and Node rejects some of them outright), and a
+// title containing `"` or `\` would break out of the quoted string.
+//
+// RFC 6266 §4.3 is the answer, and it is what browsers implement: an ASCII
+// `filename` every client understands, plus an RFC 5987 `filename*` with the
+// real UTF-8 name that every current browser prefers when present.
+
+/** Characters a filesystem or a quoted header string cannot carry. */
+const UNSAFE_PATH = /[\\/:*?"<>|]/g;
+
+/**
+ * ASCII fallback: transliterate what we can (é → e via NFD + mark strip), drop
+ * the rest. A wholly non-Latin title leaves nothing, so it falls back to a
+ * fixed stem rather than emitting `.blueprint` with no name.
+ */
+export function asciiFilenameStem(name: string, fallback = 'blueprint'): string {
+  const stem = name
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '')
+    // eslint-disable-next-line no-control-regex
+    .replace(/[^\x20-\x7E]/g, '')
+    .replace(UNSAFE_PATH, '')
+    .trim();
+  return stem.length > 0 ? stem : fallback;
+}
+
+/**
+ * A full Content-Disposition value for an attachment named `${name}${ext}`.
+ * `ext` includes its dot.
+ */
+export function attachmentDisposition(name: string, ext: string): string {
+  const utf8 = `${name.replace(UNSAFE_PATH, '')}${ext}`;
+  const ascii = `${asciiFilenameStem(name)}${ext}`;
+  // encodeURIComponent leaves !'()* unescaped; they are not attr-chars in RFC
+  // 5987, so escape them too rather than emit a header a strict parser rejects.
+  const encoded = encodeURIComponent(utf8).replace(
+    /['()!*]/g,
+    c => '%' + c.charCodeAt(0).toString(16).toUpperCase()
+  );
+  return `attachment; filename="${ascii}"; filename*=UTF-8''${encoded}`;
+}

--- a/app/websiteMeta.ts
+++ b/app/websiteMeta.ts
@@ -60,8 +60,22 @@ export const defaultWebsiteMeta: OpenGraphMeta = {
   images: [defaultImageSquare, defaultImageWide],
 };
 
+// `og:title` carries a user-supplied blueprint name, and these tags are
+// rendered raw (`<%- metaTags %>` in index-robots.ejs), so the content has to
+// be escaped here — this is the only place it can be. The old ASCII-only name
+// regex made this unreachable; Unicode titles allow `"` and `<`, so a title
+// like `x" /><script>…` would otherwise close the tag and inject into the
+// crawler-served page.
+const escapeHtmlAttribute = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
 export const htmlMetaTag = (property: OpenGraphTags, content: string) =>
-  `<meta property="${property}" content="${content}" />`;
+  `<meta property="${escapeHtmlAttribute(property)}" content="${escapeHtmlAttribute(content)}" />`;
 
 export class WebsiteMeta {
   public meta: OpenGraphMeta;

--- a/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/component-save-dialog/component-save-dialog.component.html
@@ -30,8 +30,19 @@
           <div *ngIf="f.name.errors?.['required']" i18n>
             Blueprint name is required.
           </div>
-          <div *ngIf="f.name.errors?.['invalidChars']" i18n>
-            Invalid characters in blueprint name
+          <div *ngIf="f.name.errors?.['nameReason'] === 'control'" i18n>
+            Blueprint name may not contain control characters.
+          </div>
+          <div *ngIf="f.name.errors?.['nameReason'] === 'invisible'" i18n>
+            Blueprint name may not contain invisible or direction-changing
+            characters.
+          </div>
+          <div *ngIf="f.name.errors?.['nameReason'] === 'stacked-marks'" i18n>
+            Blueprint name has too many stacked accent marks.
+          </div>
+          <div *ngIf="f.name.errors?.['nameReason'] === 'mixed-script'" i18n>
+            Each word must be written in a single alphabet — mixing Latin with
+            Cyrillic or Greek letters inside one word is not allowed.
           </div>
           <div *ngIf="f.name.errors?.['tooLong']" i18n>
             Blueprint name is too long

--- a/frontend/src/app/module-blueprint/directives/blueprint-name-validation.directive.spec.ts
+++ b/frontend/src/app/module-blueprint/directives/blueprint-name-validation.directive.spec.ts
@@ -1,0 +1,55 @@
+import { BlueprintNameValidationDirective } from "./blueprint-name-validation.directive";
+
+const makeControl = (value: string | null) => ({ value }) as any;
+
+const validate = (value: string | null) =>
+  BlueprintNameValidationDirective.validateBlueprintName(makeControl(value));
+
+// The dialog must reject exactly what POST /api/uploadblueprint rejects — the
+// failure being guarded against is a title the form accepts and the server
+// 400s. Character-class coverage lives with the shared policy in
+// lib/src/blueprint/blueprint-name.ts; this asserts the directive's mapping
+// from a policy rejection to a form error.
+describe("BlueprintNameValidationDirective", () => {
+  it("returns null for null and empty values", () => {
+    expect(validate(null)).toBeNull();
+    expect(validate("")).toBeNull();
+  });
+
+  it("accepts non-Latin titles, which the old ASCII regex rejected", () => {
+    expect(validate("电解制氧系统")).toBeNull();
+    expect(validate("Ферма для слизи")).toBeNull();
+    expect(validate("산소 발생기")).toBeNull();
+    expect(validate("Máy lọc nước")).toBeNull();
+    expect(validate("Base #1 (v2.5)")).toBeNull();
+  });
+
+  it("reports the policy reason so the dialog can explain the rejection", () => {
+    // U+202E right-to-left override, as an escape — a literal would be
+    // invisible in this file.
+    const result = validate("Base\u202eOne");
+    expect(result!["invalidChars"]).toBe(true);
+    expect(result!["nameReason"]).toBe("invisible");
+  });
+
+  it("flags Latin/Cyrillic homoglyph mixing inside one word", () => {
+    // U+043E Cyrillic small o.
+    expect(validate("R\u043edriguez")!["nameReason"]).toBe("mixed-script");
+  });
+
+  it("returns tooLong past 60 characters and null at exactly 60", () => {
+    expect(validate("a".repeat(61))!["tooLong"]).toBe(true);
+    expect(validate("a".repeat(60))).toBeNull();
+  });
+
+  it("delegates from the instance method", () => {
+    const directive = new BlueprintNameValidationDirective();
+    const spy = vi.spyOn(
+      BlueprintNameValidationDirective,
+      "validateBlueprintName",
+    );
+    const control = makeControl("Base");
+    directive.validate(control);
+    expect(spy).toHaveBeenCalledWith(control);
+  });
+});

--- a/frontend/src/app/module-blueprint/directives/blueprint-name-validation.directive.spec.ts
+++ b/frontend/src/app/module-blueprint/directives/blueprint-name-validation.directive.spec.ts
@@ -37,6 +37,14 @@ describe("BlueprintNameValidationDirective", () => {
     expect(validate("R\u043edriguez")!["nameReason"]).toBe("mixed-script");
   });
 
+  it("reports a whitespace-only title as required, not as invalid characters", () => {
+    // Non-empty to Angular's own `required`, but normalizes to nothing. U+00A0
+    // is a no-break space, written as an escape.
+    for (const value of ["   ", "\t\t", "\u00a0", " \t\u00a0 "]) {
+      expect(validate(value)).toEqual({ required: true });
+    }
+  });
+
   it("returns tooLong past 60 characters and null at exactly 60", () => {
     expect(validate("a".repeat(61))!["tooLong"]).toBe(true);
     expect(validate("a".repeat(60))).toBeNull();

--- a/frontend/src/app/module-blueprint/directives/blueprint-name-validation.directive.ts
+++ b/frontend/src/app/module-blueprint/directives/blueprint-name-validation.directive.ts
@@ -35,6 +35,11 @@ export class BlueprintNameValidationDirective implements Validator {
 
     const result = validateBlueprintName(control.value);
     if (result.ok) return null;
+    // A whitespace-only value is non-empty to Angular's own `required`, but
+    // normalizes to nothing — report it as `required` so it reuses the message
+    // the dialog already has, rather than a `nameReason` the template has no
+    // branch for (which showed the field as invalid with no explanation).
+    if (result.reason === "empty") return { required: true };
     if (result.reason === "too-long") return { tooLong: true };
     return { invalidChars: true, nameReason: result.reason };
   }

--- a/frontend/src/app/module-blueprint/directives/blueprint-name-validation.directive.ts
+++ b/frontend/src/app/module-blueprint/directives/blueprint-name-validation.directive.ts
@@ -1,5 +1,6 @@
 import { Directive } from "@angular/core";
 import { Validator, AbstractControl, NG_VALIDATORS } from "@angular/forms";
+import { validateBlueprintName } from "../../../../../lib/index";
 
 @Directive({
   selector: "[appBlueprintNameValidation]",
@@ -15,28 +16,26 @@ import { Validator, AbstractControl, NG_VALIDATORS } from "@angular/forms";
 export class BlueprintNameValidationDirective implements Validator {
   constructor() {}
 
-  static regexp = /^[a-zA-Z0-9-_ ]+$/;
   validate(control: AbstractControl): { [key: string]: any } | null {
     return BlueprintNameValidationDirective.validateBlueprintName(control);
   }
 
+  // Delegates to the shared policy in lib so the dialog rejects exactly what
+  // the upload endpoint rejects — the failure being avoided is a title the form
+  // accepts and the server then 400s. The error carries the policy's `reason`
+  // rather than its message: now that most characters are legal, a rejection
+  // has to say which rule it broke, and the wording has to stay in the template
+  // where $localize can translate it (this dialog's audience is precisely the
+  // non-English authors the relaxed policy exists for).
   static validateBlueprintName(control: AbstractControl): {
     [key: string]: any;
   } | null {
-    let returnValue: { [key: string]: any } | null = null;
-    if (control.value == null) return returnValue;
-    if (control.value.length == 0) return returnValue;
+    if (control.value == null) return null;
+    if (control.value.length == 0) return null;
 
-    if (control.value.search(BlueprintNameValidationDirective.regexp) == -1) {
-      if (returnValue == null) returnValue = {};
-      returnValue["invalidChars"] = true;
-    }
-
-    if (control.value.length > 60) {
-      if (returnValue == null) returnValue = {};
-      returnValue["tooLong"] = true;
-    }
-
-    return returnValue;
+    const result = validateBlueprintName(control.value);
+    if (result.ok) return null;
+    if (result.reason === "too-long") return { tooLong: true };
+    return { invalidChars: true, nameReason: result.reason };
   }
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -46,6 +46,7 @@ export * from './src/drawing/note-markers';
 export * from './src/blueprint/blueprint';
 export * from './src/blueprint/blueprint-helpers';
 export * from './src/blueprint/blueprint-metadata';
+export * from './src/blueprint/blueprint-name';
 export * from './src/blueprint/blueprint-analyzer';
 export * from './src/blueprint/dlc';
 export * from './src/blueprint/terrain-metadata';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -52,6 +52,7 @@ export * from './src/drawing/note-markers';
 export * from './src/blueprint/blueprint';
 export * from './src/blueprint/blueprint-helpers';
 export * from './src/blueprint/blueprint-metadata';
+export * from './src/blueprint/blueprint-name';
 export * from './src/blueprint/blueprint-analyzer';
 export * from './src/blueprint/dlc';
 export * from './src/blueprint/terrain-metadata';

--- a/lib/src/blueprint/blueprint-name.d.ts
+++ b/lib/src/blueprint/blueprint-name.d.ts
@@ -1,0 +1,33 @@
+/** Max title length, in UTF-16 code units — the unit Mongoose's maxlength counts. */
+export declare const MAX_BLUEPRINT_NAME_LENGTH = 60;
+export type BlueprintNameRejection = 'empty' | 'too-long' | 'control' | 'invisible' | 'stacked-marks' | 'mixed-script';
+export type BlueprintNameResult = {
+    ok: true;
+    name: string;
+} | {
+    ok: false;
+    reason: BlueprintNameRejection;
+    message: string;
+};
+/**
+ * Canonical stored form: NFC, every kind of whitespace collapsed to single
+ * spaces, trimmed. Idempotent — normalizing a normalized name is a no-op,
+ * which is what lets the schema validator insist on the canonical form.
+ *
+ * NFC (not NFD) so that a title typed on macOS, which hands over decomposed
+ * text, is byte-equal to the same title typed on Windows. The {owner, name}
+ * duplicate check is an exact string match, so without this a user could not
+ * overwrite their own blueprint from a different machine.
+ */
+export declare function normalizeBlueprintName(raw: string): string;
+/**
+ * Validate an already-normalized name. Callers that accept user input should
+ * go through `validateBlueprintName`, which normalizes first; this is the form
+ * the schema enforces, so that stored titles are always canonical.
+ */
+export declare function checkNormalizedBlueprintName(name: string): BlueprintNameResult;
+/** Normalize, then validate. The name in a successful result is what to store. */
+export declare function validateBlueprintName(raw: unknown): BlueprintNameResult;
+/** True only for the exact canonical form of a legal name — the schema's test. */
+export declare function isCanonicalBlueprintName(value: unknown): boolean;
+//# sourceMappingURL=blueprint-name.d.ts.map

--- a/lib/src/blueprint/blueprint-name.ts
+++ b/lib/src/blueprint/blueprint-name.ts
@@ -1,0 +1,130 @@
+// Blueprint title policy — shared by the save dialog (client-side validation),
+// the upload endpoint, and the Mongoose schema, so all three agree on exactly
+// one definition of a legal title.
+//
+// Titles used to be `/^[a-zA-Z0-9_ -]+$/`, which rejected every non-English
+// title at save. Titles are also the site's entire searchable corpus
+// (spec/multilingual-search-plan.md §0), so ASCII-only titles meant non-English
+// builds were unstorable, not merely unfindable.
+//
+// The replacement is not "allow everything". It is: allow every script a real
+// title is written in, and reject the characters whose only use in a 60-char
+// display string is to deceive or to break rendering. The list below is
+// deliberately narrow — every rule has to survive the test "does this reject a
+// legitimate Chinese, Russian, Korean or Vietnamese title?".
+
+/** Max title length, in UTF-16 code units — the unit Mongoose's maxlength counts. */
+export const MAX_BLUEPRINT_NAME_LENGTH = 60;
+
+export type BlueprintNameRejection =
+  'empty' | 'too-long' | 'control' | 'invisible' | 'stacked-marks' | 'mixed-script';
+
+export type BlueprintNameResult =
+  { ok: true; name: string } | { ok: false; reason: BlueprintNameRejection; message: string };
+
+// Anything that renders as horizontal space becomes a plain U+0020 before
+// validation: a title separated by NBSP or an ideographic space looks identical
+// to one separated by a space, so storing both forms would make two titles the
+// user cannot tell apart (and, via the {owner, name} check, two documents).
+const WHITESPACE = /[\t\n\v\f\r\u0085\u2028\u2029\p{Zs}]+/gu;
+
+// Cc = C0/C1 controls. Nothing survives the whitespace pass except characters
+// with no rendering at all (NUL, BEL, …), which have no business in a title.
+const CONTROL = /\p{Cc}/u;
+
+// Cf = format characters. This is the whole bidi-override spoofing family
+// (U+202A…U+202E, U+2066…U+2069), the invisible joiners, and U+FEFF. Two are
+// exempt because scripts genuinely need them: ZWNJ (U+200C) and ZWJ (U+200D)
+// carry meaning in Persian/Arabic/Indic text and hold emoji sequences together.
+// Cn (unassigned), Co (private use) and Cs (lone surrogate) render as tofu or
+// worse and cannot be typed deliberately by a legitimate author.
+const INVISIBLE = /[\p{Cf}\p{Cn}\p{Co}\p{Cs}]/u;
+// ZWNJ / ZWJ, written as escapes because they are invisible in a file read.
+const ALLOWED_FORMAT_G = /[\u200c\u200d]/gu;
+
+// "Zalgo": combining marks stacked far past what any orthography uses, which
+// overflows the line box and makes neighbouring UI unreadable. Vietnamese —
+// the densest legitimate case — stacks at most two marks on a base letter.
+const MAX_COMBINING_RUN = 4;
+const COMBINING_RUN = new RegExp(`\\p{M}{${MAX_COMBINING_RUN + 1},}`, 'u');
+
+// Confusable policy, deliberately minimal. The homoglyph attack that matters
+// here is a title that reads as ASCII but isn't — "Rоdriguez" with a Cyrillic
+// о, impersonating a known build. That attack requires Latin and Cyrillic (or
+// Greek) letters inside a single *word*, so that is the only thing rejected.
+//
+// Everything else mixes freely: "SPOM 电解" (Latin word + Han word) passes,
+// Japanese Han+Kana within one word passes, and any single-script word passes
+// no matter which script it is. Restricting mixing more broadly — e.g. UTS #39
+// "moderately restrictive" applied to the whole string — would reject the very
+// common "英文 name + English model number" titles this change exists to allow.
+const LATIN = /\p{Script=Latin}/u;
+const CYRILLIC = /\p{Script=Cyrillic}/u;
+const GREEK = /\p{Script=Greek}/u;
+
+const MESSAGES: Record<BlueprintNameRejection, string> = {
+  empty: 'Blueprint name is required',
+  'too-long': `Blueprint name must be ${MAX_BLUEPRINT_NAME_LENGTH} characters or fewer`,
+  control: 'Blueprint name may not contain control characters',
+  invisible: 'Blueprint name may not contain invisible or direction-changing characters',
+  'stacked-marks': 'Blueprint name has too many stacked accent marks',
+  'mixed-script':
+    'Blueprint name mixes Latin with Cyrillic or Greek letters inside one word, which is used to imitate other names. Write each word in a single alphabet.',
+};
+
+/**
+ * Canonical stored form: NFC, every kind of whitespace collapsed to single
+ * spaces, trimmed. Idempotent — normalizing a normalized name is a no-op,
+ * which is what lets the schema validator insist on the canonical form.
+ *
+ * NFC (not NFD) so that a title typed on macOS, which hands over decomposed
+ * text, is byte-equal to the same title typed on Windows. The {owner, name}
+ * duplicate check is an exact string match, so without this a user could not
+ * overwrite their own blueprint from a different machine.
+ */
+export function normalizeBlueprintName(raw: string): string {
+  return raw.normalize('NFC').replace(WHITESPACE, ' ').trim();
+}
+
+function hasMixedConfusableScripts(name: string): boolean {
+  for (const word of name.split(' ')) {
+    let scripts = 0;
+    if (LATIN.test(word)) scripts++;
+    if (CYRILLIC.test(word)) scripts++;
+    if (GREEK.test(word)) scripts++;
+    if (scripts > 1) return true;
+  }
+  return false;
+}
+
+/**
+ * Validate an already-normalized name. Callers that accept user input should
+ * go through `validateBlueprintName`, which normalizes first; this is the form
+ * the schema enforces, so that stored titles are always canonical.
+ */
+export function checkNormalizedBlueprintName(name: string): BlueprintNameResult {
+  if (name.length === 0) return reject('empty');
+  if (name.length > MAX_BLUEPRINT_NAME_LENGTH) return reject('too-long');
+  if (CONTROL.test(name)) return reject('control');
+  if (INVISIBLE.test(name.replace(ALLOWED_FORMAT_G, ''))) return reject('invisible');
+  if (COMBINING_RUN.test(name)) return reject('stacked-marks');
+  if (hasMixedConfusableScripts(name)) return reject('mixed-script');
+  return { ok: true, name };
+}
+
+/** Normalize, then validate. The name in a successful result is what to store. */
+export function validateBlueprintName(raw: unknown): BlueprintNameResult {
+  if (typeof raw !== 'string') return reject('empty');
+  return checkNormalizedBlueprintName(normalizeBlueprintName(raw));
+}
+
+/** True only for the exact canonical form of a legal name — the schema's test. */
+export function isCanonicalBlueprintName(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  if (normalizeBlueprintName(value) !== value) return false;
+  return checkNormalizedBlueprintName(value).ok;
+}
+
+function reject(reason: BlueprintNameRejection): BlueprintNameResult {
+  return { ok: false, reason, message: MESSAGES[reason] };
+}


### PR DESCRIPTION
Phase 3a of `spec/multilingual-search-plan.md`, shipped on its own as the plan sequences it — the translation half (3b) is **not** in this PR.

## What shipped

`Blueprint.name` was `/^[a-zA-Z0-9_ -]+$/`. A Chinese, Russian, Korean or Vietnamese title was a 400 at save, and a title that *did* save had already been stripped to ASCII by the author's input method — the data loss happened before the server saw it. Titles are the site's entire searchable corpus (99K chars of title vs 2.9K of description), so nothing else in the plan matters until this lands.

**One shared policy** — `lib/src/blueprint/blueprint-name.ts` — used by the save dialog, the upload endpoint and the Mongoose schema, since the failure mode is a form that accepts what the server rejects.

- **Allowed**: every script, punctuation, emoji.
- **Rejected**: control characters; `\p{Cf}` format characters (the bidi-override spoofing family) *except* ZWNJ/ZWJ, which real scripts and emoji sequences need; unassigned/private-use/surrogate code points; runs of >4 combining marks (zalgo); and Latin mixed with Cyrillic or Greek **inside a single word** — the `Rоdriguez` homoglyph spoof.

## Decisions worth reviewing

- **The confusable rule is per-word and only Latin↔Cyrillic/Greek.** Anything broader (e.g. UTS #39 moderately-restrictive over the whole string) rejects the very common "native-script title + English model number" shape — i.e. exactly the titles this exists to allow. `Ферма SPOM v2`, `SPOM 电解 v3` and Japanese Han+Kana in one word all pass; there are tests for each.
- **NFC at ingress, and only there.** Load-bearing for the `{owner, name}` duplicate check, which is an exact string match: without it a title typed on macOS (decomposed) and Windows (composed) are two documents with identical-looking names, and the author cannot overwrite their own blueprint from their other machine. Test covers exactly that.
- **No case folding.** Considered and rejected: the check has always been case-sensitive, and folding it would newly collide existing ASCII titles and change overwrite behaviour for people who never asked.
- **The schema demands the canonical form** (`isCanonicalBlueprintName`) instead of normalizing again — normalization is an ingress concern, and a non-canonical name reaching a model write is a bug that should fail rather than be silently repaired.
- **Length stays 60 UTF-16 code units**, the unit Mongoose's `maxlength` counts, so schema and endpoint cannot drift.
- **Dialog errors stay translatable.** The directive surfaces the policy's `reason`, not its English message, and the template renders an `i18n` line per reason — this dialog's audience is precisely the non-English authors the change is for.

## Security fix found while auditing

Relaxing the regex made a previously-unreachable injection reachable: the blueprint name reaches `og:title`, `WebsiteMeta.htmlMetaTag` interpolated it unescaped, and `index-robots.ejs` renders those tags raw (`<%-`). A title like `x" /><script>…` would close the tag and inject into the page served to crawlers. `htmlMetaTag` now escapes — it is the single choke point every tag passes through (`__tests__/api/website-meta.test.ts`).

## Download filenames

`GET /api/blueprints/:id/raw` interpolated the name straight into `Content-Disposition`, which a Unicode title breaks (HTTP headers are ISO-8859-1, and a `"` in a title escapes the quoted string). It now emits RFC 6266's pair: an ASCII fallback (transliterated, falling back to a fixed stem when a title has no Latin at all) plus `filename*=UTF-8''`. The client-side download path already used `sanitize-filename` — verified against Korean/Vietnamese/Chinese input rather than assumed; unchanged.

## Moderation surface — deliberately nothing built

The admin app (`frontend/src-admin`) covers feedback triage and avatar batches; it has no blueprint list, and the admin API is `/api/admin/feedback` + `/api/admin/avatars/batch`. There is no place a title is shown to a moderator. The policy *is* the control: a title that renders as something other than what it is — bidi-reordered, invisible, homoglyph-spoofed — is rejected at write, so an admin never sees one. A legitimate foreign-script title is a translation problem, which is phase 3b.

## Verification

- **Backend**: 942 passing. 10 failing, all in `workos-migration`/`workos-provision` — pre-existing local timeouts, unrelated (they are green in CI).
- **Frontend**: 1196 passing, 2 skipped. `npm run lint` clean on both projects. `npm run tsc` and `tsc -b lib` clean.
- **Search verified end to end, not assumed**: `search.test.ts` now saves a Vietnamese title through `POST /api/uploadblueprint`, asserts the derived `blueprintsearch` row carries it, and retrieves it via `getblueprints?filterName=` using both a composed and a decomposed query.
- New specs: `__tests__/lib/blueprint-name.test.ts` (policy, character class by character class), `blueprint-name-validation.directive.spec.ts`, `website-meta.test.ts`, plus reworked `blueprint-validation.test.ts` cases. Every invisible character in a test is written as a `\uXXXX` escape — a literal would be unreviewable.

## Not in this PR

- **Phase 3b, the title translation pivot** — deliberately out of scope.
- **`npm run derive-search` has still not run in prod**, so search v2 is inert there. That is an ops step (`cd /bpni/build`, dry-run first), not a code change, and it is unaffected by this PR — but a non-ASCII title is only findable once it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)