### PR TITLE
feat(search): translate unresolved query remainder to English (phase 4)

### DIFF
--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -17,6 +17,7 @@ import { TranslationService } from '../../app/api/services/translation-service';
 import { TranslationProvider } from '../../app/api/services/translation-provider';
 import { TranslationUnitModel } from '../../app/api/models/translation-unit';
 import { TranslationBudgetModel } from '../../app/api/models/translation-budget';
+import { SearchQueryModel } from '../../app/api/models/search-query';
 import { FakeTranslationProvider } from '../helpers/fake-translation-provider';
 
 // Search over blueprintsearch rows (spec/multilingual-search-plan.md Phases
@@ -529,6 +530,124 @@ describe('Search (blueprintsearch)', function () {
         .query({ filterName: 'water filter' });
       expect(response.status).to.equal(200);
       expect(response.body.blueprints.map((bp: any) => bp.id)).to.include(saved.body.id);
+    });
+  });
+
+  describe('query translation (phase 4)', function () {
+    let fake: FakeTranslationProvider;
+
+    beforeEach(async function () {
+      await TranslationUnitModel.model.deleteMany({});
+      await TranslationBudgetModel.model.deleteMany({});
+      await SearchQueryModel.model.deleteMany({});
+      fake = new FakeTranslationProvider();
+      TranslationService.setInstanceForTest(new TranslationService(fake));
+    });
+
+    afterEach(async function () {
+      delete process.env.MONTHLY_CHAR_BUDGET;
+      TranslationService.setInstanceForTest(null);
+      await TranslationUnitModel.model.deleteMany({});
+      await TranslationBudgetModel.model.deleteMany({});
+      await SearchQueryModel.model.deleteMany({});
+    });
+
+    it('skips translation entirely when every token resolves via the term dictionary', async function () {
+      const spom = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Untitled 12',
+        data: bpData(['Electrolyzer', 'GasPump']),
+      });
+
+      const ids = (await searchBlueprintIds('spom')).map(id => id.toString());
+      expect(ids).to.include((spom._id as Types.ObjectId).toString());
+      expect(fake.calls).to.have.length(0);
+
+      const row = await SearchQueryModel.model.findOne({ normalizedQuery: 'spom' });
+      expect(row!.translated).to.equal(false);
+      expect(row!.hitCount).to.equal(1);
+    });
+
+    it('does not spend a translation on a short, all-ASCII, unresolved English query', async function () {
+      await searchBlueprintIds('cool unnamed build');
+      expect(fake.calls).to.have.length(0);
+
+      const row = await SearchQueryModel.model.findOne({ normalizedQuery: 'cool unnamed build' });
+      expect(row!.translated).to.equal(false);
+    });
+
+    it('translates the unresolved remainder of a confidently non-English query and finds the English title', async function () {
+      // A real (test-only) provider returning genuine English text, so this
+      // proves the deliverable: a Vietnamese query finds an English-titled
+      // blueprint, not just that some string came back.
+      const englishProvider: TranslationProvider = {
+        isConfigured: () => true,
+        translate: async texts => texts.map(() => ({ text: 'water filter', detectedSourceLang: 'vi' })),
+      };
+      TranslationService.setInstanceForTest(new TranslationService(englishProvider));
+
+      const doc = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Water Filter Setup',
+        data: bpData(['WaterPurifier']),
+      });
+
+      const ids = (await searchBlueprintIds('máy lọc nước')).map(id => id.toString());
+      expect(ids).to.include((doc._id as Types.ObjectId).toString());
+
+      let row = null;
+      for (let attempt = 0; attempt < 20; attempt++) {
+        row = await SearchQueryModel.model.findOne({ normalizedQuery: 'máy lọc nước' });
+        if (row != null) break;
+        await new Promise(resolve => setTimeout(resolve, 50));
+      }
+      expect(row!.sourceLang).to.equal('vi');
+      expect(row!.translated).to.equal(true);
+    });
+
+    it('caches the translated remainder — a repeat query issues no second provider call', async function () {
+      await searchBlueprintIds('máy lọc nước');
+      expect(fake.calls).to.have.length(1);
+
+      await searchBlueprintIds('máy lọc nước');
+      expect(fake.calls).to.have.length(1); // second search hit the translationunits cache
+    });
+
+    it('records telemetry even when translation is not configured, and never throws', async function () {
+      fake.configured = false;
+      const ids = await searchBlueprintIds('máy lọc nước');
+      expect(ids).to.deep.equal([]);
+      expect(fake.calls).to.have.length(0);
+
+      const row = await SearchQueryModel.model.findOne({ normalizedQuery: 'máy lọc nước' });
+      expect(row!.translated).to.equal(false);
+    });
+
+    it('falls back to an untranslated (empty) search when the monthly budget is exhausted, without throwing', async function () {
+      const month = `${new Date().getUTCFullYear()}-${String(new Date().getUTCMonth() + 1).padStart(2, '0')}`;
+      process.env.MONTHLY_CHAR_BUDGET = '1';
+      await TranslationBudgetModel.model.create({ month, userId: null, charCount: 999999, requestCount: 1 });
+
+      const ids = await searchBlueprintIds('máy lọc nước');
+      expect(ids).to.deep.equal([]);
+      expect(fake.calls).to.have.length(0);
+    });
+
+    it('a translation spend counts against the searching user\'s daily cap', async function () {
+      const englishProvider: TranslationProvider = {
+        isConfigured: () => true,
+        translate: async texts => texts.map(() => ({ text: 'water filter', detectedSourceLang: 'vi' })),
+      };
+      TranslationService.setInstanceForTest(new TranslationService(englishProvider));
+
+      const userId = (testData.users.user1._id as Types.ObjectId).toString();
+      await searchBlueprintIds('máy lọc nước', { userId });
+
+      // dayKey() in translation-service.ts is exactly monthKey()-DD, which is
+      // the UTC ISO date's first 10 characters.
+      const day = new Date().toISOString().slice(0, 10);
+      const month = day.slice(0, 7);
+      const userRow = await TranslationBudgetModel.model.findOne({ userId, month, day });
+      expect(userRow).to.not.equal(null);
+      expect(userRow!.requestCount).to.be.greaterThan(0);
     });
   });
 });

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -758,7 +758,11 @@ export class BlueprintController {
       return;
     }
 
