### PR TITLE
fix(search): make derive-search work in the deploy image

### DIFF
--- a/app/api/batch/derive-search.ts
+++ b/app/api/batch/derive-search.ts
@@ -80,93 +80,99 @@ async function run(dryRun: boolean, limit: number | null) {
 
   loadGameDatabase();
   await mongoose.connect(mongoUri);
-  BlueprintModel.init();
-  BlueprintSearchModel.init();
-  // The title-translation pass goes through TranslationService, which reads
-  // the translationunits cache and the budget rows directly. db.ts inits
-  // these for the running app; a batch process gets no such bootstrap, and
-  // the failure is a TypeError on an undefined model deep inside
-  // translateMany — caught per batch and logged as "translation error,
-  // skipping", so the run still exits 0 having translated nothing.
-  TranslationUnitModel.init();
-  TranslationBudgetModel.init();
+  try {
+    BlueprintModel.init();
+    BlueprintSearchModel.init();
+    // The title-translation pass goes through TranslationService, which reads
+    // the translationunits cache and the budget rows directly. db.ts inits
+    // these for the running app; a batch process gets no such bootstrap, and
+    // the failure is a TypeError on an undefined model deep inside
+    // translateMany — caught per batch and logged as "translation error,
+    // skipping", so the run still exits 0 having translated nothing.
+    TranslationUnitModel.init();
+    TranslationBudgetModel.init();
 
-  console.log(describeScope(limit, dryRun));
+    console.log(describeScope(limit, dryRun));
 
-  // Existing rows' freshness keys, so unchanged blueprints are one $set of
-  // signals, not a full text rewrite (keeps re-runs near no-op).
-  const existing = new Map<string, string>();
-  for await (const row of BlueprintSearchModel.model
-    .find({ lang: 'en' })
-    .select('blueprintId sourceHash')
-    .cursor()) {
-    existing.set(row.blueprintId.toString(), row.sourceHash);
-  }
+    // Existing rows' freshness keys, so unchanged blueprints are one $set of
+    // signals, not a full text rewrite (keeps re-runs near no-op).
+    const existing = new Map<string, string>();
+    for await (const row of BlueprintSearchModel.model
+      .find({ lang: 'en' })
+      .select('blueprintId sourceHash')
+      .cursor()) {
+      existing.set(row.blueprintId.toString(), row.sourceHash);
+    }
 
-  const cursor = sampledCursor(BlueprintModel.model, {}, limit);
-  let processed = 0;
-  let created = 0;
-  let refreshed = 0;
-  let fresh = 0;
-  let pending: mongoose.AnyBulkWriteOperation[] = [];
-  // Scopes the translation pass to exactly the blueprints this run touched —
-  // matters when --limit samples a subset; with no limit this is every row.
-  const processedIds: mongoose.Types.ObjectId[] = [];
+    const cursor = sampledCursor(BlueprintModel.model, {}, limit);
+    let processed = 0;
+    let created = 0;
+    let refreshed = 0;
+    let fresh = 0;
+    let pending: mongoose.AnyBulkWriteOperation[] = [];
+    // Scopes the translation pass to exactly the blueprints this run touched —
+    // matters when --limit samples a subset; with no limit this is every row.
+    const processedIds: mongoose.Types.ObjectId[] = [];
 
-  async function flush() {
-    if (pending.length === 0) return;
-    // Dry run skips only the write — pending still clears, so memory stays
-    // bounded by BULK_BATCH_SIZE either way.
-    if (!dryRun) await BlueprintSearchModel.model.bulkWrite(pending as any);
-    pending = [];
-  }
+    async function flush() {
+      if (pending.length === 0) return;
+      // Dry run skips only the write — pending still clears, so memory stays
+      // bounded by BULK_BATCH_SIZE either way.
+      if (!dryRun) await BlueprintSearchModel.model.bulkWrite(pending as any);
+      pending = [];
+    }
 
-  for await (const doc of cursor) {
-    processed++;
-    processedIds.push(doc._id as mongoose.Types.ObjectId);
-    const fields = deriveSearchRow(doc);
-    const key = (doc._id as mongoose.Types.ObjectId).toString();
-    const known = existing.get(key);
-    const isFresh = known != null && known === fields.sourceHash;
-    if (known == null) created++;
-    else if (!isFresh) refreshed++;
-    else fresh++;
+    for await (const doc of cursor) {
+      processed++;
+      processedIds.push(doc._id as mongoose.Types.ObjectId);
+      const fields = deriveSearchRow(doc);
+      const key = (doc._id as mongoose.Types.ObjectId).toString();
+      const known = existing.get(key);
+      const isFresh = known != null && known === fields.sourceHash;
+      if (known == null) created++;
+      else if (!isFresh) refreshed++;
+      else fresh++;
 
-    // A fresh row only has its signals refreshed — title/origin/terms/
-    // termIds/sourceHash are left untouched so a re-run never overwrites a
-    // title the live save path (or the translation pass below) already
-    // machine-translated. A new or stale row gets the full derivation,
-    // which resets origin to 'authored' — correct for stale, since the
-    // underlying text changed and any prior translation is no longer valid.
-    pending.push({
-      updateOne: {
-        filter: { blueprintId: doc._id as mongoose.Types.ObjectId, lang: fields.lang },
-        update: { $set: isFresh ? signalsOf(fields) : fields },
-        upsert: true,
-      },
-    });
-    if (pending.length >= BULK_BATCH_SIZE) await flush();
-    if (processed % 500 === 0) console.log(`  ...${processed} processed`);
-  }
-  await flush();
+      // A fresh row only has its signals refreshed — title/origin/terms/
+      // termIds/sourceHash are left untouched so a re-run never overwrites a
+      // title the live save path (or the translation pass below) already
+      // machine-translated. A new or stale row gets the full derivation,
+      // which resets origin to 'authored' — correct for stale, since the
+      // underlying text changed and any prior translation is no longer valid.
+      pending.push({
+        updateOne: {
+          filter: { blueprintId: doc._id as mongoose.Types.ObjectId, lang: fields.lang },
+          update: { $set: isFresh ? signalsOf(fields) : fields },
+          upsert: true,
+        },
+      });
+      if (pending.length >= BULK_BATCH_SIZE) await flush();
+      if (processed % 500 === 0) console.log(`  ...${processed} processed`);
+    }
+    await flush();
 
-  console.log(`\nSearch rows — processed: ${processed}${dryRun ? ' (dry run)' : ''}`);
-  console.log(`  new: ${created}, stale (re-derived): ${refreshed}, fresh: ${fresh}`);
+    console.log(`\nSearch rows — processed: ${processed}${dryRun ? ' (dry run)' : ''}`);
+    console.log(`  new: ${created}, stale (re-derived): ${refreshed}, fresh: ${fresh}`);
 
-  const failedBatches = await translateTitles(dryRun, processedIds);
+    const failedBatches = await translateTitles(dryRun, processedIds);
 
-  await mongoose.disconnect();
-
-  // A translation pass that failed every batch still wrote 5,308 perfectly
-  // good rows, so without this the run reports success and the operator has
-  // to read stack traces to notice the phase-3b half did nothing. Same
-  // policy as import:2024 — an incomplete run exits non-zero.
-  if (failedBatches > 0) {
-    throw new Error(
-      `${failedBatches} title-translation batch(es) failed — search rows are written, but ` +
-        `non-English titles were not machine-translated. Fix the cause and re-run; ` +
-        `rows already translated are left alone.`
-    );
+    // A translation pass that failed every batch still wrote 5,308 perfectly
+    // good rows, so without this the run reports success and the operator has
+    // to read stack traces to notice the phase-3b half did nothing. Same
+    // policy as import:2024 — an incomplete run exits non-zero.
+    if (failedBatches > 0) {
+      throw new Error(
+        `${failedBatches} title-translation batch(es) failed — search rows are written, but ` +
+          `non-English titles were not machine-translated. Fix the cause and re-run; ` +
+          `rows already translated are left alone.`
+      );
+    }
+  } finally {
+    // Unconditional: without this, any rejection between connect and here
+    // leaks the connection, and the run only survives it because the CLI
+    // entry point force-exits. The failed-batch error is thrown inside the
+    // try, so it still propagates — just after disconnecting, as before.
+    await mongoose.disconnect();
   }
 }
 

--- a/app/api/batch/derive-search.ts
+++ b/app/api/batch/derive-search.ts
@@ -29,6 +29,8 @@ import {
 } from '../../../lib/index';
 import { BlueprintModel } from '../models/blueprint';
 import { BlueprintSearchModel } from '../models/blueprint-search';
+import { TranslationUnitModel } from '../models/translation-unit';
+import { TranslationBudgetModel } from '../models/translation-budget';
 import { deriveSearchRow, SearchRowFields } from '../services/search-index-service';
 import { detectLanguageCode } from '../services/language-detection-service';
 import { TranslationService } from '../services/translation-service';
@@ -80,6 +82,14 @@ async function run(dryRun: boolean, limit: number | null) {
   await mongoose.connect(mongoUri);
   BlueprintModel.init();
   BlueprintSearchModel.init();
+  // The title-translation pass goes through TranslationService, which reads
+  // the translationunits cache and the budget rows directly. db.ts inits
+  // these for the running app; a batch process gets no such bootstrap, and
+  // the failure is a TypeError on an undefined model deep inside
+  // translateMany — caught per batch and logged as "translation error,
+  // skipping", so the run still exits 0 having translated nothing.
+  TranslationUnitModel.init();
+  TranslationBudgetModel.init();
 
   console.log(describeScope(limit, dryRun));
 
@@ -143,9 +153,21 @@ async function run(dryRun: boolean, limit: number | null) {
   console.log(`\nSearch rows — processed: ${processed}${dryRun ? ' (dry run)' : ''}`);
   console.log(`  new: ${created}, stale (re-derived): ${refreshed}, fresh: ${fresh}`);
 
-  await translateTitles(dryRun, processedIds);
+  const failedBatches = await translateTitles(dryRun, processedIds);
 
   await mongoose.disconnect();
+
+  // A translation pass that failed every batch still wrote 5,308 perfectly
+  // good rows, so without this the run reports success and the operator has
+  // to read stack traces to notice the phase-3b half did nothing. Same
+  // policy as import:2024 — an incomplete run exits non-zero.
+  if (failedBatches > 0) {
+    throw new Error(
+      `${failedBatches} title-translation batch(es) failed — search rows are written, but ` +
+        `non-English titles were not machine-translated. Fix the cause and re-run; ` +
+        `rows already translated are left alone.`
+    );
+  }
 }
 
 // Phase 3b: machine-translate every confidently non-English title into its
@@ -158,13 +180,15 @@ async function run(dryRun: boolean, limit: number | null) {
 // text written earlier in the SAME call isn't visible yet.
 const TRANSLATE_BATCH_SIZE = 100;
 
+// Returns the number of batches that failed, so the caller can exit non-zero
+// rather than reporting a successful run that translated nothing.
 async function translateTitles(
   dryRun: boolean,
   blueprintIds: mongoose.Types.ObjectId[]
-): Promise<void> {
+): Promise<number> {
   if (!TranslationService.instance.isConfigured()) {
     console.log('\nTitle translation — GOOGLE_TRANSLATE_API_KEY not set, skipping.');
-    return;
+    return 0;
   }
 
   // Chunked so an unlimited run (thousands of blueprints) never issues one
@@ -200,9 +224,10 @@ async function translateTitles(
       ` (${alreadyMachine} rows already machine-translated, left alone)`
   );
 
-  if (dryRun || uniqueTitles.length === 0) return;
+  if (dryRun || uniqueTitles.length === 0) return 0;
 
   let done = 0;
+  let failedBatches = 0;
   for (let i = 0; i < uniqueTitles.length; i += TRANSLATE_BATCH_SIZE) {
     const batch = uniqueTitles.slice(i, i + TRANSLATE_BATCH_SIZE);
     let results: Awaited<ReturnType<typeof TranslationService.instance.translateMany>>;
@@ -215,6 +240,7 @@ async function translateTitles(
       console.log(`  batch ${i}-${i + batch.length} translation error, skipping`);
       console.log(err);
       done += batch.length;
+      failedBatches++;
       continue;
     }
 
@@ -236,6 +262,7 @@ async function translateTitles(
     done += batch.length;
     console.log(`  ...${done}/${uniqueTitles.length} unique titles translated`);
   }
+  return failedBatches;
 }
 
 if (require.main === module) {

--- a/deploy.Dockerfile
+++ b/deploy.Dockerfile
@@ -8,6 +8,11 @@ RUN npm ci --ignore-scripts && npm cache clean --force
 # TODO separate build build stage for asset extract
 COPY ./assets/database/database-2024.json ./assets/database/database-2024.json
 COPY ./assets/avatar-reference ./assets/avatar-reference
+# Read at runtime by search-term-dictionary (community-jargon query aliases:
+# spom, aquatuner, rodriguez…). copy_assets.sh rsyncs assets/ into build/, but
+# it can only copy what this stage COPYs in — an omission here is silent, since
+# a missing alias file only degrades query resolution rather than failing.
+COPY ./assets/search-aliases.json ./assets/search-aliases.json
 
 FROM extract as build-backend
 WORKDIR /bpni


### PR DESCRIPTION
Found by running `npm run derive-search` against prod. The row derivation itself worked — 5,308 rows written correctly — but two things around it were broken, and both failed *quietly*.

## 1. `assets/search-aliases.json` never reached the image
`copy_assets.sh` rsyncs `assets/` into `build/`, but the `extract` stage only `COPY`s `database-2024.json` and `avatar-reference` — so the alias file wasn't in the stage for the script to copy. Added the missing `COPY`.

The **running server** hits the same ENOENT, which `search-term-dictionary` catches and logs before continuing without aliases. So community jargon (`spom`, `aquatuner`, `rodriguez`, …) has silently not been resolving in prod queries. The dictionary is cached process-wide, so this needs the deploy + restart to take effect.

**No re-derive needed for this one**: aliases only populate `byTerm` (query-time resolution), never `byId` — and a row's `terms[]` comes from `byId`. Verified in the source, not assumed.

## 2. Title translation crashed on every batch
`TypeError: Cannot read properties of undefined (reading 'findOne')` — `TranslationUnitModel.model` was undefined. `db.ts` inits that model (and the budget model) for the running app; the batch process bootstraps its own models and inited only `Blueprint` + `BlueprintSearch`. Result: **446 unique non-English titles across 714 documents were not translated**. `derive-search` is the only batch script that touches `TranslationService`, so nothing else is affected.

Incidentally this confirms `GOOGLE_TRANSLATE_API_KEY` *is* set in prod — the run got past `isConfigured()` into the cache lookup.

## 3. Exit non-zero when a translation batch fails
Both failures above were survivable-by-design (caught, logged, continue), so the run printed a full success summary while the phase-3b half did nothing. The operator only noticed by reading stack traces. Now a failed batch makes the run exit non-zero with a message saying rows are written but titles are not — same policy as `import:2024`.

## Verification
Both fixes checked against negative controls rather than assumed:
- **Container build** replicating the real `extract` COPYs + the real `copy_assets.sh`: `REPRODUCED-prod-ENOENT` without the new `COPY`, `PASS` with it.
- **Model bootstrap** replicating the batch's init sequence: both models `undefined` without the new init calls (the exact prod TypeError), both resolved with them.
- Backend suite: 976 passing, 1 pre-existing local-only flake unrelated to this change (reproduces on clean master).

## After this deploys
Re-run `cd /bpni/build && npm run derive-search`. It is cheap and safe: the 5,308 rows have unchanged `sourceHash`, so they take the fresh-row path (signals only, no text rewrite), and the translation pass picks up exactly the 446 titles it missed. Well inside the free tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)