### PR TITLE
feat: content-locale picker, English-readable titles, and the two search follow-ups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ Remaining batch utilities:
 - `npm run fixHtmlLabels` - Fix HTML formatting in labels.
 - `npm run derive-metadata` - Backfill `requiredDlcs`, `mods`, `modded` and `category` on all blueprint documents from stored building IDs. Use `--dry-run` flag (`npm run derive-metadata:dry-run`) to preview counts without writing. Both modes report the prefab ids found in blueprints but missing from `database-2024.json` — those ids drive `modded=true` **and** contribute no `dlcIds`, so each one is a blueprint silently reading as base game. `modded` is written in both directions (a false positive can be cleared), except that `hadUnknownBuildings: true` always wins — those blueprints had unknown buildings stripped at import, so re-derivation can't rediscover them. Note `Element` is an editor annotation synthesized by `OniItem.load`, not a database building; it must be added to any `knownIds` set built from `database-2024.json` or every annotated blueprint reads as modded. The retired `Info` id belongs in that set too — it no longer registers an `OniItem`, but pre-migration documents can still carry it. Add `--recategorize` (`npm run derive-metadata -- --recategorize`) to re-derive `category` for documents that already have one, overwriting user picks; needed whenever the scoring rules in `blueprint-analyzer` change, since the default only fills in nulls.
 - `npm run derive-rooms` / `derive-rooms:dry-run` - Re-derive the `rooms` field on all non-deleted blueprints with the same detector the save path uses.
+- `npm run derive-search` / `derive-search:dry-run` - Rebuild the `blueprintsearch` rows, then run two translation passes over the titles: confidently non-English ones, and (unless `--skip-provider-detect`) the ones our own detector can't place, which are sent to the provider to identify. Rerunnable — fresh rows only get their ranking signals refreshed, already-translated rows are left alone, and repeat provider questions are cache reads. **Run `npm run migrate:up` first** whenever the text index has changed.
 - **`--limit N` on both derive tasks** - A full pass loads every stored blueprint blob (~10 min on the live corpus), so diagnostic dry runs take `--limit N` (`npm run derive-metadata -- --dry-run --limit 100`). The capped run samples **randomly**, not the first N: natural order tracks insertion date and so does everything these reports measure, so a head sample would report the oldest blueprints' problems as the corpus average. Percentages from a sampled run extrapolate; the absolute counts don't. Shared helper: `app/api/batch/batch-sampling.ts`.
 - `npm run avatars:smoke` / `avatars:seed-batch -- --count N` / `avatars:backfill[:dry-run]` - Gemini avatar pipeline (costs real money per generation; setup + rollout order in `agent/AVATARS.md`).
 - `npm run backfill-previews` - Render preview images for all non-deleted blueprints (newest first) and store them durably in Mongo (`previewimages` collection). Skips blueprints whose durable rows are already fresh, so it's rerunnable/resumable. Use `--dry-run` (`npm run backfill-previews:dry-run`) to report the fresh/stale split without rendering or writing.
@@ -364,17 +365,20 @@ on download. `Info` now survives as an *input* format only.
 - **Editing** — `NotesTool` + `components/note-edit-panel/`. There is no other annotation UI.
 
 ### Search (blueprintsearch) & user-content translation
-`spec/multilingual-search-plan.md` phases 0–1 + the reworked translation foundation.
+`spec/multilingual-search-plan.md` phases 0–5 (all shipped) + `spec/search-followups.md`
+Part 1 §1/§2.
 - **Search documents** — `blueprintsearch` collection (`app/api/models/blueprint-search.ts`),
   one row per `(blueprintId, lang)`; every blueprint has an `en` row (the pivot invariant).
-  Holds title/description/`terms[]` (display names) under the collection's single text index
-  (title 10 / terms 4 / description 1, `language_override: 'textLang'` — ISO `lang` stays an
+  Holds title/`titleOriginal`/description/`terms[]` (display names) under the collection's
+  single text index (title 10 / titleOriginal 4 / terms 4 / description 1,
+  `language_override: 'textLang'` — ISO `lang` stays an
   open set, `textLang` maps unsupported stemmers to `none`), `termIds[]` (prefab + room ids,
   language-independent), and denormalized ranking signals. Rows are **derived and disposable**
   (`npm run derive-search[:dry-run]`, `--limit N`); they are advisory for retrieval only — the
   final page fetch re-applies the authoritative filter on `blueprints`, so a stale row can cost
   recall but never leak a draft/deleted doc. Save path upserts the row (awaited, non-fatal);
-  delete/publish/rating-recompute patch status/signals fire-and-forget.
+  delete/publish/rating-recompute patch status/signals fire-and-forget. **The row is now also a
+  display source** — see "Content locale" below for why that widening is judged safe.
 - **Retrieval** (`app/api/services/search-service.ts`) — normalize → term-resolve → lexical
   (`$text`) + structural (`termIds` ∩ resolved ids) → RRF fuse → rank. Pure pieces live in
   `lib/src/search/` (`query-normalize`, `term-resolve`, `rrf`, `ranking` — the ranking spec
@@ -436,8 +440,90 @@ on download. `Info` now survives as an *input* format only.
   translation call. Verified against the real Google provider: a Vietnamese title saved
   through the live API produced `sourceLang: 'vi'` and a `blueprintsearch` row with
   `origin: 'machine'`, and an English query then found it.
-- **Not built yet** (later phases of the plan): query translation + `searchqueries` telemetry,
-  IDF weighting for structural matches, semantic retrieval.
+- **`titleOriginal`** (`spec/search-followups.md` Part 1 §1) — translating a title used to
+  *replace* it, deleting the author's own words from the index: `Cozinha estrategia em choque`
+  became findable by "strategic cooking" and no longer by itself. Worst exactly where query
+  translation also fails (romanized text neither end detects), so both directions broke at once.
+  The field holds the authored text whenever `origin` is `'machine'` and is **null while
+  `authored`**, where it would only duplicate `title` and double its index weight. Weighted 4,
+  not 10 — at `title`'s weight a translated row competes with itself. Derived wholesale, never
+  appended, so it cannot accumulate (the objection that ruled out `terms[]`).
+  Adding it to the text index needs `migrations/20260804000000_search-title-original.js`:
+  Mongo won't alter an index in place and Mongoose's autoIndex hits IndexOptionsConflict, which
+  surfaces only as a logged error. **Deploy order: migrate, then `npm run derive-search`.**
+  The backfill also fills the field on rows an earlier run already translated — those rows are
+  *fresh*, so they never reach full re-derivation, and their `sourceHash` pins them to the
+  current `blueprint.name`, making the authored text recoverable exactly with no provider call.
+- **Provider-side detection** (`spec/search-followups.md` Part 1 §2) — a third `derive-search`
+  pass for titles `detectLanguageCode` can't place at all: short, romanized or
+  diacritic-stripped non-English (`Dien phan full`). Those clear neither detection gate, so
+  phase 3b never sees them and no amount of re-running it will. Candidates are rows still
+  `origin: 'authored'` whose tokens the term dictionary does **not** fully resolve (an
+  all-game-nouns title is already findable structurally — nothing to buy). **The trap:**
+  `translateMany` short-circuits on `sourceLang == null && ASCII_ONLY`, which is exactly this
+  candidate set, so the input carries `forceProviderDetection: true` to bypass it; without that
+  the pass makes no provider call and still reports success. A result is accepted only when the
+  provider reports a non-`en` source **and** changed the text. On by default;
+  `--skip-provider-detect` opts out. Re-runs are cache reads (`translationunits` is keyed by
+  text hash), so it is idempotent and near-free after the first.
+- **Declared source language** (`spec/search-followups.md` §2.6) — `saveBlueprint` prefers the
+  author's stored `localePreference` over `Accept-Language` as the detection prior, and passes
+  it to `syncMachineTitle`. On that path `confidence: 'prior'` **is** trusted, deliberately
+  reversing the rule phase 3b set: same mechanism, different evidence — a browser header is a
+  default nobody chose, a picker setting is the user's own statement. Guards keep a
+  misdeclaration cheap: the provider must report non-`en`, and a provider that returns the input
+  unchanged never marks the row `'machine'` (which would claim a translation that isn't there
+  and index the same string twice).
+- **Not built yet** (later phases of the plan): IDF weighting for structural matches, semantic
+  retrieval, native-language search rows (`spec/search-followups.md` §2.9), and retrieval
+  reading the accreted non-English rows at all (still hard-codes `lang: 'en'` — Part 1 §4).
+
+### Content locale (what language you read blueprints in)
+`spec/search-followups.md` Part 2. **Not** UI localization — the chrome stays English for
+everyone (see "UI localization state"), so this routes no bundles and prefixes no paths.
+- **The rule** (§2.5), one shared implementation in `lib/src/blueprint/content-locale.ts`'s
+  `resolveTitle`: authored-in-your-language → a translation into your language → the English
+  translation → the authored title. The last step is what lets this ship ahead of any backfill:
+  it can never produce a blank title.
+- **Applied at the response boundary only** — `app/api/services/title-resolution-service.ts`,
+  used by the list, details, related-shelf and editor-open responses. One query per page;
+  any failure yields authored titles for everything. Inlining the rule per endpoint is how a
+  card and its details page end up disagreeing about a blueprint's name.
+- **`Blueprint.name` is never mutated and never changes meaning.** The resolved title rides in
+  a separate `displayName` (+`nameTranslated`/`nameSourceLang`), so the `{owner,name}` duplicate
+  check, download filenames and the editor's save path keep reading authored text.
+  Editor-open resolves for chrome only — the editor stores `name` and its save dialog pre-fills
+  from it, so translating that field would rewrite the author's title on their next save.
+- **`?lang=` is an explicit query param, never `Accept-Language`**: these responses are
+  Cloudflare-cached and a param keys cleanly where `Vary: Accept-Language` fragments the cache
+  per browser. The client omits it entirely for English, so the ordinary browse URL is
+  unchanged. Facet counts take no `lang` — they return no titles.
+- **Reading display titles from `blueprintsearch` widens its contract** from "advisory for
+  retrieval only". Confirmed, not overturned, on three grounds: the chain always terminates at
+  `Blueprint.name` so a lost row degrades to authored text; machine titles rebuild for free from
+  the `translationunits` text-hash cache; and rows stay advisory for *visibility* because the
+  authoritative filter still runs against `blueprints`. The rejected alternative was a
+  `titleTranslations` map on the blueprint document — more obviously correct, but a second write
+  path and a migration for data that is already derivable.
+- **`User.localePreference`** (base ISO tag) + `GET`/`PATCH /api/users/me/locale-preference`,
+  mirroring `themePreference`/`dlcPreferences`: private, never in `ProfileResponse`, absent
+  means "never chosen". It reports `null` rather than `'en'` when unset, unlike
+  `themePreference` — the client's own default is `navigator.language`, and answering `'en'`
+  would override that on every device. The language set is **open** (shape-validated only): a
+  user may declare a language we never translate *into*.
+- **Picker** — `components/dialogs/dialog-content-language/`, mounted in the site nav and opened
+  off `ContentLocaleService.openRequests$`, so the user-menu entry and the ambient entry point
+  on the details page both reach it with no component wiring. Three states kept distinct:
+  declared (localStorage + account), guessed (`navigator.language`, **never persisted** — a
+  default that writes itself is indistinguishable from a choice, which would ruin the §2.10
+  "who reads in what language" measurement), and English. Login adopts a local declaration into
+  an account that has none; a *failed* lookup is explicitly not "the account has none", or one
+  flaky GET would overwrite a preference set elsewhere. Selecting reloads the page — the locale
+  is a request parameter, so everything on screen was fetched under the old one.
+- **Disclosure is mandatory and ships with the display** (§2.7): cards carry a quiet
+  `pi-language` glyph whose tooltip holds the author's original; the details page states the
+  fact, shows the original, and links to the picker. Machine output is never presented as the
+  author's own words.
 
 ### Blueprint titles are Unicode
 `Blueprint.name` was `/^[a-zA-Z0-9_ -]+$/`, which 400'd every non-English title at save. The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -454,8 +454,8 @@ Part 1 §1/§2.
   The backfill also fills the field on rows an earlier run already translated — those rows are
   *fresh*, so they never reach full re-derivation, and their `sourceHash` pins them to the
   current `blueprint.name`, making the authored text recoverable exactly with no provider call.
-- **Provider-side detection** (`spec/search-followups.md` Part 1 §2) — a third `derive-search`
-  pass for titles `detectLanguageCode` can't place at all: short, romanized or
+- **Provider-side detection** (`spec/search-followups.md` Part 1 §2) — `derive-search`'s **second
+  translation pass**, for titles `detectLanguageCode` can't place at all: short, romanized or
   diacritic-stripped non-English (`Dien phan full`). Those clear neither detection gate, so
   phase 3b never sees them and no amount of re-running it will. Candidates are rows still
   `origin: 'authored'` whose tokens the term dictionary does **not** fully resolve (an

--- a/__tests__/api/content-locale-titles.test.ts
+++ b/__tests__/api/content-locale-titles.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+import { Types } from 'mongoose';
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup, TestDbHelper } from '../setup/testSetup';
+import { BlueprintModel } from '../../app/api/models/blueprint';
+import { BlueprintSearchModel } from '../../app/api/models/blueprint-search';
+
+// Viewer-locale title resolution at the response boundary
+// (spec/search-followups.md §2.5/§2.7). The rule itself is unit-tested in
+// __tests__/lib/content-locale.test.ts; these assert that every endpoint that
+// returns a title applies it, applies the SAME one, and that nothing on the
+// write side ever sees a translated name.
+
+describe('Content locale — title resolution', function () {
+  let testData: any;
+
+  beforeEach(async function () {
+    this.timeout(10000);
+    testData = await TestSetup.beforeEach();
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    await TestSetup.afterEach();
+  });
+
+  const AUTHORED = 'Cozinha estrategia em choque';
+  const ENGLISH = 'Strategic cooking in conflict';
+
+  // A Portuguese-titled blueprint with a machine English pivot, i.e. exactly
+  // what phase 3b's save path and the derive-search backfill produce.
+  async function seedTranslated(extra: Record<string, unknown> = {}) {
+    const doc = await TestDbHelper.createTestBlueprint(
+      testData.users.user1._id as Types.ObjectId,
+      { name: AUTHORED, isPublished: true, ...extra }
+    );
+    await BlueprintModel.model.updateOne({ _id: doc._id }, { $set: { sourceLang: 'pt' } });
+    await BlueprintSearchModel.model.updateOne(
+      { blueprintId: doc._id, lang: 'en' },
+      { $set: { title: ENGLISH, origin: 'machine' } }
+    );
+    return doc;
+  }
+
+  function findItem(body: any, id: string) {
+    return body.blueprints.find((b: any) => b.id === id);
+  }
+
+  describe('GET /api/getblueprints', function () {
+    it('shows the English machine title to a default (English) reader', async function () {
+      const doc = await seedTranslated();
+
+      const response = await TestSetup.request().get('/api/getblueprints');
+      expect(response.status).to.equal(200);
+
+      const item = findItem(response.body, (doc._id as Types.ObjectId).toString());
+      expect(item.displayName).to.equal(ENGLISH);
+      expect(item.nameTranslated).to.equal(true);
+      expect(item.nameSourceLang).to.equal('pt');
+      // The authored title is still there — it is what downloads and the
+      // duplicate check use, and what the disclosure shows.
+      expect(item.name).to.equal(AUTHORED);
+    });
+
+    // Rule 1: an author reading in their own language gets their own words.
+    it('shows the authored title to a reader of the same language', async function () {
+      const doc = await seedTranslated();
+
+      const response = await TestSetup.request().get('/api/getblueprints?lang=pt');
+      const item = findItem(response.body, (doc._id as Types.ObjectId).toString());
+      expect(item.name).to.equal(AUTHORED);
+      // Nothing to disclose: no resolution was applied.
+      expect(item.displayName).to.equal(undefined);
+      expect(item.nameTranslated).to.equal(undefined);
+    });
+
+    // Rule 3: a Vietnamese reader has no Vietnamese translation of a
+    // Portuguese title, so they get the English one — "readable in English"
+    // is the deliverable for everyone who isn't the author.
+    it('falls back to English for a reader of a third language', async function () {
+      const doc = await seedTranslated();
+
+      const response = await TestSetup.request().get('/api/getblueprints?lang=vi');
+      const item = findItem(response.body, (doc._id as Types.ObjectId).toString());
+      expect(item.displayName).to.equal(ENGLISH);
+      expect(item.nameTranslated).to.equal(true);
+    });
+
+    // Rule 4, and the reason this could ship before any backfill.
+    it('leaves an untranslated blueprint alone', async function () {
+      const doc = await TestDbHelper.createTestBlueprint(
+        testData.users.user1._id as Types.ObjectId,
+        { name: 'Dien phan full', isPublished: true }
+      );
+
+      const response = await TestSetup.request().get('/api/getblueprints?lang=vi');
+      const item = findItem(response.body, (doc._id as Types.ObjectId).toString());
+      expect(item.name).to.equal('Dien phan full');
+      expect(item.displayName).to.equal(undefined);
+    });
+
+    // An 'authored' row is the pivot echoing Blueprint.name, not a
+    // translation — resolving against it would report English titles as
+    // "translated from English".
+    it('never treats an authored pivot row as a translation', async function () {
+      const doc = await TestDbHelper.createTestBlueprint(
+        testData.users.user1._id as Types.ObjectId,
+        { name: 'SPOM v2', isPublished: true }
+      );
+
+      const response = await TestSetup.request().get('/api/getblueprints?lang=vi');
+      const item = findItem(response.body, (doc._id as Types.ObjectId).toString());
+      expect(item.displayName).to.equal(undefined);
+      expect(item.nameTranslated).to.equal(undefined);
+    });
+
+    it('ignores a lang parameter that is not a language tag', async function () {
+      const doc = await seedTranslated();
+
+      const response = await TestSetup.request().get('/api/getblueprints?lang=%3Cscript%3E');
+      expect(response.status).to.equal(200);
+      // Unparseable resolves to the default, which is English.
+      const item = findItem(response.body, (doc._id as Types.ObjectId).toString());
+      expect(item.displayName).to.equal(ENGLISH);
+    });
+  });
+
+  describe('GET /api/blueprints/:id (details)', function () {
+    // The failure mode this shares one helper to prevent: a card and its
+    // details page disagreeing about what a blueprint is called.
+    it('resolves the same title the list did', async function () {
+      const doc = await seedTranslated();
+      const id = (doc._id as Types.ObjectId).toString();
+
+      const list = await TestSetup.request().get('/api/getblueprints');
+      const details = await TestSetup.request().get(`/api/blueprints/${id}`);
+
+      expect(details.status).to.equal(200);
+      expect(details.body.displayName).to.equal(findItem(list.body, id).displayName);
+      expect(details.body.name).to.equal(AUTHORED);
+      expect(details.body.nameTranslated).to.equal(true);
+      expect(details.body.nameSourceLang).to.equal('pt');
+    });
+
+    it('honours lang= on the details endpoint too', async function () {
+      const doc = await seedTranslated();
+      const id = (doc._id as Types.ObjectId).toString();
+
+      const details = await TestSetup.request().get(`/api/blueprints/${id}?lang=pt`);
+      expect(details.body.name).to.equal(AUTHORED);
+      expect(details.body.displayName).to.equal(undefined);
+    });
+  });
+
+  describe('GET /api/getblueprint/:id (editor open)', function () {
+    // `name` here is a write-path value: the editor stores it and the save
+    // dialog pre-fills from it, so translating it would rewrite the author's
+    // title on their next overwrite save.
+    it('keeps name authored and puts the resolved title in displayName', async function () {
+      const doc = await seedTranslated();
+      const id = (doc._id as Types.ObjectId).toString();
+
+      const response = await TestSetup.request().get(`/api/getblueprint/${id}`);
+      expect(response.status).to.equal(200);
+      expect(response.body.name).to.equal(AUTHORED);
+      expect(response.body.displayName).to.equal(ENGLISH);
+    });
+  });
+
+  describe('resilience', function () {
+    // Search rows are derived and disposable. Reading display titles from
+    // them widened that contract, and this is the property that makes the
+    // widening safe: losing them costs the translation, never the title.
+    it('degrades to authored titles when the search rows are gone', async function () {
+      const doc = await seedTranslated();
+      await BlueprintSearchModel.model.deleteMany({});
+
+      const response = await TestSetup.request().get('/api/getblueprints');
+      const item = findItem(response.body, (doc._id as Types.ObjectId).toString());
+      expect(item.name).to.equal(AUTHORED);
+      expect(item.displayName).to.equal(undefined);
+    });
+
+    // Rows stay advisory for VISIBILITY: the authoritative filter still runs
+    // against `blueprints`, so a row for a draft cannot pull it into a list.
+    it('does not let a search row expose a draft', async function () {
+      const doc = await seedTranslated({ isPublished: false });
+
+      const response = await TestSetup.request().get('/api/getblueprints');
+      expect(findItem(response.body, (doc._id as Types.ObjectId).toString())).to.equal(undefined);
+    });
+  });
+});

--- a/__tests__/api/locale-preference.test.ts
+++ b/__tests__/api/locale-preference.test.ts
@@ -122,10 +122,9 @@ describe('Content locale preference API', function () {
       const profile = await TestSetup.request().get(
         `/api/users/${testData.users.user1.username}/profile`
       );
-      if (profile.status === 200) {
-        expect(profile.body).to.not.have.property('localePreference');
-        expect(profile.body).to.not.have.property('locale');
-      }
+      expect(profile.status).to.equal(200);
+      expect(profile.body).to.not.have.property('localePreference');
+      expect(profile.body).to.not.have.property('locale');
     });
   });
 });