-    const searchMatches = await BlueprintController.resolveSearchMatches(parsed.filterName);
+    const searchMatches = await BlueprintController.resolveSearchMatches(
+      parsed.filterName,
+      req,
+      userId || null
+    );
     const isAdmin = userJwt?.role === 'admin';
     const viewer = { userId, isAdmin };
 
@@ -850,12 +854,20 @@ export class BlueprintController {
   // Resolves filterName through the search service when v2 is enabled.
   // null = no search clause (no query, kill switch off, or the search layer
   // errored — in which case the caller falls back to the legacy name regex).
+  // req/userId feed the query-translation path (phase 4): the Accept-
+  // Language prior for telemetry, and userId so a translation spend counts
+  // against that user's daily cap rather than only the anonymous site pool.
   private static async resolveSearchMatches(
-    filterName: string | null
+    filterName: string | null,
+    req: Request,
+    userId: string | null
   ): Promise<SearchMatch[] | null> {
     if (filterName == null || !searchV2Enabled()) return null;
     try {
-      return await searchBlueprints(filterName);
+      return await searchBlueprints(filterName, {
+        localePrior: BlueprintController.authorLocalePrior(req),
+        userId,
+      });
     } catch (err) {
       console.log('search resolution error — falling back to name regex');
       console.log(err);
@@ -951,8 +963,9 @@ export class BlueprintController {
     // "how many blueprints are in this category" must not depend on a view
     // setting).
     const searchIds =
-      (await BlueprintController.resolveSearchMatches(parsed.filterName))?.map(match => match.id) ??
-      null;
+      (
+        await BlueprintController.resolveSearchMatches(parsed.filterName, req, userId || null)
+      )?.map(match => match.id) ?? null;
 
     const isAdmin = userJwt?.role === 'admin';
     const viewer = { userId, isAdmin };

--- a/app/api/db.ts
+++ b/app/api/db.ts
@@ -15,6 +15,7 @@ import { AvatarBatchModel } from './models/avatar-batch';
 import { TranslationUnitModel } from './models/translation-unit';
 import { BlueprintSearchModel } from './models/blueprint-search';
 import { TranslationBudgetModel } from './models/translation-budget';
+import { SearchQueryModel } from './models/search-query';
 
 export class Database {
   constructor() {
@@ -46,6 +47,7 @@ export class Database {
       TranslationUnitModel.init();
       BlueprintSearchModel.init();
       TranslationBudgetModel.init();
+      SearchQueryModel.init();
     });
     mongoose.connection.on('error', err => {
       if (process.env.NODE_ENV !== 'test') {

--- a/app/api/models/search-query.ts
+++ b/app/api/models/search-query.ts
@@ -1,0 +1,45 @@
+import mongoose, { Document, Model } from 'mongoose';
+
+// Query-side telemetry (spec/multilingual-search-plan.md phase 4): one row
+// per distinct (normalizedQuery, sourceLang) pair, so a repeated vocabulary
+// of a few hundred real queries costs a few hundred rows, not one per
+// request. Recorded on EVERY search — resolved-with-no-translation and
+// English queries included — because the point is the language
+// distribution itself (which `.po` to acquire next, §2.2), not just the
+// queries that spent money. `sourceLang` is null when detection had neither
+// a confident statistical read nor a locale prior to fall back on; that is
+// still a real bucket in the distribution, so it is logged, not dropped.
+export interface SearchQuery extends Document {
+  normalizedQuery: string;
+  sourceLang: string | null;
+  // Whether the most recent occurrence of this query used a machine
+  // translation to reach its results — can flip between true/false across
+  // occurrences (a budget exhausted on one request may have recovered by
+  // the next).
+  translated: boolean;
+  hitCount: number;
+  lastSeenAt: Date;
+}
+
+export class SearchQueryModel {
+  static model: Model<SearchQuery>;
+
+  public static init() {
+    const schema = new mongoose.Schema(
+      {
+        normalizedQuery: { type: String, required: true },
+        sourceLang: { type: String, default: null },
+        translated: { type: Boolean, default: false },
+        hitCount: { type: Number, default: 0 },
+        lastSeenAt: { type: Date, default: Date.now },
+      },
+      { collection: 'searchqueries' }
+    );
+
+    schema.index({ normalizedQuery: 1, sourceLang: 1 }, { unique: true });
+
+    SearchQueryModel.model =
+      (mongoose.models['SearchQuery'] as Model<SearchQuery>) ??
+      mongoose.model<SearchQuery>('SearchQuery', schema);
+  }
+}

--- a/app/api/services/search-query-service.ts
+++ b/app/api/services/search-query-service.ts
@@ -1,0 +1,22 @@
+import { SearchQueryModel } from '../models/search-query';
+
+// Fire-and-forget telemetry write for the query pipeline (phase 4). Never
+// awaited by a caller — a search response must not wait on it, same
+// rationale as syncSearchRowStatus. Failure is logged, never fatal.
+export function recordSearchQuery(
+  normalizedQuery: string,
+  sourceLang: string | null,
+  translated: boolean
+): void {
+  if (normalizedQuery.length === 0) return;
+  SearchQueryModel.model
+    .updateOne(
+      { normalizedQuery, sourceLang },
+      { $set: { translated, lastSeenAt: new Date() }, $inc: { hitCount: 1 } },
+      { upsert: true }
+    )
+    .catch(err => {
+      console.log('search query telemetry error');
+      console.log(err);
+    });
+}

--- a/app/api/services/search-service.ts
+++ b/app/api/services/search-service.ts
@@ -9,6 +9,9 @@ import {
 } from '../../../lib/index';
 import { BlueprintSearchModel } from '../models/blueprint-search';
 import { getSearchTermDictionary } from './search-term-dictionary';
+import { detectLanguage, detectLanguageCode } from './language-detection-service';
+import { TranslationBudgetExceeded, TranslationService } from './translation-service';
+import { recordSearchQuery } from './search-query-service';
 
 // Search retrieval pipeline (spec/multilingual-search-plan.md §2.3/§2.4/§2.6):
 //   normalize → term-resolve → lexical + structural retrieval → RRF → rank.
@@ -103,13 +106,56 @@ async function structuralRetrieval(resolvedIds: string[]): Promise<RetrievedRow[
   return rows as RetrievedRow[];
 }
 
+export interface SearchOptions {
+  // Author/viewer's UI-locale guess (Accept-Language) — telemetry only here.
+  // The decision to spend a translation call always re-detects from the
+  // query text alone with no prior, same split as search-index-service's
+  // confidentTitleLang: a prior-derived guess is real enough to log, not
+  // confident enough to bill.
+  localePrior?: string | null;
+  // Drives the per-user daily translation cap; null for anonymous/system
+  // callers (site-wide monthly budget still applies either way).
+  userId?: string | null;
+}
+
+// Attempts to translate the unresolved remainder of a query to English,
+// cached hard via the same translationunits text-hash cache every other
+// translation path uses (§1) — a repeat of the same nonsense query is free
+// after the first hit. Never throws: a budget-exceeded or provider error
+// just means the search proceeds on the untranslated tokens.
+async function translateQueryRemainder(
+  remainder: string,
+  sourceLang: string,
+  userId: string | null
+): Promise<string | null> {
+  if (!TranslationService.instance.isConfigured()) return null;
+  try {
+    const result = await TranslationService.instance.translateOne(
+      { sourceText: remainder, sourceLang, targetLang: 'en' },
+      userId
+    );
+    return result.degraded ? null : result.translatedText;
+  } catch (err) {
+    if (err instanceof TranslationBudgetExceeded) {
+      console.log('search query translation budget exceeded — searching untranslated');
+    } else {
+      console.log('search query translation error');
+      console.log(err);
+    }
+    return null;
+  }
+}
+
 /**
  * Resolves a free-text search to a relevance-ordered blueprint id list.
  * Returns [] when nothing matches (callers turn that into an empty page via
  * an $in match on nothing).
  */
-export async function searchBlueprintIds(query: string): Promise<mongoose.Types.ObjectId[]> {
-  return (await searchBlueprints(query)).map(match => match.id);
+export async function searchBlueprintIds(
+  query: string,
+  options?: SearchOptions
+): Promise<mongoose.Types.ObjectId[]> {
+  return (await searchBlueprints(query, options)).map(match => match.id);
 }
 
 /**
@@ -117,18 +163,59 @@ export async function searchBlueprintIds(query: string): Promise<mongoose.Types.
  * signals a collapse needs. Callers that collapse duplicates use this;
  * callers that only need a filter (facet counts) use the id list.
  */
-export async function searchBlueprints(query: string): Promise<SearchMatch[]> {
+export async function searchBlueprints(
+  query: string,
+  options: SearchOptions = {}
+): Promise<SearchMatch[]> {
   const tokens = tokenize(query);
   if (tokens.length === 0) return [];
   const normalizedQuery = tokens.join(' ');
+  const dictionary = getSearchTermDictionary();
 
   // Resolve before anything else (§2.4): game nouns and community jargon
-  // become structural ids without any further machinery.
-  const resolution = resolveTerms(tokens, getSearchTermDictionary());
+  // become structural ids without any further machinery, at zero cost.
+  const resolution = resolveTerms(tokens, dictionary);
 
+  // Telemetry-only read: informed by the locale prior, so it also captures
+  // queries the strict/no-prior check below won't act on (§2.2's "log it
+  // from day one" — the language distribution is the point, not just the
+  // queries that spent money).
+  const telemetryLang = detectLanguage(normalizedQuery, { prior: options.localePrior ?? null }).lang;
+
+  let lexicalTokens = tokens;
+  let structuralIds = resolution.resolvedIds;
+  let translated = false;
+
+  if (resolution.unresolvedTokens.length > 0) {
+    // Fresh, no-prior detection — the strict billing gate. A prior alone
+    // (e.g. an English query from a browser set to Vietnamese) must never
+    // trigger a spend.
+    const confidentLang = detectLanguageCode(normalizedQuery);
+    if (confidentLang != null && confidentLang !== 'en') {
+      const remainder = resolution.unresolvedTokens.join(' ');
+      const translatedRemainder = await translateQueryRemainder(
+        remainder,
+        confidentLang,
+        options.userId ?? null
+      );
+      if (translatedRemainder != null) {
+        translated = true;
+        const translatedTokens = tokenize(translatedRemainder);
+        lexicalTokens = [...resolution.matchedTokens, ...translatedTokens];
+        const extra = resolveTerms(translatedTokens, dictionary);
+        for (const id of extra.resolvedIds) {
+          if (!structuralIds.includes(id)) structuralIds.push(id);
+        }
+      }
+    }
+  }
+
+  recordSearchQuery(normalizedQuery, telemetryLang, translated);
+
+  const lexicalQuery = lexicalTokens.join(' ');
   const [lexical, structural] = await Promise.all([
-    lexicalRetrieval(normalizedQuery),
-    structuralRetrieval(resolution.resolvedIds),
+    lexicalRetrieval(lexicalQuery),
+    structuralRetrieval(structuralIds),
   ]);
 
   const fused = fuseRanks([
@@ -145,11 +232,14 @@ export async function searchBlueprints(query: string): Promise<SearchMatch[]> {
 
   // "The title says what you typed": every query token appears in the
   // normalized title (see RankingCandidate.titleMatch for why RRF alone
-  // can't express this).
+  // can't express this). Uses lexicalTokens, not the raw query tokens — a
+  // translated query's original-language tokens can never appear in an
+  // English row's title, so the effective (possibly-translated) tokens are
+  // what "says what you typed" has to mean once translation ran.
   const titleMatches = (title: string | undefined): boolean => {
     if (title == null) return false;
     const titleTokens = new Set(tokenize(title));
-    return tokens.every(token => titleTokens.has(token));
+    return lexicalTokens.every(token => titleTokens.has(token));
   };
 
   const candidates: RankingCandidate[] = fused.map(({ id, score }) => {


### PR DESCRIPTION
## Summary

Phase 4 of `spec/multilingual-search-plan.md` (local, gitignored — see §4.5 for the full write-up): query-side translation, so a non-English searcher can now reach the corpus, not just an English searcher reaching a non-English title (phase 3b, PR #202).

- **Resolve before translate** (§2.4, unchanged cost profile): `resolveTerms` runs first over the query tokens. A query that's entirely game jargon/prefab names still makes zero provider calls.
- When tokens are left unresolved **and** the query is confidently non-English — a fresh, no-prior `detectLanguageCode` check, the same strict billing gate as phase 3b's `confidentTitleLang` (a locale-prior guess is logged, never billed) — the **unresolved remainder** (not the whole query) is translated to English through the existing `TranslationService`/`translationunits` text-hash cache. The translated tokens are re-run through term resolution (catches game nouns the translation surfaces) and folded into the `$text` lexical query.
- New `searchqueries` collection (`app/api/models/search-query.ts`) records **every** query — resolved-for-free and plain-English included — via a second, prior-informed `detectLanguage` call used only for telemetry. Unique on `(normalizedQuery, sourceLang)` so a repeated vocabulary costs one row, not one per request.
- `authorLocalePrior(req)` (already private on `BlueprintController`, used by the save path) is reused as-is for the locale prior — no extraction needed, since the new call site is a static method on the same class.
- `searchBlueprints`/`searchBlueprintIds` gained a `SearchOptions { localePrior, userId }` param; `userId` comes from the request JWT (null if anonymous) so a translation spend counts against that searcher's daily cap — `getblueprints` is a public, unauthenticated GET, unlike the existing translate endpoints, so per-user attribution matters even without new rate limiting (Cloudflare's job, per CLAUDE.md — none added).

## Verified

- Unit tests (`__tests__/api/search.test.ts`, "query translation (phase 4)"): zero provider calls for a fully-resolved or short all-ASCII query, a real translation + match against a fake provider, cache reuse on a repeat query, telemetry recorded even when translation isn't configured, budget-exhaustion falls back to an untranslated (here, empty) result set without throwing, and a spend increments the searching user's daily budget row.
- End to end against the dev server with the real Google Translate key: uploaded a blueprint titled "Water Filter Phase4 Verify", searched `filterName=máy lọc nước` (Vietnamese), got a match. Confirmed in Mongo: `translationunits` cached `máy lọc nước → water purifier` (`detectedSourceLang: 'vi'`), and `searchqueries` logged `{sourceLang: 'vi', translated: true}`. Verification blueprint deleted afterward.
- `npm run tsc` clean, full backend suite green (972 passing).

## Test plan

- [x] `npm run tsc`
- [x] `npm run test` (972 passing)
- [x] Manual end-to-end against dev server with real `GOOGLE_TRANSLATE_API_KEY`

## Deferred (per session scope)

- Phase 5 (lazy accretion) and phase 6 (semantic retrieval) — not started, as planned.
- `npm run derive-search` still hasn't run in prod (carried over from phase 3b — blocking for search v2 to find anything).
- Prod has no `GOOGLE_TRANSLATE_API_KEY` configured (carried over).

🤖 Generated with [Claude Code](https://claude.com/claude-code)