### PR TITLE
feat: add offline diacritic translation experiment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,9 @@ Dockerfile
 /frontend/tmp
 /frontend/out-tsc
 
+# Development-only, offline provider experiment; never compile it into a deploy image.
+/app/api/experiments
+
 # Only exists if Bazel was run
 /frontend/bazel-out
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,12 @@
 # Server-rendered blueprint preview image cache (regenerated on demand)
 /preview-cache
 
+# Offline LLM diacritic experiment reservations and provider responses
+/tmp/llm-diacritic-ab/
+
+# Local implementation plans and working specifications
+/specs/
+
 # avatar smoke test scratch output
 avatar-smoke-test*.png
 

--- a/__tests__/api/experiments/diacritic-ab.test.ts
+++ b/__tests__/api/experiments/diacritic-ab.test.ts
@@ -1,0 +1,251 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { ArtifactStore } from '../../../app/api/experiments/diacritic-ab/artifacts';
+import {
+  assertDoRequestWithinCap,
+  assertGoogleCharacters,
+  calculateMaximumCost,
+  fullReservation,
+} from '../../../app/api/experiments/diacritic-ab/caps';
+import {
+  DigitalOceanExperimentClient,
+  GoogleExperimentClient,
+  GoogleTransport,
+  validateLlmOutputs,
+} from '../../../app/api/experiments/diacritic-ab/clients';
+import { DO_ENDPOINT, DO_MODEL } from '../../../app/api/experiments/diacritic-ab/constants';
+import {
+  blindResults,
+  mechanicalRows,
+  observedCost,
+} from '../../../app/api/experiments/diacritic-ab/evaluation';
+import {
+  loadFixture,
+  stripVietnameseDiacritics,
+  validateFixture,
+} from '../../../app/api/experiments/diacritic-ab/fixture';
+import { buildDoRequest } from '../../../app/api/experiments/diacritic-ab/prompts';
+import {
+  ArmOutput,
+  ArmResult,
+  HttpRequest,
+  HttpTransport,
+} from '../../../app/api/experiments/diacritic-ab/types';
+
+describe('diacritic A/B experiment', () => {
+  const cases = loadFixture();
+
+  describe('fixture and stripping', () => {
+    it('strips combining marks and Vietnamese d with stroke', () => {
+      expect(stripVietnameseDiacritics('Điện phân nước ĐẦY')).to.equal('Dien phan nuoc DAY');
+      expect(stripVietnameseDiacritics('a\u0301')).to.equal('a');
+    });
+
+    it('loads the fixed category mix within the hard character cap', () => {
+      expect(cases).to.have.length(12);
+      expect(new Set(cases.map(item => item.id)).size).to.equal(12);
+      expect(cases.filter(item => item.category === 'live')).to.have.length(2);
+      expect(cases.filter(item => item.category === 'synthetic')).to.have.length(6);
+      expect(cases.filter(item => item.category === 'ambiguous')).to.have.length(2);
+      expect(cases.filter(item => item.category === 'control')).to.have.length(2);
+      expect(cases.reduce((sum, item) => sum + item.asciiInput.length, 0)).to.be.at.most(256);
+    });
+
+    it('rejects duplicates, non-ASCII input, and non-mechanical synthetic input', () => {
+      const duplicate = cases.map(item => ({ ...item }));
+      duplicate[1].id = duplicate[0].id;
+      expect(() => validateFixture(duplicate)).to.throw('Duplicate fixture id');
+      const nonAscii = cases.map(item => ({ ...item }));
+      nonAscii[0].asciiInput = 'Điện phân';
+      expect(() => validateFixture(nonAscii)).to.throw('not ASCII');
+      const mismatched = cases.map(item => ({ ...item }));
+      mismatched.find(item => item.category === 'synthetic')!.asciiInput = 'wrong';
+      expect(() => validateFixture(mismatched)).to.throw('not mechanically stripped');
+    });
+  });
+
+  describe('caps', () => {
+    it('calculates the acknowledged worst case exactly', () => {
+      expect(calculateMaximumCost()).to.equal(0.0175104);
+      expect(fullReservation()).to.deep.include({
+        doCalls: 2,
+        googleCalls: 3,
+        doInputTokens: 8192,
+        doOutputTokens: 1536,
+        googleSourceCharacters: 768,
+        maximumUsd: 0.0175104,
+      });
+    });
+
+    it('accepts exact per-request boundaries and rejects one unit over', () => {
+      expect(assertDoRequestWithinCap('x'.repeat(4032))).to.equal(4096);
+      expect(() => assertDoRequestWithinCap('x'.repeat(4033))).to.throw('per-call cap');
+      expect(assertGoogleCharacters(['x'.repeat(256)], 256)).to.equal(256);
+      expect(() => assertGoogleCharacters(['x'.repeat(257)], 256)).to.throw('source characters');
+    });
+  });
+
+  describe('prompt serialization', () => {
+    it('pins model/settings and keeps evaluation ground truth out of both requests', () => {
+      for (const mode of ['end-to-end', 'restore'] as const) {
+        const request = buildDoRequest(cases, mode);
+        const serialized = JSON.stringify(request);
+        expect(request.model).to.equal(DO_MODEL);
+        expect(request.temperature).to.equal(0);
+        expect(request.max_completion_tokens).to.equal(768);
+        expect(request.response_format.type).to.equal('json_schema');
+        expect(serialized).not.to.contain('canonicalVietnamese');
+        expect(serialized).not.to.contain('acceptableEnglish');
+        expect(serialized).not.to.contain('reviewerNote');
+        expect(serialized).not.to.contain('Điện phân');
+        expect(serialized).not.to.contain('Electrolysis');
+        expect(serialized).not.to.contain('Short tone collision');
+        expect(assertDoRequestWithinCap(serialized)).to.be.at.most(4096);
+      }
+    });
+  });
+
+  describe('experiment clients', () => {
+    it('sends one Google batch with auto detection and one with forced Vietnamese', async () => {
+      const calls: { texts: string[]; options: unknown }[] = [];
+      const transport: GoogleTransport = {
+        async translate(texts, options) {
+          calls.push({ texts, options });
+          return [texts.map(text => `translated:${text}`), { data: { translations: [] } }];
+        },
+      };
+      const client = new GoogleExperimentClient(transport);
+      await client.translate(
+        cases.map(item => item.asciiInput),
+        'auto'
+      );
+      await client.translate(
+        cases.map(item => item.asciiInput),
+        'vi'
+      );
+      expect(calls).to.have.length(2);
+      expect(calls[0].options).to.deep.equal({ to: 'en', format: 'text' });
+      expect(calls[1].options).to.deep.equal({ to: 'en', format: 'text', from: 'vi' });
+      expect(calls[0].texts).to.have.length(12);
+    });
+
+    it('pins the DO endpoint/model and validates complete aligned output and usage', async () => {
+      const requests: HttpRequest[] = [];
+      const outputs = resolvedOutputs(false);
+      const transport: HttpTransport = {
+        async send(request) {
+          requests.push(request);
+          if (request.method === 'GET') return { status: 200, body: { data: [{ id: DO_MODEL }] } };
+          return {
+            status: 200,
+            body: {
+              choices: [{ message: { content: JSON.stringify({ results: outputs }) } }],
+              usage: { prompt_tokens: 400, completion_tokens: 200 },
+            },
+          };
+        },
+      };
+      const client = new DigitalOceanExperimentClient(transport);
+      await client.assertModelAvailable();
+      const result = await client.complete(buildDoRequest(cases, 'restore'), cases, 'restore');
+      expect(result.outputs).to.deep.equal(outputs);
+      expect(result.usage).to.deep.equal({ promptTokens: 400, completionTokens: 200 });
+      expect(requests[0].url).to.equal(`${DO_ENDPOINT}/v1/models`);
+      expect(requests[1].url).to.equal(`${DO_ENDPOINT}/v1/chat/completions`);
+      expect(JSON.parse(requests[1].body!).model).to.equal(DO_MODEL);
+    });
+
+    it('captures a raw DO response before failing closed on missing usage', async () => {
+      const raw = {
+        choices: [{ message: { content: JSON.stringify({ results: resolvedOutputs(false) }) } }],
+      };
+      const transport: HttpTransport = {
+        async send() {
+          return { status: 200, body: raw };
+        },
+      };
+      let captured: unknown;
+      const client = new DigitalOceanExperimentClient(transport);
+      try {
+        await client.complete(buildDoRequest(cases, 'restore'), cases, 'restore', value => {
+          captured = value;
+        });
+        expect.fail('missing usage should fail');
+      } catch (error) {
+        expect((error as Error).message).to.contain('omitted token usage');
+      }
+      expect(captured).to.equal(raw);
+    });
+
+    it('rejects missing, duplicate, unknown, and extra output IDs', () => {
+      const base = resolvedOutputs(false);
+      expect(() => validateLlmOutputs(base.slice(1), cases, 'restore')).to.throw('exactly 12');
+      const duplicate = base.map(item => ({ ...item }));
+      duplicate[1].id = duplicate[0].id;
+      expect(() => validateLlmOutputs(duplicate, cases, 'restore')).to.throw('malformed row');
+      const unknown = base.map(item => ({ ...item }));
+      unknown[0].id = 'unknown';
+      expect(() => validateLlmOutputs(unknown, cases, 'restore')).to.throw('malformed row');
+      expect(() => validateLlmOutputs([...base, base[0]], cases, 'restore')).to.throw('exactly 12');
+    });
+  });
+
+  describe('artifacts and evaluation', () => {
+    let directory: string;
+    afterEach(() => {
+      if (directory) fs.rmSync(directory, { recursive: true, force: true });
+    });
+
+    it('creates a reservation once and refuses to overwrite it', () => {
+      directory = fs.mkdtempSync(path.join(os.tmpdir(), 'diacritic-ledger-'));
+      const store = new ArtifactStore(directory);
+      store.createReservation({ state: 'reserved', usd: 0.02 });
+      expect(store.read('reservation.json')).to.deep.equal({ state: 'reserved', usd: 0.02 });
+      expect(() => store.createReservation({ state: 'reserved' })).to.throw('already exists');
+    });
+
+    it('computes mechanical measures/cost and emits a blinded review mapping', () => {
+      const arms: ArmResult[] = [
+        { arm: 'google-auto', outputs: resolvedOutputs(true), googleSourceCharacters: 125 },
+        { arm: 'google-vi', outputs: resolvedOutputs(true), googleSourceCharacters: 125 },
+        {
+          arm: 'llm-end-to-end',
+          outputs: resolvedOutputs(true),
+          usage: { promptTokens: 100, completionTokens: 50 },
+        },
+        {
+          arm: 'restore-google',
+          outputs: resolvedOutputs(true),
+          usage: { promptTokens: 100, completionTokens: 50 },
+          googleSourceCharacters: 130,
+        },
+      ];
+      expect(mechanicalRows(cases, arms)).to.have.length(48);
+      const changedControl = resolvedOutputs(true);
+      changedControl.find(item => item.id === 'control-main-base')!.english = 'Main Base';
+      const controlMetric = mechanicalRows(cases, [
+        { arm: 'google-auto', outputs: changedControl },
+      ]).find(item => item.id === 'control-main-base')!;
+      expect(controlMetric.noOp).to.equal(true);
+      expect(controlMetric.controlPreserved).to.equal(false);
+      expect(observedCost(arms).complete).to.equal(true);
+      expect(observedCost(arms).usd).to.be.greaterThan(0);
+      const blind = blindResults(cases, arms);
+      expect(Object.keys(blind.mapping)).to.have.members(['A', 'B', 'C', 'D']);
+      expect(blind.review).to.contain('Do not unblind arm labels');
+      expect(blind.review).not.to.contain('google-auto');
+    });
+  });
+
+  function resolvedOutputs(withEnglish: boolean): ArmOutput[] {
+    return cases.map(item => ({
+      id: item.id,
+      status: 'resolved',
+      restoredVi: item.canonicalVietnamese ?? item.asciiInput,
+      ...(withEnglish ? { english: item.acceptableEnglish?.[0] ?? item.asciiInput } : {}),
+      alternatives: [],
+    }));
+  }
+});