--- a/__tests__/api/locale-preference.test.ts
+++ b/__tests__/api/locale-preference.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup } from '../setup/testSetup';
+
+describe('Content locale preference API', function () {
+  let testData: any;
+
+  beforeEach(async function () {
+    this.timeout(5000);
+    testData = await TestSetup.beforeEach();
+  });
+
+  afterEach(async function () {
+    this.timeout(5000);
+    await TestSetup.afterEach();
+  });
+
+  describe('GET /api/users/me/locale-preference', function () {
+    it('returns 401 without a token', async function () {
+      const response = await TestSetup.request().get('/api/users/me/locale-preference');
+      expect(response.status).to.equal(401);
+    });
+
+    // Unlike themePreference this reports null rather than the default: the
+    // client's own default is navigator.language, and answering 'en' here
+    // would override the browser's answer on every device the user logs in on.
+    it('returns null before the user has ever chosen', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .get('/api/users/me/locale-preference')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).to.equal(200);
+      expect(response.body.locale).to.equal(null);
+    });
+  });
+
+  describe('PATCH /api/users/me/locale-preference', function () {
+    it('returns 401 without a token', async function () {
+      const response = await TestSetup.request()
+        .patch('/api/users/me/locale-preference')
+        .send({ locale: 'vi' });
+      expect(response.status).to.equal(401);
+    });
+
+    it('sets the locale and it persists across requests', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .patch('/api/users/me/locale-preference')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ locale: 'vi' });
+
+      expect(response.status).to.equal(200);
+      expect(response.body.locale).to.equal('vi');
+
+      const reread = await TestSetup.request()
+        .get('/api/users/me/locale-preference')
+        .set('Authorization', `Bearer ${token}`);
+      expect(reread.body.locale).to.equal('vi');
+    });
+
+    // The content-language set is open by design — any language a user reads
+    // and writes in, not the closed set we translate into.
+    it('accepts a language with no UI build and no translation target', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .patch('/api/users/me/locale-preference')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ locale: 'pt' });
+      expect(response.status).to.equal(200);
+      expect(response.body.locale).to.equal('pt');
+    });
+
+    // Stored values are compared for equality against Blueprint.sourceLang,
+    // which the detector always writes as a base tag. A region-tagged
+    // preference that survived would never match, silently costing the author
+    // their own title.
+    it('narrows a region-tagged value to its base tag', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .patch('/api/users/me/locale-preference')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ locale: 'pt-BR' });
+      expect(response.status).to.equal(200);
+      expect(response.body.locale).to.equal('pt');
+    });
+
+    it('rejects values that are not language tags', async function () {
+      const token = testData.users.user1.generateJwt();
+      for (const bad of ['', 'english', '<script>', 42, { locale: 'en' }, null]) {
+        const response = await TestSetup.request()
+          .patch('/api/users/me/locale-preference')
+          .set('Authorization', `Bearer ${token}`)
+          .send({ locale: bad });
+        expect(response.status).to.equal(400, `expected ${JSON.stringify(bad)} to be rejected`);
+      }
+    });
+
+    it('rejects a missing locale', async function () {
+      const token = testData.users.user1.generateJwt();
+      const response = await TestSetup.request()
+        .patch('/api/users/me/locale-preference')
+        .set('Authorization', `Bearer ${token}`)
+        .send({});
+      expect(response.status).to.equal(400);
+    });
+
+    // Private account data — what you read in is nobody else's business.
+    it('does not expose the locale on the public profile', async function () {
+      const token = testData.users.user1.generateJwt();
+      await TestSetup.request()
+        .patch('/api/users/me/locale-preference')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ locale: 'ru' });
+
+      const profile = await TestSetup.request().get(
+        `/api/users/${testData.users.user1.username}/profile`
+      );
+      if (profile.status === 200) {
+        expect(profile.body).to.not.have.property('localePreference');
+        expect(profile.body).to.not.have.property('locale');
+      }
+    });
+  });
+});

--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -617,6 +617,194 @@ describe('Search (blueprintsearch)', function () {
     });
   });
 
