### PR TITLE
docs: refresh status after the content-locale merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,11 +175,17 @@ Uses MongoDB 8.0.23 locally and in CI (prod upgrade from 7.0.34 pending) with Mo
 
 ## Current Status
 
-- **Phase**: OniExtract2024 flat-icon rendering (current asset pipeline)
-- **Date**: 2026-07-12
+- **Phase**: multilingual search + content locale (search plan phases 0–5 and
+  `spec/search-followups.md` Part 1 §1/§2 + Part 2 all shipped). Asset pipeline is still
+  OniExtract2024 flat-icon rendering.
+- **Date**: 2026-08-04
 - **Node.js**: 20.19.4 (via volta)
 - **Stack**: TypeScript 5.9.3 strict (both trees) · Mongoose 8.24 · Express 5.2 · Canvas 3.2.3 · Angular 20 · PrimeNG 20 · ESLint 9 flat config · Prettier 3 (both trees) · husky 9 + lint-staged 16
-- **Tests**: ✅ Backend 796 passing (Mocha 11 + Chai 4; 2 workos-provision specs flake locally, green in CI) · Frontend 1120 passing (Vitest/jsdom)
+- **Tests**: ✅ Backend 1022 passing (Mocha 11 + Chai 4; a few DB-heavy API specs time out under
+  load locally and pass on a clean run) · Frontend 1226 passing (Vitest/jsdom)
+- **⚠️ Pending prod activation**: `npm run migrate:up` then `npm run derive-search` (in that
+  order — see "Search (blueprintsearch)"). Until both run, no row has a `titleOriginal` and
+  romanized non-English titles are still untranslated.
 - **Build**: ✅ `npm run tsc` clean · `npm run build` clean
 - **Lint**: `cd frontend && npm run lint` (ESLint 9 flat config, `frontend/eslint.config.js`); backend has no ESLint yet — Prettier only
 

--- a/agent/SESSION_NOTES.md
+++ b/agent/SESSION_NOTES.md
@@ -1,3 +1,56 @@
+# Session Notes - 2026-08-04
+
+## What We Accomplished ✅
+
+### Content locale + search follow-ups (PR #206, merged)
+
+All of `spec/search-followups.md` Part 2 plus Part 1 §1 and §2, in one branch — the pieces
+only make sense together: surfacing a machine title without disclosure puts words in an
+author's mouth, and trusting provider-side detection without `titleOriginal` can lose a good
+match.
+
+- **`User.localePreference`** + private `GET`/`PATCH /api/users/me/locale-preference`.
+  Reports `null` (not `'en'`) when unset, unlike `themePreference` — the client's default is
+  `navigator.language` and answering `'en'` would override it on every device.
+- **Content-language picker** in the site nav, opened off a service subject so the user menu
+  and the details-page disclosure both reach it with no component wiring.
+- **`?lang=` + one shared title resolver** applied at the response boundary of the list,
+  details, related-shelf and editor-open responses.
+- **`titleOriginal`** in the text index (weight 4) — translating a title used to delete the
+  author's own words from the index.
+- **Provider-side detection pass** in `derive-search` for titles our detector can't place.
+- **Declared `sourceLang`** on the save path.
+
+### Decisions worth remembering
+
+- **`blueprintsearch` is now a display source**, widening its "advisory for retrieval only"
+  contract. Confirmed rather than overturned; reasoning and the rejected
+  `titleTranslations`-on-the-document alternative are in `title-resolution-service.ts`.
+- **The resolved title is `displayName`, never `name`.** Returning a translated value in a
+  response's `name` field is the same mutation seen from the client — the editor stores it,
+  the save dialog pre-fills from it, and the details page builds the download filename from
+  it.
+- **The picker is deliberately absent from the editor.** Selecting reloads the page (the
+  locale is a request parameter), which would discard unsaved editor work.
+
+### Gotchas found
+
+- **`translateMany` short-circuits on `sourceLang == null && ASCII_ONLY`** — exactly the
+  romanized-title candidate set. `forceProviderDetection` bypasses it; without that the pass
+  makes zero provider calls and still reports success.
+- **A long-lived local test DB keeps stale indexes** and Mongo won't redefine one in place.
+  The symptom was a search test finding nothing, never an index error — CI (fresh mongo)
+  never sees it. `__tests__/hooks.ts` now runs `syncIndexes()` and reports failures by model.
+
+### Left for the next session
+
+**Prod activation is blocking and not done**: `npm run migrate:up` then
+`npm run derive-search`, in that order. See `agent/TODO.md`.
+
+- **Tests**: backend 1022, frontend 1226 — all green.
+
+---
+
 # Session Notes - 2026-07-05
 
 ## What We Accomplished ✅

--- a/agent/TODO.md
+++ b/agent/TODO.md
@@ -1,12 +1,58 @@
 # Agent TODO - Blueprint Not Included
 
 ## Current Status