--- a/__tests__/api/experiments/diacritic-ab.test.ts
+++ b/__tests__/api/experiments/diacritic-ab.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { ArtifactStore } from '../../../app/api/experiments/diacritic-ab/artifacts';
+import { ArtifactStore, sha256 } from '../../../app/api/experiments/diacritic-ab/artifacts';
 import {
   assertDoRequestWithinCap,
   assertGoogleCharacters,
@@ -33,6 +33,7 @@ import {
   HttpRequest,
   HttpTransport,
 } from '../../../app/api/experiments/diacritic-ab/types';
+import { loadReviewed402Continuation } from '../../../app/api/experiments/translate-diacritic-ab';
 
 describe('diacritic A/B experiment', () => {
   const cases = loadFixture();
@@ -179,6 +180,26 @@ describe('diacritic A/B experiment', () => {
       expect(captured).to.equal(raw);
     });
 
+    it('captures a raw DO error body before failing closed on HTTP 402', async () => {
+      const raw = { id: 'payment_required', message: 'Prepayment required' };
+      const transport: HttpTransport = {
+        async send() {
+          return { status: 402, body: raw };
+        },
+      };
+      let captured: unknown;
+      const client = new DigitalOceanExperimentClient(transport);
+      try {
+        await client.complete(buildDoRequest(cases, 'restore'), cases, 'restore', value => {
+          captured = value;
+        });
+        expect.fail('HTTP 402 should fail');
+      } catch (error) {
+        expect((error as Error).message).to.contain('HTTP 402');
+      }
+      expect(captured).to.equal(raw);
+    });
+
     it('rejects missing, duplicate, unknown, and extra output IDs', () => {
       const base = resolvedOutputs(false);
       expect(() => validateLlmOutputs(base.slice(1), cases, 'restore')).to.throw('exactly 12');
@@ -204,6 +225,53 @@ describe('diacritic A/B experiment', () => {
       store.createReservation({ state: 'reserved', usd: 0.02 });
       expect(store.read('reservation.json')).to.deep.equal({ state: 'reserved', usd: 0.02 });
       expect(() => store.createReservation({ state: 'reserved' })).to.throw('already exists');
+    });
+
+    it('accepts only the exact reviewed 402 continuation artifacts once', () => {
+      directory = fs.mkdtempSync(path.join(os.tmpdir(), 'diacritic-resume-'));
+      const store = new ArtifactStore(directory);
+      const fixtureHash = sha256(
+        fs.readFileSync('app/api/experiments/fixtures/vi-diacritic-cases.json')
+      );
+      const sourceCharacters = cases.reduce((sum, item) => sum + item.asciiInput.length, 0);
+      const googleAuto: ArmResult = {
+        arm: 'google-auto',
+        outputs: resolvedOutputs(true).map(({ restoredVi: _restoredVi, ...output }) => output),
+        googleSourceCharacters: sourceCharacters,
+      };
+      const googleVi: ArmResult = {
+        arm: 'google-vi',
+        outputs: resolvedOutputs(true).map(({ restoredVi: _restoredVi, ...output }) => output),
+        googleSourceCharacters: sourceCharacters,
+      };
+      store.writeJson('reservation.json', {
+        state: 'failed',
+        failure: 'DO completion request failed with HTTP 402',
+        calls: { digitalOcean: 2, google: 3 },
+        manifestFixtureSha256: fixtureHash,
+      });
+      store.writeJson('results.json', {
+        partial: true,
+        arms: [googleAuto, googleVi],
+        operationalFailure: {
+          arm: 'llm-end-to-end',
+          message: 'DO completion request failed with HTTP 402',
+        },
+      });
+      store.writeJson('responses/google-auto.json', { data: {} });
+      store.writeJson('responses/google-vi.json', { data: {} });
+
+      expect(loadReviewed402Continuation(store, cases, fixtureHash).results).to.deep.equal([
+        googleAuto,
+        googleVi,
+      ]);
+      store.writeJson('reservation.json', {
+        ...(store.read('reservation.json') as Record<string, unknown>),
+        resume: { authorizedAt: new Date().toISOString() },
+      });
+      expect(() => loadReviewed402Continuation(store, cases, fixtureHash)).to.throw(
+        'single reviewed HTTP 402 state'
+      );
     });
 
     it('computes mechanical measures/cost and emits a blinded review mapping', () => {

--- a/app/api/experiments/diacritic-ab/artifacts.ts
+++ b/app/api/experiments/diacritic-ab/artifacts.ts
@@ -1,0 +1,79 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+export function sha256(value: string | Buffer): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function json(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export class ArtifactStore {
+  public readonly responsesDir: string;
+
+  public constructor(public readonly directory: string) {
+    this.responsesDir = path.join(directory, 'responses');
+  }
+
+  public prepare(): void {
+    fs.mkdirSync(this.responsesDir, { recursive: true, mode: 0o700 });
+  }
+
+  public path(name: string): string {
+    return path.join(this.directory, name);
+  }
+
+  public exists(name: string): boolean {
+    return fs.existsSync(this.path(name));
+  }
+
+  public read(name: string): unknown {
+    return JSON.parse(fs.readFileSync(this.path(name), 'utf8')) as unknown;
+  }
+
+  public writeJson(name: string, value: unknown): void {
+    this.atomicReplace(this.path(name), json(value));
+  }
+
+  public writeText(name: string, value: string): void {
+    this.atomicReplace(this.path(name), value);
+  }
+
+  public createReservation(value: unknown): void {
+    this.prepare();
+    const destination = this.path('reservation.json');
+    const temporary = this.writeTemporary(destination, json(value));
+    try {
+      // link is an atomic create-if-absent operation. It cannot overwrite a
+      // reservation left by a crash or an earlier run.
+      fs.linkSync(temporary, destination);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+        throw new Error('A reservation already exists; review the artifact before any rerun');
+      }
+      throw error;
+    } finally {
+      fs.unlinkSync(temporary);
+    }
+  }
+
+  private atomicReplace(destination: string, contents: string): void {
+    this.prepare();
+    const temporary = this.writeTemporary(destination, contents);
+    fs.renameSync(temporary, destination);
+  }
+
+  private writeTemporary(destination: string, contents: string): string {
+    const temporary = `${destination}.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`;
+    const fd = fs.openSync(temporary, 'wx', 0o600);
+    try {
+      fs.writeFileSync(fd, contents, 'utf8');
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    return temporary;
+  }
+}

--- a/app/api/experiments/diacritic-ab/caps.ts
+++ b/app/api/experiments/diacritic-ab/caps.ts
@@ -1,0 +1,65 @@
+import { CAPS, MAX_APPROVED_RATES, RATES } from './constants';
+
+export interface Reservation {
+  doCalls: number;
+  googleCalls: number;
+  doInputTokens: number;
+  doOutputTokens: number;
+  googleSourceCharacters: number;
+  maximumUsd: number;
+}
+
+export function calculateMaximumCost(): number {
+  return (
+    (CAPS.doInputTokens * RATES.doInputUsdPerMillionTokens) / 1_000_000 +
+    (CAPS.doOutputTokens * RATES.doOutputUsdPerMillionTokens) / 1_000_000 +
+    (CAPS.googleSourceCharacters * RATES.googleUsdPerMillionCharacters) / 1_000_000
+  );
+}
+
+export function assertApprovedRates(): void {
+  for (const key of Object.keys(MAX_APPROVED_RATES) as (keyof typeof MAX_APPROVED_RATES)[]) {
+    if (RATES[key] > MAX_APPROVED_RATES[key]) {
+      throw new Error(
+        `Recorded ${key} exceeds its approved rate; review the plan before executing`
+      );
+    }
+  }
+}
+
+export function fullReservation(): Reservation {
+  assertApprovedRates();
+  const maximumUsd = calculateMaximumCost();
+  if (maximumUsd > CAPS.acknowledgedUsd) {
+    throw new Error(`Maximum $${maximumUsd.toFixed(7)} exceeds acknowledged ceiling`);
+  }
+  return {
+    doCalls: CAPS.doCalls,
+    googleCalls: CAPS.googleCalls,
+    doInputTokens: CAPS.doInputTokens,
+    doOutputTokens: CAPS.doOutputTokens,
+    googleSourceCharacters: CAPS.googleSourceCharacters,
+    maximumUsd,
+  };
+}
+
+export function assertDoRequestWithinCap(serializedBody: string): number {
+  // Every UTF-8 byte is treated as a token, plus 64 tokens for protocol/message
+  // framing. This substantially over-counts this ASCII-heavy prompt and needs no
+  // model tokenizer dependency.
+  const conservativeTokens = Buffer.byteLength(serializedBody, 'utf8') + 64;
+  if (conservativeTokens > CAPS.doInputTokensPerCall) {
+    throw new Error(
+      `DO request reserves ${conservativeTokens} input tokens; per-call cap is ${CAPS.doInputTokensPerCall}`
+    );
+  }
+  return conservativeTokens;
+}
+
+export function assertGoogleCharacters(texts: string[], maximum: number): number {
+  const characters = texts.reduce((sum, text) => sum + text.length, 0);
+  if (characters > maximum) {
+    throw new Error(`Google request has ${characters} source characters; cap is ${maximum}`);
+  }
+  return characters;
+}

--- a/app/api/experiments/diacritic-ab/clients.ts
+++ b/app/api/experiments/diacritic-ab/clients.ts
@@ -1,0 +1,198 @@
+import { TranslateRequest } from '@google-cloud/translate/build/src/v2';
+import { CAPS, DO_ENDPOINT, DO_MODEL, DO_TIMEOUT_MS, GOOGLE_TIMEOUT_MS } from './constants';
+import { assertDoRequestWithinCap, assertGoogleCharacters } from './caps';
+import { DoRequestBody, LlmMode } from './prompts';
+import {
+  ArmOutput,
+  DiacriticCase,
+  HttpRequest,
+  HttpResponse,
+  HttpTransport,
+  TokenUsage,
+} from './types';
+
+interface GoogleMetadata {
+  data?: { translations?: { translatedText?: string; detectedSourceLanguage?: string }[] };
+  [key: string]: unknown;
+}
+
+export interface GoogleTransport {
+  translate(texts: string[], options: TranslateRequest): Promise<[string[], GoogleMetadata]>;
+}
+
+export interface GoogleBatchResult {
+  texts: string[];
+  raw: GoogleMetadata;
+  sourceCharacters: number;
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`Experiment request timed out after ${timeoutMs}ms`)),
+      timeoutMs
+    );
+    promise.then(
+      value => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      error => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}
+
+export class GoogleExperimentClient {
+  public constructor(private readonly transport: GoogleTransport) {}
+
+  public async translate(
+    texts: string[],
+    source: 'auto' | 'vi',
+    captureRaw?: (raw: GoogleMetadata) => void
+  ): Promise<GoogleBatchResult> {
+    const sourceCharacters = assertGoogleCharacters(texts, CAPS.sourceCharacters);
+    const options: TranslateRequest = { to: 'en', format: 'text' };
+    if (source === 'vi') options.from = 'vi';
+    const [translated, raw] = await withTimeout(
+      this.transport.translate(texts, options),
+      GOOGLE_TIMEOUT_MS
+    );
+    captureRaw?.(raw);
+    if (!Array.isArray(translated) || translated.length !== texts.length) {
+      throw new Error(
+        `Google returned ${translated?.length ?? 0} results for ${texts.length} inputs`
+      );
+    }
+    return { texts: translated, raw, sourceCharacters };
+  }
+}
+
+interface ChatCompletionResponse {
+  choices?: { message?: { content?: string } }[];
+  usage?: { prompt_tokens?: number; completion_tokens?: number };
+  [key: string]: unknown;
+}
+
+export interface DoBatchResult {
+  outputs: ArmOutput[];
+  raw: ChatCompletionResponse;
+  usage: TokenUsage;
+}
+
+export class DigitalOceanExperimentClient {
+  public constructor(private readonly transport: HttpTransport) {}
+
+  public async assertModelAvailable(): Promise<void> {
+    const response = await this.transport.send({
+      url: `${DO_ENDPOINT}/v1/models`,
+      method: 'GET',
+      headers: {},
+      timeoutMs: DO_TIMEOUT_MS,
+    });
+    assertSuccess(response, 'DO model-list request');
+    const data = (response.body as { data?: { id?: string }[] })?.data;
+    if (!Array.isArray(data) || !data.some(model => model.id === DO_MODEL)) {
+      throw new Error(`Required model ${DO_MODEL} is unavailable to this key`);
+    }
+  }
+
+  public async complete(
+    requestBody: DoRequestBody,
+    cases: DiacriticCase[],
+    mode: LlmMode,
+    captureRaw?: (raw: ChatCompletionResponse) => void
+  ): Promise<DoBatchResult> {
+    if (requestBody.model !== DO_MODEL) throw new Error(`Unexpected model: ${requestBody.model}`);
+    const serialized = JSON.stringify(requestBody);
+    assertDoRequestWithinCap(serialized);
+    const response = await this.transport.send({
+      url: `${DO_ENDPOINT}/v1/chat/completions`,
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: serialized,
+      timeoutMs: DO_TIMEOUT_MS,
+    });
+    assertSuccess(response, 'DO completion request');
+    const raw = response.body as ChatCompletionResponse;
+    captureRaw?.(raw);
+    const content = raw.choices?.[0]?.message?.content;
+    if (typeof content !== 'string') throw new Error('DO response has no completion content');
+    const promptTokens = raw.usage?.prompt_tokens;
+    const completionTokens = raw.usage?.completion_tokens;
+    if (!Number.isInteger(promptTokens) || !Number.isInteger(completionTokens)) {
+      throw new Error('DO response omitted token usage');
+    }
+    if (
+      promptTokens! > CAPS.doInputTokensPerCall ||
+      completionTokens! > CAPS.doOutputTokensPerCall
+    ) {
+      throw new Error('DO reported usage beyond a per-call cap');
+    }
+    const parsed = JSON.parse(content) as { results?: unknown };
+    return {
+      outputs: validateLlmOutputs(parsed.results, cases, mode),
+      raw,
+      usage: { promptTokens: promptTokens!, completionTokens: completionTokens! },
+    };
+  }
+}
+
+function assertSuccess(response: HttpResponse, operation: string): void {
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(`${operation} failed with HTTP ${response.status}`);
+  }
+}
+
+export function validateLlmOutputs(
+  value: unknown,
+  cases: DiacriticCase[],
+  mode: LlmMode
+): ArmOutput[] {
+  if (!Array.isArray(value) || value.length !== cases.length) {
+    throw new Error(`LLM result must contain exactly ${cases.length} rows`);
+  }
+  const expected = new Set(cases.map(item => item.id));
+  const seen = new Set<string>();
+  for (const raw of value) {
+    const item = raw as Partial<ArmOutput>;
+    if (
+      typeof item.id !== 'string' ||
+      !expected.has(item.id) ||
+      seen.has(item.id) ||
+      (item.status !== 'resolved' && item.status !== 'ambiguous') ||
+      typeof item.restoredVi !== 'string' ||
+      !Array.isArray(item.alternatives) ||
+      item.alternatives.length > 3 ||
+      item.alternatives.some(alt => typeof alt !== 'string') ||
+      (mode === 'end-to-end' && typeof item.english !== 'string')
+    ) {
+      throw new Error('LLM result has an unknown, duplicate, missing, or malformed row');
+    }
+    seen.add(item.id);
+  }
+  if (seen.size !== expected.size) throw new Error('LLM result ID set does not match the fixture');
+  return value as ArmOutput[];
+}
+
+export function createFetchTransport(apiKey: string): HttpTransport {
+  return {
+    async send(request: HttpRequest): Promise<HttpResponse> {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), request.timeoutMs);
+      try {
+        const response = await fetch(request.url, {
+          method: request.method,
+          headers: { ...request.headers, authorization: `Bearer ${apiKey}` },
+          body: request.body,
+          signal: controller.signal,
+        });
+        return { status: response.status, body: (await response.json()) as unknown };
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}

--- a/app/api/experiments/diacritic-ab/clients.ts
+++ b/app/api/experiments/diacritic-ab/clients.ts
@@ -115,9 +115,9 @@ export class DigitalOceanExperimentClient {
       body: serialized,
       timeoutMs: DO_TIMEOUT_MS,
     });
-    assertSuccess(response, 'DO completion request');
     const raw = response.body as ChatCompletionResponse;
     captureRaw?.(raw);
+    assertSuccess(response, 'DO completion request');
     const content = raw.choices?.[0]?.message?.content;
     if (typeof content !== 'string') throw new Error('DO response has no completion content');
     const promptTokens = raw.usage?.prompt_tokens;

--- a/app/api/experiments/diacritic-ab/constants.ts
+++ b/app/api/experiments/diacritic-ab/constants.ts
@@ -1,0 +1,40 @@
+export const ARTIFACT_DIR = 'tmp/llm-diacritic-ab';
+export const FIXTURE_PATH = 'app/api/experiments/fixtures/vi-diacritic-cases.json';
+
+export const DO_ENDPOINT = 'https://inference.do-ai.run';
+export const DO_MODEL = 'openai-gpt-4o-mini';
+export const DO_TIMEOUT_MS = 30_000;
+export const GOOGLE_TIMEOUT_MS = 15_000;
+
+export const CAPS = Object.freeze({
+  fixtureCases: 12,
+  sourceCharacters: 256,
+  doCalls: 2,
+  googleCalls: 3,
+  doInputTokensPerCall: 4096,
+  doOutputTokensPerCall: 768,
+  doInputTokens: 8192,
+  doOutputTokens: 1536,
+  googleSourceCharacters: 768,
+  retries: 0,
+  concurrency: 1,
+  acknowledgedUsd: 0.02,
+});
+
+export const RATES = Object.freeze({
+  verifiedOn: '2026-08-04',
+  doInputUsdPerMillionTokens: 0.15,
+  doOutputUsdPerMillionTokens: 0.6,
+  googleUsdPerMillionCharacters: 20,
+});
+
+export const MAX_APPROVED_RATES = Object.freeze({
+  doInputUsdPerMillionTokens: 0.15,
+  doOutputUsdPerMillionTokens: 0.6,
+  googleUsdPerMillionCharacters: 20,
+});
+
+export const PROMPT_VERSIONS = Object.freeze({
+  endToEnd: 'vi-diacritic-end-to-end-v1',
+  restore: 'vi-diacritic-restore-v1',
+});

--- a/app/api/experiments/diacritic-ab/evaluation.ts
+++ b/app/api/experiments/diacritic-ab/evaluation.ts
@@ -1,0 +1,117 @@
+import crypto from 'crypto';
+import { RATES } from './constants';
+import { ArmResult, DiacriticCase, ExperimentArm } from './types';
+
+function normalized(value: string | undefined): string {
+  return (value ?? '').trim().replace(/\s+/g, ' ').toLocaleLowerCase('en');
+}
+
+function whitespaceNormalized(value: string | undefined): string {
+  return (value ?? '').trim().replace(/\s+/g, ' ');
+}
+
+export interface MechanicalRow {
+  arm: ExperimentArm;
+  id: string;
+  noOp: boolean;
+  exactRestoration: boolean | null;
+  restorationDifference: { expected: string; actual: string } | null;
+  controlPreserved: boolean | null;
+}
+
+export function mechanicalRows(cases: DiacriticCase[], arms: ArmResult[]): MechanicalRow[] {
+  const byId = new Map(cases.map(item => [item.id, item]));
+  return arms.flatMap(arm =>
+    arm.outputs.map(output => {
+      const item = byId.get(output.id)!;
+      const candidate = output.english ?? output.restoredVi;
+      const exactRestoration =
+        item.canonicalVietnamese == null || output.restoredVi == null
+          ? null
+          : output.restoredVi === item.canonicalVietnamese;
+      return {
+        arm: arm.arm,
+        id: output.id,
+        noOp:
+          output.status !== 'ambiguous' && normalized(candidate) === normalized(item.asciiInput),
+        exactRestoration,
+        restorationDifference:
+          exactRestoration === false
+            ? { expected: item.canonicalVietnamese!, actual: output.restoredVi! }
+            : null,
+        controlPreserved:
+          item.category === 'control'
+            ? whitespaceNormalized(candidate) === whitespaceNormalized(item.asciiInput)
+            : null,
+      };
+    })
+  );
+}
+
+export function observedCost(arms: ArmResult[]): { usd: number; complete: boolean } {
+  let usd = 0;
+  for (const arm of arms) {
+    if (arm.usage != null) {
+      usd += (arm.usage.promptTokens * RATES.doInputUsdPerMillionTokens) / 1_000_000;
+      usd += (arm.usage.completionTokens * RATES.doOutputUsdPerMillionTokens) / 1_000_000;
+    }
+    if (arm.googleSourceCharacters != null) {
+      usd += (arm.googleSourceCharacters * RATES.googleUsdPerMillionCharacters) / 1_000_000;
+    }
+  }
+  return { usd, complete: arms.length === 4 };
+}
+
+function shuffled<T>(values: T[]): T[] {
+  const result = [...values];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = crypto.randomInt(i + 1);
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+export function blindResults(
+  cases: DiacriticCase[],
+  arms: ArmResult[]
+): { mapping: Record<string, ExperimentArm>; review: string } {
+  const armNames = shuffled(arms.map(arm => arm.arm));
+  const labels = ['A', 'B', 'C', 'D'];
+  const mapping = Object.fromEntries(
+    labels.map((label, index) => [label, armNames[index]])
+  ) as Record<string, ExperimentArm>;
+  const armByName = new Map(arms.map(arm => [arm.arm, arm]));
+  const rows = shuffled(
+    labels.flatMap(label => {
+      const arm = armByName.get(mapping[label])!;
+      return arm.outputs.map(output => ({ label, output }));
+    })
+  );
+  const byId = new Map(cases.map(item => [item.id, item]));
+  const lines = [
+    '# Vietnamese diacritic A/B review',
+    '',
+    'Score each row: 0 wrong, 1 related, 2 correct, 3 natural. Do not unblind arm labels until grading is complete.',
+    '',
+    '| Row | Case | Input | Arm | Restored Vietnamese | English | Status / alternatives | Score | VI acceptable? | EN acceptable? | Ambiguity justified? | Harmful confidence? | Correction |',
+    '| ---: | --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- | --- | --- |',
+  ];
+  rows.forEach(({ label, output }, index) => {
+    const input = byId.get(output.id)!.asciiInput;
+    const status =
+      output.status === 'ambiguous' ? `ambiguous: ${output.alternatives.join('; ')}` : 'resolved';
+    const cells = [
+      index + 1,
+      output.id,
+      input,
+      label,
+      output.restoredVi ?? '—',
+      output.english ?? '—',
+      status,
+    ];
+    lines.push(
+      `| ${cells.map(value => String(value).replace(/\|/g, '\\|')).join(' | ')} |  |  |  |  |  |  |`
+    );
+  });
+  return { mapping, review: `${lines.join('\n')}\n` };
+}

--- a/app/api/experiments/diacritic-ab/fixture.ts
+++ b/app/api/experiments/diacritic-ab/fixture.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+import { CAPS, FIXTURE_PATH } from './constants';
+import { CaseCategory, DiacriticCase } from './types';
+
+const CATEGORIES = new Set<CaseCategory>(['live', 'synthetic', 'ambiguous', 'control']);
+
+export function stripVietnameseDiacritics(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/đ/g, 'd')
+    .replace(/Đ/g, 'D')
+    .normalize('NFC');
+}
+
+export function validateFixture(value: unknown): DiacriticCase[] {
+  if (!Array.isArray(value) || value.length !== CAPS.fixtureCases) {
+    throw new Error(`Fixture must contain exactly ${CAPS.fixtureCases} cases`);
+  }
+  const cases = value as DiacriticCase[];
+  const ids = new Set<string>();
+  for (const item of cases) {
+    if (
+      item == null ||
+      typeof item.id !== 'string' ||
+      typeof item.asciiInput !== 'string' ||
+      !CATEGORIES.has(item.category)
+    ) {
+      throw new Error('Fixture contains a malformed case');
+    }
+    if (ids.has(item.id)) throw new Error(`Duplicate fixture id: ${item.id}`);
+    ids.add(item.id);
+    if (!/^[\x00-\x7f]*$/.test(item.asciiInput)) {
+      throw new Error(`Fixture input is not ASCII: ${item.id}`);
+    }
+    if (item.category === 'synthetic') {
+      if (item.canonicalVietnamese == null) {
+        throw new Error(`Synthetic case lacks canonicalVietnamese: ${item.id}`);
+      }
+      if (stripVietnameseDiacritics(item.canonicalVietnamese) !== item.asciiInput) {
+        throw new Error(`Synthetic case was not mechanically stripped: ${item.id}`);
+      }
+    }
+  }
+  const characters = cases.reduce((sum, item) => sum + item.asciiInput.length, 0);
+  if (characters > CAPS.sourceCharacters) {
+    throw new Error(`Fixture has ${characters} source characters; cap is ${CAPS.sourceCharacters}`);
+  }
+  return cases;
+}
+
+export function loadFixture(rootDir = process.cwd()): DiacriticCase[] {
+  const raw = fs.readFileSync(path.resolve(rootDir, FIXTURE_PATH), 'utf8');
+  return validateFixture(JSON.parse(raw) as unknown);
+}

--- a/app/api/experiments/diacritic-ab/prompts.ts
+++ b/app/api/experiments/diacritic-ab/prompts.ts
@@ -1,0 +1,72 @@
+import { CAPS, DO_MODEL, PROMPT_VERSIONS } from './constants';
+import { DiacriticCase } from './types';
+
+export type LlmMode = 'end-to-end' | 'restore';
+
+const SHARED_PROMPT = `Inputs are user-authored Oxygen Not Included blueprint titles that may be Vietnamese typed without diacritics. Use ONI context only to disambiguate; never invent absent details. Preserve digits, version markers, punctuation, and ASCII game jargon such as SPOM. Return English or acronym-only controls unchanged. If meaning is genuinely underdetermined, use status "ambiguous" and at most three plausible alternatives instead of guessing. Return only data matching the schema.`;
+
+function responseSchema(mode: LlmMode): Record<string, unknown> {
+  const properties: Record<string, unknown> = {
+    id: { type: 'string' },
+    status: { type: 'string', enum: ['resolved', 'ambiguous'] },
+    restoredVi: { type: 'string' },
+    alternatives: { type: 'array', items: { type: 'string' }, maxItems: 3 },
+  };
+  const required = ['id', 'status', 'restoredVi', 'alternatives'];
+  if (mode === 'end-to-end') {
+    properties.english = { type: 'string' };
+    required.push('english');
+  }
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      results: {
+        type: 'array',
+        minItems: CAPS.fixtureCases,
+        maxItems: CAPS.fixtureCases,
+        items: { type: 'object', additionalProperties: false, properties, required },
+      },
+    },
+    required: ['results'],
+  };
+}
+
+export interface DoRequestBody {
+  model: typeof DO_MODEL;
+  messages: { role: 'system' | 'user'; content: string }[];
+  temperature: 0;
+  max_completion_tokens: number;
+  response_format: {
+    type: 'json_schema';
+    json_schema: { name: string; strict: true; schema: Record<string, unknown> };
+  };
+}
+
+export function buildDoRequest(cases: DiacriticCase[], mode: LlmMode): DoRequestBody {
+  // Only IDs and experiment inputs enter the provider layer. Ground truth and
+  // reviewer notes remain in fixture/evaluation code.
+  const inputs = cases.map(item => ({ id: item.id, text: item.asciiInput }));
+  const task =
+    mode === 'end-to-end'
+      ? 'Restore the intended Vietnamese and translate its meaning to English.'
+      : 'Restore the intended Vietnamese only; do not translate it to English.';
+  const version = mode === 'end-to-end' ? PROMPT_VERSIONS.endToEnd : PROMPT_VERSIONS.restore;
+  return {
+    model: DO_MODEL,
+    messages: [
+      { role: 'system', content: `${version}\n${SHARED_PROMPT}\n${task}` },
+      { role: 'user', content: JSON.stringify({ inputs }) },
+    ],
+    temperature: 0,
+    max_completion_tokens: CAPS.doOutputTokensPerCall,
+    response_format: {
+      type: 'json_schema',
+      json_schema: {
+        name: `vi_diacritic_${mode.replace(/-/g, '_')}`,
+        strict: true,
+        schema: responseSchema(mode),
+      },
+    },
+  };
+}

--- a/app/api/experiments/diacritic-ab/types.ts
+++ b/app/api/experiments/diacritic-ab/types.ts
@@ -1,0 +1,49 @@
+export type CaseCategory = 'live' | 'synthetic' | 'ambiguous' | 'control';
+export type ExperimentArm = 'google-auto' | 'google-vi' | 'llm-end-to-end' | 'restore-google';
+export type RestorationStatus = 'resolved' | 'ambiguous';
+
+export interface DiacriticCase {
+  id: string;
+  asciiInput: string;
+  canonicalVietnamese?: string;
+  acceptableEnglish?: string[];
+  category: CaseCategory;
+  reviewerNote?: string;
+}
+
+export interface ArmOutput {
+  id: string;
+  status: RestorationStatus;
+  restoredVi?: string;
+  english?: string;
+  alternatives: string[];
+}
+
+export interface TokenUsage {
+  promptTokens: number;
+  completionTokens: number;
+}
+
+export interface ArmResult {
+  arm: ExperimentArm;
+  outputs: ArmOutput[];
+  usage?: TokenUsage;
+  googleSourceCharacters?: number;
+}
+
+export interface HttpRequest {
+  url: string;
+  method: 'GET' | 'POST';
+  headers: Record<string, string>;
+  body?: string;
+  timeoutMs: number;
+}
+
+export interface HttpResponse {
+  status: number;
+  body: unknown;
+}
+
+export interface HttpTransport {
+  send(request: HttpRequest): Promise<HttpResponse>;
+}

--- a/app/api/experiments/fixtures/vi-diacritic-cases.json
+++ b/app/api/experiments/fixtures/vi-diacritic-cases.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "live-dien-phan",
+    "asciiInput": "Dien phan",
+    "canonicalVietnamese": "Điện phân",
+    "acceptableEnglish": ["Electrolysis"],
+    "category": "live"
+  },
+  {
+    "id": "live-dien-phan-2",
+    "asciiInput": "Dien phan 2",
+    "canonicalVietnamese": "Điện phân 2",
+    "acceptableEnglish": ["Electrolysis 2"],
+    "category": "live"
+  },
+  {
+    "id": "synthetic-water-electrolysis",
+    "asciiInput": "Dien phan nuoc",
+    "canonicalVietnamese": "Điện phân nước",
+    "acceptableEnglish": ["Water electrolysis"],
+    "category": "synthetic"
+  },
+  {
+    "id": "synthetic-water-purification",
+    "asciiInput": "Loc nuoc ban",
+    "canonicalVietnamese": "Lọc nước bẩn",
+    "acceptableEnglish": ["Polluted water purification", "Dirty water purification"],
+    "category": "synthetic"
+  },
+  {
+    "id": "synthetic-gas-pump",
+    "asciiInput": "Bom khi tu dong",
+    "canonicalVietnamese": "Bơm khí tự động",
+    "acceptableEnglish": ["Automatic gas pump", "Automated gas pumping"],
+    "category": "synthetic"
+  },
+  {
+    "id": "synthetic-gas-storage",
+    "asciiInput": "Kho chua khi 2",
+    "canonicalVietnamese": "Kho chứa khí 2",
+    "acceptableEnglish": ["Gas storage 2"],
+    "category": "synthetic"
+  },
+  {
+    "id": "synthetic-spom-oxygen",
+    "asciiInput": "SPOM tao oxy",
+    "canonicalVietnamese": "SPOM tạo oxy",
+    "acceptableEnglish": ["SPOM oxygen production", "SPOM makes oxygen"],
+    "category": "synthetic"
+  },
+  {
+    "id": "synthetic-cooling-power",
+    "asciiInput": "Lam mat bang dien",
+    "canonicalVietnamese": "Làm mát bằng điện",
+    "acceptableEnglish": ["Electric cooling", "Cooling with electricity"],
+    "category": "synthetic"
+  },
+  {
+    "id": "ambiguous-ma",
+    "asciiInput": "ma",
+    "acceptableEnglish": ["ghost", "mother", "but", "horse", "code"],
+    "category": "ambiguous",
+    "reviewerNote": "Short tone collision; an ambiguous response is expected."
+  },
+  {
+    "id": "ambiguous-khi",
+    "asciiInput": "khi",
+    "acceptableEnglish": ["gas", "when", "monkey"],
+    "category": "ambiguous",
+    "reviewerNote": "Tone and context can change the meaning; abstention is acceptable."
+  },
+  {
+    "id": "control-spom-v3",
+    "asciiInput": "SPOM v3",
+    "acceptableEnglish": ["SPOM v3"],
+    "category": "control"
+  },
+  {
+    "id": "control-main-base",
+    "asciiInput": "Main base",
+    "acceptableEnglish": ["Main base"],
+    "category": "control"
+  }
+]

--- a/app/api/experiments/translate-diacritic-ab.ts
+++ b/app/api/experiments/translate-diacritic-ab.ts
@@ -1,0 +1,310 @@
+import fs from 'fs';
+import path from 'path';
+import { Translate } from '@google-cloud/translate/build/src/v2';
+import dotenv from 'dotenv';
+import { ArtifactStore, sha256 } from './diacritic-ab/artifacts';
+import {
+  assertDoRequestWithinCap,
+  assertGoogleCharacters,
+  fullReservation,
+} from './diacritic-ab/caps';
+import {
+  createFetchTransport,
+  DigitalOceanExperimentClient,
+  GoogleExperimentClient,
+} from './diacritic-ab/clients';
+import {
+  ARTIFACT_DIR,
+  CAPS,
+  DO_ENDPOINT,
+  DO_MODEL,
+  FIXTURE_PATH,
+  PROMPT_VERSIONS,
+  RATES,
+} from './diacritic-ab/constants';
+import { blindResults, mechanicalRows, observedCost } from './diacritic-ab/evaluation';
+import { loadFixture } from './diacritic-ab/fixture';
+import { buildDoRequest } from './diacritic-ab/prompts';
+import { ArmOutput, ArmResult, DiacriticCase, ExperimentArm } from './diacritic-ab/types';
+
+interface CliOptions {
+  execute: boolean;
+  acknowledged: boolean;
+}
+
+function parseCli(argv: string[]): CliOptions {
+  const allowed = new Set(['--execute', '--ack-max-usd=0.02']);
+  const unknown = argv.filter(arg => !allowed.has(arg));
+  if (unknown.length > 0) throw new Error(`Unknown argument(s): ${unknown.join(', ')}`);
+  const execute = argv.includes('--execute');
+  const acknowledged = argv.includes('--ack-max-usd=0.02');
+  if (!execute && acknowledged) throw new Error('The acknowledgement is valid only with --execute');
+  if (execute && !acknowledged) {
+    throw new Error('Live execution requires the exact acknowledgement --ack-max-usd=0.02');
+  }
+  return { execute, acknowledged };
+}
+
+function promptHash(request: ReturnType<typeof buildDoRequest>): string {
+  const withoutInputs = {
+    ...request,
+    messages: request.messages.map(message =>
+      message.role === 'user' ? { ...message, content: '<fixture-inputs>' } : message
+    ),
+  };
+  return sha256(JSON.stringify(withoutInputs));
+}
+
+function cacheIdentity(
+  arm: ExperimentArm,
+  provider: string,
+  promptVersion: string,
+  fixtureHash: string
+): string {
+  return sha256(`${arm}\n${provider}\n${promptVersion}\n${fixtureHash}`);
+}
+
+function makeManifest(rootDir: string, cases: DiacriticCase[]) {
+  const fixtureBytes = fs.readFileSync(path.resolve(rootDir, FIXTURE_PATH));
+  const fixtureHash = sha256(fixtureBytes);
+  const endToEnd = buildDoRequest(cases, 'end-to-end');
+  const restore = buildDoRequest(cases, 'restore');
+  const serializedEndToEnd = JSON.stringify(endToEnd);
+  const serializedRestore = JSON.stringify(restore);
+  const sourceCharacters = cases.reduce((sum, item) => sum + item.asciiInput.length, 0);
+  const reservation = fullReservation();
+  const manifest = {
+    experiment: 'vi-diacritic-ab-v1',
+    createdAt: new Date().toISOString(),
+    fixture: { path: FIXTURE_PATH, sha256: fixtureHash, cases: cases.length, sourceCharacters },
+    prompts: {
+      endToEnd: { version: PROMPT_VERSIONS.endToEnd, sha256: promptHash(endToEnd) },
+      restore: { version: PROMPT_VERSIONS.restore, sha256: promptHash(restore) },
+    },
+    provider: {
+      digitalOcean: { endpoint: DO_ENDPOINT, model: DO_MODEL },
+      google: { api: 'basic-v2' },
+    },
+    requestReservations: {
+      doEndToEndInputTokens: assertDoRequestWithinCap(serializedEndToEnd),
+      doRestoreInputTokens: assertDoRequestWithinCap(serializedRestore),
+      doOutputTokensPerCall: CAPS.doOutputTokensPerCall,
+      googleCharactersPerFixtureBatch: assertGoogleCharacters(
+        cases.map(item => item.asciiInput),
+        CAPS.sourceCharacters
+      ),
+    },
+    calls: { digitalOceanInference: 2, googleTranslation: 3, retries: 0, concurrency: 1 },
+    rates: RATES,
+    rateSources: {
+      digitalOcean: 'https://docs.digitalocean.com/products/inference/details/pricing/',
+      google: 'https://cloud.google.com/translate/pricing',
+    },
+    caps: CAPS,
+    reservation,
+    identities: {
+      googleAuto: cacheIdentity('google-auto', 'google-basic-v2', 'batch-auto-v1', fixtureHash),
+      googleVi: cacheIdentity('google-vi', 'google-basic-v2', 'batch-forced-vi-v1', fixtureHash),
+      llmEndToEnd: cacheIdentity('llm-end-to-end', DO_MODEL, PROMPT_VERSIONS.endToEnd, fixtureHash),
+      restoreGoogle: cacheIdentity(
+        'restore-google',
+        `${DO_MODEL}+google-basic-v2`,
+        PROMPT_VERSIONS.restore,
+        fixtureHash
+      ),
+    },
+  };
+  return { manifest, endToEnd, restore, reservation };
+}
+
+function printPreflight(
+  manifest: ReturnType<typeof makeManifest>['manifest'],
+  execute: boolean
+): void {
+  console.log(JSON.stringify(manifest, null, 2));
+  console.log(
+    execute
+      ? `Live execution acknowledged. Reserving exactly 2 DO calls, 3 Google calls, and $${manifest.reservation.maximumUsd.toFixed(7)} maximum calculated usage ($0.02 fail-closed ledger).`
+      : 'Offline dry run complete. No live client was constructed and no provider request was sent.'
+  );
+}
+
+function googleOutputs(cases: DiacriticCase[], texts: string[]): ArmOutput[] {
+  return cases.map((item, index) => ({
+    id: item.id,
+    status: 'resolved',
+    english: texts[index],
+    alternatives: [],
+  }));
+}
+
+function armGoogleCharacters(...values: number[]): number {
+  return values.reduce((sum, value) => sum + value, 0);
+}
+
+async function executeLive(
+  store: ArtifactStore,
+  cases: DiacriticCase[],
+  endToEndRequest: ReturnType<typeof buildDoRequest>,
+  restoreRequest: ReturnType<typeof buildDoRequest>,
+  manifest: ReturnType<typeof makeManifest>['manifest'],
+  reservation: ReturnType<typeof fullReservation>
+): Promise<void> {
+  if (store.exists('reservation.json')) {
+    console.log(JSON.stringify(store.read('reservation.json'), null, 2));
+    if (store.exists('results.json')) {
+      console.log(JSON.stringify(store.read('results.json'), null, 2));
+    }
+    throw new Error(
+      'Reservation already exists; captured or partial results require manual review'
+    );
+  }
+  dotenv.config();
+  const doKey = process.env.DO_INFERENCE_API_KEY;
+  const googleKey = process.env.GOOGLE_TRANSLATE_API_KEY;
+  if (!doKey || !googleKey) {
+    throw new Error('DO_INFERENCE_API_KEY and GOOGLE_TRANSLATE_API_KEY are required for --execute');
+  }
+  const now = new Date().toISOString();
+  store.createReservation({
+    state: 'reserved',
+    reservedAt: now,
+    updatedAt: now,
+    calls: { digitalOcean: reservation.doCalls, google: reservation.googleCalls },
+    tokens: { input: reservation.doInputTokens, output: reservation.doOutputTokens },
+    googleSourceCharacters: reservation.googleSourceCharacters,
+    usd: CAPS.acknowledgedUsd,
+    calculatedMaximumUsd: reservation.maximumUsd,
+    manifestFixtureSha256: manifest.fixture.sha256,
+  });
+  const updateReservation = (
+    state: 'running' | 'complete' | 'failed',
+    extra: Record<string, unknown> = {}
+  ) =>
+    store.writeJson('reservation.json', {
+      ...(store.read('reservation.json') as Record<string, unknown>),
+      state,
+      updatedAt: new Date().toISOString(),
+      ...extra,
+    });
+
+  const doClient = new DigitalOceanExperimentClient(createFetchTransport(doKey));
+  const googleSdk = new Translate({ key: googleKey, autoRetry: false, maxRetries: 0 });
+  const googleClient = new GoogleExperimentClient(googleSdk);
+  const inputs = cases.map(item => item.asciiInput);
+  const results: ArmResult[] = [];
+  let currentOperation = 'model-access';
+  const persistPartialResults = () =>
+    store.writeJson('results.json', {
+      partial: true,
+      updatedAt: new Date().toISOString(),
+      arms: results,
+      mechanical: mechanicalRows(cases, results),
+      observedCost: observedCost(results),
+    });
+  try {
+    updateReservation('running');
+    await doClient.assertModelAvailable();
+
+    currentOperation = 'google-auto';
+    const googleAuto = await googleClient.translate(inputs, 'auto', raw =>
+      store.writeJson('responses/google-auto.json', raw)
+    );
+    results.push({
+      arm: 'google-auto',
+      outputs: googleOutputs(cases, googleAuto.texts),
+      googleSourceCharacters: googleAuto.sourceCharacters,
+    });
+    persistPartialResults();
+
+    currentOperation = 'google-vi';
+    const googleVi = await googleClient.translate(inputs, 'vi', raw =>
+      store.writeJson('responses/google-vi.json', raw)
+    );
+    results.push({
+      arm: 'google-vi',
+      outputs: googleOutputs(cases, googleVi.texts),
+      googleSourceCharacters: googleVi.sourceCharacters,
+    });
+    persistPartialResults();
+
+    currentOperation = 'llm-end-to-end';
+    const llmEndToEnd = await doClient.complete(endToEndRequest, cases, 'end-to-end', raw =>
+      store.writeJson('responses/llm-end-to-end.json', raw)
+    );
+    results.push({ arm: 'llm-end-to-end', outputs: llmEndToEnd.outputs, usage: llmEndToEnd.usage });
+    persistPartialResults();
+
+    currentOperation = 'restore-google';
+    const restored = await doClient.complete(restoreRequest, cases, 'restore', raw =>
+      store.writeJson('responses/llm-restore.json', raw)
+    );
+    const restoredTexts = restored.outputs.map(output => output.restoredVi!);
+    const restoreGoogle = await googleClient.translate(restoredTexts, 'vi', raw =>
+      store.writeJson('responses/restore-google.json', raw)
+    );
+    const combined = restored.outputs.map((output, index) => ({
+      ...output,
+      english: restoreGoogle.texts[index],
+    }));
+    results.push({
+      arm: 'restore-google',
+      outputs: combined,
+      usage: restored.usage,
+      googleSourceCharacters: restoreGoogle.sourceCharacters,
+    });
+    persistPartialResults();
+
+    const blind = blindResults(cases, results);
+    store.writeJson('results.json', {
+      completedAt: new Date().toISOString(),
+      partial: false,
+      arms: results,
+      mechanical: mechanicalRows(cases, results),
+      observedCost: observedCost(results),
+      blindMapping: blind.mapping,
+      googleCharacters: armGoogleCharacters(
+        googleAuto.sourceCharacters,
+        googleVi.sourceCharacters,
+        restoreGoogle.sourceCharacters
+      ),
+    });
+    store.writeText('review.md', blind.review);
+    updateReservation('complete', { completedAt: new Date().toISOString() });
+  } catch (error) {
+    const message = (error as Error).message
+      .split(doKey)
+      .join('[REDACTED]')
+      .split(googleKey)
+      .join('[REDACTED]');
+    store.writeJson('results.json', {
+      partial: true,
+      updatedAt: new Date().toISOString(),
+      arms: results,
+      mechanical: mechanicalRows(cases, results),
+      observedCost: observedCost(results),
+      operationalFailure: { arm: currentOperation, message },
+    });
+    updateReservation('failed', { failure: message });
+    throw new Error(message);
+  }
+}
+
+export async function main(argv = process.argv.slice(2), rootDir = process.cwd()): Promise<void> {
+  const options = parseCli(argv);
+  const cases = loadFixture(rootDir);
+  const { manifest, endToEnd, restore, reservation } = makeManifest(rootDir, cases);
+  const store = new ArtifactStore(path.resolve(rootDir, ARTIFACT_DIR));
+  store.prepare();
+  store.writeJson('manifest.json', manifest);
+  printPreflight(manifest, options.execute);
+  if (!options.execute) return;
+  await executeLive(store, cases, endToEnd, restore, manifest, reservation);
+}
+
+if (require.main === module) {
+  main().catch(error => {
+    process.stderr.write(`${(error as Error).message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/app/api/experiments/translate-diacritic-ab.ts
+++ b/app/api/experiments/translate-diacritic-ab.ts
@@ -28,21 +28,26 @@ import { buildDoRequest } from './diacritic-ab/prompts';
 import { ArmOutput, ArmResult, DiacriticCase, ExperimentArm } from './diacritic-ab/types';
 
 interface CliOptions {
-  execute: boolean;
+  mode: 'dry-run' | 'execute' | 'resume-reviewed-402';
   acknowledged: boolean;
 }
 
 function parseCli(argv: string[]): CliOptions {
-  const allowed = new Set(['--execute', '--ack-max-usd=0.02']);
+  const allowed = new Set(['--execute', '--resume-reviewed-402', '--ack-max-usd=0.02']);
   const unknown = argv.filter(arg => !allowed.has(arg));
   if (unknown.length > 0) throw new Error(`Unknown argument(s): ${unknown.join(', ')}`);
   const execute = argv.includes('--execute');
+  const resume = argv.includes('--resume-reviewed-402');
   const acknowledged = argv.includes('--ack-max-usd=0.02');
-  if (!execute && acknowledged) throw new Error('The acknowledgement is valid only with --execute');
-  if (execute && !acknowledged) {
+  if (execute && resume)
+    throw new Error('--execute and --resume-reviewed-402 are mutually exclusive');
+  if (!execute && !resume && acknowledged) {
+    throw new Error('The acknowledgement is valid only with a live execution mode');
+  }
+  if ((execute || resume) && !acknowledged) {
     throw new Error('Live execution requires the exact acknowledgement --ack-max-usd=0.02');
   }
-  return { execute, acknowledged };
+  return { mode: resume ? 'resume-reviewed-402' : execute ? 'execute' : 'dry-run', acknowledged };
 }
 
 function promptHash(request: ReturnType<typeof buildDoRequest>): string {
@@ -119,14 +124,22 @@ function makeManifest(rootDir: string, cases: DiacriticCase[]) {
 
 function printPreflight(
   manifest: ReturnType<typeof makeManifest>['manifest'],
-  execute: boolean
+  mode: CliOptions['mode']
 ): void {
   console.log(JSON.stringify(manifest, null, 2));
-  console.log(
-    execute
-      ? `Live execution acknowledged. Reserving exactly 2 DO calls, 3 Google calls, and $${manifest.reservation.maximumUsd.toFixed(7)} maximum calculated usage ($0.02 fail-closed ledger).`
-      : 'Offline dry run complete. No live client was constructed and no provider request was sent.'
-  );
+  if (mode === 'execute') {
+    console.log(
+      `Live execution acknowledged. Reserving exactly 2 DO calls, 3 Google calls, and $${manifest.reservation.maximumUsd.toFixed(7)} maximum calculated usage ($0.02 fail-closed ledger).`
+    );
+  } else if (mode === 'resume-reviewed-402') {
+    console.log(
+      'Reviewed HTTP 402 continuation acknowledged. Reusing 2 captured Google arms and reserving only the remaining 2 DO calls plus 1 Google call.'
+    );
+  } else {
+    console.log(
+      'Offline dry run complete. No live client was constructed and no provider request was sent.'
+    );
+  }
 }
 
 function googleOutputs(cases: DiacriticCase[], texts: string[]): ArmOutput[] {
@@ -140,6 +153,105 @@ function googleOutputs(cases: DiacriticCase[], texts: string[]): ArmOutput[] {
 
 function armGoogleCharacters(...values: number[]): number {
   return values.reduce((sum, value) => sum + value, 0);
+}
+
+interface Reviewed402Reservation {
+  state?: unknown;
+  failure?: unknown;
+  calls?: { digitalOcean?: unknown; google?: unknown };
+  manifestFixtureSha256?: unknown;
+  resume?: unknown;
+  [key: string]: unknown;
+}
+
+interface PartialResultsArtifact {
+  partial?: unknown;
+  arms?: unknown;
+  operationalFailure?: { arm?: unknown; message?: unknown };
+}
+
+function validateCapturedGoogleArm(
+  value: unknown,
+  expectedArm: 'google-auto' | 'google-vi',
+  cases: DiacriticCase[]
+): ArmResult {
+  const arm = value as Partial<ArmResult>;
+  const expectedIds = new Set(cases.map(item => item.id));
+  const outputs = arm.outputs;
+  if (
+    arm.arm !== expectedArm ||
+    !Array.isArray(outputs) ||
+    outputs.length !== cases.length ||
+    arm.googleSourceCharacters !== cases.reduce((sum, item) => sum + item.asciiInput.length, 0)
+  ) {
+    throw new Error(`Captured ${expectedArm} arm does not match the reviewed fixture`);
+  }
+  const seen = new Set<string>();
+  for (const output of outputs) {
+    if (
+      typeof output.id !== 'string' ||
+      !expectedIds.has(output.id) ||
+      seen.has(output.id) ||
+      output.status !== 'resolved' ||
+      typeof output.english !== 'string' ||
+      !Array.isArray(output.alternatives) ||
+      output.alternatives.length !== 0
+    ) {
+      throw new Error(`Captured ${expectedArm} output is incomplete or misaligned`);
+    }
+    seen.add(output.id);
+  }
+  return arm as ArmResult;
+}
+
+export function loadReviewed402Continuation(
+  store: ArtifactStore,
+  cases: DiacriticCase[],
+  fixtureHash: string
+): { reservation: Reviewed402Reservation; results: ArmResult[] } {
+  if (!store.exists('reservation.json') || !store.exists('results.json')) {
+    throw new Error('Reviewed HTTP 402 continuation requires reservation.json and results.json');
+  }
+  const reservation = store.read('reservation.json') as Reviewed402Reservation;
+  const partial = store.read('results.json') as PartialResultsArtifact;
+  if (
+    reservation.state !== 'failed' ||
+    reservation.failure !== 'DO completion request failed with HTTP 402' ||
+    reservation.calls?.digitalOcean !== CAPS.doCalls ||
+    reservation.calls?.google !== CAPS.googleCalls ||
+    reservation.manifestFixtureSha256 !== fixtureHash ||
+    reservation.resume != null
+  ) {
+    throw new Error(
+      'Reservation is not the single reviewed HTTP 402 state authorized for continuation'
+    );
+  }
+  if (
+    partial.partial !== true ||
+    partial.operationalFailure?.arm !== 'llm-end-to-end' ||
+    partial.operationalFailure.message !== 'DO completion request failed with HTTP 402' ||
+    !Array.isArray(partial.arms) ||
+    partial.arms.length !== 2
+  ) {
+    throw new Error('Partial results are not the reviewed two-Google-arm HTTP 402 artifact');
+  }
+  for (const name of ['llm-end-to-end.json', 'llm-restore.json', 'restore-google.json']) {
+    if (fs.existsSync(path.join(store.responsesDir, name))) {
+      throw new Error(`Cannot continue because responses/${name} already exists`);
+    }
+  }
+  for (const name of ['google-auto.json', 'google-vi.json']) {
+    if (!fs.existsSync(path.join(store.responsesDir, name))) {
+      throw new Error(`Cannot continue without responses/${name}`);
+    }
+  }
+  return {
+    reservation,
+    results: [
+      validateCapturedGoogleArm(partial.arms[0], 'google-auto', cases),
+      validateCapturedGoogleArm(partial.arms[1], 'google-vi', cases),
+    ],
+  };
 }
 
 async function executeLive(
@@ -290,6 +402,120 @@ async function executeLive(
   }
 }
 
+async function resumeReviewed402(
+  store: ArtifactStore,
+  cases: DiacriticCase[],
+  endToEndRequest: ReturnType<typeof buildDoRequest>,
+  restoreRequest: ReturnType<typeof buildDoRequest>,
+  manifest: ReturnType<typeof makeManifest>['manifest']
+): Promise<void> {
+  const reviewed = loadReviewed402Continuation(store, cases, manifest.fixture.sha256);
+  dotenv.config();
+  const doKey = process.env.DO_INFERENCE_API_KEY;
+  const googleKey = process.env.GOOGLE_TRANSLATE_API_KEY;
+  if (!doKey || !googleKey) {
+    throw new Error(
+      'DO_INFERENCE_API_KEY and GOOGLE_TRANSLATE_API_KEY are required for the continuation'
+    );
+  }
+  const updateReservation = (state: string, extra: Record<string, unknown> = {}) =>
+    store.writeJson('reservation.json', {
+      ...(store.read('reservation.json') as Record<string, unknown>),
+      state,
+      updatedAt: new Date().toISOString(),
+      ...extra,
+    });
+  updateReservation('resume-running', {
+    resume: {
+      authorizedAt: new Date().toISOString(),
+      reason: 'manually-reviewed-http-402-before-inference',
+      consumedBeforeResume: { digitalOcean: 0, google: 2 },
+      remainingCalls: { digitalOcean: 2, google: 1 },
+    },
+  });
+
+  const doClient = new DigitalOceanExperimentClient(createFetchTransport(doKey));
+  const googleSdk = new Translate({ key: googleKey, autoRetry: false, maxRetries: 0 });
+  const googleClient = new GoogleExperimentClient(googleSdk);
+  const results = [...reviewed.results];
+  let currentOperation = 'model-access';
+  const persistPartialResults = () =>
+    store.writeJson('results.json', {
+      partial: true,
+      updatedAt: new Date().toISOString(),
+      arms: results,
+      mechanical: mechanicalRows(cases, results),
+      observedCost: observedCost(results),
+      continuation: 'reviewed-http-402',
+    });
+  try {
+    await doClient.assertModelAvailable();
+
+    currentOperation = 'llm-end-to-end';
+    const llmEndToEnd = await doClient.complete(endToEndRequest, cases, 'end-to-end', raw =>
+      store.writeJson('responses/llm-end-to-end.json', raw)
+    );
+    results.push({ arm: 'llm-end-to-end', outputs: llmEndToEnd.outputs, usage: llmEndToEnd.usage });
+    persistPartialResults();
+
+    currentOperation = 'restore-google';
+    const restored = await doClient.complete(restoreRequest, cases, 'restore', raw =>
+      store.writeJson('responses/llm-restore.json', raw)
+    );
+    const restoredTexts = restored.outputs.map(output => output.restoredVi!);
+    const restoreGoogle = await googleClient.translate(restoredTexts, 'vi', raw =>
+      store.writeJson('responses/restore-google.json', raw)
+    );
+    results.push({
+      arm: 'restore-google',
+      outputs: restored.outputs.map((output, index) => ({
+        ...output,
+        english: restoreGoogle.texts[index],
+      })),
+      usage: restored.usage,
+      googleSourceCharacters: restoreGoogle.sourceCharacters,
+    });
+    persistPartialResults();
+
+    const blind = blindResults(cases, results);
+    store.writeJson('results.json', {
+      completedAt: new Date().toISOString(),
+      partial: false,
+      arms: results,
+      mechanical: mechanicalRows(cases, results),
+      observedCost: observedCost(results),
+      blindMapping: blind.mapping,
+      googleCharacters: results.reduce(
+        (sum, result) => sum + (result.googleSourceCharacters ?? 0),
+        0
+      ),
+      continuation: 'reviewed-http-402',
+    });
+    store.writeText('review.md', blind.review);
+    updateReservation('complete', {
+      completedAt: new Date().toISOString(),
+      resumeCompletedAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    const message = (error as Error).message
+      .split(doKey)
+      .join('[REDACTED]')
+      .split(googleKey)
+      .join('[REDACTED]');
+    store.writeJson('results.json', {
+      partial: true,
+      updatedAt: new Date().toISOString(),
+      arms: results,
+      mechanical: mechanicalRows(cases, results),
+      observedCost: observedCost(results),
+      operationalFailure: { arm: currentOperation, message },
+      continuation: 'reviewed-http-402',
+    });
+    updateReservation('failed', { resumeFailure: message });
+    throw new Error(message);
+  }
+}
+
 export async function main(argv = process.argv.slice(2), rootDir = process.cwd()): Promise<void> {
   const options = parseCli(argv);
   const cases = loadFixture(rootDir);
@@ -297,9 +523,13 @@ export async function main(argv = process.argv.slice(2), rootDir = process.cwd()
   const store = new ArtifactStore(path.resolve(rootDir, ARTIFACT_DIR));
   store.prepare();
   store.writeJson('manifest.json', manifest);
-  printPreflight(manifest, options.execute);
-  if (!options.execute) return;
-  await executeLive(store, cases, endToEnd, restore, manifest, reservation);
+  printPreflight(manifest, options.mode);
+  if (options.mode === 'dry-run') return;
+  if (options.mode === 'resume-reviewed-402') {
+    await resumeReviewed402(store, cases, endToEnd, restore, manifest);
+  } else {
+    await executeLive(store, cases, endToEnd, restore, manifest, reservation);
+  }
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary

- add a fixed 12-case Vietnamese diacritic fixture and experiment-local Google/DO clients
- enforce non-overridable call, token, character, retry, concurrency, and USD ceilings with a fail-closed reservation ledger
- capture raw/normalized artifacts and generate blinded native-speaker review sheets
- keep the experiment absent from production scripts, services, and Docker images

## Design notes

- the implementation plan remains local under the gitignored specs directory
- the checked-in fixture lives with the experiment so a fresh clone can run the offline preflight
- DigitalOcean is pinned to openai-gpt-4o-mini at https://inference.do-ai.run
- live execution requires the exact --ack-max-usd=0.02 acknowledgement and has not been run
- synthetic fixture phrases still require native-speaker approval before live execution

## Validation

- npm run build:lib
- npm run tsc
- 12 network-free focused tests passing
- offline dry run: DO request bounds 2,088 / 2,044 conservative tokens; calculated maximum USD 0.0175104

The normal repository Mocha hook requires local Mongo. The isolated experiment suite was also run directly without those DB hooks and passed.