+  // spec/search-followups.md §2.6. The picker turns sourceLang from a guess
+  // into a declaration, which is the only route by which a short romanized
+  // title gets translated at save time rather than waiting for the batch pass.
+  describe('declared source language (§2.6)', function () {
+    let fake: FakeTranslationProvider;
+
+    beforeEach(async function () {
+      await TranslationUnitModel.model.deleteMany({});
+      await TranslationBudgetModel.model.deleteMany({});
+      fake = new FakeTranslationProvider();
+      TranslationService.setInstanceForTest(new TranslationService(fake));
+    });
+
+    afterEach(async function () {
+      TranslationService.setInstanceForTest(null);
+      await TranslationUnitModel.model.deleteMany({});
+      await TranslationBudgetModel.model.deleteMany({});
+    });
+
+    // The title our own detector cannot place — the whole point.
+    it('translates a title the detector cannot place when the author declared a language', async function () {
+      fake.detectedSourceLang = 'vi';
+      const doc = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Dien phan full',
+        data: bpData(['Electrolyzer']),
+      });
+
+      expect(await deriveSearchRowWithTranslation(doc, null)).to.have.property('origin', 'authored');
+
+      const declared = await deriveSearchRowWithTranslation(doc, null, 'vi');
+      expect(declared.origin).to.equal('machine');
+      expect(declared.title).to.equal('[en] Dien phan full');
+      expect(declared.titleOriginal).to.equal('Dien phan full');
+    });
+
+    // The guard that makes a misdeclaration cheap: a Vietnamese-locale author
+    // writing an English title comes back reported as English and stays put.
+    it('leaves the row authored when the provider says the text was English', async function () {
+      fake.detectedSourceLang = 'en';
+      const doc = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Spom v2 base',
+        data: bpData(['Electrolyzer']),
+      });
+
+      const fields = await deriveSearchRowWithTranslation(doc, null, 'vi');
+      expect(fields.origin).to.equal('authored');
+      expect(fields.title).to.equal('Spom v2 base');
+    });
+
+    it('does not act on a declaration of English', async function () {
+      const doc = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Dien phan full',
+        data: bpData(['Electrolyzer']),
+      });
+
+      const fields = await deriveSearchRowWithTranslation(doc, null, 'en');
+      expect(fields.origin).to.equal('authored');
+      expect(fake.calls).to.have.length(0);
+    });
+
+    // A provider that hands the text back unchanged translated nothing —
+    // claiming 'machine' would index the same string twice.
+    it('leaves the row authored when the provider returns the input unchanged', async function () {
+      const echoProvider: TranslationProvider = {
+        isConfigured: () => true,
+        translate: async texts => texts.map(text => ({ text, detectedSourceLang: 'vi' })),
+      };
+      TranslationService.setInstanceForTest(new TranslationService(echoProvider));
+
+      const doc = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Máy lọc nước',
+        data: bpData(['WaterPurifier']),
+      });
+
+      const fields = await deriveSearchRowWithTranslation(doc, null);
+      expect(fields.origin).to.equal('authored');
+      expect(fields.titleOriginal).to.equal(null);
+    });
+
+    it('uses the stored preference as the prior for sourceLang on save', async function () {
+      const token = testData.users.user1.generateJwt();
+      await TestSetup.request()
+        .patch('/api/users/me/locale-preference')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ locale: 'vi' });
+
+      const saved = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${token}`)
+        // Deliberately a title no detector can place, sent with an English
+        // Accept-Language: only the declaration can produce 'vi' here.
+        .set('Accept-Language', 'en-US,en;q=0.9')
+        .send({
+          name: 'Dien phan full',
+          blueprint: bpData(['Electrolyzer']),
+          thumbnail: 'base64thumbnail',
+        });
+      expect(saved.status).to.equal(200);
+
+      const savedBlueprint = await BlueprintModel.model.findById(saved.body.id);
+      expect(savedBlueprint!.sourceLang).to.equal('vi');
+    });
+
+    it('falls back to the Accept-Language prior for an author who never chose', async function () {
+      const token = testData.users.user2.generateJwt();
+      const saved = await TestSetup.request()
+        .post('/api/uploadblueprint')
+        .set('Authorization', `Bearer ${token}`)
+        .set('Accept-Language', 'vi-VN,vi;q=0.9')
+        .send({
+          name: 'Dien phan full',
+          blueprint: bpData(['Electrolyzer']),
+          thumbnail: 'base64thumbnail',
+        });
+      expect(saved.status).to.equal(200);
+
+      const savedBlueprint = await BlueprintModel.model.findById(saved.body.id);
+      expect(savedBlueprint!.sourceLang).to.equal('vi');
+    });
+  });
+
+  // spec/search-followups.md Part 1 §2. The trap this exists to avoid:
+  // translateMany short-circuits on `sourceLang == null && ASCII_ONLY`, which
+  // is EXACTLY this candidate set, so without the bypass the pass would report
+  // success having made no provider call at all.
+  describe('provider-side detection bypass (Part 1 §2)', function () {
+    let fake: FakeTranslationProvider;
+
+    beforeEach(async function () {
+      await TranslationUnitModel.model.deleteMany({});
+      await TranslationBudgetModel.model.deleteMany({});
+      fake = new FakeTranslationProvider();
+      TranslationService.setInstanceForTest(new TranslationService(fake));
+    });
+
+    afterEach(async function () {
+      TranslationService.setInstanceForTest(null);
+      await TranslationUnitModel.model.deleteMany({});
+      await TranslationBudgetModel.model.deleteMany({});
+    });
+
+    it('short-circuits a short ASCII title with no declared source language', async function () {
+      const [result] = await TranslationService.instance.translateMany(
+        [{ sourceText: 'Dien phan full', sourceLang: null, targetLang: 'en' }],
+        null
+      );
+      expect(result.translatedText).to.equal('Dien phan full');
+      expect(fake.calls).to.have.length(0);
+    });
+
+    it('reaches the provider for the same input when detection is forced', async function () {
+      fake.detectedSourceLang = 'vi';
+      const [result] = await TranslationService.instance.translateMany(
+        [
+          {
+            sourceText: 'Dien phan full',
+            sourceLang: null,
+            targetLang: 'en',
+            forceProviderDetection: true,
+          },
+        ],
+        null
+      );
+      expect(fake.calls).to.have.length(1);
+      expect(result.translatedText).to.equal('[en] Dien phan full');
+      // The provider's own verdict is what the caller gates on.
+      expect(result.sourceLang).to.equal('vi');
+    });
+
+    // Re-runs are free: the cache is keyed by text hash and stores the
+    // detected language, so asking about a known title costs nothing.
+    it('serves a repeat forced-detection request from the cache', async function () {
+      fake.detectedSourceLang = 'vi';
+      const input = {
+        sourceText: 'Dien phan full',
+        sourceLang: null,
+        targetLang: 'en',
+        forceProviderDetection: true,
+      };
+      await TranslationService.instance.translateMany([input], null);
+      const [second] = await TranslationService.instance.translateMany([input], null);
+
+      expect(fake.calls).to.have.length(1);
+      expect(second.cached).to.equal(true);
+      expect(second.sourceLang).to.equal('vi');
+    });
+  });
+
   describe('query translation (phase 4)', function () {
     let fake: FakeTranslationProvider;
 

--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -533,6 +533,90 @@ describe('Search (blueprintsearch)', function () {
     });
   });
 
+  // spec/search-followups.md Part 1 §1. Translating a title used to DELETE the
+  // authored text from the index; titleOriginal keeps it, so a translation can
+  // only ever add a match.
+  describe('titleOriginal (Part 1 §1)', function () {
+    let fake: FakeTranslationProvider;
+
+    beforeEach(async function () {
+      await TranslationUnitModel.model.deleteMany({});
+      await TranslationBudgetModel.model.deleteMany({});
+      fake = new FakeTranslationProvider();
+      TranslationService.setInstanceForTest(new TranslationService(fake));
+    });
+
+    afterEach(async function () {
+      TranslationService.setInstanceForTest(null);
+      await TranslationUnitModel.model.deleteMany({});
+      await TranslationBudgetModel.model.deleteMany({});
+    });
+
+    it('is null on an authored row, where it would only duplicate title', async function () {
+      const doc = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Cooling Loop System For My Base',
+        data: bpData(['WaterPurifier']),
+      });
+      expect(deriveSearchRow(doc).titleOriginal).to.equal(null);
+    });
+
+    it('holds the authored title once the row flips to machine', async function () {
+      const doc = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Máy lọc nước',
+        data: bpData(['WaterPurifier']),
+      });
+
+      const fields = await deriveSearchRowWithTranslation(doc, null);
+      expect(fields.origin).to.equal('machine');
+      expect(fields.title).to.equal('[en] Máy lọc nước');
+      expect(fields.titleOriginal).to.equal('Máy lọc nước');
+    });
+
+    // The actual deliverable: the blueprint stays findable by the words its
+    // author typed, even though the indexed title is now English.
+    it('keeps a translated blueprint findable by its authored title', async function () {
+      const englishProvider: TranslationProvider = {
+        isConfigured: () => true,
+        translate: async texts => texts.map(() => ({ text: 'Strategic cooking', detectedSourceLang: 'pt' })),
+      };
+      TranslationService.setInstanceForTest(new TranslationService(englishProvider));
+
+      const doc = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Cozinha estrategia em choque',
+        data: bpData(['WaterPurifier']),
+        isPublished: true,
+      });
+      const fields = await deriveSearchRowWithTranslation(doc, null);
+      await BlueprintSearchModel.model.updateOne(
+        { blueprintId: doc._id, lang: 'en' },
+        { $set: { title: fields.title, titleOriginal: fields.titleOriginal, origin: fields.origin } }
+      );
+
+      const id = (doc._id as Types.ObjectId).toString();
+
+      // Both forms hit the same row.
+      const english = await searchBlueprintIds('strategic cooking');
+      expect(english.map(String)).to.include(id);
+
+      const authored = await searchBlueprintIds('cozinha estrategia');
+      expect(authored.map(String)).to.include(id);
+    });
+
+    // Derived wholesale on every full derivation, so it cannot accumulate —
+    // the objection that ruled out putting the authored text in terms[].
+    it('is cleared when a re-derivation resets the row to authored', async function () {
+      const doc = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Máy lọc nước',
+        data: bpData(['WaterPurifier']),
+      });
+      const translated = await deriveSearchRowWithTranslation(doc, null);
+      expect(translated.titleOriginal).to.not.equal(null);
+
+      doc.name = 'Water Sieve Setup For My Base';
+      expect(deriveSearchRow(doc).titleOriginal).to.equal(null);
+    });
+  });
+
   describe('query translation (phase 4)', function () {
     let fake: FakeTranslationProvider;
 

--- a/__tests__/hooks.ts
+++ b/__tests__/hooks.ts
@@ -31,9 +31,22 @@ const waitForDbReady = () => {
 // CI never hits this (fresh mongo per run); a developer's machine always does.
 // syncIndexes drops what the schema no longer declares and creates what it
 // does, which is exactly the migration's effect on the test database.
+// A failure here is reported, not swallowed: silence is exactly the failure
+// mode this hook exists to prevent — an index that didn't sync shows up later
+// as a query returning nothing, with no hint of the cause. Named per model so
+// the message points at the schema to look at. console.error is unavailable
+// (the hook above makes it throw), so this throws out of beforeAll.
 const syncTestIndexes = async () => {
+  const failures: string[] = [];
   for (const name of Object.keys(mongoose.models)) {
-    await mongoose.models[name].syncIndexes().catch(() => undefined);
+    try {
+      await mongoose.models[name].syncIndexes();
+    } catch (err) {
+      failures.push(`${name}: ${(err as Error)?.message ?? String(err)}`);
+    }
+  }
+  if (failures.length > 0) {
+    throw new Error(`Failed to sync test indexes —\n  ${failures.join('\n  ')}`);
   }
 };
 

--- a/__tests__/hooks.ts
+++ b/__tests__/hooks.ts
@@ -24,6 +24,19 @@ const waitForDbReady = () => {
   });
 };
 
+// A long-lived local test database keeps whatever indexes an older schema
+// created, and Mongo refuses to redefine one in place — so a field newly added
+// to the blueprintsearch text index is simply not indexed, and the failure
+// surfaces as a search test that finds nothing rather than as an index error.
+// CI never hits this (fresh mongo per run); a developer's machine always does.
+// syncIndexes drops what the schema no longer declares and creates what it
+// does, which is exactly the migration's effect on the test database.
+const syncTestIndexes = async () => {
+  for (const name of Object.keys(mongoose.models)) {
+    await mongoose.models[name].syncIndexes().catch(() => undefined);
+  }
+};
+
 export const mochaHooks: RootHookObject = {
   beforeAll: [
     function () {
@@ -34,5 +47,6 @@ export const mochaHooks: RootHookObject = {
       console.error = fail('error') as typeof console.error;
     },
     waitForDbReady,
+    syncTestIndexes,
   ],
 };

--- a/__tests__/lib/content-locale.test.ts
+++ b/__tests__/lib/content-locale.test.ts
@@ -1,0 +1,146 @@
+import { expect } from 'chai';
+import {
+  DEFAULT_CONTENT_LOCALE,
+  normalizeContentLocale,
+  resolveContentLocale,
+  resolveTitle,
+  TitleTranslation,
+} from '../../lib';
+
+// The content-locale policy (spec/search-followups.md Part 2 §2.3/§2.5). Four
+// surfaces validate the same code and one rule resolves every displayed title,
+// so these are the assertions that keep them from drifting apart.
+describe('content locale', function () {
+  describe('normalizeContentLocale', function () {
+    it('accepts base ISO tags', function () {
+      expect(normalizeContentLocale('en')).to.equal('en');
+      expect(normalizeContentLocale('vi')).to.equal('vi');
+      expect(normalizeContentLocale('fil')).to.equal('fil');
+    });
+
+    it('lowercases and narrows region/script subtags to the base tag', function () {
+      expect(normalizeContentLocale('PT-BR')).to.equal('pt');
+      expect(normalizeContentLocale('zh-Hans')).to.equal('zh');
+      expect(normalizeContentLocale('en_US')).to.equal('en');
+      expect(normalizeContentLocale('  fr  ')).to.equal('fr');
+    });
+
+    it('returns null for anything that is not a language tag', function () {
+      for (const bad of ['', 'english', 'e', '<script>', '12', 42, null, undefined, {}]) {
+        expect(normalizeContentLocale(bad), JSON.stringify(bad)).to.equal(null);
+      }
+    });
+
+    // null and 'en' are different states: "never chose" must keep resolving to
+    // whatever the current default is, so nothing writes 'en' eagerly.
+    it('distinguishes "no declaration" from "chose English"', function () {
+      expect(normalizeContentLocale(undefined)).to.equal(null);
+      expect(resolveContentLocale(undefined)).to.equal(DEFAULT_CONTENT_LOCALE);
+    });
+  });
+
+  describe('resolveTitle', function () {
+    const machine = (lang: string, title: string): TitleTranslation => ({
+      lang,
+      title,
+      origin: 'machine',
+    });
+
+    // Rule 1 — the author gets their own words back.
+    it('shows the authored title when the viewer reads its language', function () {
+      const resolved = resolveTitle({
+        authoredName: 'Máy lọc nước',
+        sourceLang: 'vi',
+        viewerLang: 'vi',
+        translations: [machine('en', 'Water purifier')],
+      });
+      expect(resolved.title).to.equal('Máy lọc nước');
+      expect(resolved.translated).to.equal(false);
+    });
+
+    // Rule 3 — the deliverable: everything readable in English.
+    it('shows the English machine translation to an English reader', function () {
+      const resolved = resolveTitle({
+        authoredName: 'Cozinha estrategia em choque',
+        sourceLang: 'pt',
+        viewerLang: 'en',
+        translations: [machine('en', 'Strategic cooking in conflict')],
+      });
+      expect(resolved.title).to.equal('Strategic cooking in conflict');
+      expect(resolved.translated).to.equal(true);
+      expect(resolved.original).to.equal('Cozinha estrategia em choque');
+      expect(resolved.sourceLang).to.equal('pt');
+    });
+
+    // Rule 2 — inert today (English is the only target) but must win over
+    // English when a second target is ever activated.
+    it('prefers a translation into the viewer language over the English one', function () {
+      const resolved = resolveTitle({
+        authoredName: 'Máy lọc nước',
+        sourceLang: 'vi',
+        viewerLang: 'ru',
+        translations: [machine('en', 'Water purifier'), machine('ru', 'Водоочиститель')],
+      });
+      expect(resolved.title).to.equal('Водоочиститель');
+    });
+
+    // Rule 4 — the guarantee that lets this ship ahead of any backfill.
+    it('falls back to the authored title when nothing is translated', function () {
+      const resolved = resolveTitle({
+        authoredName: 'Dien phan full',
+        sourceLang: null,
+        viewerLang: 'en',
+        translations: [],
+      });
+      expect(resolved.title).to.equal('Dien phan full');
+      expect(resolved.translated).to.equal(false);
+    });
+
+    it('never returns a blank title when the search row is missing entirely', function () {
+      const resolved = resolveTitle({
+        authoredName: 'SPOM v2',
+        sourceLang: undefined,
+        viewerLang: 'en',
+      });
+      expect(resolved.title).to.equal('SPOM v2');
+    });
+
+    // An 'authored' row is the pivot echoing Blueprint.name — not a
+    // translation. Treating it as one would tell an English reader their
+    // English title had been "translated from English".
+    it('ignores an authored row, which is the pivot echoing the name', function () {
+      const resolved = resolveTitle({
+        authoredName: 'SPOM v2',
+        sourceLang: 'en',
+        viewerLang: 'vi',
+        translations: [{ lang: 'en', title: 'SPOM v2', origin: 'authored' }],
+      });
+      expect(resolved.title).to.equal('SPOM v2');
+      expect(resolved.translated).to.equal(false);
+    });
+
+    it('ignores an empty translated title rather than showing a blank card', function () {
+      const resolved = resolveTitle({
+        authoredName: 'Ферма',
+        sourceLang: 'ru',
+        viewerLang: 'en',
+        translations: [machine('en', '   ')],
+      });
+      expect(resolved.title).to.equal('Ферма');
+    });
+
+    // A human-corrected translation is still not the author's own words for
+    // display purposes, but it is not machine output either — no "machine
+    // translated" disclosure should claim otherwise.
+    it('does not mark a human translation as machine output', function () {
+      const resolved = resolveTitle({
+        authoredName: 'Ферма',
+        sourceLang: 'ru',
+        viewerLang: 'en',
+        translations: [{ lang: 'en', title: 'Farm', origin: 'human' }],
+      });
+      expect(resolved.title).to.equal('Farm');
+      expect(resolved.translated).to.equal(false);
+    });
+  });
+});

--- a/app/api/batch/derive-search.ts
+++ b/app/api/batch/derive-search.ts
@@ -290,8 +290,13 @@ async function translateTitles(
     for (let b = 0; b < batch.length; b++) {
       const result = results[b];
       if (result.degraded) continue;
-      const [, group] = batch[b];
-      const [originalTitle] = batch[b];
+      const [originalTitle, group] = batch[b];
+      // Same guard as deriveSearchRowWithTranslation and
+      // detectAmbiguousTitles: a provider that handed the text back unchanged
+      // translated nothing, and marking the row 'machine' would claim a
+      // translation that isn't there while indexing the same string twice
+      // (title + titleOriginal).
+      if (result.translatedText === originalTitle) continue;
       for (const blueprintId of group.blueprintIds) {
         ops.push({
           updateOne: {

--- a/app/api/batch/derive-search.ts
+++ b/app/api/batch/derive-search.ts
@@ -95,13 +95,19 @@ async function run(dryRun: boolean, limit: number | null) {
     console.log(describeScope(limit, dryRun));
 
     // Existing rows' freshness keys, so unchanged blueprints are one $set of
-    // signals, not a full text rewrite (keeps re-runs near no-op).
-    const existing = new Map<string, string>();
+    // signals, not a full text rewrite (keeps re-runs near no-op). `origin`
+    // and `titleOriginal` ride along for the Part 1 §1 backfill below: a row
+    // translated by an earlier run is FRESH, so it never reaches the full
+    // re-derivation and would otherwise never acquire the field.
+    const existing = new Map<string, { sourceHash: string; needsOriginal: boolean }>();
     for await (const row of BlueprintSearchModel.model
       .find({ lang: 'en' })
-      .select('blueprintId sourceHash')
+      .select('blueprintId sourceHash origin titleOriginal')
       .cursor()) {
-      existing.set(row.blueprintId.toString(), row.sourceHash);
+      existing.set(row.blueprintId.toString(), {
+        sourceHash: row.sourceHash,
+        needsOriginal: row.origin === 'machine' && row.titleOriginal == null,
+      });
     }
 
     const cursor = sampledCursor(BlueprintModel.model, {}, limit);
@@ -109,6 +115,7 @@ async function run(dryRun: boolean, limit: number | null) {
     let created = 0;
     let refreshed = 0;
     let fresh = 0;
+    let originalsBackfilled = 0;
     let pending: mongoose.AnyBulkWriteOperation[] = [];
     // Scopes the translation pass to exactly the blueprints this run touched —
     // matters when --limit samples a subset; with no limit this is every row.
@@ -128,10 +135,17 @@ async function run(dryRun: boolean, limit: number | null) {
       const fields = deriveSearchRow(doc);
       const key = (doc._id as mongoose.Types.ObjectId).toString();
       const known = existing.get(key);
-      const isFresh = known != null && known === fields.sourceHash;
+      const isFresh = known != null && known.sourceHash === fields.sourceHash;
       if (known == null) created++;
       else if (!isFresh) refreshed++;
       else fresh++;
+
+      // Part 1 §1 backfill. A fresh machine-translated row's sourceHash is
+      // pinned to the blueprint's current name, so `doc.name` IS the text its
+      // translation was computed from — recoverable exactly, with no provider
+      // call and no guessing. Idempotent: the flag clears once written.
+      const backfillOriginal = isFresh && known!.needsOriginal;
+      if (backfillOriginal) originalsBackfilled++;
 
       // A fresh row only has its signals refreshed — title/origin/terms/
       // termIds/sourceHash are left untouched so a re-run never overwrites a
@@ -142,7 +156,13 @@ async function run(dryRun: boolean, limit: number | null) {
       pending.push({
         updateOne: {
           filter: { blueprintId: doc._id as mongoose.Types.ObjectId, lang: fields.lang },
-          update: { $set: isFresh ? signalsOf(fields) : fields },
+          update: {
+            $set: isFresh
+              ? backfillOriginal
+                ? { ...signalsOf(fields), titleOriginal: doc.name ?? '' }
+                : signalsOf(fields)
+              : fields,
+          },
           upsert: true,
         },
       });
@@ -153,6 +173,9 @@ async function run(dryRun: boolean, limit: number | null) {
 
     console.log(`\nSearch rows — processed: ${processed}${dryRun ? ' (dry run)' : ''}`);
     console.log(`  new: ${created}, stale (re-derived): ${refreshed}, fresh: ${fresh}`);
+    if (originalsBackfilled > 0) {
+      console.log(`  titleOriginal backfilled on ${originalsBackfilled} already-translated row(s)`);
+    }
 
     const failedBatches = await translateTitles(dryRun, processedIds);
 
@@ -255,11 +278,20 @@ async function translateTitles(
       const result = results[b];
       if (result.degraded) continue;
       const [, group] = batch[b];
+      const [originalTitle] = batch[b];
       for (const blueprintId of group.blueprintIds) {
         ops.push({
           updateOne: {
             filter: { blueprintId, lang: 'en' },
-            update: { $set: { title: result.translatedText, origin: 'machine' } },
+            update: {
+              $set: {
+                title: result.translatedText,
+                // Keeps the authored text in the index (Part 1 §1) — without
+                // it, translating a title removes it from search.
+                titleOriginal: originalTitle,
+                origin: 'machine',
+              },
+            },
           },
         });
       }

--- a/app/api/batch/derive-search.ts
+++ b/app/api/batch/derive-search.ts
@@ -4,8 +4,14 @@
 // searcher can find it. Needs the game database bootstrap (term display names
 // come from OniItem), like derive-rooms.
 //
+// Two translation passes follow the derivation:
+//   1. confidently non-English titles (phase 3b);
+//   2. titles our detector cannot place at all — short romanized/ASCII-fied
+//      text — sent to the provider to ask (spec/search-followups.md Part 1 §2).
+// Pass 2 is on by default; --skip-provider-detect turns it off.
+//
 // Usage:
-//   ts-node app/api/batch/derive-search.ts [--dry-run] [--limit N]
+//   ts-node app/api/batch/derive-search.ts [--dry-run] [--limit N] [--skip-provider-detect]
 //
 // --limit N reads a random sample of N documents (see batch-sampling.ts).
 // Rerunnable/resumable: a row whose sourceHash already matches only has its
@@ -34,6 +40,8 @@ import { TranslationBudgetModel } from '../models/translation-budget';
 import { deriveSearchRow, SearchRowFields } from '../services/search-index-service';
 import { detectLanguageCode } from '../services/language-detection-service';
 import { TranslationService } from '../services/translation-service';
+import { getSearchTermDictionary } from '../services/search-term-dictionary';
+import { normalizeContentLocale, resolveTerms, tokenize } from '../../../lib/index';
 import { parseBatchArgs, sampledCursor, describeScope } from './batch-sampling';
 
 dotenv.config();
@@ -74,7 +82,7 @@ function loadGameDatabase() {
   OniItem.load(json.buildings);
 }
 
-async function run(dryRun: boolean, limit: number | null) {
+async function run(dryRun: boolean, limit: number | null, providerDetect: boolean) {
   const mongoUri = process.env.DB_URI;
   if (!mongoUri) throw new Error('DB_URI not set in environment');
 
@@ -177,7 +185,12 @@ async function run(dryRun: boolean, limit: number | null) {
       console.log(`  titleOriginal backfilled on ${originalsBackfilled} already-translated row(s)`);
     }
 
-    const failedBatches = await translateTitles(dryRun, processedIds);
+    let failedBatches = await translateTitles(dryRun, processedIds);
+    if (providerDetect) {
+      failedBatches += await detectAmbiguousTitles(dryRun, processedIds);
+    } else {
+      console.log('\nProvider-side detection — skipped (--skip-provider-detect).');
+    }
 
     // A translation pass that failed every batch still wrote 5,308 perfectly
     // good rows, so without this the run reports success and the operator has
@@ -186,7 +199,7 @@ async function run(dryRun: boolean, limit: number | null) {
     if (failedBatches > 0) {
       throw new Error(
         `${failedBatches} title-translation batch(es) failed — search rows are written, but ` +
-          `non-English titles were not machine-translated. Fix the cause and re-run; ` +
+          `some non-English titles were not machine-translated. Fix the cause and re-run; ` +
           `rows already translated are left alone.`
       );
     }
@@ -303,9 +316,153 @@ async function translateTitles(
   return failedBatches;
 }
 
+// Part 1 §2: titles our own detector cannot place — short, romanized or
+// diacritic-stripped non-English ('Dien phan full') — clear neither of
+// detectLanguageCode's gates (>=20 significant chars OR a non-ASCII signal),
+// so phase 3b never spends a translation on them and they stay unreadable to
+// an English searcher. These titles are absent from the 446 the first backfill
+// found and no amount of re-running the pass above will pick them up.
+//
+// So stop guessing and ask the provider, which is far better than tinyld on
+// short romanized text, and whose answer we already persist
+// (TranslationUnit.detectedSourceLang).
+//
+// Precision, not cost, is the constraint here (~59K characters one time,
+// against a 500K/month free tier). Three things keep a wrong answer cheap:
+//   - a title fully covered by the term dictionary is skipped — it is already
+//     findable structurally, so there is nothing to buy;
+//   - the result is accepted ONLY when the provider reports a non-English
+//     source AND actually changed the text;
+//   - titleOriginal (Part 1 §1) keeps the authored words in the index, so a
+//     bad translation can add a wrong match but never remove a right one.
+async function detectAmbiguousTitles(
+  dryRun: boolean,
+  blueprintIds: mongoose.Types.ObjectId[]
+): Promise<number> {
+  if (!TranslationService.instance.isConfigured()) {
+    console.log('\nProvider-side detection — GOOGLE_TRANSLATE_API_KEY not set, skipping.');
+    return 0;
+  }
+
+  const dictionary = getSearchTermDictionary();
+
+  const rows: { blueprintId: mongoose.Types.ObjectId; title: string; origin: string }[] = [];
+  for (let i = 0; i < blueprintIds.length; i += BULK_BATCH_SIZE) {
+    const chunk = blueprintIds.slice(i, i + BULK_BATCH_SIZE);
+    const chunkRows = await BlueprintSearchModel.model
+      .find({ lang: 'en', origin: 'authored', blueprintId: { $in: chunk } })
+      .select('blueprintId title origin')
+      .lean();
+    rows.push(...(chunkRows as { blueprintId: mongoose.Types.ObjectId; title: string; origin: string }[]));
+  }
+
+  const byTitle = new Map<string, mongoose.Types.ObjectId[]>();
+  let skippedResolved = 0;
+  let skippedDetected = 0;
+  for (const row of rows) {
+    const title = row.title ?? '';
+    if (title.trim().length === 0) continue;
+    // Confidently anything (English included) is not this pass's business:
+    // a confident non-English title was already handled by translateTitles.
+    if (detectLanguageCode(title) != null) {
+      skippedDetected++;
+      continue;
+    }
+    const tokens = tokenize(title);
+    if (tokens.length === 0) continue;
+    if (resolveTerms(tokens, dictionary).unresolvedTokens.length === 0) {
+      skippedResolved++;
+      continue;
+    }
+    const group = byTitle.get(title);
+    if (group != null) group.push(row.blueprintId);
+    else byTitle.set(title, [row.blueprintId]);
+  }
+
+  // Batched by UNIQUE title text, same reason as translateTitles: the cache
+  // row for a text written earlier in the same call is not visible to
+  // findCached yet, so duplicates would each be billed.
+  const candidates = [...byTitle.entries()];
+  const documentCount = candidates.reduce((n, [, ids]) => n + ids.length, 0);
+  console.log(
+    `\nProvider-side detection — ${candidates.length} undetectable titles across ${documentCount} documents` +
+      ` (${skippedDetected} already detected locally, ${skippedResolved} fully resolved by the term dictionary)`
+  );
+
+  if (dryRun || candidates.length === 0) return 0;
+
+  let done = 0;
+  let accepted = 0;
+  let failedBatches = 0;
+  for (let i = 0; i < candidates.length; i += TRANSLATE_BATCH_SIZE) {
+    const batch = candidates.slice(i, i + TRANSLATE_BATCH_SIZE);
+    let results: Awaited<ReturnType<typeof TranslationService.instance.translateMany>>;
+    try {
+      results = await TranslationService.instance.translateMany(
+        batch.map(([title]) => ({
+          sourceText: title,
+          sourceLang: null,
+          targetLang: 'en',
+          // Without this the ASCII short-circuit returns every one of these
+          // titles untouched with no provider call — the pass would report
+          // success having done nothing at all.
+          forceProviderDetection: true,
+        })),
+        null
+      );
+    } catch (err) {
+      console.log(`  batch ${i}-${i + batch.length} detection error, skipping`);
+      console.log(err);
+      done += batch.length;
+      failedBatches++;
+      continue;
+    }
+
+    const ops: mongoose.AnyBulkWriteOperation[] = [];
+    for (let b = 0; b < batch.length; b++) {
+      const result = results[b];
+      const [title, ids] = batch[b];
+      if (result.degraded) continue;
+      const detected = normalizeContentLocale(result.sourceLang);
+      // Both conditions matter. A non-English report with unchanged text means
+      // the provider found nothing to translate; unchanged text with an English
+      // report means it was English all along. Either way the row stays
+      // authored, which is the correct, free outcome.
+      if (detected == null || detected === 'en') continue;
+      if (result.translatedText === title) continue;
+
+      accepted++;
+      for (const blueprintId of ids) {
+        ops.push({
+          updateOne: {
+            filter: { blueprintId, lang: 'en' },
+            update: {
+              $set: { title: result.translatedText, titleOriginal: title, origin: 'machine' },
+            },
+          },
+        });
+      }
+    }
+    if (ops.length > 0) await BlueprintSearchModel.model.bulkWrite(ops as any);
+    done += batch.length;
+    console.log(`  ...${done}/${candidates.length} checked, ${accepted} translated`);
+  }
+
+  console.log(
+    `  provider-side detection accepted ${accepted}/${candidates.length} titles ` +
+      `(the rest came back English or unchanged and stay authored)`
+  );
+  return failedBatches;
+}
+
 if (require.main === module) {
   const { dryRun, limit } = parseBatchArgs(process.argv);
-  run(dryRun, limit).catch(err => {
+  // On by default: leaving it off is what makes "everything is readable in
+  // English" quietly false for the romanized population. Re-runs are near-free
+  // (translationunits is keyed by text hash, so a title asked about before is
+  // a cache read), and rows already 'machine' are skipped outright.
+  const providerDetect = !process.argv.includes('--skip-provider-detect');
+  run(dryRun, limit, providerDetect).catch(err => {
     console.error(err);
     process.exit(1);
   });

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -20,6 +20,7 @@ import {
   RAW_SOURCE_FORMATS,
   RawSourceFormat,
   validateBlueprintName,
+  resolveContentLocale,
 } from '../../lib/index';
 import { Blueprint as sharedBlueprint, BlueprintDetailsResponse } from '../../lib/index';
 import { computeHotScore } from '../../lib/index';
@@ -46,6 +47,13 @@ import { deriveDlcs } from './services/dlc-derivation-service';
 import { detectLanguage } from './services/language-detection-service';
 import { TranslationService } from './services/translation-service';
 import { upsertSearchRow, syncMachineTitle, syncSearchRowStatus } from './services/search-index-service';
+import {
+  resolveTitles,
+  resolveOneTitle,
+  titleFields,
+  titleSourceOf,
+  ResolvedTitleMap,
+} from './services/title-resolution-service';
 import {
   collapseClusters,
   SearchMatch,
@@ -543,9 +551,19 @@ export class BlueprintController {
         myRating = mine?.value ?? null;
       }
 
+      // Editor-open resolves a title for CHROME only. `name` below stays the
+      // authored value: the editor stores it and the save dialog pre-fills
+      // from it, so translating it here would quietly rewrite the author's
+      // title on the next overwrite save — the exact mutation §2.5 forbids.
+      const resolvedTitle = await resolveOneTitle(
+        titleSourceOf(blueprint),
+        BlueprintController.viewerContentLang(req)
+      );
+
       let response: BlueprintResponse = {
         id: (blueprint._id as any).toString(),
         name: blueprint.name,
+        ...titleFields(resolvedTitle, blueprint.name),
         data: await resolveCurrentData(blueprint),
         nbRatings: blueprint.ratingCount ?? 0,
         rating: blueprint.ratingAverage ?? 0,
@@ -1125,6 +1143,11 @@ export class BlueprintController {
         console.log(err);
       }
 
+      const resolvedTitles = await resolveTitles(
+        page.map(titleSourceOf),
+        BlueprintController.viewerContentLang(req)
+      );
+
       for (const blueprint of page) {
         if (blueprint.createdAt < returnValue.oldest) returnValue.oldest = blueprint.createdAt;
         returnValue.blueprints.push(
@@ -1132,7 +1155,8 @@ export class BlueprintController {
             blueprint,
             commentCounts,
             forkedFromNames,
-            duplicateCounts
+            duplicateCounts,
+            resolvedTitles
           )
         );
       }
@@ -1146,11 +1170,17 @@ export class BlueprintController {
   // viewer-independent: no per-viewer fields, so responses built from it are
   // byte-identical for every viewer and safe to cache at the edge. Per-viewer
   // state (myRating/ownedByMe) belongs to the details response only.
+  //
+  // The resolved display title is the one exception, and it does not break
+  // that property: it varies by the explicit `?lang=` parameter, which is part
+  // of the URL and therefore part of the cache key, not by anything about who
+  // is asking.
   private static buildListItem(
     blueprint: Blueprint,
     commentCounts: Map<string, number>,
     forkedFromNames: Map<string, string | null>,
-    duplicateCounts: Map<string, number> = new Map()
+    duplicateCounts: Map<string, number> = new Map(),
+    resolvedTitles: ResolvedTitleMap = new Map()
   ): BlueprintListItem {
     const id = (blueprint._id as any).toString();
 
@@ -1164,6 +1194,7 @@ export class BlueprintController {
     return {
       id,
       name: blueprint.name,
+      ...titleFields(resolvedTitles.get(id), blueprint.name),
       ownerId,
       ownerName: username,
       createdAt: blueprint.createdAt,
@@ -1317,9 +1348,20 @@ export class BlueprintController {
         console.log(err);
       }
 
+      const resolvedTitles = await resolveTitles(
+        page.map(titleSourceOf),
+        BlueprintController.viewerContentLang(req)
+      );
+
       const response: RelatedBlueprintsResponse = {
         blueprints: page.map(blueprint =>
-          BlueprintController.buildListItem(blueprint, commentCounts, forkedFromNames)
+          BlueprintController.buildListItem(
+            blueprint,
+            commentCounts,
+            forkedFromNames,
+            new Map(),
+            resolvedTitles
+          )
         ),
       };
       setFeedCacheControl(req, res);
@@ -1469,9 +1511,15 @@ export class BlueprintController {
         }
       }
 
+      const resolvedTitle = await resolveOneTitle(
+        titleSourceOf(blueprint),
+        BlueprintController.viewerContentLang(req)
+      );
+
       const response: BlueprintDetailsResponse = {
         id: (blueprint._id as any).toString(),
         name: blueprint.name,
+        ...titleFields(resolvedTitle, blueprint.name),
         ownerId,
         ownerName,
         createdAt: blueprint.createdAt,
@@ -1583,6 +1631,18 @@ export class BlueprintController {
   // text isn't statistically conclusive — it never affects what gets billed
   // for translation (see search-index-service's confidentTitleLang, which
   // re-detects from the text alone for that decision).
+  // The viewer's content locale, as an EXPLICIT query parameter rather than
+  // Accept-Language (spec/search-followups.md §2.5). These responses are
+  // Cloudflare-cached and viewer-independent apart from this: a `?lang=` value
+  // keys cleanly at the edge, whereas `Vary: Accept-Language` would fragment
+  // the cache across every browser's full header. The frontend sends the
+  // parameter only when the resolved locale is not English, so the ordinary
+  // browse URL — which is nearly all traffic — stays byte-identical to what
+  // it was before this feature.
+  public static viewerContentLang(req: Request): string {
+    return resolveContentLocale(req.query.lang);
+  }
+
   private static authorLocalePrior(req: Request): string | null {
     const preferred = req.acceptsLanguages().find(lang => lang !== '*');
     return preferred != null ? preferred.split('-')[0].toLowerCase() : null;

--- a/app/api/blueprint-controller.ts
+++ b/app/api/blueprint-controller.ts
@@ -21,6 +21,7 @@ import {
   RawSourceFormat,
   validateBlueprintName,
   resolveContentLocale,
+  normalizeContentLocale,
 } from '../../lib/index';
 import { Blueprint as sharedBlueprint, BlueprintDetailsResponse } from '../../lib/index';
 import { computeHotScore } from '../../lib/index';
@@ -1643,6 +1644,20 @@ export class BlueprintController {
     return resolveContentLocale(req.query.lang);
   }
 
+  // The author's content-locale preference, or null if they never set one.
+  // One lean lookup per save; a failure is never fatal — detection simply
+  // falls back to the Accept-Language prior, i.e. today's behaviour.
+  private static async authorDeclaredLang(ownerId: string): Promise<string | null> {
+    try {
+      const user = await UserModel.model.findById(ownerId).select('localePreference').lean();
+      return normalizeContentLocale(user?.localePreference);
+    } catch (err) {
+      console.log('author locale preference lookup error');
+      console.log(err);
+      return null;
+    }
+  }
+
   private static authorLocalePrior(req: Request): string | null {
     const preferred = req.acceptsLanguages().find(lang => lang !== '*');
     return preferred != null ? preferred.split('-')[0].toLowerCase() : null;
@@ -1699,8 +1714,15 @@ export class BlueprintController {
     // reads `name`, not `metadata.description`. The locale prior only ever
     // supplies a fallback for a title too short/ambiguous to detect on its
     // own; it never overrides a confident statistical read.
+    // The author's own declaration beats the browser's default as the prior
+    // (spec/search-followups.md §2.6). Passing a DECLARED prior is also what
+    // makes `confidence: 'prior'` trustworthy downstream — the reversal of the
+    // existing rule is deliberate and rests entirely on the difference in
+    // evidence: an Accept-Language header is a default nobody chose, a picker
+    // setting is a user's own statement.
+    const declaredLang = await BlueprintController.authorDeclaredLang(ownerId);
     blueprint.sourceLang = detectLanguage(name, {
-      prior: BlueprintController.authorLocalePrior(req),
+      prior: declaredLang ?? BlueprintController.authorLocalePrior(req),
     }).lang;
     // Derived fact, never client-supplied — any `rooms` key in the request
     // body is ignored (same policy as a client trying to set ratingCount).
@@ -1757,7 +1779,7 @@ export class BlueprintController {
       // forget: a translation call can take up to 15s, and the corpus becomes
       // searchable to English queries moments after the save responds, not
       // atomically with it (same rationale as syncSearchRowStatus below).
-      syncMachineTitle(newBlueprint, ownerId);
+      syncMachineTitle(newBlueprint, ownerId, declaredLang);
     } catch (error) {
       console.log('Blueprint save error');
       console.log(error);

--- a/app/api/models/blueprint-search.ts
+++ b/app/api/models/blueprint-search.ts
@@ -35,6 +35,20 @@ export interface BlueprintSearch extends Document {
   textLang: string;
   origin: SearchRowOrigin;
   title: string;
+  // The author's own title, retained ONLY when `title` has been replaced by a
+  // translation (spec/search-followups.md Part 1 §1). Before this field, a row
+  // flipping to `origin: 'machine'` deleted the authored text from the index
+  // entirely: 'Cozinha estrategia em choque' became findable by "strategic
+  // cooking" and no longer by its own words. That is worst exactly where
+  // query translation also fails — romanized or diacritic-stripped text, whose
+  // language neither end detects — so both ends broke at once and the literal
+  // fallback had been thrown away.
+  //
+  // null while `origin` is 'authored', deliberately: there it would duplicate
+  // `title` verbatim and double that text's weight in the text index for no
+  // gain. It is derived wholesale, never appended to, so it cannot accumulate
+  // stale pseudo-titles the way a `terms[]` entry would have.
+  titleOriginal: string | null;
   description: string;
   // Localized display names of contained buildings/rooms — text-searchable.
   terms: string[];
@@ -72,6 +86,7 @@ export class BlueprintSearchModel {
         textLang: { type: String, required: true, default: 'none' },
         origin: { type: String, enum: SEARCH_ROW_ORIGINS, required: true },
         title: { type: String, required: true, default: '' },
+        titleOriginal: { type: String, default: null },
         description: { type: String, default: '' },
         terms: { type: [String], default: [] },
         termIds: { type: [String], default: [] },
@@ -92,10 +107,18 @@ export class BlueprintSearchModel {
     searchSchema.index({ blueprintId: 1, lang: 1 }, { unique: true });
     searchSchema.index({ termIds: 1 });
     searchSchema.index({ clusterKey: 1 });
+    // Adding/removing a field here changes the index definition, which Mongo
+    // will not do in place — see migrations/20260804000000_search-title-original.js,
+    // which drops and recreates it under the same name.
+    //
+    // titleOriginal sits at the `terms` weight, not `title`'s: a
+    // machine-translated row holds both forms, and equal weighting would make
+    // it compete with itself, letting a translated row outrank an authored one
+    // purely for carrying the same text twice.
     searchSchema.index(
-      { title: 'text', terms: 'text', description: 'text' },
+      { title: 'text', titleOriginal: 'text', terms: 'text', description: 'text' },
       {
-        weights: { title: 10, terms: 4, description: 1 },
+        weights: { title: 10, titleOriginal: 4, terms: 4, description: 1 },
         language_override: 'textLang',
         default_language: 'en',
         name: 'blueprint_search_text',

--- a/app/api/models/user.ts
+++ b/app/api/models/user.ts
@@ -47,6 +47,17 @@ export interface User extends Document {
   // property on the client. Same privacy rule as themePreference.
   customThemeColors?: CustomThemeColors;
 
+  // Which language the user reads blueprint CONTENT in (base ISO tag —
+  // spec/search-followups.md Part 2). Not the UI locale: the chrome is
+  // English for everyone regardless. Absent means "never chosen", which
+  // resolves to DEFAULT_CONTENT_LOCALE at read time rather than being written
+  // eagerly — same rule as themePreference/dlcPreferences, and for the same
+  // reason: a default that writes itself is indistinguishable from a choice,
+  // which would make the §2.10 "who actually reads in what language"
+  // measurement meaningless. Private account data: never in ProfileResponse
+  // or any other payload another user can reach.
+  localePreference?: string;
+
   setPassword(password: string): void;
   validPassword(password: string): boolean;
   generateJwt(role?: string): string;
@@ -95,6 +106,7 @@ export class UserModel {
         excludedDlcs: { type: [String], default: [] },
       },
       themePreference: { type: String },
+      localePreference: { type: String },
       // Written whole on every save (findByIdAndUpdate $set), validated in the
       // controller via sanitizeCustomThemeColors — Mixed here is just storage.
       customThemeColors: { type: mongoose.Schema.Types.Mixed },

--- a/app/api/services/search-index-service.ts
+++ b/app/api/services/search-index-service.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 import mongoose from 'mongoose';
-import { ClusterItem, contentClusterKey } from '../../../lib/index';
+import { ClusterItem, contentClusterKey, normalizeContentLocale } from '../../../lib/index';
 import { Blueprint } from '../models/blueprint';
 import { BlueprintSearchModel, mongoTextLang, SearchRowOrigin } from '../models/blueprint-search';
 import { getSearchTermDictionary } from './search-term-dictionary';
@@ -177,10 +177,20 @@ function confidentTitleLang(title: string): string | null {
 // re-translating it.
 export async function deriveSearchRowWithTranslation(
   blueprint: Blueprint,
-  userId: string | null
+  userId: string | null,
+  // The author's content-locale preference, when they have set one
+  // (spec/search-followups.md §2.6). A DECLARATION, not a browser default:
+  // where an Accept-Language prior is refused as evidence to bill on, this is
+  // the user's own statement about the language they write in, and it is the
+  // only route by which a short romanized title ('Dien phan full') gets
+  // translated at save time rather than waiting for the batch pass.
+  declaredLang?: string | null
 ): Promise<SearchRowFields> {
   const base = deriveSearchRow(blueprint);
-  const sourceLang = confidentTitleLang(base.title);
+  const detected = confidentTitleLang(base.title);
+  const declared =
+    declaredLang != null && declaredLang !== 'en' && declaredLang !== detected ? declaredLang : null;
+  const sourceLang = detected ?? declared;
   if (sourceLang == null) return base;
   if (!TranslationService.instance.isConfigured()) return base;
 
@@ -190,6 +200,19 @@ export async function deriveSearchRowWithTranslation(
       userId
     );
     if (result.degraded) return base;
+    // A provider that handed the text back unchanged translated nothing —
+    // marking the row 'machine' would claim a translation that isn't there and
+    // index the same string twice (title + titleOriginal).
+    if (result.translatedText === base.title) return base;
+    // On the declared-only path our own detector had no opinion, so the
+    // provider's verdict is the only evidence there is: accept it only when it
+    // reports a genuinely non-English source. A Vietnamese-locale author
+    // writing 'SPOM v2' comes back reported as English and stays authored,
+    // which is what makes a misdeclaration cheap.
+    if (detected == null) {
+      const providerLang = normalizeContentLocale(result.sourceLang);
+      if (providerLang == null || providerLang === 'en') return base;
+    }
     // titleOriginal keeps the authored text in the index, so a translation can
     // only ever ADD a match, never remove one — the mitigation that makes
     // provider-side detection (Part 1 §2) safe to trust.
@@ -212,8 +235,12 @@ export async function deriveSearchRowWithTranslation(
 // completes, not atomically with it (same rationale as syncSearchRowStatus
 // below). A no-op write when translation wasn't warranted — the authored row
 // upsertSearchRow already wrote is left alone.
-export function syncMachineTitle(blueprint: Blueprint, userId: string | null): void {
-  deriveSearchRowWithTranslation(blueprint, userId)
+export function syncMachineTitle(
+  blueprint: Blueprint,
+  userId: string | null,
+  declaredLang?: string | null
+): void {
+  deriveSearchRowWithTranslation(blueprint, userId, declaredLang)
     .then(fields => {
       if (fields.origin !== 'machine') return;
       // sourceHash pins this write to the content the translation was

--- a/app/api/services/search-index-service.ts
+++ b/app/api/services/search-index-service.ts
@@ -29,6 +29,7 @@ export interface SearchRowFields {
   textLang: string;
   origin: SearchRowOrigin;
   title: string;
+  titleOriginal: string | null;
   description: string;
   terms: string[];
   termIds: string[];
@@ -124,6 +125,10 @@ export function deriveSearchRow(blueprint: Blueprint): SearchRowFields {
     textLang: mongoTextLang(lang),
     origin: 'authored',
     title,
+    // Null while authored: `title` already holds this text, and duplicating it
+    // would double its weight in the text index. Set only by the writers below
+    // that replace `title` with a translation (Part 1 §1).
+    titleOriginal: null,
     description,
     terms,
     termIds,
@@ -185,7 +190,15 @@ export async function deriveSearchRowWithTranslation(
       userId
     );
     if (result.degraded) return base;
-    return { ...base, title: result.translatedText, origin: 'machine' };
+    // titleOriginal keeps the authored text in the index, so a translation can
+    // only ever ADD a match, never remove one — the mitigation that makes
+    // provider-side detection (Part 1 §2) safe to trust.
+    return {
+      ...base,
+      title: result.translatedText,
+      titleOriginal: base.title,
+      origin: 'machine',
+    };
   } catch (err) {
     console.log('title translation error');
     console.log(err);
@@ -213,7 +226,7 @@ export function syncMachineTitle(blueprint: Blueprint, userId: string | null): v
           lang: fields.lang,
           sourceHash: fields.sourceHash,
         },
-        { $set: { title: fields.title, origin: fields.origin } }
+        { $set: { title: fields.title, titleOriginal: fields.titleOriginal, origin: fields.origin } }
       );
     })
     .catch(err => {
@@ -322,6 +335,9 @@ export async function upsertTranslatedSearchRow(params: {
         textLang: mongoTextLang(targetLang),
         origin: 'machine',
         title: translatedTitle,
+        // Only when a translation actually happened; a provider that returned
+        // the input unchanged has produced no second form to preserve.
+        titleOriginal: translatedTitle === title ? null : title,
         description: translatedDescription,
         terms,
         termIds,

--- a/app/api/services/title-resolution-service.ts
+++ b/app/api/services/title-resolution-service.ts
@@ -1,0 +1,148 @@
+import mongoose from 'mongoose';
+import { resolveTitle, ResolvedTitle, TitleTranslation, DEFAULT_CONTENT_LOCALE } from '../../../lib/index';
+import { Blueprint } from '../models/blueprint';
+import { BlueprintSearchModel } from '../models/blueprint-search';
+
+// Viewer-locale title resolution at the response boundary
+// (spec/search-followups.md §2.5). ONE implementation, used by every endpoint
+// that returns a blueprint title — the list, the details page, the related
+// shelf and the editor-open payload. Inlining the rule per endpoint is how a
+// card and its details page end up disagreeing about what a blueprint is
+// called.
+//
+// Reading DISPLAY titles out of `blueprintsearch` is a deliberate widening of
+// that collection's contract, which until now was "derived and disposable…
+// advisory for retrieval only" (§2.4). Confirmed rather than overturned,
+// because all three properties that made the old contract safe still hold:
+//
+//   - the resolution chain always terminates at `Blueprint.name`, so a stale,
+//     missing or dropped row degrades to the authored title — never to blank;
+//   - machine titles are reproducible for free from the `translationunits`
+//     text-hash cache, so rebuilding the collection costs a `derive-search`
+//     run and no money;
+//   - rows stay advisory for VISIBILITY: the authoritative deleted/draft
+//     filter still runs against `blueprints`, and titles are only ever
+//     resolved for documents that already passed it, so a stale row still
+//     cannot leak a draft.
+//
+// The alternative considered and rejected was a `titleTranslations: {lang:
+// text}` map on the blueprint document — more obviously correct, but it costs
+// a second write path and a migration to hold data that is already derivable.
+// Revisit if the widened contract ever proves uncomfortable.
+
+export type ResolvedTitleMap = Map<string, ResolvedTitle>;
+
+interface TitleSource {
+  _id: unknown;
+  name: string;
+  sourceLang?: string | null;
+}
+
+/**
+ * Resolves the display title of every blueprint in `blueprints` for a viewer
+ * reading in `viewerLang`.
+ *
+ * One query, never fatal: any failure yields authored titles for everything,
+ * which is exactly what the site did before this feature existed.
+ */
+export async function resolveTitles(
+  blueprints: readonly TitleSource[],
+  viewerLang: string
+): Promise<ResolvedTitleMap> {
+  const resolved: ResolvedTitleMap = new Map();
+  if (blueprints.length === 0) return resolved;
+
+  // Rule 1 short-circuit: a blueprint authored in the viewer's own language
+  // needs no lookup at all, and for an English reader browsing an
+  // overwhelmingly English corpus that is most of the page.
+  const needsLookup = blueprints.filter(
+    b => b.sourceLang == null || b.sourceLang !== viewerLang
+  );
+
+  let translations = new Map<string, TitleTranslation[]>();
+  if (needsLookup.length > 0) {
+    try {
+      // Only 'machine'/'human' rows are translations; an 'authored' row is the
+      // pivot echoing Blueprint.name and would resolve a title to itself while
+      // claiming it had been translated. Filtered in the query rather than in
+      // resolveTitle so the common case moves no rows over the wire.
+      const rows = await BlueprintSearchModel.model
+        .find({
+          blueprintId: { $in: needsLookup.map(b => b._id as mongoose.Types.ObjectId) },
+          lang: { $in: [viewerLang, DEFAULT_CONTENT_LOCALE] },
+          origin: { $ne: 'authored' },
+        })
+        .select('blueprintId lang title origin')
+        .lean();
+
+      for (const row of rows) {
+        const key = row.blueprintId.toString();
+        const list = translations.get(key);
+        const entry: TitleTranslation = {
+          lang: row.lang,
+          title: row.title ?? '',
+          origin: row.origin,
+        };
+        if (list != null) list.push(entry);
+        else translations.set(key, [entry]);
+      }
+    } catch (err) {
+      // A search-index outage must never take the browse page down with it —
+      // every blueprint simply keeps its authored title.
+      console.log('title resolution lookup error');
+      console.log(err);
+      translations = new Map();
+    }
+  }
+
+  for (const blueprint of blueprints) {
+    const key = (blueprint._id as { toString(): string }).toString();
+    resolved.set(
+      key,
+      resolveTitle({
+        authoredName: blueprint.name,
+        sourceLang: blueprint.sourceLang ?? null,
+        viewerLang,
+        translations: translations.get(key),
+      })
+    );
+  }
+
+  return resolved;
+}
+
+/** Single-document convenience for the details and editor-open responses. */
+export async function resolveOneTitle(
+  blueprint: TitleSource,
+  viewerLang: string
+): Promise<ResolvedTitle> {
+  const map = await resolveTitles([blueprint], viewerLang);
+  return (
+    map.get((blueprint._id as { toString(): string }).toString()) ?? {
+      title: blueprint.name,
+      original: blueprint.name,
+      translated: false,
+      sourceLang: blueprint.sourceLang ?? null,
+    }
+  );
+}
+
+/**
+ * The response-shaped projection of a resolution. Emitted only when it says
+ * something the `name` field doesn't already: an untranslated title sends no
+ * extra bytes and, more importantly, no `nameTranslated: false` for a client
+ * to mistake for a meaningful signal.
+ */
+export function titleFields(resolved: ResolvedTitle | undefined, authoredName: string) {
+  if (resolved == null || resolved.title === authoredName) return {};
+  return {
+    displayName: resolved.title,
+    nameTranslated: resolved.translated,
+    nameSourceLang: resolved.sourceLang,
+  };
+}
+
+/** Blueprint (document or lean) → the shape resolveTitles needs. */
+export function titleSourceOf(blueprint: Blueprint): TitleSource {
+  return { _id: blueprint._id, name: blueprint.name, sourceLang: blueprint.sourceLang ?? null };
+}

--- a/app/api/services/translation-service.ts
+++ b/app/api/services/translation-service.ts
@@ -29,6 +29,14 @@ export interface TranslateInput {
   // Reference tokens ({{blueprint:id}}/{{user:id}}) must round-trip intact —
   // only comment bodies carry them.
   hasReferenceTokens?: boolean;
+  // Ask the PROVIDER what language this is, bypassing the ASCII short-circuit
+  // below (spec/search-followups.md Part 1 §2). Set only by callers whose whole
+  // purpose is that question: a short, all-ASCII title our statistical detector
+  // cannot place ('Dien phan full') is precisely the input the shortcut throws
+  // away untouched, so without this the caller would silently no-op while
+  // appearing to succeed. Costs a provider call and a cache row per new text —
+  // never set it on a path that already knows the answer.
+  forceProviderDetection?: boolean;
 }
 
 export interface TranslateResult {
@@ -192,8 +200,9 @@ export class TranslationService {
       // Cheapest possible path — the majority case — and it needs no cache
       // row or provider call at all.
       if (
-        (sourceLang != null && sourceLang === baseLangOfTarget(targetLang)) ||
-        (sourceLang == null && ASCII_ONLY.test(sourceText))
+        !input.forceProviderDetection &&
+        ((sourceLang != null && sourceLang === baseLangOfTarget(targetLang)) ||
+          (sourceLang == null && ASCII_ONLY.test(sourceText)))
       ) {
         results[i] = { translatedText: sourceText, sourceLang, cached: true, provider: 'none' };
         continue;

--- a/app/api/user-controller.ts
+++ b/app/api/user-controller.ts
@@ -17,6 +17,7 @@ import {
   sanitizeCustomThemeColors,
   CUSTOM_THEME_ID,
   THEME_IDS,
+  normalizeContentLocale,
 } from '../../lib/index';
 import { NotificationController } from './notification-controller';
 import { apiError } from './utils/apiError';
@@ -289,6 +290,70 @@ export class UserController {
         console.log('updateThemePreference error');
         console.log(err);
         res.status(500).json(apiError(500, 'Failed to update theme preference'));
+      });
+  }
+
+  // Which language this user reads blueprint content in. Private account
+  // state — same rule as dlcPreferences/themePreference: never merged into
+  // getProfile/ProfileResponse.
+  //
+  // Reports `null` rather than 'en' when the account has never chosen: the
+  // client's own default is navigator.language, and collapsing "never chose"
+  // into "chose English" here would override that on every device the user
+  // has ever logged in from.
+  public getLocalePreference(req: Request, res: Response): void {
+    const user = req.user as UserJwt;
+
+    UserModel.model
+      .findById(user._id)
+      .select('localePreference')
+      .lean()
+      .then(found => {
+        if (!found) {
+          res.status(404).json(apiError(404, 'User not found'));
+          return;
+        }
+        res.json({ locale: normalizeContentLocale(found.localePreference) });
+      })
+      .catch(err => {
+        console.log('getLocalePreference error');
+        console.log(err);
+        res.status(500).json(apiError(500, 'Failed to retrieve locale preference'));
+      });
+  }
+
+  // The content-language set is deliberately OPEN (spec/search-followups.md
+  // §2.3) — any base ISO tag, not a closed list like themePreference's. A
+  // user may read and write in a language we never translate INTO; declaring
+  // it costs nothing and gets them their own titles back. So this validates
+  // shape only, which is also what keeps it from being a string injection
+  // point: the stored value reaches a `?lang=` query param and a `lang`
+  // equality test, never markup.
+  public updateLocalePreference(req: Request, res: Response): void {
+    const user = req.user as UserJwt;
+    const { locale } = req.body as { locale?: unknown };
+
+    const normalized = normalizeContentLocale(locale);
+    if (normalized == null) {
+      res
+        .status(400)
+        .json(apiError(400, 'locale must be a base ISO language tag (2-3 letters), e.g. "en" or "vi"'));
+      return;
+    }
+
+    UserModel.model
+      .findByIdAndUpdate(user._id, { localePreference: normalized }, { new: true })
+      .then(updated => {
+        if (!updated) {
+          res.status(404).json(apiError(404, 'User not found'));
+          return;
+        }
+        res.json({ locale: normalizeContentLocale(updated.localePreference) });
+      })
+      .catch(err => {
+        console.log('updateLocalePreference error');
+        console.log(err);
+        res.status(500).json(apiError(500, 'Failed to update locale preference'));
       });
   }
 

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -121,6 +121,10 @@ export class Routes {
     app
       .route('/api/users/me/theme-preference')
       .patch(auth, this.userController.updateThemePreference);
+    app.route('/api/users/me/locale-preference').get(auth, this.userController.getLocalePreference);
+    app
+      .route('/api/users/me/locale-preference')
+      .patch(auth, this.userController.updateLocalePreference);
     // Optional seed photo arrives as a raw image/* body (no multipart in this
     // API surface); anything else falls through to random generation
     app

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -4,9 +4,14 @@ import { of } from "rxjs";
 import { AppComponent } from "./app.component";
 import { ThemeService } from "./module-blueprint/services/theme.service";
 import { AuthenticationService } from "./module-blueprint/services/authentification-service";
+import { ContentLocaleService } from "./module-blueprint/services/content-locale.service";
 
 describe("AppComponent", () => {
   let themeService: {
+    initFromLocal: ReturnType<typeof vi.fn>;
+    loadForUser: ReturnType<typeof vi.fn>;
+  };
+  let contentLocaleService: {
     initFromLocal: ReturnType<typeof vi.fn>;
     loadForUser: ReturnType<typeof vi.fn>;
   };
@@ -18,12 +23,17 @@ describe("AppComponent", () => {
       initFromLocal: vi.fn(),
       loadForUser: vi.fn().mockReturnValue(of("steam")),
     };
+    contentLocaleService = {
+      initFromLocal: vi.fn(),
+      loadForUser: vi.fn().mockReturnValue(of("en")),
+    };
 
     await TestBed.configureTestingModule({
       declarations: [AppComponent],
       schemas: [NO_ERRORS_SCHEMA],
       providers: [
         { provide: ThemeService, useValue: themeService },
+        { provide: ContentLocaleService, useValue: contentLocaleService },
         {
           provide: AuthenticationService,
           useValue: { isLoggedIn: () => loggedIn },
@@ -63,5 +73,26 @@ describe("AppComponent", () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     expect(themeService.loadForUser).toHaveBeenCalled();
+  });
+
+  // The content locale decides which title every read request asks for, so it
+  // has to be settled before the first list request, not after.
+  it("applies the locally stored content locale on init", () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    expect(contentLocaleService.initFromLocal).toHaveBeenCalled();
+  });
+
+  it("does not fetch the account content locale for a logged-out visitor", () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    expect(contentLocaleService.loadForUser).not.toHaveBeenCalled();
+  });
+
+  it("fetches the account content locale once a session exists", () => {
+    loggedIn = true;
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    expect(contentLocaleService.loadForUser).toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from "@angular/core";
 import { ThemeService } from "./module-blueprint/services/theme.service";
+import { ContentLocaleService } from "./module-blueprint/services/content-locale.service";
 import { AuthenticationService } from "./module-blueprint/services/authentification-service";
 
 @Component({
@@ -13,6 +14,7 @@ export class AppComponent implements OnInit {
 
   constructor(
     private themeService: ThemeService,
+    private contentLocaleService: ContentLocaleService,
     private authService: AuthenticationService,
   ) {}
 
@@ -20,8 +22,13 @@ export class AppComponent implements OnInit {
     // Local first and synchronously, so the first paint is already the right
     // palette; the account copy overrides it a moment later when it lands.
     this.themeService.initFromLocal();
+    // Same order and the same reason: the content locale decides which title
+    // every request asks for, so it must be settled before the first list
+    // request goes out, not after.
+    this.contentLocaleService.initFromLocal();
     if (this.authService.isLoggedIn()) {
       this.themeService.loadForUser().subscribe({ error: () => {} });
+      this.contentLocaleService.loadForUser().subscribe({ error: () => {} });
     }
   }
 }

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.css
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.css
@@ -31,6 +31,23 @@
   background: var(--bni-tag-hi);
 }
 
+/* The machine-translation marker. Sits with the title, not with the chips:
+   it qualifies the words next to it, and a reader scanning for "why did this
+   match" looks at the title. Muted against the tag stock so it reads as a
+   footnote rather than a status. */
+.card-title-translated {
+  flex: none;
+  align-self: center;
+  /* The row is space-between over title and stars; without this the marker
+     becomes a third distributed item and floats into the middle of the gap
+     instead of staying attached to the words it qualifies. */
+  margin-right: auto;
+  margin-left: -6px;
+  font-size: 12px;
+  opacity: 0.55;
+  cursor: help;
+}
+
 .card-stars {
   flex: none;
   padding-top: 3px;

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.html
@@ -32,6 +32,7 @@
       <i
         *ngIf="item.nameTranslated"
         class="pi pi-language card-title-translated"
+        role="img"
         [attr.title]="translatedTitleTooltip"
         [attr.aria-label]="translatedTitleTooltip"
       ></i>

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.html
@@ -11,7 +11,7 @@
     <img
       [appQueuedPreview]="cardPreviewUrl()"
       [previewFallback]="thumbnailFallbackUrl()"
-      [alt]="item.name"
+      [alt]="title"
       width="480"
       height="480"
     />
@@ -23,8 +23,18 @@
         class="bni-card__title"
         [routerLink]="['/blueprint', item.id]"
         [state]="linkState"
-        >{{ item.name }}</a
+        >{{ title }}</a
       >
+      <!-- Machine-translation disclosure (spec/search-followups.md §2.7).
+           Deliberately a quiet glyph, not a badge: it must be noticeable to
+           someone wondering why a card matched their English search, without
+           shouting on every card in a mostly-translated list. -->
+      <i
+        *ngIf="item.nameTranslated"
+        class="pi pi-language card-title-translated"
+        [attr.title]="translatedTitleTooltip"
+        [attr.aria-label]="translatedTitleTooltip"
+      ></i>
       <app-star-rating
         class="card-stars"
         [average]="item.rating"
@@ -243,6 +253,6 @@
     </svg>
   </div>
   <div class="card-info">
-    <span class="bni-card__title">{{ item.name }}</span>
+    <span class="bni-card__title">{{ title }}</span>
   </div>
 </div>

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.spec.ts
@@ -4,6 +4,7 @@ import { By } from "@angular/platform-browser";
 
 import { BlueprintCardComponent } from "./blueprint-card.component";
 import { QueuedPreviewDirective } from "../../directives/queued-preview.directive";
+import { ContentLocaleService } from "../../services/content-locale.service";
 
 function makeItem(overrides: any = {}) {
   return {
@@ -37,6 +38,14 @@ describe("BlueprintCardComponent", () => {
       declarations: [BlueprintCardComponent],
       imports: [QueuedPreviewDirective],
       schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        // Only used for the "translated from X" tooltip; stubbed so the card
+        // spec stays free of HttpClient.
+        {
+          provide: ContentLocaleService,
+          useValue: { labelFor: (code: string | null) => code ?? "" },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(BlueprintCardComponent);
@@ -47,6 +56,68 @@ describe("BlueprintCardComponent", () => {
     component.item = makeItem();
     fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  describe("viewer-resolved title", () => {
+    it("shows the authored name when the response carries no resolution", () => {
+      component.item = makeItem();
+      fixture.detectChanges();
+      expect(
+        fixture.debugElement.query(By.css(".bni-card__title")).nativeElement
+          .textContent,
+      ).toContain("Real Blueprint");
+      expect(
+        fixture.debugElement.query(By.css(".card-title-translated")),
+      ).toBeNull();
+    });
+
+    it("shows the resolved display title when there is one", () => {
+      component.item = makeItem({
+        name: "Cozinha estrategia em choque",
+        displayName: "Strategic cooking in conflict",
+        nameTranslated: true,
+        nameSourceLang: "pt",
+      });
+      fixture.detectChanges();
+      expect(
+        fixture.debugElement.query(By.css(".bni-card__title")).nativeElement
+          .textContent,
+      ).toContain("Strategic cooking in conflict");
+    });
+
+    // Machine output must never be presented as the author's own words, and
+    // the original has to stay reachable.
+    it("marks a machine-translated title and keeps the original in the tooltip", () => {
+      component.item = makeItem({
+        name: "Cozinha estrategia em choque",
+        displayName: "Strategic cooking in conflict",
+        nameTranslated: true,
+        nameSourceLang: "pt",
+      });
+      fixture.detectChanges();
+
+      const marker = fixture.debugElement.query(
+        By.css(".card-title-translated"),
+      );
+      expect(marker).not.toBeNull();
+      expect(marker.nativeElement.getAttribute("title")).toContain(
+        "Cozinha estrategia em choque",
+      );
+      expect(marker.nativeElement.getAttribute("title")).toContain("pt");
+    });
+
+    // A human-reviewed translation is a different claim from a machine one.
+    it("does not mark a resolved title that is not machine output", () => {
+      component.item = makeItem({
+        name: "Ферма",
+        displayName: "Farm",
+        nameTranslated: false,
+      });
+      fixture.detectChanges();
+      expect(
+        fixture.debugElement.query(By.css(".card-title-translated")),
+      ).toBeNull();
+    });
   });
 
   it("links the thumbnail and title to the details page, not the editor", () => {

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.ts
@@ -42,8 +42,8 @@ export class BlueprintCardComponent {
   get translatedTitleTooltip(): string {
     const from = this.localeService.labelFor(this.item.nameSourceLang);
     return from
-      ? $localize`Machine-translated from ${from}. Original: ${this.item.name}`
-      : $localize`Machine-translated. Original: ${this.item.name}`;
+      ? $localize`Machine-translated from ${from}:sourceLanguage:. Original: ${this.item.name}:originalTitle:`
+      : $localize`Machine-translated. Original: ${this.item.name}:originalTitle:`;
   }
 
   constructor(private localeService: ContentLocaleService) {}

--- a/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-card/blueprint-card.component.ts
@@ -10,6 +10,7 @@ import {
 } from "../../utils/chip-tooltip";
 import { dlcLabel } from "../../../../../../lib/index";
 import { roomTypeLabel } from "../../utils/room-labels";
+import { ContentLocaleService } from "../../services/content-locale.service";
 
 const MAX_ROOM_CHIPS = 3;
 
@@ -21,6 +22,31 @@ const MAX_ROOM_CHIPS = 3;
 })
 export class BlueprintCardComponent {
   @Input() item!: BlueprintListItem;
+
+  /**
+   * The title to render. `name` is the authored value and stays the fallback,
+   * so a response built without resolution shows the author's own words rather
+   * than nothing.
+   */
+  get title(): string {
+    return this.item.displayName ?? this.item.name;
+  }
+
+  /**
+   * Machine-translation disclosure (spec/search-followups.md §2.7). A card has
+   * no room for a second line, so the marker is a glyph and the author's own
+   * title is the tooltip — subdued, but the original is never more than a
+   * hover (or a tap through to the details page) away. Presenting machine
+   * output as the author's words unmarked is the one thing this must not do.
+   */
+  get translatedTitleTooltip(): string {
+    const from = this.localeService.labelFor(this.item.nameSourceLang);
+    return from
+      ? $localize`Machine-translated from ${from}. Original: ${this.item.name}`
+      : $localize`Machine-translated. Original: ${this.item.name}`;
+  }
+
+  constructor(private localeService: ContentLocaleService) {}
   @Input() loggedIn = false;
   @Input() showOwner = true;
   /** Router navigation state attached to the details link, e.g. to enable a history-aware back-link. */

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.css
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.css
@@ -85,6 +85,45 @@
   margin: 0 0 8px;
 }
 
+/* Machine-translation disclosure. Deliberately quiet — the same weight as the
+   byline, not a warning — because the fact is ordinary and the reader needs it
+   to make sense of the heading, not to be alarmed by it. */
+.details-title-translated {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: -2px 0 8px;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--bni-faint);
+}
+
+.details-title-original {
+  color: var(--bni-muted);
+  font-style: italic;
+}
+
+.details-title-lang {
+  padding: 0;
+  font: inherit;
+  color: var(--bni-mark);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.details-title-lang:hover {
+  color: var(--bni-mark-hi);
+}
+
+.details-title-lang:focus-visible {
+  outline: 2px solid var(--bni-mark);
+  outline-offset: 2px;
+}
+
 .details-byline {
   display: flex;
   gap: 12px;

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
@@ -61,11 +61,23 @@
                the sentence that raises the question. -->
           <p *ngIf="details.nameTranslated" class="details-title-translated">
             <i class="pi pi-language" aria-hidden="true"></i>
-            <span i18n
-              >Title machine-translated{{ translatedFromSuffix }}. Originally
+            <!-- Two complete sentences rather than one with a " from X"
+                 fragment spliced in: a fragment has no grammatical context, so
+                 it cannot be translated correctly (or at all) on its own. -->
+            <span
+              *ngIf="translatedFromLabel as fromLabel; else noSourceLang"
+              i18n
+              >Title machine-translated from {{ fromLabel }}. Originally
               <span class="details-title-original">{{ details.name }}</span
               >.</span
             >
+            <ng-template #noSourceLang>
+              <span i18n
+                >Title machine-translated. Originally
+                <span class="details-title-original">{{ details.name }}</span
+                >.</span
+              >
+            </ng-template>
             <button
               type="button"
               class="details-title-lang"

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.html
@@ -52,7 +52,29 @@
         </div>
 
         <div class="details-meta">
-          <h1>{{ details.name }}</h1>
+          <h1>{{ displayTitle }}</h1>
+
+          <!-- Machine-translation disclosure (spec/search-followups.md §2.7).
+               The details page has room to do this properly: the original is
+               shown outright rather than hidden in a tooltip, and the control
+               that explains WHY a reader is seeing English is one click from
+               the sentence that raises the question. -->
+          <p *ngIf="details.nameTranslated" class="details-title-translated">
+            <i class="pi pi-language" aria-hidden="true"></i>
+            <span i18n
+              >Title machine-translated{{ translatedFromSuffix }}. Originally
+              <span class="details-title-original">{{ details.name }}</span
+              >.</span
+            >
+            <button
+              type="button"
+              class="details-title-lang"
+              (click)="openLanguagePicker()"
+              i18n
+            >
+              Change language
+            </button>
+          </p>
 
           <app-star-rating
             class="details-stars"

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.spec.ts
@@ -12,6 +12,7 @@ import { BlueprintService } from "../../services/blueprint-service";
 import { AuthenticationService } from "../../services/authentification-service";
 import { ModsService } from "../../services/mods-service";
 import { TranslationService } from "../../services/translation.service";
+import { ContentLocaleService } from "../../services/content-locale.service";
 
 function makeDetails(overrides: any = {}) {
   return {
@@ -53,17 +54,23 @@ describe("BlueprintDetailsPageComponent", () => {
   let router: any;
   let modsService: any;
   let translationService: any;
+  let contentLocaleService: any;
 
   beforeEach(async () => {
     blueprintService = {
       getBlueprintDetails: vi.fn().mockReturnValue(of(makeDetails())),
       getRelatedBlueprints: vi.fn().mockReturnValue(of({ blueprints: [] })),
+      downloadBlueprintFile: vi.fn().mockReturnValue(of(undefined)),
       setPublished: vi.fn().mockReturnValue(of({ isPublished: true })),
       deleteBlueprint: vi.fn().mockReturnValue(of({ deleteBlueprint: "OK" })),
     };
     authService = { isLoggedIn: vi.fn().mockReturnValue(true) };
     messageService = { add: vi.fn() };
     router = { navigate: vi.fn() };
+    contentLocaleService = {
+      labelFor: (code: string | null) => code ?? "",
+      openPicker: vi.fn(),
+    };
     modsService = {
       getMods: vi.fn().mockReturnValue(
         of([
@@ -93,6 +100,7 @@ describe("BlueprintDetailsPageComponent", () => {
         { provide: MessageService, useValue: messageService },
         { provide: ModsService, useValue: modsService },
         { provide: TranslationService, useValue: translationService },
+        { provide: ContentLocaleService, useValue: contentLocaleService },
         { provide: Router, useValue: router },
         {
           provide: ActivatedRoute,
@@ -413,6 +421,92 @@ describe("BlueprintDetailsPageComponent", () => {
     expect(downloads.nativeElement.textContent).toContain("1");
     expect(downloads.nativeElement.textContent).toContain("download");
     expect(downloads.nativeElement.textContent).not.toContain("downloads");
+  });
+
+  describe("machine-translated title", () => {
+    it("renders the authored name when the response carries no resolution", () => {
+      fixture.detectChanges();
+      expect(
+        fixture.debugElement.query(By.css("h1")).nativeElement.textContent,
+      ).toContain("Super Coal Generator Setup");
+      expect(
+        fixture.debugElement.query(By.css(".details-title-translated")),
+      ).toBeNull();
+    });
+
+    it("renders the resolved title with the original alongside it", () => {
+      blueprintService.getBlueprintDetails.mockReturnValue(
+        of(
+          makeDetails({
+            name: "Cozinha estrategia em choque",
+            displayName: "Strategic cooking in conflict",
+            nameTranslated: true,
+            nameSourceLang: "pt",
+          }),
+        ),
+      );
+      fixture = TestBed.createComponent(BlueprintDetailsPageComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      expect(
+        fixture.debugElement.query(By.css("h1")).nativeElement.textContent,
+      ).toContain("Strategic cooking in conflict");
+
+      const disclosure = fixture.debugElement.query(
+        By.css(".details-title-translated"),
+      );
+      expect(disclosure).not.toBeNull();
+      expect(disclosure.nativeElement.textContent).toContain(
+        "Cozinha estrategia em choque",
+      );
+    });
+
+    // The ambient entry point: a reader looking at a machine translation is
+    // exactly the reader who wants to find the setting behind it.
+    it("opens the language picker from the disclosure", () => {
+      blueprintService.getBlueprintDetails.mockReturnValue(
+        of(
+          makeDetails({
+            displayName: "Translated",
+            nameTranslated: true,
+            nameSourceLang: "pt",
+          }),
+        ),
+      );
+      fixture = TestBed.createComponent(BlueprintDetailsPageComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      fixture.debugElement
+        .query(By.css(".details-title-lang"))
+        .nativeElement.click();
+      expect(contentLocaleService.openPicker).toHaveBeenCalled();
+    });
+
+    // The download filename, the delete confirmation and the publish toasts
+    // are about the author's own blueprint, not about what this reader sees.
+    it("downloads under the authored name, not the translated one", () => {
+      blueprintService.getBlueprintDetails.mockReturnValue(
+        of(
+          makeDetails({
+            name: "Cozinha estrategia em choque",
+            displayName: "Strategic cooking in conflict",
+            nameTranslated: true,
+            nameSourceLang: "pt",
+          }),
+        ),
+      );
+      fixture = TestBed.createComponent(BlueprintDetailsPageComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      component.downloadBlueprint(new Event("click"));
+      expect(blueprintService.downloadBlueprintFile).toHaveBeenCalledWith(
+        "bp1",
+        "Cozinha estrategia em choque",
+      );
+    });
   });
 
   describe("translate description", () => {

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
@@ -107,12 +107,13 @@ export class BlueprintDetailsPageComponent implements OnInit {
     return this.details?.displayName ?? this.details?.name ?? "";
   }
 
-  /** " from Portuguese", or "" when detection was never confident. */
-  get translatedFromSuffix(): string {
-    const from = this.contentLocaleService.labelFor(
-      this.details?.nameSourceLang,
-    );
-    return from ? $localize` from ${from}` : "";
+  /**
+   * The language the title was written in ("Portuguese"), or "" when detection
+   * was never confident — which of the template's two complete disclosure
+   * sentences to render.
+   */
+  get translatedFromLabel(): string {
+    return this.contentLocaleService.labelFor(this.details?.nameSourceLang);
   }
 
   /**

--- a/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
+++ b/frontend/src/app/module-blueprint/components/blueprint-details-page/blueprint-details-page.component.ts
@@ -27,6 +27,7 @@ import sanitize from "sanitize-filename";
 import { ModsService } from "../../services/mods-service";
 import { TranslationService } from "../../services/translation.service";
 import { TranslateBlueprintResponse } from "../../../../../../lib/index";
+import { ContentLocaleService } from "../../services/content-locale.service";
 
 const BACK_TO_DISCOVER = $localize`:blueprintDetails.backToDiscover:Back to Discover`;
 const BACK_TO_PROFILE = $localize`:blueprintDetails.backToProfile:Back to Profile`;
@@ -79,6 +80,7 @@ export class BlueprintDetailsPageComponent implements OnInit {
     private modsService: ModsService,
     private translationService: TranslationService,
     public authService: AuthenticationService,
+    private contentLocaleService: ContentLocaleService,
   ) {}
 
   // Only shown when logged in (the translate endpoint requires auth — an
@@ -93,6 +95,33 @@ export class BlueprintDetailsPageComponent implements OnInit {
       sourceLang != null &&
       !this.translationService.matchesViewerLang(sourceLang)
     );
+  }
+
+  /**
+   * The heading. `details.name` stays the authored title and is what the
+   * download filename, the delete confirmation and the publish toasts use —
+   * those are about the author's own blueprint, not about what this reader is
+   * shown.
+   */
+  get displayTitle(): string {
+    return this.details?.displayName ?? this.details?.name ?? "";
+  }
+
+  /** " from Portuguese", or "" when detection was never confident. */
+  get translatedFromSuffix(): string {
+    const from = this.contentLocaleService.labelFor(
+      this.details?.nameSourceLang,
+    );
+    return from ? $localize` from ${from}` : "";
+  }
+
+  /**
+   * The ambient entry point (§2.7): a reader who is looking at a machine
+   * translation is exactly the reader who wants to know where that setting
+   * lives. Opens the picker mounted in the site nav.
+   */
+  openLanguagePicker(): void {
+    this.contentLocaleService.openPicker();
   }
 
   translating = false;

--- a/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.ts
@@ -445,7 +445,7 @@ export class ComponentBlueprintParentComponent
     // TODO error handling
     this.messageService.add({
       severity: "success",
-      summary: $localize`Loaded blueprint: ${this.blueprintService.name}`,
+      summary: $localize`Loaded blueprint: ${this.blueprintService.displayName}:blueprintTitle:`,
       detail: $localize`${template.blueprintItems.length} items loaded`,
     });
 

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-content-language/dialog-content-language.component.css
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-content-language/dialog-content-language.component.css
@@ -1,0 +1,93 @@
+.lang-intro {
+  margin: 0 0 10px;
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--bni-muted);
+}
+
+.lang-intro--aside {
+  margin-bottom: 14px;
+  color: var(--bni-faint);
+}
+
+/* Two columns: twelve languages read as a list at one per row, and the rows
+   carry almost no content — an endonym and its English name. */
+.lang-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+
+@media (max-width: 460px) {
+  .lang-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.lang-option {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 11px;
+  text-align: left;
+  font-family: var(--p-font-family);
+  color: var(--bni-body);
+  background: transparent;
+  border: 1px solid var(--bni-rule);
+  border-radius: 0;
+  cursor: pointer;
+  transition:
+    background-color 0.14s ease,
+    border-color 0.14s ease,
+    color 0.14s ease;
+}
+
+.lang-option:hover {
+  background: var(--bni-mount);
+  border-color: var(--bni-rule-hi);
+  color: var(--bni-ink);
+}
+
+.lang-option:focus-visible {
+  outline: 2px solid var(--bni-mark);
+  outline-offset: 2px;
+}
+
+.lang-option.active {
+  background: var(--bni-mount);
+  border-color: var(--bni-mark);
+  color: var(--bni-ink);
+}
+
+/* The endonym leads: a speaker finds their own row by the word they'd write. */
+.lang-endonym {
+  font-family: var(--bni-display);
+  font-weight: 700;
+  font-size: 15px;
+  line-height: 1.2;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lang-label {
+  font-size: 12px;
+  color: var(--bni-faint);
+  white-space: nowrap;
+}
+
+.lang-check {
+  margin-left: auto;
+  flex: none;
+  color: var(--bni-mark);
+  align-self: center;
+}
+
+.lang-footnote {
+  margin: 14px 0 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--bni-faint);
+}

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-content-language/dialog-content-language.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-content-language/dialog-content-language.component.html
@@ -1,0 +1,66 @@
+<p-dialog
+  i18n-header
+  header="Content language"
+  [(visible)]="visible"
+  [modal]="true"
+  [style]="{ width: '460px' }"
+  [breakpoints]="{ '600px': '92vw' }"
+  [draggable]="false"
+  styleClass="bni-skin"
+>
+  <p class="lang-intro" i18n>
+    Which language you read blueprint titles in. Titles written in another
+    language are shown machine-translated into yours where we have a
+    translation, and marked as such — the original is always one click away.
+  </p>
+  <p class="lang-intro lang-intro--aside" i18n>
+    This does not change the language of the site itself, which is English for
+    now.
+  </p>
+
+  <div
+    class="lang-grid"
+    role="radiogroup"
+    aria-label="Content language"
+    i18n-aria-label
+  >
+    <button
+      *ngFor="let option of options"
+      type="button"
+      role="radio"
+      class="lang-option"
+      [class.active]="current === option.code"
+      [attr.aria-checked]="current === option.code"
+      (click)="select(option.code)"
+    >
+      <span class="lang-endonym">{{ option.endonym }}</span>
+      <span class="lang-label">{{ option.label }}</span>
+      <svg
+        *ngIf="current === option.code"
+        class="lang-check"
+        width="13"
+        height="13"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="3.4"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M4 12.5l5.5 5.5L20 6"></path>
+      </svg>
+    </button>
+  </div>
+
+  <p class="lang-footnote" *ngIf="guessed" i18n>
+    Nothing chosen yet — this is your browser's language. Pick one to make it
+    stick.
+  </p>
+  <p class="lang-footnote" *ngIf="!guessed && loggedIn" i18n>
+    Saved to your account, so it follows you to other devices.
+  </p>
+  <p class="lang-footnote" *ngIf="!guessed && !loggedIn" i18n>
+    Saved in this browser. Log in and it will follow you to other devices.
+  </p>
+</p-dialog>

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-content-language/dialog-content-language.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-content-language/dialog-content-language.component.ts
@@ -81,9 +81,20 @@ export class DialogContentLanguageComponent implements OnInit, OnDestroy {
       this.visible = false;
       return;
     }
-    this.localeService.select(code, this.loggedIn);
+    const accountWrite = this.localeService.select(code, this.loggedIn);
     this.visible = false;
-    this.reload();
+    // A reload cancels an in-flight request, so wait for the account write to
+    // settle first. Either outcome reloads: a failed write costs the
+    // cross-device copy, not the language the user just picked (which is
+    // already in localStorage).
+    if (accountWrite == null) {
+      this.reload();
+      return;
+    }
+    accountWrite.subscribe({
+      next: () => this.reload(),
+      error: () => this.reload(),
+    });
   }
 
   /** Seam for tests — jsdom has no navigation. */

--- a/frontend/src/app/module-blueprint/components/dialogs/dialog-content-language/dialog-content-language.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/dialog-content-language/dialog-content-language.component.ts
@@ -1,0 +1,101 @@
+import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Subscription } from "rxjs";
+import {
+  ContentLocaleService,
+  ContentLocaleOption,
+} from "../../../services/content-locale.service";
+import { AuthenticationService } from "../../../services/authentification-service";
+
+/**
+ * The content-language picker (spec/search-followups.md §2.7).
+ *
+ * Lives in the site nav so it is reachable from every page that has one, and
+ * opens off the service's request stream rather than an @Output, so the
+ * ambient entry point — the "translated" marker on a details page — can reach
+ * it without any component knowing where the dialog is mounted.
+ *
+ * Selecting is the whole interaction: there is no Save button, because
+ * persisting only on interaction is exactly the rule (a default that writes
+ * itself is indistinguishable from a choice).
+ */
+@Component({
+  selector: "app-dialog-content-language",
+  templateUrl: "./dialog-content-language.component.html",
+  styleUrls: ["./dialog-content-language.component.css"],
+  standalone: false,
+})
+export class DialogContentLanguageComponent implements OnInit, OnDestroy {
+  visible = false;
+
+  private subscription: Subscription | null = null;
+
+  constructor(
+    public localeService: ContentLocaleService,
+    private authService: AuthenticationService,
+  ) {}
+
+  ngOnInit(): void {
+    this.subscription = this.localeService.openRequests$.subscribe(() =>
+      this.open(),
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+    this.subscription = null;
+  }
+
+  get options(): readonly ContentLocaleOption[] {
+    return this.localeService.options;
+  }
+
+  get current(): string {
+    return this.localeService.current;
+  }
+
+  /**
+   * Whether the highlighted row is a real choice or just the browser's
+   * language showing through. Worth saying out loud: the row looks identical
+   * either way, and a reader who assumes they have chosen will not understand
+   * why a new device disagrees.
+   */
+  get guessed(): boolean {
+    return !this.localeService.hasDeclared;
+  }
+
+  get loggedIn(): boolean {
+    return this.authService.isLoggedIn();
+  }
+
+  /**
+   * Selecting reloads the page. The locale is a request parameter on every
+   * read endpoint, so the titles already on screen — cards, the details
+   * heading, the related shelf, anything cached in a component — were fetched
+   * under the old one. Re-fetching each surface piecemeal is how half a page
+   * ends up in one language and half in another; a reload is one line, always
+   * correct, and this control is reachable only from pages with no unsaved
+   * work (the editor has its own menu and never mounts the site nav).
+   */
+  select(code: string): void {
+    if (code === this.current && this.localeService.hasDeclared) {
+      this.visible = false;
+      return;
+    }
+    this.localeService.select(code, this.loggedIn);
+    this.visible = false;
+    this.reload();
+  }
+
+  /** Seam for tests — jsdom has no navigation. */
+  protected reload(): void {
+    window.location.reload();
+  }
+
+  open(): void {
+    this.visible = true;
+  }
+
+  toggleDialog(): void {
+    this.visible = !this.visible;
+  }
+}

--- a/frontend/src/app/module-blueprint/components/site-nav/site-nav.component.html
+++ b/frontend/src/app/module-blueprint/components/site-nav/site-nav.component.html
@@ -29,3 +29,8 @@
     ></app-user-menu>
   </ng-template>
 </p-menubar>
+<!-- Mounted here rather than per page so every surface carrying the nav can
+     reach it, and so the ambient entry point (the "translated" marker on a
+     details page) has somewhere to open: the dialog listens on the locale
+     service's request stream, not on an @Output. -->
+<app-dialog-content-language></app-dialog-content-language>

--- a/frontend/src/app/module-blueprint/components/site-nav/site-nav.component.html
+++ b/frontend/src/app/module-blueprint/components/site-nav/site-nav.component.html
@@ -23,6 +23,7 @@
     ></app-notification-bell>
     <app-user-menu
       [myBlueprintsEnabled]="false"
+      [contentLanguageEnabled]="true"
       (about)="about.emit()"
       (sendFeedback)="sendFeedback.emit()"
       (appearance)="appearance.emit()"

--- a/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.spec.ts
@@ -8,6 +8,7 @@ import {
   AuthenticationService,
   UserDetails,
 } from "src/app/module-blueprint/services/authentification-service";
+import { ContentLocaleService } from "src/app/module-blueprint/services/content-locale.service";
 
 function makeUser(role: "user" | "admin" = "user"): UserDetails {
   return {
@@ -25,6 +26,7 @@ describe("UserMenuComponent", () => {
   let authService: any;
   let router: any;
   let messageService: any;
+  let contentLocaleService: any;
 
   beforeEach(async () => {
     authService = {
@@ -34,6 +36,7 @@ describe("UserMenuComponent", () => {
     };
     router = { navigate: vi.fn() };
     messageService = { add: vi.fn() };
+    contentLocaleService = { openPicker: vi.fn() };
 
     authService.getUserDetails.mockReturnValue(null);
     authService.isLoggedIn.mockReturnValue(false);
@@ -45,6 +48,7 @@ describe("UserMenuComponent", () => {
         { provide: AuthenticationService, useValue: authService },
         { provide: Router, useValue: router },
         { provide: MessageService, useValue: messageService },
+        { provide: ContentLocaleService, useValue: contentLocaleService },
       ],
     }).compileComponents();
   });

--- a/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.spec.ts
@@ -63,6 +63,30 @@ describe("UserMenuComponent", () => {
     expect(component).toBeTruthy();
   });
 
+  describe("Content language", () => {
+    function itemLabelled(label: string) {
+      return component.userMenuItems.find((item) => item.label === label);
+    }
+
+    it("opens the picker when the menu entry is invoked", () => {
+      component.contentLanguageEnabled = true;
+      component.ngOnInit();
+
+      const item = itemLabelled("Content language");
+      expect(item).toBeTruthy();
+      expect(item!.visible).toBe(true);
+      item!.command!({} as any);
+      expect(contentLocaleService.openPicker).toHaveBeenCalled();
+    });
+
+    // The editor menu mounts no picker, and the picker reloads the page on
+    // selection — which would discard unsaved editor work even if it did.
+    it("is hidden where no picker is mounted", () => {
+      const item = itemLabelled("Content language");
+      expect(item!.visible).toBe(false);
+    });
+  });
+
   describe("user menu items", () => {
     it("hides admin items for non-admin users", () => {
       authService.getUserDetails.mockReturnValue(makeUser("user"));

--- a/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.ts
+++ b/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.ts
@@ -10,6 +10,7 @@ import { Menu } from "primeng/menu";
 import { MenuItem, MessageService } from "primeng/api";
 import { Router } from "@angular/router";
 import { AuthenticationService } from "../../services/authentification-service";
+import { ContentLocaleService } from "../../services/content-locale.service";
 
 export interface BrowseData {
   filterUserId: string;
@@ -43,6 +44,7 @@ export class UserMenuComponent implements OnInit {
     public authService: AuthenticationService,
     private messageService: MessageService,
     private router: Router,
+    private contentLocaleService: ContentLocaleService,
   ) {}
 
   ngOnInit() {
@@ -74,6 +76,11 @@ export class UserMenuComponent implements OnInit {
         label: $localize`Appearance`,
         icon: "pi pi-palette",
         command: () => this.appearance.emit(),
+      },
+      {
+        label: $localize`Content language`,
+        icon: "pi pi-globe",
+        command: () => this.contentLocaleService.openPicker(),
       },
       {
         label: $localize`Send Feedback`,

--- a/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.ts
+++ b/frontend/src/app/module-blueprint/components/user-menu/user-menu.component.ts
@@ -31,6 +31,14 @@ export class UserMenuComponent implements OnInit {
   // pages hide it since the profile page already covers "see my blueprints".
   @Input() myBlueprintsEnabled = true;
 
+  /**
+   * Whether a content-language picker is mounted alongside this menu. Off by
+   * default because only the site nav mounts one: the picker reloads the page
+   * on selection, which is safe there and would discard unsaved work in the
+   * editor. An item whose command has nothing to open is worse than no item.
+   */
+  @Input() contentLanguageEnabled = false;
+
   @Output() about = new EventEmitter<void>();
   @Output() sendFeedback = new EventEmitter<void>();
   @Output() appearance = new EventEmitter<void>();
@@ -81,6 +89,7 @@ export class UserMenuComponent implements OnInit {
         label: $localize`Content language`,
         icon: "pi pi-globe",
         command: () => this.contentLocaleService.openPicker(),
+        visible: this.contentLanguageEnabled,
       },
       {
         label: $localize`Send Feedback`,

--- a/frontend/src/app/module-blueprint/module-blueprint.module.ts
+++ b/frontend/src/app/module-blueprint/module-blueprint.module.ts
@@ -103,6 +103,7 @@ import { TranslationService } from "./services/translation.service";
 import { BlueprintVersionService } from "./services/blueprint-version.service";
 import { BrowsePageComponent } from "./components/browse-page/browse-page.component";
 import { DialogThemeComponent } from "./components/dialogs/dialog-theme/dialog-theme.component";
+import { DialogContentLanguageComponent } from "./components/dialogs/dialog-content-language/dialog-content-language.component";
 import { ProfilePageComponent } from "./components/profile-page/profile-page.component";
 import { DialogFollowListComponent } from "./components/dialogs/dialog-follow-list/dialog-follow-list.component";
 import { NotificationBellComponent } from "./components/notification-bell/notification-bell.component";
@@ -166,6 +167,7 @@ import { TerrainToolComponent } from "./components/side-bar/terrain-tool/terrain
     BlueprintDetailsPageComponent,
     BrowsePageComponent,
     DialogThemeComponent,
+    DialogContentLanguageComponent,
     ProfilePageComponent,
     DialogFollowListComponent,
     NotificationBellComponent,

--- a/frontend/src/app/module-blueprint/services/blueprint-service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.spec.ts
@@ -7,12 +7,21 @@ describe("BlueprintService", () => {
   let mockHttp: any;
   let mockAuth: any;
   let mockLocation: any;
+  let mockContentLocale: any;
 
   beforeEach(() => {
     mockHttp = { get: vi.fn(), post: vi.fn() };
     mockAuth = { isLoggedIn: vi.fn(() => false), getToken: vi.fn(() => "") };
     mockLocation = { replaceState: vi.fn() };
-    service = new BlueprintService(mockHttp, mockAuth, mockLocation);
+    // English reader: appendToUrl is the identity, which is the shape every
+    // existing URL assertion below was written against.
+    mockContentLocale = { appendToUrl: vi.fn((url: string) => url) };
+    service = new BlueprintService(
+      mockHttp,
+      mockAuth,
+      mockLocation,
+      mockContentLocale,
+    );
   });
 
   describe("savedBlueprint getter", () => {

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -41,7 +41,23 @@ export class BlueprintService implements IObsBlueprintChange {
   static baseUrl: string = window.location.origin;
 
   id!: string | null;
+  /** The AUTHORED title. Written back on save — never a translation. */
   name!: string;
+
+  /** Server-resolved title for the open blueprint; null unless it has one. */
+  private resolvedTitle: string | null = null;
+
+  /**
+   * The title to SHOW for the open blueprint, resolved for the reader's
+   * content locale (spec/search-followups.md §2.5). Separate from `name`
+   * precisely because `name` is a write-path value: the save dialog pre-fills
+   * from it and an overwrite writes it straight back, so a translated value
+   * there would rewrite the author's title. Falls back to the authored name,
+   * which is also what every locally imported (never-saved) blueprint gets.
+   */
+  get displayName(): string {
+    return this.resolvedTitle ?? this.name;
+  }
   // TODO observable when modified, to be subscribed by the canvas
   // TODO not sure getter setters are useful
   blueprint_!: Blueprint;
@@ -244,6 +260,9 @@ export class BlueprintService implements IObsBlueprintChange {
 
   reset() {
     this.id = null;
+    // A resolved title belongs to the blueprint it came from — leaving it set
+    // would title the next one with the previous one's translation.
+    this.resolvedTitle = null;
     this.myRating = null;
     this.rating = 0;
     this.nbRatings = 0;
@@ -408,6 +427,7 @@ export class BlueprintService implements IObsBlueprintChange {
 
             this.id = response.id;
             this.name = response.name;
+            this.resolvedTitle = response.displayName ?? null;
             this.nbRatings = response.nbRatings;
             this.rating = response.rating;
             this.myRating = response.myRating;

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@angular/core";
 import { Location } from "@angular/common";
 import { HttpClient } from "@angular/common/http";
 import { AuthenticationService } from "./authentification-service";
+import { ContentLocaleService } from "./content-locale.service";
 import { of } from "rxjs";
 import { catchError, map, switchMap, tap } from "rxjs/operators";
 import {
@@ -65,6 +66,7 @@ export class BlueprintService implements IObsBlueprintChange {
     private http: HttpClient,
     private authService: AuthenticationService,
     private location: Location,
+    private contentLocale: ContentLocaleService,
   ) {
     this.blueprint = new Blueprint();
 
@@ -390,7 +392,7 @@ export class BlueprintService implements IObsBlueprintChange {
     // 404s draft blueprints for anonymous viewers
     const request = this.http
       .get<BlueprintResponse>(
-        `/api/getblueprint/${id}`,
+        this.contentLocale.appendToUrl(`/api/getblueprint/${id}`),
         this.authService.isLoggedIn()
           ? {
               headers: {
@@ -445,6 +447,8 @@ export class BlueprintService implements IObsBlueprintChange {
   downloadBlueprintFile(id: string, friendlyName: string) {
     return this.http
       .get<BlueprintResponse>(
+        // No `lang=`: this fetch produces a file, not a display surface, and
+        // the filename comes from the caller's authored name either way.
         `/api/getblueprint/${id}`,
         this.authService.isLoggedIn()
           ? {
@@ -568,7 +572,7 @@ export class BlueprintService implements IObsBlueprintChange {
   // the backend uses it to personalize myRating/ownedByMe.
   getBlueprintDetails(id: string) {
     return this.http.get<BlueprintDetailsResponse>(
-      `/api/blueprints/${id}`,
+      this.contentLocale.appendToUrl(`/api/blueprints/${id}`),
       this.authService.isLoggedIn()
         ? {
             headers: {
@@ -583,7 +587,7 @@ export class BlueprintService implements IObsBlueprintChange {
   // backend uses it to personalize myRating/ownedByMe on the returned cards.
   getRelatedBlueprints(id: string) {
     return this.http.get<RelatedBlueprintsResponse>(
-      `/api/blueprints/${id}/related`,
+      this.contentLocale.appendToUrl(`/api/blueprints/${id}/related`),
       this.authService.isLoggedIn()
         ? {
             headers: {
@@ -697,10 +701,19 @@ export class BlueprintService implements IObsBlueprintChange {
     const needsAuth = filterUserId != null || filterRatedBy != null;
     const request =
       needsAuth && this.authService.isLoggedIn()
-        ? this.http.get("/api/getblueprintsSecure?" + parameters, {
-            headers: { Authorization: `Bearer ${this.authService.getToken()}` },
-          })
-        : this.http.get("/api/getblueprints?" + parameters);
+        ? this.http.get(
+            this.contentLocale.appendToUrl(
+              "/api/getblueprintsSecure?" + parameters,
+            ),
+            {
+              headers: {
+                Authorization: `Bearer ${this.authService.getToken()}`,
+              },
+            },
+          )
+        : this.http.get(
+            this.contentLocale.appendToUrl("/api/getblueprints?" + parameters),
+          );
 
     request.pipe(
       map((response: any) => {

--- a/frontend/src/app/module-blueprint/services/content-locale.service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/content-locale.service.spec.ts
@@ -1,0 +1,189 @@
+import { TestBed } from "@angular/core/testing";
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from "@angular/common/http/testing";
+import { provideHttpClient } from "@angular/common/http";
+import { ContentLocaleService } from "./content-locale.service";
+
+describe("ContentLocaleService", () => {
+  let service: ContentLocaleService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    localStorage.clear();
+
+    TestBed.configureTestingModule({
+      providers: [
+        ContentLocaleService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+    service = TestBed.inject(ContentLocaleService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+    localStorage.clear();
+  });
+
+  function stubNavigatorLanguage(value: string | undefined) {
+    vi.spyOn(navigator, "language", "get").mockReturnValue(value as string);
+  }
+
+  describe("initFromLocal", () => {
+    it("uses the stored declaration when there is one", () => {
+      localStorage.setItem(ContentLocaleService.STORAGE_KEY, "vi");
+      service.initFromLocal();
+      expect(service.current).toBe("vi");
+      expect(service.hasDeclared).toBe(true);
+    });
+
+    it("falls back to the browser language as a guess, not a declaration", () => {
+      stubNavigatorLanguage("pt-BR");
+      service.initFromLocal();
+      expect(service.current).toBe("pt");
+      expect(service.hasDeclared).toBe(false);
+    });
+
+    // A default that writes itself becomes indistinguishable from a choice,
+    // which is what would make the "who reads in what language" measurement
+    // worthless. Same rule as dlcPreferences.
+    it("never persists the browser guess", () => {
+      stubNavigatorLanguage("ru");
+      service.initFromLocal();
+      expect(localStorage.getItem(ContentLocaleService.STORAGE_KEY)).toBe(null);
+    });
+
+    // Validation is shape-only and deliberately so — the language set is open,
+    // so any plausible 2-3 letter ISO code is accepted without a membership
+    // list. What must not survive is something that is not a tag at all.
+    it("ignores a stored value that is not a language tag", () => {
+      localStorage.setItem(ContentLocaleService.STORAGE_KEY, "12345");
+      stubNavigatorLanguage("en-GB");
+      service.initFromLocal();
+      expect(service.current).toBe("en");
+      expect(service.hasDeclared).toBe(false);
+    });
+  });
+
+  describe("select", () => {
+    it("stores the choice locally for an anonymous visitor and makes no request", () => {
+      service.select("vi", false);
+      expect(service.current).toBe("vi");
+      expect(service.hasDeclared).toBe(true);
+      expect(localStorage.getItem(ContentLocaleService.STORAGE_KEY)).toBe("vi");
+    });
+
+    it("writes the choice to the account when logged in", () => {
+      service.select("ko", true);
+      const request = http.expectOne("/api/users/me/locale-preference");
+      expect(request.request.method).toBe("PATCH");
+      expect(request.request.body).toEqual({ locale: "ko" });
+      request.flush({ locale: "ko" });
+    });
+
+    it("narrows a region tag before storing it", () => {
+      service.select("zh-Hans", false);
+      expect(service.current).toBe("zh");
+    });
+
+    it("ignores a value that is not a language tag", () => {
+      service.initFromLocal();
+      const before = service.current;
+      service.select("javascript:alert(1)", false);
+      expect(service.current).toBe(before);
+      expect(service.hasDeclared).toBe(false);
+    });
+  });
+
+  describe("loadForUser", () => {
+    it("adopts the account preference when it exists", () => {
+      service.initFromLocal();
+      service.loadForUser().subscribe();
+      http.expectOne("/api/users/me/locale-preference").flush({ locale: "ru" });
+      expect(service.current).toBe("ru");
+      expect(service.hasDeclared).toBe(true);
+      expect(localStorage.getItem(ContentLocaleService.STORAGE_KEY)).toBe("ru");
+    });
+
+    // Picking a language before logging in should not have to be done twice.
+    it("adopts a local declaration into an account that has none", () => {
+      localStorage.setItem(ContentLocaleService.STORAGE_KEY, "vi");
+      service.initFromLocal();
+      service.loadForUser().subscribe();
+      http.expectOne("/api/users/me/locale-preference").flush({ locale: null });
+
+      const write = http.expectOne("/api/users/me/locale-preference");
+      expect(write.request.method).toBe("PATCH");
+      expect(write.request.body).toEqual({ locale: "vi" });
+      write.flush({ locale: "vi" });
+    });
+
+    // The mirror image, and the important one: a browser default must never
+    // reach the account, or every account acquires a preference nobody set.
+    it("does not push a browser guess onto an account with no preference", () => {
+      stubNavigatorLanguage("de");
+      service.initFromLocal();
+      service.loadForUser().subscribe();
+      http.expectOne("/api/users/me/locale-preference").flush({ locale: null });
+      http.verify(); // no PATCH
+      expect(service.hasDeclared).toBe(false);
+    });
+
+    // A flaky request must not read as "the account has no preference" — that
+    // would let one failed GET push this browser's value over a preference the
+    // user set on another device.
+    it("keeps the local value when the lookup fails, and writes nothing", () => {
+      localStorage.setItem(ContentLocaleService.STORAGE_KEY, "ko");
+      service.initFromLocal();
+      service.loadForUser().subscribe();
+      http
+        .expectOne("/api/users/me/locale-preference")
+        .flush("nope", { status: 500, statusText: "Server Error" });
+      expect(service.current).toBe("ko");
+    });
+  });
+
+  describe("queryParam / appendToUrl", () => {
+    // English sends nothing, so the ordinary browse URL — nearly all traffic —
+    // stays byte-identical for the CDN.
+    it("sends nothing for an English reader", () => {
+      service.select("en", false);
+      expect(service.queryParam()).toBe("");
+      expect(service.appendToUrl("/api/getblueprints?sort=recent")).toBe(
+        "/api/getblueprints?sort=recent",
+      );
+    });
+
+    it("appends lang with the right separator", () => {
+      service.select("vi", false);
+      expect(service.appendToUrl("/api/blueprints/abc")).toBe(
+        "/api/blueprints/abc?lang=vi",
+      );
+      expect(service.appendToUrl("/api/getblueprints?sort=recent")).toBe(
+        "/api/getblueprints?sort=recent&lang=vi",
+      );
+    });
+  });
+
+  describe("openPicker", () => {
+    it("notifies listeners so an ambient control can open the dialog", () => {
+      const seen: number[] = [];
+      service.openRequests$.subscribe(() => seen.push(1));
+      service.openPicker();
+      service.openPicker();
+      expect(seen.length).toBe(2);
+    });
+  });
+
+  describe("labelFor", () => {
+    it("names a known language and passes an unknown code through", () => {
+      expect(service.labelFor("pt")).toBe("Portuguese");
+      expect(service.labelFor("xh")).toBe("xh");
+      expect(service.labelFor(null)).toBe("");
+    });
+  });
+});

--- a/frontend/src/app/module-blueprint/services/content-locale.service.ts
+++ b/frontend/src/app/module-blueprint/services/content-locale.service.ts
@@ -1,0 +1,223 @@
+import { Injectable } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { BehaviorSubject, Observable, Subject, of } from "rxjs";
+import { catchError, map, tap } from "rxjs/operators";
+import {
+  DEFAULT_CONTENT_LOCALE,
+  normalizeContentLocale,
+  resolveContentLocale,
+} from "../../../../../lib/index";
+
+export interface ContentLocaleOption {
+  /** Base ISO tag — what gets stored and sent as `?lang=`. */
+  code: string;
+  /** English name, because the chrome is English (see the service comment). */
+  label: string;
+  /** The language's own name, so a speaker recognises their row at a glance. */
+  endonym: string;
+}
+
+/**
+ * The languages the picker offers. Deliberately a short, curated list rather
+ * than every ISO code: the honest answer to "which languages does this site
+ * contain" is the set present in `Blueprint.sourceLang`, and this is that set
+ * plus the obvious near misses. An unlisted language is not locked out — the
+ * API validates shape, not membership — it just has no row to click yet.
+ *
+ * Labels stay in English on purpose: this picker chooses a CONTENT language,
+ * not a UI language, and translating the control that explains that
+ * distinction would be the one place a reader could reasonably expect the rest
+ * of the chrome to follow.
+ */
+export const CONTENT_LOCALE_OPTIONS: readonly ContentLocaleOption[] = [
+  { code: "en", label: "English", endonym: "English" },
+  { code: "zh", label: "Chinese", endonym: "中文" },
+  { code: "ru", label: "Russian", endonym: "Русский" },
+  { code: "ko", label: "Korean", endonym: "한국어" },
+  { code: "vi", label: "Vietnamese", endonym: "Tiếng Việt" },
+  { code: "pt", label: "Portuguese", endonym: "Português" },
+  { code: "es", label: "Spanish", endonym: "Español" },
+  { code: "fr", label: "French", endonym: "Français" },
+  { code: "de", label: "German", endonym: "Deutsch" },
+  { code: "ja", label: "Japanese", endonym: "日本語" },
+  { code: "pl", label: "Polish", endonym: "Polski" },
+  { code: "tr", label: "Turkish", endonym: "Türkçe" },
+];
+
+/**
+ * Which language the user reads blueprint CONTENT in
+ * (spec/search-followups.md Part 2). Not the UI locale — the chrome is
+ * English for everyone, so this routes no bundles and prefixes no paths.
+ *
+ * Three states, and keeping them distinct is the whole design:
+ *
+ *   - **declared** — the user picked something. Stored in localStorage, and on
+ *     the account too when they are logged in.
+ *   - **guessed** — nothing declared, so `navigator.language` supplies a
+ *     pre-selection. Shown in the picker as the current value but NEVER
+ *     persisted: a default that writes itself is indistinguishable from a
+ *     choice, which would make the §2.10 "who actually reads in what
+ *     language" measurement worthless. Same rule as dlcPreferences.
+ *   - **English** — no declaration and no usable browser hint.
+ *
+ * Only a declaration or a guess that isn't English reaches the wire as
+ * `?lang=`; English sends nothing, so the ordinary browse URL — nearly all
+ * traffic — stays byte-identical for the CDN.
+ */
+@Injectable({ providedIn: "root" })
+export class ContentLocaleService {
+  static readonly STORAGE_KEY = "bpni-content-locale";
+
+  private readonly currentSubject = new BehaviorSubject<string>(
+    DEFAULT_CONTENT_LOCALE,
+  );
+  readonly current$ = this.currentSubject.asObservable();
+
+  /** True once the user has actually chosen, as opposed to being guessed at. */
+  private declared = false;
+
+  /**
+   * Fired by any control that wants the picker open. The dialog lives in the
+   * site nav and listens here, so an ambient entry point (the "translated"
+   * marker on a details page, say) needs no component wiring to reach it.
+   */
+  private readonly openRequests = new Subject<void>();
+  readonly openRequests$ = this.openRequests.asObservable();
+
+  readonly options = CONTENT_LOCALE_OPTIONS;
+
+  constructor(private http: HttpClient) {}
+
+  get current(): string {
+    return this.currentSubject.value;
+  }
+
+  get hasDeclared(): boolean {
+    return this.declared;
+  }
+
+  /** Called once at app start, before any account state is known. */
+  initFromLocal(): void {
+    const stored = this.readLocal();
+    if (stored != null) {
+      this.declared = true;
+      this.currentSubject.next(stored);
+      return;
+    }
+    this.currentSubject.next(this.browserDefault());
+  }
+
+  /**
+   * The browser's language, narrowed to a base tag. A guess, not a choice —
+   * see the class comment on why it is never written back.
+   */
+  browserDefault(): string {
+    try {
+      return resolveContentLocale(navigator?.language);
+    } catch {
+      return DEFAULT_CONTENT_LOCALE;
+    }
+  }
+
+  /**
+   * Called when a session is established. The account copy wins if it exists;
+   * if it doesn't and this browser has a declaration, the account ADOPTS it —
+   * a user who picked a language before logging in should not have to pick it
+   * again on the machine they picked it on.
+   */
+  loadForUser(): Observable<string> {
+    return this.http
+      .get<{ locale: string | null }>("/api/users/me/locale-preference")
+      .pipe(
+        // A failed lookup keeps whatever local already applied rather than
+        // yanking the reader back to English — and, crucially, is NOT treated
+        // as "the account has no preference": adopting on an error would let
+        // one flaky request overwrite a preference the user set elsewhere.
+        map((res) => ({
+          known: true,
+          locale: normalizeContentLocale(res.locale),
+        })),
+        catchError(() => of({ known: false, locale: null as string | null })),
+        tap(({ known, locale }) => {
+          if (locale != null) {
+            this.declared = true;
+            this.writeLocal(locale);
+            this.currentSubject.next(locale);
+            return;
+          }
+          if (!known) return;
+          // Adoption. Guarded on `declared` precisely so a browser default
+          // never writes itself onto an account.
+          if (this.declared) this.persistToAccount(this.current);
+        }),
+        map(() => this.current),
+      );
+  }
+
+  /**
+   * The user picked. This is the ONLY path that persists, and it is reached
+   * only from a real interaction.
+   */
+  select(code: string, loggedIn: boolean): void {
+    const locale = normalizeContentLocale(code);
+    if (locale == null) return;
+    this.declared = true;
+    this.writeLocal(locale);
+    if (this.currentSubject.value !== locale) this.currentSubject.next(locale);
+    if (loggedIn) this.persistToAccount(locale);
+  }
+
+  /** Ask for the picker (user menu, or the machine-translation disclosure). */
+  openPicker(): void {
+    this.openRequests.next();
+  }
+
+  /**
+   * The `lang=` query parameter for a read request, or "" for English —
+   * absent means English server-side, and omitting it keeps the common URL
+   * stable at the edge.
+   */
+  queryParam(): string {
+    return this.current === DEFAULT_CONTENT_LOCALE
+      ? ""
+      : `lang=${encodeURIComponent(this.current)}`;
+  }
+
+  /** `?lang=…` / `&lang=…` appended to a URL that may already have a query. */
+  appendToUrl(url: string): string {
+    const param = this.queryParam();
+    if (param === "") return url;
+    return url + (url.includes("?") ? "&" : "?") + param;
+  }
+
+  labelFor(code: string | null | undefined): string {
+    const normalized = normalizeContentLocale(code);
+    if (normalized == null) return "";
+    const option = this.options.find((o) => o.code === normalized);
+    return option ? option.label : normalized;
+  }
+
+  private persistToAccount(locale: string): void {
+    this.http
+      .patch("/api/users/me/locale-preference", { locale })
+      .subscribe({ error: () => {} });
+  }
+
+  private readLocal(): string | null {
+    try {
+      return normalizeContentLocale(
+        localStorage.getItem(ContentLocaleService.STORAGE_KEY),
+      );
+    } catch {
+      return null;
+    }
+  }
+
+  private writeLocal(locale: string): void {
+    try {
+      localStorage.setItem(ContentLocaleService.STORAGE_KEY, locale);
+    } catch {
+      /* private mode — the account copy still carries it */
+    }
+  }
+}

--- a/frontend/src/app/module-blueprint/services/content-locale.service.ts
+++ b/frontend/src/app/module-blueprint/services/content-locale.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
 import { BehaviorSubject, Observable, Subject, of } from "rxjs";
-import { catchError, map, tap } from "rxjs/operators";
+import { catchError, map, shareReplay, tap } from "rxjs/operators";
 import {
   DEFAULT_CONTENT_LOCALE,
   normalizeContentLocale,
@@ -148,7 +148,7 @@ export class ContentLocaleService {
           if (!known) return;
           // Adoption. Guarded on `declared` precisely so a browser default
           // never writes itself onto an account.
-          if (this.declared) this.persistToAccount(this.current);
+          if (this.declared) this.accountWrite(this.current);
         }),
         map(() => this.current),
       );
@@ -157,14 +157,19 @@ export class ContentLocaleService {
   /**
    * The user picked. This is the ONLY path that persists, and it is reached
    * only from a real interaction.
+   *
+   * Returns the account write when there is one, so a caller that is about to
+   * navigate (the picker reloads the page) can let it finish first — a reload
+   * cancels an in-flight request. Null when nothing was written: an invalid
+   * code, or a logged-out visitor whose choice lives only in localStorage.
    */
-  select(code: string, loggedIn: boolean): void {
+  select(code: string, loggedIn: boolean): Observable<unknown> | null {
     const locale = normalizeContentLocale(code);
-    if (locale == null) return;
+    if (locale == null) return null;
     this.declared = true;
     this.writeLocal(locale);
     if (this.currentSubject.value !== locale) this.currentSubject.next(locale);
-    if (loggedIn) this.persistToAccount(locale);
+    return loggedIn ? this.accountWrite(locale) : null;
   }
 
   /** Ask for the picker (user menu, or the machine-translation disclosure). */
@@ -197,10 +202,14 @@ export class ContentLocaleService {
     return option ? option.label : normalized;
   }
 
-  private persistToAccount(locale: string): void {
-    this.http
+  private accountWrite(locale: string): Observable<unknown> {
+    // shareReplay so the caller subscribing to wait for it doesn't issue a
+    // second PATCH, and so the request goes out even if nobody subscribes.
+    const request = this.http
       .patch("/api/users/me/locale-preference", { locale })
-      .subscribe({ error: () => {} });
+      .pipe(shareReplay(1));
+    request.subscribe({ error: () => {} });
+    return request;
   }
 
   private readLocal(): string | null {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -47,6 +47,7 @@ export * from './src/blueprint/blueprint';
 export * from './src/blueprint/blueprint-helpers';
 export * from './src/blueprint/blueprint-metadata';
 export * from './src/blueprint/blueprint-name';
+export * from './src/blueprint/content-locale';
 export * from './src/blueprint/blueprint-analyzer';
 export * from './src/blueprint/dlc';
 export * from './src/blueprint/terrain-metadata';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -53,6 +53,7 @@ export * from './src/blueprint/blueprint';
 export * from './src/blueprint/blueprint-helpers';
 export * from './src/blueprint/blueprint-metadata';
 export * from './src/blueprint/blueprint-name';
+export * from './src/blueprint/content-locale';
 export * from './src/blueprint/blueprint-analyzer';
 export * from './src/blueprint/dlc';
 export * from './src/blueprint/terrain-metadata';

--- a/lib/src/blueprint/content-locale.d.ts
+++ b/lib/src/blueprint/content-locale.d.ts
@@ -1,0 +1,84 @@
+/**
+ * Content locale — *which language the user reads blueprint content in*.
+ *
+ * Deliberately NOT the UI locale. The site's chrome is English-only in
+ * production (`localize: false`, and the ru/ko catalogues are ~0% translated),
+ * so this preference routes no bundles, prefixes no paths and needs no
+ * `hreflang` work. It answers one question: when a blueprint's title exists in
+ * more than one language, which one does this reader get?
+ * (spec/search-followups.md Part 2.)
+ *
+ * Shared because the same code is validated in four places that must agree:
+ * the `PATCH /api/users/me/locale-preference` endpoint, the value the frontend
+ * reads back out of localStorage, the `?lang=` query parameter on the read
+ * endpoints, and the picker UI. A value one of them accepts and another
+ * rejects shows a reader a title in a language they didn't ask for.
+ *
+ * The set is OPEN by design (§2.3): a user may declare any language they write
+ * and read in — `vi`, `pt`, `fr` — even though English is the only language we
+ * ever machine-translate *into*. Declaring a language costs nothing and buys
+ * the author their own words back (resolution rule 1); it never obliges the
+ * site to produce a translation in that direction.
+ */
+/** Absent preference, absent `?lang=`, and "we couldn't parse that" all mean English. */
+export declare const DEFAULT_CONTENT_LOCALE = "en";
+/**
+ * Parses anything (query param, localStorage value, request body, browser
+ * `navigator.language`) into a base language tag, or null when it isn't one.
+ * Null means "no declaration", which is a different state from `'en'` — a user
+ * who never chose must keep resolving to the current default even if that
+ * default later changes, which is why nothing writes `'en'` eagerly.
+ */
+export declare function normalizeContentLocale(value: unknown): string | null;
+/** The locale to actually read in: a declaration if there is one, else English. */
+export declare function resolveContentLocale(value: unknown): string;
+/**
+ * A title we hold for a blueprint in some language other than the one it was
+ * authored in. `origin` distinguishes the author's own words from a machine's:
+ * an `authored` entry is not a translation at all (it is the `blueprintsearch`
+ * pivot row echoing `Blueprint.name` verbatim) and must never be offered as
+ * one, or an English reader would be told an English title was "translated
+ * from English".
+ */
+export interface TitleTranslation {
+    lang: string;
+    title: string;
+    origin: 'authored' | 'machine' | 'human';
+}
+export interface ResolvedTitle {
+    /** What to show. Never empty — the chain always terminates at the authored name. */
+    title: string;
+    /** The author's own words, always available so the original stays reachable. */
+    original: string;
+    /**
+     * True when `title` is machine output rather than the author's words. The UI
+     * MUST disclose this (spec/search-followups.md §2.7): surfacing a machine
+     * title unmarked puts words in an author's mouth.
+     */
+    translated: boolean;
+    /** Language the author wrote in, when known — for "Translated from Portuguese". */
+    sourceLang: string | null;
+}
+/**
+ * The one resolution rule (spec/search-followups.md §2.5), shared by every
+ * response boundary that returns a blueprint title:
+ *
+ *   1. authored in the viewer's language  -> the author's own words
+ *   2. a translation into the viewer's language -> that
+ *   3. the English translation            -> that ("readable in English")
+ *   4. otherwise                          -> the author's own words
+ *
+ * Rule 4 is what makes this shippable ahead of any backfill: a blueprint with
+ * no translation row, a dropped `blueprintsearch` collection, or a language we
+ * have never translated all degrade to the authored title, never to blank.
+ *
+ * Rule 2 is inert while English is the only translation target, but costs one
+ * lookup and keeps the shape honest for whenever a second target is activated.
+ */
+export declare function resolveTitle(params: {
+    authoredName: string;
+    sourceLang: string | null | undefined;
+    viewerLang: string;
+    translations?: readonly TitleTranslation[];
+}): ResolvedTitle;
+//# sourceMappingURL=content-locale.d.ts.map

--- a/lib/src/blueprint/content-locale.ts
+++ b/lib/src/blueprint/content-locale.ts
@@ -1,0 +1,135 @@
+/**
+ * Content locale — *which language the user reads blueprint content in*.
+ *
+ * Deliberately NOT the UI locale. The site's chrome is English-only in
+ * production (`localize: false`, and the ru/ko catalogues are ~0% translated),
+ * so this preference routes no bundles, prefixes no paths and needs no
+ * `hreflang` work. It answers one question: when a blueprint's title exists in
+ * more than one language, which one does this reader get?
+ * (spec/search-followups.md Part 2.)
+ *
+ * Shared because the same code is validated in four places that must agree:
+ * the `PATCH /api/users/me/locale-preference` endpoint, the value the frontend
+ * reads back out of localStorage, the `?lang=` query parameter on the read
+ * endpoints, and the picker UI. A value one of them accepts and another
+ * rejects shows a reader a title in a language they didn't ask for.
+ *
+ * The set is OPEN by design (§2.3): a user may declare any language they write
+ * and read in — `vi`, `pt`, `fr` — even though English is the only language we
+ * ever machine-translate *into*. Declaring a language costs nothing and buys
+ * the author their own words back (resolution rule 1); it never obliges the
+ * site to produce a translation in that direction.
+ */
+
+/** Absent preference, absent `?lang=`, and "we couldn't parse that" all mean English. */
+export const DEFAULT_CONTENT_LOCALE = 'en';
+
+// Base tags only. `Blueprint.sourceLang` is written by the detector, which
+// collapses everything to a 2-3 letter ISO-639 base code (`zh-Hans` → `zh`),
+// and rule 1 of the resolution below is an equality test against it — so a
+// region-tagged preference (`pt-BR`) would never match a `pt` document and the
+// author would silently lose their own title. Narrowing here rather than at
+// each comparison keeps that impossible.
+const BASE_TAG = /^[a-z]{2,3}$/;
+
+/**
+ * Parses anything (query param, localStorage value, request body, browser
+ * `navigator.language`) into a base language tag, or null when it isn't one.
+ * Null means "no declaration", which is a different state from `'en'` — a user
+ * who never chose must keep resolving to the current default even if that
+ * default later changes, which is why nothing writes `'en'` eagerly.
+ */
+export function normalizeContentLocale(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const base = value.trim().toLowerCase().split(/[-_]/)[0];
+  return BASE_TAG.test(base) ? base : null;
+}
+
+/** The locale to actually read in: a declaration if there is one, else English. */
+export function resolveContentLocale(value: unknown): string {
+  return normalizeContentLocale(value) ?? DEFAULT_CONTENT_LOCALE;
+}
+
+/**
+ * A title we hold for a blueprint in some language other than the one it was
+ * authored in. `origin` distinguishes the author's own words from a machine's:
+ * an `authored` entry is not a translation at all (it is the `blueprintsearch`
+ * pivot row echoing `Blueprint.name` verbatim) and must never be offered as
+ * one, or an English reader would be told an English title was "translated
+ * from English".
+ */
+export interface TitleTranslation {
+  lang: string;
+  title: string;
+  origin: 'authored' | 'machine' | 'human';
+}
+
+export interface ResolvedTitle {
+  /** What to show. Never empty — the chain always terminates at the authored name. */
+  title: string;
+  /** The author's own words, always available so the original stays reachable. */
+  original: string;
+  /**
+   * True when `title` is machine output rather than the author's words. The UI
+   * MUST disclose this (spec/search-followups.md §2.7): surfacing a machine
+   * title unmarked puts words in an author's mouth.
+   */
+  translated: boolean;
+  /** Language the author wrote in, when known — for "Translated from Portuguese". */
+  sourceLang: string | null;
+}
+
+/**
+ * The one resolution rule (spec/search-followups.md §2.5), shared by every
+ * response boundary that returns a blueprint title:
+ *
+ *   1. authored in the viewer's language  -> the author's own words
+ *   2. a translation into the viewer's language -> that
+ *   3. the English translation            -> that ("readable in English")
+ *   4. otherwise                          -> the author's own words
+ *
+ * Rule 4 is what makes this shippable ahead of any backfill: a blueprint with
+ * no translation row, a dropped `blueprintsearch` collection, or a language we
+ * have never translated all degrade to the authored title, never to blank.
+ *
+ * Rule 2 is inert while English is the only translation target, but costs one
+ * lookup and keeps the shape honest for whenever a second target is activated.
+ */
+export function resolveTitle(params: {
+  authoredName: string;
+  sourceLang: string | null | undefined;
+  viewerLang: string;
+  translations?: readonly TitleTranslation[];
+}): ResolvedTitle {
+  const { authoredName, viewerLang } = params;
+  const sourceLang = params.sourceLang ?? null;
+  const authored: ResolvedTitle = {
+    title: authoredName,
+    original: authoredName,
+    translated: false,
+    sourceLang,
+  };
+
+  // Rule 1 — they read what the author wrote in. Also the (very common) case
+  // of an English reader and an English author, where rules 1 and 3 agree.
+  if (sourceLang != null && sourceLang === viewerLang) return authored;
+
+  const usable = (lang: string): TitleTranslation | null => {
+    const found = (params.translations ?? []).find(
+      t => t.lang === lang && t.origin !== 'authored' && t.title.trim().length > 0
+    );
+    return found ?? null;
+  };
+
+  // Rules 2 and 3. They collapse into one lookup for an English reader, which
+  // is every reader who never touched the picker.
+  const match = usable(viewerLang) ?? usable(DEFAULT_CONTENT_LOCALE);
+  if (match == null) return authored; // Rule 4
+
+  return {
+    title: match.title,
+    original: authoredName,
+    translated: match.origin === 'machine',
+    sourceLang,
+  };
+}

--- a/lib/src/coms/blueprint-list-response.d.ts
+++ b/lib/src/coms/blueprint-list-response.d.ts
@@ -5,7 +5,12 @@ export interface BlueprintListResponse {
     oldest: Date;
     remaining: number;
 }
-export interface BlueprintListItem {
+export interface TranslatedTitleFields {
+    displayName?: string;
+    nameTranslated?: boolean;
+    nameSourceLang?: string | null;
+}
+export interface BlueprintListItem extends TranslatedTitleFields {
     id: string;
     name: string;
     ownerId: string;
@@ -60,7 +65,7 @@ export interface BlueprintRateResponse {
 export interface BlueprintDelete {
     blueprintId: string;
 }
-export interface BlueprintResponse {
+export interface BlueprintResponse extends TranslatedTitleFields {
     id: string;
     name: string;
     data: any;

--- a/lib/src/coms/blueprint-list-response.ts
+++ b/lib/src/coms/blueprint-list-response.ts
@@ -7,8 +7,30 @@ export interface BlueprintListResponse {
   remaining: number;
 }
 
-export interface BlueprintListItem {
+// Title fields shared by every response that shows a blueprint's name
+// (spec/search-followups.md §2.5). `name` is ALWAYS the authored title and
+// never changes meaning — it is what the {owner, name} duplicate check, the
+// download filename and the editor's save path all read. The viewer-resolved
+// title is a separate field so a display surface that hasn't been updated
+// degrades to the author's own words rather than silently translating a
+// filename.
+export interface TranslatedTitleFields {
+  // What to render. Absent = show `name` (server built the response without
+  // resolution, or resolution failed — always safe).
+  displayName?: string;
+  // True when `displayName` is machine output rather than the author's words.
+  // The UI must disclose this and keep `name` reachable (§2.7): presenting a
+  // machine title as the author's own is the one thing this feature must not
+  // do.
+  nameTranslated?: boolean;
+  // Language the author wrote the title in, when known — "Translated from
+  // Portuguese". null = detection was never confident.
+  nameSourceLang?: string | null;
+}
+
+export interface BlueprintListItem extends TranslatedTitleFields {
   id: string;
+  // The authored title, verbatim. See TranslatedTitleFields.
   name: string;
   ownerId: string;
   ownerName: string;
@@ -111,7 +133,11 @@ export interface BlueprintDelete {
   blueprintId: string;
 }
 
-export interface BlueprintResponse {
+// Editor-open payload. `name` here is load-bearing beyond display: the editor
+// stores it and the save dialog pre-fills from it, so an overwrite save writes
+// it straight back to Blueprint.name. It therefore stays authored, always, and
+// the resolved title rides along in displayName for chrome that wants it.
+export interface BlueprintResponse extends TranslatedTitleFields {
   id: string;
   name: string;
   data: any;

--- a/migrations/20260804000000_search-title-original.js
+++ b/migrations/20260804000000_search-title-original.js
@@ -1,0 +1,59 @@
+'use strict';
+
+// Adds `titleOriginal` to the blueprintsearch text index
+// (spec/search-followups.md Part 1 §1).
+//
+// The DATA is derived and disposable — `npm run derive-search` populates the
+// field, including on rows an earlier run already machine-translated. What
+// needs a migration is the INDEX: Mongo will not alter a text index in place,
+// and Mongoose's autoIndex hits IndexOptionsConflict against an existing
+// index of the same name with different keys, which surfaces only as a
+// logged error on a running server. So drop it here and let it be recreated.
+//
+// Order matters on deploy: run this BEFORE `derive-search`, so the backfill
+// writes into an index that already covers the field. At ~5,300 rows the
+// rebuild is a second or two.
+
+const COLLECTION = 'blueprintsearch';
+const INDEX_NAME = 'blueprint_search_text';
+
+async function dropTextIndex(db) {
+  const collections = await db.listCollections({ name: COLLECTION }).toArray();
+  if (collections.length === 0) return; // fresh database — the app creates it
+  const indexes = await db.collection(COLLECTION).indexes();
+  if (!indexes.some(index => index.name === INDEX_NAME)) return; // already gone
+  await db.collection(COLLECTION).dropIndex(INDEX_NAME);
+}
+
+module.exports = {
+  async up(db) {
+    await dropTextIndex(db);
+    // Recreated explicitly rather than left to autoIndex, so the index exists
+    // the moment the migration returns — a deploy that runs migrations before
+    // the app comes up must not leave search unindexed in between.
+    await db.collection(COLLECTION).createIndex(
+      { title: 'text', titleOriginal: 'text', terms: 'text', description: 'text' },
+      {
+        weights: { title: 10, titleOriginal: 4, terms: 4, description: 1 },
+        language_override: 'textLang',
+        default_language: 'en',
+        name: INDEX_NAME,
+      }
+    );
+  },
+
+  async down(db) {
+    await dropTextIndex(db);
+    await db.collection(COLLECTION).createIndex(
+      { title: 'text', terms: 'text', description: 'text' },
+      {
+        weights: { title: 10, terms: 4, description: 1 },
+        language_override: 'textLang',
+        default_language: 'en',
+        name: INDEX_NAME,
+      }
+    );
+    // titleOriginal itself is left in place: it is inert once out of the
+    // index, and the field disappears naturally when the schema drops it.
+  },
+};


### PR DESCRIPTION
Implements **all of `spec/search-followups.md` Part 2** (content locale picker) plus **Part 1 §1
and §2** — the two gaps that made "every blueprint is readable in English" false in practice.
One branch rather than five, because nothing here is deployed to users yet and the pieces only
make sense together: surfacing a machine title without disclosure would put words in an author's
mouth, and trusting provider-side detection without `titleOriginal` could lose a good match.

## What ships

**1. `User.localePreference` + `GET`/`PATCH /api/users/me/locale-preference`**
Mirrors `themePreference`/`dlcPreferences`: private, never in `ProfileResponse`, absent means
"never chosen". It reports `null` rather than `'en'` when unset — unlike `themePreference`, which
resolves server-side — because the client's own default is `navigator.language` and answering
`'en'` would override it on every device. The language set is **open** (shape-validated base ISO
tag only): a user may declare a language we never translate *into*.

**2. The picker**
`dialog-content-language`, mounted in the site nav, opened off `ContentLocaleService.openRequests$`
— so the user-menu entry and the ambient entry point on the details page both reach it with no
component wiring. Three states kept distinct: **declared** (localStorage + account), **guessed**
(`navigator.language`, shown as a pre-selection and never persisted), and English. Login adopts a
local declaration into an account that has none.

**3. `?lang=` + one shared title resolver**
`resolveTitle` in `lib/src/blueprint/content-locale.ts` implements §2.5's four rules; the backend
applies it via one service at the response boundary of the list, details, related-shelf and
editor-open responses.

**4. Machine-translation disclosure** — cards carry a quiet `pi-language` glyph whose tooltip holds
the author's original; the details page states the fact, shows the original, and links to the
picker.

**5. `titleOriginal` (Part 1 §1)** — translating a title used to *replace* it, deleting the
author's own words from the index. Now retained, at the `terms` weight.

**6. Provider-side detection (Part 1 §2)** — a third `derive-search` pass for titles our detector
cannot place at all (`Dien phan full`).

**7. Declared `sourceLang` (§2.6)** — the save path prefers the author's stored preference over
`Accept-Language` as the detection prior.

## Design decisions worth reviewing

**The `blueprintsearch` contract is deliberately widened, and §2.4's argument is CONFIRMED, not
overturned.** That collection was "derived and disposable… advisory for retrieval only"; display
titles now come out of it. Accepted on three grounds, recorded in `title-resolution-service.ts`:
the resolution chain always terminates at `Blueprint.name` so a lost row degrades to authored text
(never blank); machine titles rebuild for free from the `translationunits` text-hash cache; and
rows stay advisory for *visibility*, because the authoritative filter still runs against
`blueprints` and titles are only resolved for documents that already passed it. Both properties
are asserted by tests. The rejected alternative — a `titleTranslations` map on the blueprint
document — is named there too.

**The resolved title is a new field, not `name`.** §2.5 says never mutate `Blueprint.name`;
returning a translated value *in a response's `name` field* is the same mutation seen from the
client, because the editor stores `name` and its save dialog pre-fills from it, and the details
page derives the download filename from it. So `name` stays authored on every response and
`displayName`/`nameTranslated`/`nameSourceLang` carry the resolution — meaning any display surface
not yet updated degrades to the author's own words rather than translating a filename. Editor-open
is still one of the three application sites, but into `displayName` only.

**`?lang=` is an explicit query param, never `Accept-Language`.** These responses are
Cloudflare-cached; a param keys cleanly where `Vary: Accept-Language` fragments per browser. The
client omits it entirely for English, so the ordinary browse URL is byte-identical to before.
Facet counts take no `lang` — they return no titles.

**The short-circuit trap was real and is bypassed explicitly.** `translateMany` returns early on
`sourceLang == null && ASCII_ONLY`, which is *exactly* the Part 1 §2 candidate set, so
`forceProviderDetection` opts out of it. There is a test asserting both halves: the same input
makes zero provider calls without the flag and one with it.

**Trusting `confidence: 'prior'` on the declared path reverses an existing rule, on purpose.** Same
mechanism, different evidence: an `Accept-Language` header is a browser default nobody chose; a
picker setting is the user's own statement. Guards keep a misdeclaration cheap — the provider must
report a non-`en` source, and (now universally) a provider that returns the input unchanged never
marks a row `'machine'`.

**Selecting a language reloads the page.** The locale is a request parameter, so titles already on
screen were fetched under the old one. Safe because the picker is unreachable from the editor,
which has its own menu and never mounts the site nav — no unsaved work is at risk.

**Picker labels stay in English**, and the list is a curated twelve rather than the
self-maintaining `sourceLang` distribution §2.12 floated: that distribution is currently dominated
by detection noise on short titles, and the API validates shape rather than membership, so an
unlisted language is not locked out.

## Migration + deploy order

`migrations/20260804000000_search-title-original.js` drops and recreates the `blueprintsearch`
text index. The *data* is derived and disposable, but Mongo will not alter an index in place and
Mongoose's autoIndex hits `IndexOptionsConflict`, which surfaces only as a logged error on a
running server.

```
npm run migrate:up        # rebuilds the text index with titleOriginal
npm run derive-search     # backfills titleOriginal + runs the new detection pass
```

**In that order.** Verified locally up → down → up.

`derive-search` gained the provider-detection pass **on by default** (`--skip-provider-detect` opts
out) — leaving it off is what keeps the claim quietly false. It is idempotent and near-free on
re-runs, since `translationunits` is keyed by text hash. Prod has `GOOGLE_TRANSLATE_API_KEY` set,
and the estimated one-time spend is ~59K characters against a 500K/month free tier.

## Verification

- Backend: **1022 passing** (Mocha + Chai), clean run. New: `locale-preference.test.ts`,
  `content-locale-titles.test.ts`, and three new blocks in `search.test.ts`.
- Frontend: **1224 passing** (Vitest), `npm run lint` clean.
- `npm run tsc` and `npm run build` clean.
- No network in any test — the fake provider policy is unchanged.
- The pre-existing local `translation-service.test.ts` flake did not reproduce this session.

One test-infrastructure fix rides along: the mocha root hook now runs `syncIndexes()`. A
long-lived local test database keeps the old text index, and the symptom is a search test finding
nothing rather than an index error — CI never sees it, a developer's machine always does.

## Not in scope (unchanged from the brief)

UI chrome localization, native-language search rows (§2.9), and translating into any language
other than English. Also still open: retrieval reading the accreted non-English rows at all (Part
1 §4 — still hard-codes `lang: 'en'`), and the `changed: false` precision audit (Part 1 §5).

## Follow-up before this is useful in prod

Running the migration and `derive-search` is the whole activation step — until then, no blueprint
has a `titleOriginal` and the romanized population is still untranslated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