-- **Phase**: Social evolution — likes, auto-derived metadata, profiles/follows/activity feed, blueprint comments, and the blueprint details page all shipped
-- **Date**: 2026-07-06
+- **Phase**: Multilingual search + content locale — search plan phases 0–5 shipped, plus
+  `spec/search-followups.md` Part 1 §1/§2 and all of Part 2 (PR #206)
+- **Date**: 2026-08-04
 - **Branch**: `master`
-- **Stack**: Node 20.19.4 · TypeScript 5.9.2 strict · Mongoose 8.18.1 · Express 5.1.0 · Canvas 3.2.3 · Angular 20 · PrimeNG 20
-- **Tests**: 326 backend (Mocha + Chai) · 573 frontend (Vitest, 2 skipped) — all green
+- **Stack**: Node 20.19.4 · TypeScript 5.9.3 strict · Mongoose 8.24 · Express 5.2 · Canvas 3.2.3 · Angular 20 · PrimeNG 20
+- **Tests**: 1022 backend (Mocha + Chai) · 1226 frontend (Vitest, 2 skipped) — all green
 - **Enforcement**: zero-warning flags enabled backend, lib, and frontend (`strict` + `strictTemplates`); CI improvements all complete (mongo:8.0.23 + mongosh health check)
+
+## ⚠️ Blocking: activate the content-locale work in prod
+
+PR #206 is merged but **inert until two commands run, in this order**:
+
+```bash
+cd /bpni/build
+npm run migrate:up        # 20260804000000_search-title-original — rebuilds the text index
+npm run derive-search     # backfills titleOriginal + runs provider-side detection
+```
+
+Take a DB backup first (DO dashboard → Backups → Create backup now), per the migration
+runbook. `derive-search` is rerunnable; do a `derive-search:dry-run` first to see the
+candidate counts. The detection pass spends real money against `GOOGLE_TRANSLATE_API_KEY`
+(one-time, ~59K characters, inside the 500K/month free tier) — re-runs are cache reads.
+
+Until this runs: no row has a `titleOriginal` (so a machine-translated blueprint is still
+unfindable by its authored title), and romanized non-English titles are still untranslated.
+
+## Multilingual search — what's left
+
+Full detail in `spec/multilingual-search-plan.md` §4.5 and `spec/search-followups.md`.
+
+- **Retrieval never reads the non-English rows** (followups Part 1 §4). Phase 5 accretes
+  rows in the reader's language, but `lexicalRetrieval`/`structuralRetrieval` still
+  hard-code `lang: 'en'`. They cost nothing and buy nothing until a viewer-language signal
+  is threaded in — which `?lang=` now supplies for the first time, so this is unblocked.
+- **`changed: false` precision audit** (followups Part 1 §5). Cheap aggregate; measures
+  whether `confidentTitleLang` over-fires. Worth running against prod **after** the
+  activation above, since the new detection pass adds to the population.
+- **Native-language search rows** (followups §2.9). Now that `sourceLang` can be declared,
+  writing a row with `lang: sourceLang` holding the authored text verbatim is free — no API
+  call. It overlaps `titleOriginal`; design them together or there will be two mechanisms
+  for one job.
+- **Sticky "always show original titles"** (followups §2.12) — does an English reader ever
+  want the authored title instead? Product question, not mechanical.
+- **Phase 6 — semantic retrieval**, only if `searchqueries` telemetry justifies it. It held
+  ~2 dev rows as of 2026-08-04; needs real production traffic first.
+- **IDF weighting for structural matches** (plan §2.3 B) — still ordered by raw matched-id
+  count.
+- **`.po` acquisition** for non-English term dictionaries (plan §7.3) — research and
+  licensing, not engineering, but it caps how good non-English search gets at zero cost.
+- **Near-duplicate clustering** (plan §2.5 signal 2, multiset Jaccard) — needs a global
+  pass, so it was skipped in phase 2. Its consumer, the **fork-migration offer to cluster
+  members**, is the feature whose absence produced 86 copies of one ranch.
 
 ## OniExtract2024 follow-ups
 
@@ -153,6 +199,8 @@ WorkOS in-app auth work; rate limiting is Cloudflare's job — do not add expres
 
 ## Next steps
 
+0. **Activate PR #206 in prod** — migrate, then `derive-search`. See the blocking section
+   above; nothing about the content-locale feature works until this runs.
 1. Rename `import:2024` to a version-neutral script name (keep alias one cycle).
 2. Export side: emit `uiImageRect` for the 145 buildings still missing it.
 3. Monitor WorkOS legacy-user migration (`GET /api/migration/status`); retire the legacy


### PR DESCRIPTION
Docs-only follow-up to #206.

Both status blocks had drifted badly — `agent/TODO.md` still claimed 326 backend / 573
frontend tests against an actual 1022 / 1226, and dated the project to 2026-07-06.

- **CLAUDE.md** — status block refreshed, and a pointer to the pending prod activation.
- **agent/TODO.md** — status refreshed; new blocking section for the activation; the
  remaining multilingual-search work collected in one place instead of spread across two
  gitignored spec files.
- **agent/SESSION_NOTES.md** — entry for the session, weighted toward the decisions and
  gotchas a later reader would otherwise re-derive (why the resolved title is `displayName`
  and not `name`; why the picker is deliberately absent from the editor; the `translateMany`
  ASCII short-circuit; the stale-index-in-a-long-lived-test-DB trap).

**The operationally important bit:** #206 is merged but inert. It needs

```
npm run migrate:up      # rebuilds the blueprintsearch text index for titleOriginal
npm run derive-search   # backfills it + runs provider-side detection
```

in that order, from `/bpni/build`, after a DB backup. Until then no row has a
`titleOriginal` and romanized non-English titles are still untranslated.

Also noted: the merge **unblocked** followups Part 1 §4. Retrieval still hard-codes
`lang: 'en'`, and the viewer-language signal it was waiting on is exactly what `?lang=` now
provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
