### PR TITLE
feat(search): Gemini romanized-Vietnamese title gate

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,9 @@ Dockerfile
 /frontend/tmp
 /frontend/out-tsc
 
+# Development-only, offline provider experiment; never compile it into a deploy image.
+/app/api/experiments
+
 # Only exists if Bazel was run
 /frontend/bazel-out
 

--- a/.env.sample
+++ b/.env.sample
@@ -22,7 +22,8 @@ WORKOS_CLIENT_ID="client_your_client_id_here"
 WORKOS_PLATFORM_ORG_ID="org_your_org_id_here"
 SITE_URL="http://localhost:3000"
 
-# Gemini avatar generation (agent/AVATARS.md)
+# Gemini features (avatar generation and the separately gated Vietnamese-title
+# search derivation)
 # Create a key at https://aistudio.google.com/apikey — image models need a
 # billing-enabled project (no free tier). Leave unset to disable the feature.
 GEMINI_API_KEY=""
@@ -31,6 +32,17 @@ GEMINI_API_KEY=""
 # AVATAR_CLASSIFY_MODEL="gemini-3.5-flash"
 # AVATAR_POOL_LOW_WATER="5"
 # AVATAR_POOL_REFILL="5"
+
+# Romanized-Vietnamese blueprint titles -> English search titles. Cache reads
+# remain available when disabled. New calls require all three: the exact true
+# kill switch, the shared GEMINI_API_KEY, and a positive integer micro-USD
+# monthly allowance. Keep false/0 until migrations and the no-network
+# derive-search dry-run have been reviewed.
+GEMINI_VI_TITLE_TRANSLATION_ENABLED="false"
+GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD="0"
+# Hard caps may be lowered but not raised above these code-pinned defaults.
+# GEMINI_VI_TITLE_MAX_INPUT_TOKENS="4096"
+# GEMINI_VI_TITLE_MAX_OUTPUT_TOKENS="768"
 
 # User content translation (spec/user-content-translation-impl.md)
 # API key at https://console.cloud.google.com/apis/credentials, project needs

--- a/.env.test
+++ b/.env.test
@@ -11,3 +11,8 @@ FRONTEND_URL=http://localhost:4200
 WORKOS_API_KEY=sk_test_dummy_key_for_testing
 WORKOS_CLIENT_ID=client_test_dummy_client_id
 GOOGLE_TRANSLATE_API_KEY=
+# Batch scripts call a bare dotenv.config(), so every key the real .env may
+# hold must be blanked here or tests make live, billable calls.
+GEMINI_API_KEY=
+GEMINI_VI_TITLE_TRANSLATION_ENABLED=false
+GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD=0

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 
 # Offline LLM diacritic experiment reservations and provider responses
 /tmp/llm-diacritic-ab/
+/tmp/llm-diacritic-ab-gemini/
 
 # Local implementation plans and working specifications
 /specs/

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@
 # Offline LLM diacritic experiment reservations and provider responses
 /tmp/llm-diacritic-ab/
 /tmp/llm-diacritic-ab-gemini/
+/tmp/llm-diacritic-ab-gemini-3-1/
+/tmp/llm-diacritic-ab-gemini-3-1-sandbox-failure/
 
 # Local implementation plans and working specifications
 /specs/

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,12 @@
 # Server-rendered blueprint preview image cache (regenerated on demand)
 /preview-cache
 
+# Offline LLM diacritic experiment reservations and provider responses
+/tmp/llm-diacritic-ab/
+
+# Local implementation plans and working specifications
+/specs/
+
 # avatar smoke test scratch output
 avatar-smoke-test*.png
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,7 +449,10 @@ Part 1 §1/§2.
   search layer errors.
 - **Translation cache** — `translationunits` (`app/api/models/translation-unit.ts`), keyed
   `{textHash, sourceLang('auto' when unknown), targetLang, mode}` — by **text**, never by document:
-  identical text is billed once corpus-wide. `mode:'standard'` preserves Google/human behavior;
+  identical text is billed once per full cache key, so every document sharing a title and a
+  target language reuses one translation. Differing on any key component — a second target
+  language, or the Gemini mode against the standard one — is a separate row and a separate
+  charge. `mode:'standard'` preserves Google/human behavior;
   accepted Gemini romanized-Vietnamese titles use `mode:'vi-romanized-title-v1'`, source `vi`,
   target `en`, plus immutable prompt/model, restored Vietnamese, and token provenance.
   Ambiguous/negative/invalid Gemini answers are never cached. Google character-budget behavior

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ This is the source repository for blueprintnotincluded.org, a web application fo
   - JWT authentication for user sessions
   - Blueprint processing and image generation using Canvas and PIXI.js
   - Batch processing scripts for assets in `app/api/batch/`
-  
+
 - **Frontend**: Angular application (`frontend/` directory)
   - Blueprint visualization and editing interface
   - Multi-language support (English, Chinese, Russian, Korean)
@@ -29,27 +29,32 @@ This is the source repository for blueprintnotincluded.org, a web application fo
 ## Development Commands
 
 ### Development (Recommended)
+
 - `./dev-setup.sh` - Start dependencies (database + mail)
 - `npm run dev` - Start backend with live reloading
 - `cd frontend && npm start` - Start frontend with live reloading
 - Frontend: http://localhost:4200, Backend: http://localhost:3000
 
 ### Production Testing
+
 - `docker compose up` - Start with pre-built images
 - Visit: http://localhost:3000
 
 ### Backend Development
+
 - `npm run dev` - Start development server with auto-reload
 - `npm run tsc` - Compile TypeScript
 - `npm run build` - Full build (backend + frontend + lib)
 - `npm run serve:prod` - Run production build
 
 ### Testing
+
 - `npm run test` - Run tests with database setup
 - `npm run test:only` - Run tests without database setup
 - `npm run test:db-setup` - Setup test database only
 
 ### Frontend Development (from frontend/ directory)
+
 - `npm start` - Start Angular development server
 - `npm run build` - Build for production
 - `npm run lint` - Run Angular linting
@@ -57,9 +62,11 @@ This is the source repository for blueprintnotincluded.org, a web application fo
 - `npm run test:coverage` - Run tests with V8 coverage report
 
 ### Asset Processing
+
 **OniExtract2024 import (current pipeline):** after dropping a fresh export into
 `export/` (`export/database/`, `export/ui_image/`, `export/connection_sprites/`),
 run the single repeatable step:
+
 - `npm run import:2024` - Regenerate `database-2024.json` into both asset roots
   (`assets/database/` + `frontend/src/assets/database/`), content-aware sync `ui_image/`
   and `connection_sprites/` into both roots, flatten `po_string.json` into the frontend's
@@ -75,7 +82,7 @@ run the single repeatable step:
 - Sprite sync rewrites a file only when it actually changed and prunes removed ones, so
   unchanged icons keep their mtime and git shows only real changes. The export is NOT
   byte-deterministic across game updates (Klei re-rasterizes untouched art), so a PNG
-  that differs in bytes is additionally checked *perceptually* (`pngVisuallyEqual`:
+  that differs in bytes is additionally checked _perceptually_ (`pngVisuallyEqual`:
   alpha-premultiply → small Gaussian blur → count pixels still differing) and preserved
   when the pixels are visually identical. The blur is what distinguishes real redraws from
   sub-pixel re-rasterization jitter even on densely-textured sprites. Re-importing the same
@@ -93,16 +100,18 @@ The legacy 2020/2023 atlas pipeline has been removed — the `generate-icons/whi
 `enhanced-extract-export`, `extract-export`, `test-canvas`, and `add-info-icons` batch scripts
 and their `npm run generate*` / `seed` / `enhancedSeed` / `testCanvas` entries no longer exist.
 Remaining batch utilities:
+
 - `npm run fixHtmlLabels` - Fix HTML formatting in labels.
 - `npm run derive-metadata` - Backfill `requiredDlcs`, `mods`, `modded` and `category` on all blueprint documents from stored building IDs. Use `--dry-run` flag (`npm run derive-metadata:dry-run`) to preview counts without writing. Both modes report the prefab ids found in blueprints but missing from `database-2024.json` — those ids drive `modded=true` **and** contribute no `dlcIds`, so each one is a blueprint silently reading as base game. `modded` is written in both directions (a false positive can be cleared), except that `hadUnknownBuildings: true` always wins — those blueprints had unknown buildings stripped at import, so re-derivation can't rediscover them. Note `Element` is an editor annotation synthesized by `OniItem.load`, not a database building; it must be added to any `knownIds` set built from `database-2024.json` or every annotated blueprint reads as modded. The retired `Info` id belongs in that set too — it no longer registers an `OniItem`, but pre-migration documents can still carry it. Add `--recategorize` (`npm run derive-metadata -- --recategorize`) to re-derive `category` for documents that already have one, overwriting user picks; needed whenever the scoring rules in `blueprint-analyzer` change, since the default only fills in nulls.
 - `npm run derive-rooms` / `derive-rooms:dry-run` - Re-derive the `rooms` field on all non-deleted blueprints with the same detector the save path uses.
-- `npm run derive-search` / `derive-search:dry-run` - Rebuild the `blueprintsearch` rows, then run two translation passes over the titles: confidently non-English ones, and (unless `--skip-provider-detect`) the ones our own detector can't place, which are sent to the provider to identify. Rerunnable — fresh rows only get their ranking signals refreshed, already-translated rows are left alone, and repeat provider questions are cache reads. **Run `npm run migrate:up` first** whenever the text index has changed.
+- `npm run derive-search` / `derive-search:dry-run` - Rebuild the `blueprintsearch` rows, then run two translation passes over the titles: confidently non-English ones through Google, and (unless `--skip-provider-detect`) conservative undetectable ASCII candidates through Gemini's romanized-Vietnamese gate first. Only explicit `not-vietnamese` results continue to Google's general provider detection; ambiguous/invalid results remain authored. Gemini batches are at most 12 titles / 720 characters, concurrency 1, zero retries. Dry-run constructs no Gemini client and reports exact title/document/character/batch/token/micro-USD ceilings. Rerunnable — fresh rows only get their ranking signals refreshed, already-translated rows are left alone, and accepted translations are cache reads. **Run `npm run migrate:up` first** whenever the text or translation-unit index has changed.
 - **`--limit N` on both derive tasks** - A full pass loads every stored blueprint blob (~10 min on the live corpus), so diagnostic dry runs take `--limit N` (`npm run derive-metadata -- --dry-run --limit 100`). The capped run samples **randomly**, not the first N: natural order tracks insertion date and so does everything these reports measure, so a head sample would report the oldest blueprints' problems as the corpus average. Percentages from a sampled run extrapolate; the absolute counts don't. Shared helper: `app/api/batch/batch-sampling.ts`.
 - `npm run avatars:smoke` / `avatars:seed-batch -- --count N` / `avatars:backfill[:dry-run]` - Gemini avatar pipeline (costs real money per generation; setup + rollout order in `agent/AVATARS.md`).
 - `npm run backfill-previews` - Render preview images for all non-deleted blueprints (newest first) and store them durably in Mongo (`previewimages` collection). Skips blueprints whose durable rows are already fresh, so it's rerunnable/resumable. Use `--dry-run` (`npm run backfill-previews:dry-run`) to report the fresh/stale split without rendering or writing.
 - **Running batch tasks in production:** the deploy image has no devDependencies or TS sources, but ships `package.json` + `scripts/batch.sh` into `/bpni/build`, so the same npm task names work there: `cd /bpni/build && npm run avatars:seed-batch -- --count 10` (likewise `derive-metadata`, `backfill-previews`, `migrate:up`, …). `batch.sh` dispatches to compiled `app/api/batch/<name>.js` in the image and `ts-node` in a dev checkout. Direct `node app/api/batch/<name>.js` also works. New prod-runnable batch tasks must go through `scripts/batch.sh`, and any files they read at runtime must land in `build/` (copy_assets.sh + a `COPY` in deploy.Dockerfile). Full checklist: README "Running batch tasks in production".
 
 ### Docker
+
 - `docker-compose up` - Full development environment with database
 - `docker build . -t bpni:latest` - Build production image
 
@@ -130,13 +139,15 @@ gh api repos/blueprintnotincluded/blueprintnotincluded/actions/permissions/workf
 The GitHub repo is at https://github.com/blueprintnotincluded/blueprintnotincluded.
 
 ### CI Workflows
+
 - `backend-test.yml` — runs on push/PR to master touching backend paths
-- `frontend-test.yml` — runs on push/PR to master touching frontend paths  
+- `frontend-test.yml` — runs on push/PR to master touching frontend paths
 - `publish.yml` — deploys to DigitalOcean on push to master only
 
 ## Environment Configuration
 
 Copy `.env.sample` to `.env` and configure:
+
 - `DB_URI` - MongoDB connection string
 - `JWT_SECRET` - Secret key for JWT tokens
 - `ENV_NAME` - Environment identifier (`production` enables Mailjet; otherwise nodemailer/SMTP)
@@ -147,6 +158,7 @@ Copy `.env.sample` to `.env` and configure:
 ## Database
 
 Uses MongoDB 8.0.23 locally and in CI (prod upgrade from 7.0.34 pending) with Mongoose models in `app/api/models/`:
+
 - `blueprint.ts` - Blueprint documents
 - `user.ts` - User accounts
 
@@ -162,11 +174,13 @@ Uses MongoDB 8.0.23 locally and in CI (prod upgrade from 7.0.34 pending) with Mo
 ## Testing
 
 **Backend**: Mocha with Chai and TypeScript support. Test files in `__tests__/` directory. The test database setup script creates a clean test environment.
+
 - **Framework**: Mocha with Chai — do not introduce Jest
 - **Maintenance**: When removing large dependency sets, regenerate package-lock.json with `rm package-lock.json && npm install` to prevent corruption
 - **Email in tests**: `emailService.ts` skips SMTP when `NODE_ENV=test` — no mail server needed
 
 **Frontend**: Vitest with jsdom (no real browser). Runner: `@angular/build:unit-test`. Coverage via `@vitest/coverage-v8`.
+
 - All specs in `frontend/src/**/*.spec.ts`; run with `npm test` from `frontend/`
 - Run a single spec via the `--include` glob: `npm test -- --include='**/login-page.component.spec.ts'`. Do NOT run `vitest`/`ng test` against a bare file path — globals and the Angular TestBed are wired by the builder setup file, so plain `vitest run <file>` fails with `describe is not defined`
 - `npm run test:coverage` generates a text summary + lcov report
@@ -199,8 +213,10 @@ Uses MongoDB 8.0.23 locally and in CI (prod upgrade from 7.0.34 pending) with Mo
 - **Lint**: `cd frontend && npm run lint` (ESLint 9 flat config, `frontend/eslint.config.js`); backend has no ESLint yet — Prettier only
 
 ### Asset rendering: OniExtract2024 flat icons
+
 Rendering uses the 2024 flat-icon model, not the retired multi-sprite atlas. Contract and
 converter details: `app/api/batch/convert-export-2024.md`.
+
 - **Types**: `lib/src/b-export/b-export-2024.ts` — raw 2024 export shapes (13 files).
 - **Import**: `app/api/batch/convert-export-2024.ts` (`npm run import:2024`) → consolidated
   `database-2024.json` written to both asset roots (committed; the `.zip` is a gitignored
@@ -216,7 +232,7 @@ converter details: `app/api/batch/convert-export-2024.md`.
   menu keeps the single canonical icon (`iconUrl`).
 - **Utility ports** (275/449 buildings): `BBuildingDef2024.utilities[]` carries each
   input/output port as `{offset, type, isSecondary}`. The U59 export emits `type` as the
-  `ConnectionType` enum *name* (string); the converter maps it to the int via
+  `ConnectionType` enum _name_ (string); the converter maps it to the int via
   `CONNECTION_TYPE_BY_NAME`. Offsets are pre-rotation/y-up/footprint-relative and already
   match the website's internal convention (no transform). `BlueprintItem.drawPixiUtility`
   draws the markers per overlay; the 8 indicator sprites (`input`/`output`/`logicInput`…)
@@ -230,7 +246,9 @@ converter details: `app/api/batch/convert-export-2024.md`.
   `kPrefabID.requiredDlcIds`. Used by `BlueprintAnalyzer` to derive metadata.
 
 ### Keyboard shortcuts
+
 Editor input goes through an action layer, never raw key comparisons.
+
 - **`frontend/src/app/module-blueprint/keybindings/shortcut-actions.ts`** — the catalogue of
   rebindable actions (id, category, label, default chords). Defaults mirror Oxygen Not
   Included's own controls where the game has an equivalent action; website-only actions take
@@ -249,7 +267,8 @@ Editor input goes through an action layer, never raw key comparisons.
 - **UI**: `components/dialogs/dialog-keybindings/` — Edit ▸ Keyboard shortcuts, or `Shift+/`.
 
 ### Terrain annotations (geysers, vents, volcanoes)
-Natural map features placed on a blueprint as *annotations* — "this pump array sits on a
+
+Natural map features placed on a blueprint as _annotations_ — "this pump array sits on a
 chlorine vent". Dupes cannot build them, so they are excluded from every build-related model:
 no `BlueprintItem`, no material cost, no ingredient totals, no build order, and never an entry
 in the exported `buildings` array (a geyser written as a building resolves to a null
@@ -276,7 +295,7 @@ in the exported `buildings` array (a geyser written as a building resolves to a 
 - **Storage** — the mod's v6.2.0 top-level `metadata` field, which deserializes into a C#
   `Dictionary<string, string>`: **flat, string-valued only**. Any other JSON token type is
   silently dropped on the next in-game save (`"count": 3` dies, `"count": "3"` lives). So the
-  whole payload is one JSON-encoded *string* under `bni/terrain`
+  whole payload is one JSON-encoded _string_ under `bni/terrain`
   (`lib/src/blueprint/terrain-metadata.ts`), namespaced because the mod does not namespace its
   own keys and reserves the right to add some. Foreign keys are read whole, mutated narrowly,
   and written whole back — including across the server-side MDB hop
@@ -290,7 +309,7 @@ in the exported `buildings` array (a geyser written as a building resolves to a 
   and plans when either minimum is negative, but does **not** touch `metadata`. So
   `toBniBlueprint` mirrors that arithmetic itself (`lib/src/blueprint/bpv2-sanitize.ts`) and
   shifts the annotations by the identical offset, making the mod's own pass a guaranteed no-op
-  on every file we write. Note the mod shifts *both* axes once *either* is negative, so a
+  on every file we write. Note the mod shifts _both_ axes once _either_ is negative, so a
   positive minY moves the blueprint down — an export that disagreed would leave the mod
   something to do, which is exactly what desyncs the markers.
   The **import** side deliberately does not re-origin: terrain shares a coordinate space with
@@ -321,7 +340,7 @@ in the exported `buildings` array (a geyser written as a building resolves to a 
   into the game instead of being dropped on export, and it costs no new model — world notes
   already render, export, undo and import. It also carries no explanatory text, because the
   mod writes only id/mass/temp for an element note and discards title/text/tint.
-  *Seeded, not owned* — the user then edits or deletes them with the note tool, so deleting
+  _Seeded, not owned_ — the user then edits or deletes them with the note tool, so deleting
   the annotation leaves them alone rather than discarding their edits, and a cell that already
   holds a note is never overwritten. The annotation and its base are one
   `emitBlueprintChanged`, hence one undo step.
@@ -333,7 +352,7 @@ in the exported `buildings` array (a geyser written as a building resolves to a 
   `color` (white) and `uiColor` (magenta) are both sentinels — the game never renders it as a
   material — so it gets a render-time `NEUTRONIUM_DISPLAY_COLOR` (`#0e0e0e`, the near-black
   the game's own tile reads as), with the database left as the export wrote it. The override
-  applies wherever Neutronium is drawn: element cells *and* the element-note badges the
+  applies wherever Neutronium is drawn: element cells _and_ the element-note badges the
   terrain tool seeds (`noteBadgeColor`). This lets the user draw or extend a base by hand.
 - **Active tile / area of effect** — a feature acts on exactly ONE cell, not on its whole
   footprint, and the cell differs by kind: a **volcano** erupts from the middle of its 3x3
@@ -343,12 +362,12 @@ in the exported `buildings` array (a geyser written as a building resolves to a 
   Fissure, Oil Reservoir, Tidal Spring, NiobiumGeyser) carry no shape and fall back to the
   volcano cell. Current split: 18 geyser-offset, 13 volcano-offset.
   Selecting a feature highlights that single cell, the way a selected building shows its
-  `areasOfEffect`; the footprint outline is the feature's *body*, not its effect. Offsets are
+  `areasOfEffect`; the footprint outline is the feature's _body_, not its effect. Offsets are
   emitted per feature by the importer (`terrainActiveTile()` → `BTerrainFeature.activeTile`)
   rather than derived at render time, so an exception is a data fix.
   `TerrainFeature.importFrom` clamps into the footprint; an unknown id falls back to its own
   anchor. Drawn on a second Graphics layer kept above the icons — unlike a building's AoE it
-  sits *inside* the art, so underneath it would be invisible. Magenta because it overprints
+  sits _inside_ the art, so underneath it would be invisible. Magenta because it overprints
   grey rock, blue ice and orange lava alike (a warm marker vanished into the volcano sprite).
   **Gotcha:** the frontend reads the gitignored `database-2024.zip`, regenerated by
   `prestart`. Starting the dev server with `npx ng serve` instead of `npm start` skips that,
@@ -362,10 +381,12 @@ in the exported `buildings` array (a geyser written as a building resolves to a 
   `blueprintItems`, so an annotation-only blueprint gets no stored preview.
 
 ### World notes (annotations)
+
 The mod's world notes are the **only** annotation model. The website's own `Info` type — a
 pseudo-building with a title, body and coloured badge — is retired: it could not be written to
 a .blueprint file at all, so `toBniBlueprint` skipped it and every website annotation vanished
-on download. `Info` now survives as an *input* format only.
+on download. `Info` now survives as an _input_ format only.
+
 - **Conversion** — `lib/src/blueprint/note-conversion.ts` (`infoBuildingToWorldNote`), applied
   in `Blueprint.importFromMdb`. Badge colour → `tinthex`, the twelve `InfoIcon`s → the mod's
   `note_info`/`note_warn`/`note_question`/`note_num_N` symbols, both written explicitly because
@@ -380,8 +401,10 @@ on download. `Info` now survives as an *input* format only.
 - **Editing** — `NotesTool` + `components/note-edit-panel/`. There is no other annotation UI.
 
 ### Search (blueprintsearch) & user-content translation
+
 `spec/multilingual-search-plan.md` phases 0–5 (all shipped) + `spec/search-followups.md`
 Part 1 §1/§2.
+
 - **Search documents** — `blueprintsearch` collection (`app/api/models/blueprint-search.ts`),
   one row per `(blueprintId, lang)`; every blueprint has an `en` row (the pivot invariant).
   Holds title/`titleOriginal`/description/`terms[]` (display names) under the collection's
@@ -425,12 +448,15 @@ Part 1 §1/§2.
   legacy escaped-regex substring match, which also remains the automatic fallback if the
   search layer errors.
 - **Translation cache** — `translationunits` (`app/api/models/translation-unit.ts`), keyed
-  `{textHash, sourceLang('auto' when unknown), targetLang}` — by **text**, never by document:
-  identical text is billed once corpus-wide. Replaced the per-document `translations` cache
-  before anything shipped (prod-empty, so no migration). Budget guard unchanged
-  (`translation-budget.ts`).
+  `{textHash, sourceLang('auto' when unknown), targetLang, mode}` — by **text**, never by document:
+  identical text is billed once corpus-wide. `mode:'standard'` preserves Google/human behavior;
+  accepted Gemini romanized-Vietnamese titles use `mode:'vi-romanized-title-v1'`, source `vi`,
+  target `en`, plus immutable prompt/model, restored Vietnamese, and token provenance.
+  Ambiguous/negative/invalid Gemini answers are never cached. Google character-budget behavior
+  is unchanged; Gemini maximum/observed micro-USD and token accounting shares the site-month row
+  in `translation-budget.ts`.
 - **Language detection** — `detectLanguage(text, {prior}) → {lang, confidence:
-  'high'|'prior'|'none'}` (`language-detection-service.ts`): statistical margin for ≥20 chars;
+'high'|'prior'|'none'}` (`language-detection-service.ts`): statistical margin for ≥20 chars;
   short texts need a stronger margin AND a non-ASCII signal, else they fall to the caller's
   prior (recorded as `'prior'` so callers can decide whether to spend money on it).
   `detectLanguageCode()` is the high-confidence-only convenience the save paths use.
@@ -473,7 +499,7 @@ Part 1 §1/§2.
   through the live API produced `sourceLang: 'vi'` and a `blueprintsearch` row with
   `origin: 'machine'`, and an English query then found it.
 - **`titleOriginal`** (`spec/search-followups.md` Part 1 §1) — translating a title used to
-  *replace* it, deleting the author's own words from the index: `Cozinha estrategia em choque`
+  _replace_ it, deleting the author's own words from the index: `Cozinha estrategia em choque`
   became findable by "strategic cooking" and no longer by itself. Worst exactly where query
   translation also fails (romanized text neither end detects), so both directions broke at once.
   The field holds the authored text whenever `origin` is `'machine'` and is **null while
@@ -484,7 +510,7 @@ Part 1 §1/§2.
   Mongo won't alter an index in place and Mongoose's autoIndex hits IndexOptionsConflict, which
   surfaces only as a logged error. **Deploy order: migrate, then `npm run derive-search`.**
   The backfill also fills the field on rows an earlier run already translated — those rows are
-  *fresh*, so they never reach full re-derivation, and their `sourceHash` pins them to the
+  _fresh_, so they never reach full re-derivation, and their `sourceHash` pins them to the
   current `blueprint.name`, making the authored text recoverable exactly with no provider call.
 - **Provider-side detection** (`spec/search-followups.md` Part 1 §2) — `derive-search`'s **second
   translation pass**, for titles `detectLanguageCode` can't place at all: short, romanized or
@@ -516,8 +542,10 @@ Part 1 §1/§2.
   generate.
 
 ### Content locale (what language you read blueprints in)
+
 `spec/search-followups.md` Part 2. **Not** UI localization — the chrome stays English for
 everyone (see "UI localization state"), so this routes no bundles and prefixes no paths.
+
 - **The rule** (§2.5), one shared implementation in `lib/src/blueprint/content-locale.ts`'s
   `resolveTitle`: authored-in-your-language → a translation into your language → the English
   translation → the authored title. The last step is what lets this ship ahead of any backfill:
@@ -538,7 +566,7 @@ everyone (see "UI localization state"), so this routes no bundles and prefixes n
 - **Reading display titles from `blueprintsearch` widens its contract** from "advisory for
   retrieval only". Confirmed, not overturned, on three grounds: the chain always terminates at
   `Blueprint.name` so a lost row degrades to authored text; machine titles rebuild for free from
-  the `translationunits` text-hash cache; and rows stay advisory for *visibility* because the
+  the `translationunits` text-hash cache; and rows stay advisory for _visibility_ because the
   authoritative filter still runs against `blueprints`. The rejected alternative was a
   `titleTranslations` map on the blueprint document — more obviously correct, but a second write
   path and a migration for data that is already derivable.
@@ -547,14 +575,14 @@ everyone (see "UI localization state"), so this routes no bundles and prefixes n
   means "never chosen". It reports `null` rather than `'en'` when unset, unlike
   `themePreference` — the client's own default is `navigator.language`, and answering `'en'`
   would override that on every device. The language set is **open** (shape-validated only): a
-  user may declare a language we never translate *into*.
+  user may declare a language we never translate _into_.
 - **Picker** — `components/dialogs/dialog-content-language/`, mounted in the site nav and opened
   off `ContentLocaleService.openRequests$`, so the user-menu entry and the ambient entry point
   on the details page both reach it with no component wiring. Three states kept distinct:
   declared (localStorage + account), guessed (`navigator.language`, **never persisted** — a
   default that writes itself is indistinguishable from a choice, which would ruin the §2.10
   "who reads in what language" measurement), and English. Login adopts a local declaration into
-  an account that has none; a *failed* lookup is explicitly not "the account has none", or one
+  an account that has none; a _failed_ lookup is explicitly not "the account has none", or one
   flaky GET would overwrite a preference set elsewhere. Selecting reloads the page — the locale
   is a request parameter, so everything on screen was fetched under the old one.
 - **Disclosure is mandatory and ships with the display** (§2.7): cards carry a quiet
@@ -563,13 +591,15 @@ everyone (see "UI localization state"), so this routes no bundles and prefixes n
   author's own words.
 
 ### Blueprint titles are Unicode
+
 `Blueprint.name` was `/^[a-zA-Z0-9_ -]+$/`, which 400'd every non-English title at save. The
 policy is now one shared module, `lib/src/blueprint/blueprint-name.ts`, used by the save
 dialog (`blueprint-name-validation.directive.ts`), the upload endpoint and the Mongoose
 schema — three surfaces that must not be able to disagree, since the failure mode is a form
 that accepts what the server rejects.
+
 - **Allowed**: every script, punctuation, emoji. **Rejected**: control characters, `\p{Cf}`
-  format characters (bidi overrides and the rest) *except* ZWNJ/ZWJ, unassigned/private-use/
+  format characters (bidi overrides and the rest) _except_ ZWNJ/ZWJ, unassigned/private-use/
   surrogate code points, runs of more than 4 combining marks, and Latin mixed with Cyrillic or
   Greek **inside one word** — the "Rоdriguez" homoglyph spoof. The confusable rule is per-word
   and only those scripts on purpose: mixing across words is ordinary (`Ферма SPOM v2`,
@@ -594,6 +624,7 @@ that accepts what the server rejects.
   letters, and search rows are derived on save (covered end-to-end in `search.test.ts`).
 
 ### Blueprint metadata auto-derivation
+
 `requiredDlcs`, `gameVersion` and `modded` are derived deterministically from the blueprint
 content — users no longer set these manually. `multiplayerSafe` has been removed entirely.
 
@@ -603,7 +634,7 @@ content — users no longer set these manually. `multiplayerSafe` has been remov
     current model; `deriveGameVersion` below is retained only until the frontend stops
     importing it (step 4 of `spec/dlc-requirements-plan.md`).
   - `deriveGameVersion(buildingDlcIds: string[][]): GameVersion` — **superseded.** Collapses
-    the set to the highest-priority DLC found, so it can't express "needs Frosty *and*
+    the set to the highest-priority DLC found, so it can't express "needs Frosty _and_
     Bionic", and its `DLC5_ID`→bionicBooster mapping is wrong (DLC5 is the Aquatic pack).
   - `deriveModded(prefabIds: string[], knownIds: Set<string>): boolean` — true if any ID is absent
     from the loaded database
@@ -631,8 +662,8 @@ content — users no longer set these manually. `multiplayerSafe` has been remov
   `createdAt`-sorted index and applies the exclusion as a per-doc FETCH filter) — checked with
   `explain()`, not a collscan, just no extra narrowing.
 - **DLC exclusion preference** — `dlcPreferences.excludedDlcs` on `User` (raw ids, `default:
-  []`), read/written via `GET`/`PATCH /api/users/me/dlc-preferences`. Applied automatically on
-  Discover load for a logged-in user *only* when the URL has no explicit `excludeDlc` param;
+[]`), read/written via `GET`/`PATCH /api/users/me/dlc-preferences`. Applied automatically on
+  Discover load for a logged-in user _only_ when the URL has no explicit `excludeDlc` param;
   written back only on real interaction (toggle/clear), never merely from loading it, never for
   a logged-out visitor. Private account data — never in `ProfileResponse` or any other
   user-facing payload.
@@ -648,10 +679,12 @@ content — users no longer set these manually. `multiplayerSafe` has been remov
 - **Backfill** — `npm run derive-metadata` re-derives `gameVersion`, `requiredDlcs`, `mods`
   and `modded` for all existing blueprints. **The `?dlc=` filter matches nothing until this
   runs** — no document written before the field existed has a set at all (prod: `cd /bpni/build
-  && npm run derive-metadata`, dry-run first).
+&& npm run derive-metadata`, dry-run first).
 
 ### Session Management Files
+
 Check these files in `agent/` directory for current status:
+
 - `agent/TODO.md` - Improvement roadmap and remaining work
 - `agent/SESSION_NOTES.md` - Session-by-session progress
 - `agent/WORKOS_PLAN.md` - WorkOS auth operational reference (env mapping, admin roles)
@@ -659,6 +692,7 @@ Check these files in `agent/` directory for current status:
 - `UPGRADE_PLAN.md` - Upgrade history and strategy
 
 ### Quick Status Check Commands
+
 ```bash
 # Environment verification
 node --version        # Should be 20.19.4
@@ -674,6 +708,7 @@ head -20 agent/TODO.md
 ```
 
 ### All Upgrade Phases Complete
+
 1. ✅ **Phase 1A**: Node.js 20.18.0 → 20.19.4 (volta + .nvmrc)
 2. ✅ **Phase 1B**: lib TypeScript 3.5.3 → 5.9.2, ES2020 target
 3. ✅ **Phase 2A**: Backend TypeScript 4.9.5 → 5.9.2, strict mode
@@ -684,6 +719,7 @@ head -20 agent/TODO.md
 8. ✅ **CI**: All GitHub Actions improvements applied
 
 ### Key Constraints
+
 - Canvas 3.x requires Node 20 — do not upgrade to Node 22
 - All test infrastructure is Mocha + Chai — do not introduce Jest
 - Rate limiting is handled by Cloudflare — do not add express-rate-limit
@@ -694,6 +730,7 @@ Uses **migrate-mongo** — Rails-style versioned migrations tracked in the `migr
 Migration files live in `migrations/` as plain CommonJS `.js` files (no compilation needed).
 
 ### Commands
+
 ```bash
 npm run migrate:status          # show applied / pending migrations
 npm run migrate:up              # run all pending migrations
@@ -702,6 +739,7 @@ npm run migrate:create -- <name>  # scaffold a new migration file
 ```
 
 ### Authoring a migration
+
 Scaffold with `npm run migrate:create -- <name>`, then fill in `up` and `down`:
 
 ```js
@@ -717,12 +755,14 @@ module.exports = {
 ```
 
 Rules:
+
 - Both `up` and `down` must be idempotent (safe to re-run if interrupted).
 - Never `$unset` the old field in the same operation that reads it as a filter.
 - Set new fields first, verify counts, clean up old fields in a separate migration.
 - Leave orphaned old fields in place; they disappear naturally once removed from the Mongoose schema.
 
 ### Credential rules
+
 - Admin URI (`doadmin`) — DO app console env only. Never on local machine.
 - `doctl` — installed; use it freely for reads (app logs, specs, deployments). The API
   token is normally **read-only**; writes (`doctl apps update` etc.) fail by design. For
@@ -733,6 +773,7 @@ Rules:
 - `/prod-dump/` — gitignored. Real prod data; never commit.
 
 ### Pre-merge process for every migration
+
 ```bash
 # 1. Tests pass
 npm run test
@@ -755,6 +796,7 @@ DB_URI=mongodb://localhost:27017/bpni-prod npm run migrate:up
 ```
 
 ### Post-deploy execution (DO app console)
+
 ```bash
 # DO dashboard → prod cluster → Backups → Create backup now  (wait for completion)
 npm run migrate:status   # confirm which migrations are pending
@@ -767,6 +809,7 @@ npm run migrate:up
 `{ deletedAt: { $exists: false } }` so it safely no-ops on already-migrated documents.
 
 ### Rollback
+
 `npm run migrate:down` rolls back the last migration via its `down` method.
 For a full restore: DO dashboard → Backups → restore the pre-deploy snapshot to a new cluster → update `DB_URI` env var in App Platform.
 
@@ -779,6 +822,7 @@ requests, so a session that ends with only local commits is a dead session — t
 sits invisible until someone comes back and pushes it. Do not stop at "committed".
 
 **Session start:**
+
 1. `git fetch origin master`
 2. Create a new branch based on `origin/master` (master is push-protected; never work on it)
 
@@ -788,6 +832,7 @@ Commit autonomously at every logical break point — do NOT pause to ask permiss
 A logical break point is: a feature complete, a refactor complete, tests passing, a migration applied, or any other self-contained unit of work.
 
 Commit message format:
+
 - Subject: conventional commits style (`feat:`, `fix:`, `chore:`, `refactor:`, `test:`, `docs:`), ≤72 chars
 - Body (when the why is non-obvious): explain motivation and any constraints a future reader would need; skip if the subject is self-explanatory
 - Always append a `Co-Authored-By` trailer with the current model name, e.g. `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
@@ -795,12 +840,14 @@ Commit message format:
 Stage only relevant files — never `git add -A` blindly. Do not skip hooks (`--no-verify`).
 
 **Session end — push and open a PR (autonomously, without asking):**
+
 1. Update any committed docs that describe shipped state (e.g. `spec/ROADMAP.md`, `agent/TODO.md`) so they reflect what this branch ships
 2. `git push -u origin <branch>`
 3. `gh pr create` with a real description: what shipped, design decisions and spec deviations, how it was verified (test counts, migrations run), and anything deferred
 4. Report the PR URL as the session's final output
 
 ## Important Instructions
+
 Do what has been asked; nothing more, nothing less.
 NEVER create files unless they're absolutely necessary for achieving your goal.
 ALWAYS prefer editing an existing file to creating a new one.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It is a combined curated version of the original blueprintnotincluded web app.
 ## Development Setup
 
 ### Development (Recommended)
+
 For ARM64 Macs and local development with live reloading:
 
 ```bash
@@ -27,6 +28,7 @@ cd frontend && npm start # Frontend with live reloading
 - **Mail testing**: http://localhost:8025 (Mailpit web UI)
 
 ### Production Testing
+
 Test with pre-built images (may require AMD64 emulation on ARM64 Macs):
 
 ```bash
@@ -49,6 +51,7 @@ Run npm tasks by name from the build directory — same task names as local dev:
 cd /bpni/build
 npm run migrate:status
 npm run migrate:up
+npm run derive-search:dry-run
 npm run avatars:smoke
 npm run avatars:seed-batch -- --count 10
 npm run derive-metadata:dry-run
@@ -60,11 +63,36 @@ Batch tasks dispatch through `scripts/batch.sh`, which runs the compiled
 `.ts` source (dev checkout). Direct invocation also works as a fallback:
 `node app/api/batch/<name>.js [args]` (no `--` separator needed).
 
+`derive-search:dry-run` performs the romanized-Vietnamese candidate census
+without constructing a Gemini client or reading `GEMINI_API_KEY`. It reports
+unique titles, affected documents, source characters, planned batches, token
+ceilings, and the maximum micro-USD reservation. Gemini batches are fixed at
+no more than 12 titles / 720 source characters, concurrency 1, and zero retries.
+
+For the Vietnamese-title rollout, deploy with
+`GEMINI_VI_TITLE_TRANSLATION_ENABLED=false` and
+`GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD=0`, then:
+
+1. Back up Mongo and run `npm run migrate:up`. Migration order is
+   `20260804000000_search-title-original.js` followed by
+   `20260805000000_translation-unit-modes.js`.
+2. Run `npm run derive-search:dry-run` and review its exact census and maximum
+   reservation before choosing a positive monthly allowance.
+3. Enable the kill switch and reviewed allowance, restart the API, then run
+   `npm run derive-search` once. Do not run the old Google-only provider
+   detection backfill before this code is deployed.
+
+Rollback sets the kill switch false and the allowance to zero, then restarts
+the API. This stops new Gemini calls while accepted cache rows remain usable;
+authored `Blueprint.name` values are never changed. If quality problems require
+removal, delete only translation units with mode `vi-romanized-title-v1` and
+rebuild the disposable search rows from authored blueprints.
+
 **Shipping new batch/asset code — deploy-image checklist.** Code that works locally can
 still fail in the image; before relying on something in production, confirm:
 
 - Runtime file reads (assets, fixtures) resolve relative to `/bpni/build` and the files
-  actually land there — via `scripts/copy_assets.sh` *and* a `COPY` line in
+  actually land there — via `scripts/copy_assets.sh` _and_ a `COPY` line in
   `deploy.Dockerfile` (the build stage only copies what's explicitly listed).
 - Any package the script imports is in `dependencies`, not `devDependencies`.
 - New npm tasks meant for production go through `scripts/batch.sh` (plain `ts-node`
@@ -87,6 +115,7 @@ Run the image and backend
 Visit http://localhost:3000
 
 ## Image reconstruction
+
 Export iamges from oniextract2020
 Copy assets/manual/ into assets/images
 `npm run fixHtmlLabels -- database.json`

--- a/README.md
+++ b/README.md
@@ -73,14 +73,44 @@ For the Vietnamese-title rollout, deploy with
 `GEMINI_VI_TITLE_TRANSLATION_ENABLED=false` and
 `GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD=0`, then:
 
-1. Back up Mongo and run `npm run migrate:up`. Migration order is
+1. Run `npm run migrate:up`. Migration order is
    `20260804000000_search-title-original.js` followed by
-   `20260805000000_translation-unit-modes.js`.
+   `20260805000000_translation-unit-modes.js`. Both are additive and reversible
+   with `npm run migrate:down`; neither drops a field or rewrites text.
 2. Run `npm run derive-search:dry-run` and review its exact census and maximum
    reservation before choosing a positive monthly allowance.
 3. Enable the kill switch and reviewed allowance, restart the API, then run
    `npm run derive-search` once. Do not run the old Google-only provider
    detection backfill before this code is deployed.
+
+**Staging and production share one database.** Two consequences worth knowing
+before running any migration:
+
+- migrate-mongo's `migrations` tracking collection is shared too, so whichever
+  environment runs `migrate:up` first applies it for both. The second one
+  reports nothing pending — that is correct, not a skipped step.
+- There is therefore no safe rehearsal on staging. Migrating staging has
+  already migrated production. Rehearse locally against a prod restore instead
+  (see "Pre-merge process for every migration" in CLAUDE.md).
+
+Because every migration is effectively run twice against the same data, each
+must be idempotent, and must match indexes by **key pattern rather than by
+name**. Mongoose's `autoIndex` races migrations on deploy: whichever creates an
+index first wins, and if the two disagree about its name the loser fails with
+`Index already exists with a different name`. Either pin the same explicit
+name in both the schema and the migration, or match on the key pattern — the
+Vietnamese-title migration does both.
+
+If `derive-search` hits a Gemini **401/403** (bad, revoked, or unauthorized
+key) or **429** (rate limit / quota exhausted), the pass stops immediately
+rather than trying the remaining batches, and logs
+`Gemini pass STOPPED ... needs action, not a retry` with the count of
+unprocessed titles. This matters because budget is reserved *before* each
+call: continuing would spend the whole monthly allowance on failures. Fix the
+cause and re-run — accepted translations are cached and translated rows are
+skipped, so a re-run resumes rather than redoing. An exhausted allowance stops
+the pass the same way. Ordinary one-off errors (a 500, a malformed response)
+still skip just that batch.
 
 Rollback sets the kill switch false and the allowance to zero, then restarts
 the API. This stops new Gemini calls while accepted cache rows remain usable;

--- a/README.md
+++ b/README.md
@@ -73,15 +73,24 @@ For the Vietnamese-title rollout, deploy with
 `GEMINI_VI_TITLE_TRANSLATION_ENABLED=false` and
 `GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD=0`, then:
 
-1. Run `npm run migrate:up`. Migration order is
+1. Run `npm run migrate:up` **before the new code serves traffic**. The
+   translation cache now filters on `mode`, so against un-migrated rows a
+   lookup misses and the write then collides with the old three-field unique
+   index — a duplicate-key error on ordinary translation, not just on the
+   Vietnamese path. Migration order is
    `20260804000000_search-title-original.js` followed by
    `20260805000000_translation-unit-modes.js`. Both are additive and reversible
    with `npm run migrate:down`; neither drops a field or rewrites text.
 2. Run `npm run derive-search:dry-run` and review its exact census and maximum
    reservation before choosing a positive monthly allowance.
-3. Enable the kill switch and reviewed allowance, restart the API, then run
-   `npm run derive-search` once. Do not run the old Google-only provider
-   detection backfill before this code is deployed.
+3. Set `GEMINI_VI_TITLE_TRANSLATION_ENABLED=true` and
+   `GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD` to the reviewed value, restart the
+   API, then run `npm run derive-search` once. Do not run the old Google-only
+   provider detection backfill before this code is deployed.
+
+   The API logs `[vi-title] ENABLED (monthly cap N micro-USD)` at startup when
+   all three conditions are met, and `[vi-title] DISABLED (...)` otherwise —
+   check that line before running the backfill.
 
 **Staging and production share one database.** Two consequences worth knowing
 before running any migration:
@@ -112,8 +121,8 @@ skipped, so a re-run resumes rather than redoing. An exhausted allowance stops
 the pass the same way. Ordinary one-off errors (a 500, a malformed response)
 still skip just that batch.
 
-Rollback sets the kill switch false and the allowance to zero, then restarts
-the API. This stops new Gemini calls while accepted cache rows remain usable;
+Rollback sets `GEMINI_VI_TITLE_TRANSLATION_ENABLED=false` and
+`GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD=0`, then restarts the API. This stops new Gemini calls while accepted cache rows remain usable;
 authored `Blueprint.name` values are never changed. If quality problems require
 removal, delete only translation units with mode `vi-romanized-title-v1` and
 rebuild the disposable search rows from authored blueprints.

--- a/__tests__/api/experiments/diacritic-ab.test.ts
+++ b/__tests__/api/experiments/diacritic-ab.test.ts
@@ -1,0 +1,251 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { ArtifactStore } from '../../../app/api/experiments/diacritic-ab/artifacts';
+import {
+  assertDoRequestWithinCap,
+  assertGoogleCharacters,
+  calculateMaximumCost,
+  fullReservation,
+} from '../../../app/api/experiments/diacritic-ab/caps';
+import {
+  DigitalOceanExperimentClient,
+  GoogleExperimentClient,
+  GoogleTransport,
+  validateLlmOutputs,
+} from '../../../app/api/experiments/diacritic-ab/clients';
+import { DO_ENDPOINT, DO_MODEL } from '../../../app/api/experiments/diacritic-ab/constants';
+import {
+  blindResults,
+  mechanicalRows,
+  observedCost,
+} from '../../../app/api/experiments/diacritic-ab/evaluation';
+import {
+  loadFixture,
+  stripVietnameseDiacritics,
+  validateFixture,
+} from '../../../app/api/experiments/diacritic-ab/fixture';
+import { buildDoRequest } from '../../../app/api/experiments/diacritic-ab/prompts';
+import {
+  ArmOutput,
+  ArmResult,
+  HttpRequest,
+  HttpTransport,
+} from '../../../app/api/experiments/diacritic-ab/types';
+
+describe('diacritic A/B experiment', () => {
+  const cases = loadFixture();
+
+  describe('fixture and stripping', () => {
+    it('strips combining marks and Vietnamese d with stroke', () => {
+      expect(stripVietnameseDiacritics('Điện phân nước ĐẦY')).to.equal('Dien phan nuoc DAY');
+      expect(stripVietnameseDiacritics('a\u0301')).to.equal('a');
+    });
+
+    it('loads the fixed category mix within the hard character cap', () => {
+      expect(cases).to.have.length(12);
+      expect(new Set(cases.map(item => item.id)).size).to.equal(12);
+      expect(cases.filter(item => item.category === 'live')).to.have.length(2);
+      expect(cases.filter(item => item.category === 'synthetic')).to.have.length(6);
+      expect(cases.filter(item => item.category === 'ambiguous')).to.have.length(2);
+      expect(cases.filter(item => item.category === 'control')).to.have.length(2);
+      expect(cases.reduce((sum, item) => sum + item.asciiInput.length, 0)).to.be.at.most(256);
+    });
+
+    it('rejects duplicates, non-ASCII input, and non-mechanical synthetic input', () => {
+      const duplicate = cases.map(item => ({ ...item }));
+      duplicate[1].id = duplicate[0].id;
+      expect(() => validateFixture(duplicate)).to.throw('Duplicate fixture id');
+      const nonAscii = cases.map(item => ({ ...item }));
+      nonAscii[0].asciiInput = 'Điện phân';
+      expect(() => validateFixture(nonAscii)).to.throw('not ASCII');
+      const mismatched = cases.map(item => ({ ...item }));
+      mismatched.find(item => item.category === 'synthetic')!.asciiInput = 'wrong';
+      expect(() => validateFixture(mismatched)).to.throw('not mechanically stripped');
+    });
+  });
+
+  describe('caps', () => {
+    it('calculates the acknowledged worst case exactly', () => {
+      expect(calculateMaximumCost()).to.equal(0.0175104);
+      expect(fullReservation()).to.deep.include({
+        doCalls: 2,
+        googleCalls: 3,
+        doInputTokens: 8192,
+        doOutputTokens: 1536,
+        googleSourceCharacters: 768,
+        maximumUsd: 0.0175104,
+      });
+    });
+
+    it('accepts exact per-request boundaries and rejects one unit over', () => {
+      expect(assertDoRequestWithinCap('x'.repeat(4032))).to.equal(4096);
+      expect(() => assertDoRequestWithinCap('x'.repeat(4033))).to.throw('per-call cap');
+      expect(assertGoogleCharacters(['x'.repeat(256)], 256)).to.equal(256);
+      expect(() => assertGoogleCharacters(['x'.repeat(257)], 256)).to.throw('source characters');
+    });
+  });
+
+  describe('prompt serialization', () => {
+    it('pins model/settings and keeps evaluation ground truth out of both requests', () => {
+      for (const mode of ['end-to-end', 'restore'] as const) {
+        const request = buildDoRequest(cases, mode);
+        const serialized = JSON.stringify(request);
+        expect(request.model).to.equal(DO_MODEL);
+        expect(request.temperature).to.equal(0);
+        expect(request.max_completion_tokens).to.equal(768);
+        expect(request.response_format.type).to.equal('json_schema');
+        expect(serialized).not.to.contain('canonicalVietnamese');
+        expect(serialized).not.to.contain('acceptableEnglish');
+        expect(serialized).not.to.contain('reviewerNote');
+        expect(serialized).not.to.contain('Điện phân');
+        expect(serialized).not.to.contain('Electrolysis');
+        expect(serialized).not.to.contain('Short tone collision');
+        expect(assertDoRequestWithinCap(serialized)).to.be.at.most(4096);
+      }
+    });
+  });
+
+  describe('experiment clients', () => {
+    it('sends one Google batch with auto detection and one with forced Vietnamese', async () => {
+      const calls: { texts: string[]; options: unknown }[] = [];
+      const transport: GoogleTransport = {
+        async translate(texts, options) {
+          calls.push({ texts, options });
+          return [texts.map(text => `translated:${text}`), { data: { translations: [] } }];
+        },
+      };
+      const client = new GoogleExperimentClient(transport);
+      await client.translate(
+        cases.map(item => item.asciiInput),
+        'auto'
+      );
+      await client.translate(
+        cases.map(item => item.asciiInput),
+        'vi'
+      );
+      expect(calls).to.have.length(2);
+      expect(calls[0].options).to.deep.equal({ to: 'en', format: 'text' });
+      expect(calls[1].options).to.deep.equal({ to: 'en', format: 'text', from: 'vi' });
+      expect(calls[0].texts).to.have.length(12);
+    });
+
+    it('pins the DO endpoint/model and validates complete aligned output and usage', async () => {
+      const requests: HttpRequest[] = [];
+      const outputs = resolvedOutputs(false);
+      const transport: HttpTransport = {
+        async send(request) {
+          requests.push(request);
+          if (request.method === 'GET') return { status: 200, body: { data: [{ id: DO_MODEL }] } };
+          return {
+            status: 200,
+            body: {
+              choices: [{ message: { content: JSON.stringify({ results: outputs }) } }],
+              usage: { prompt_tokens: 400, completion_tokens: 200 },
+            },
+          };
+        },
+      };
+      const client = new DigitalOceanExperimentClient(transport);
+      await client.assertModelAvailable();
+      const result = await client.complete(buildDoRequest(cases, 'restore'), cases, 'restore');
+      expect(result.outputs).to.deep.equal(outputs);
+      expect(result.usage).to.deep.equal({ promptTokens: 400, completionTokens: 200 });
+      expect(requests[0].url).to.equal(`${DO_ENDPOINT}/v1/models`);
+      expect(requests[1].url).to.equal(`${DO_ENDPOINT}/v1/chat/completions`);
+      expect(JSON.parse(requests[1].body!).model).to.equal(DO_MODEL);
+    });
+
+    it('captures a raw DO response before failing closed on missing usage', async () => {
+      const raw = {
+        choices: [{ message: { content: JSON.stringify({ results: resolvedOutputs(false) }) } }],
+      };
+      const transport: HttpTransport = {
+        async send() {
+          return { status: 200, body: raw };
+        },
+      };
+      let captured: unknown;
+      const client = new DigitalOceanExperimentClient(transport);
+      try {
+        await client.complete(buildDoRequest(cases, 'restore'), cases, 'restore', value => {
+          captured = value;
+        });
+        expect.fail('missing usage should fail');
+      } catch (error) {
+        expect((error as Error).message).to.contain('omitted token usage');
+      }
+      expect(captured).to.equal(raw);
+    });
+
+    it('rejects missing, duplicate, unknown, and extra output IDs', () => {
+      const base = resolvedOutputs(false);
+      expect(() => validateLlmOutputs(base.slice(1), cases, 'restore')).to.throw('exactly 12');
+      const duplicate = base.map(item => ({ ...item }));
+      duplicate[1].id = duplicate[0].id;
+      expect(() => validateLlmOutputs(duplicate, cases, 'restore')).to.throw('malformed row');
+      const unknown = base.map(item => ({ ...item }));
+      unknown[0].id = 'unknown';
+      expect(() => validateLlmOutputs(unknown, cases, 'restore')).to.throw('malformed row');
+      expect(() => validateLlmOutputs([...base, base[0]], cases, 'restore')).to.throw('exactly 12');
+    });
+  });
+
+  describe('artifacts and evaluation', () => {
+    let directory: string;
+    afterEach(() => {
+      if (directory) fs.rmSync(directory, { recursive: true, force: true });
+    });
+
+    it('creates a reservation once and refuses to overwrite it', () => {
+      directory = fs.mkdtempSync(path.join(os.tmpdir(), 'diacritic-ledger-'));
+      const store = new ArtifactStore(directory);
+      store.createReservation({ state: 'reserved', usd: 0.02 });
+      expect(store.read('reservation.json')).to.deep.equal({ state: 'reserved', usd: 0.02 });
+      expect(() => store.createReservation({ state: 'reserved' })).to.throw('already exists');
+    });
+
+    it('computes mechanical measures/cost and emits a blinded review mapping', () => {
+      const arms: ArmResult[] = [
+        { arm: 'google-auto', outputs: resolvedOutputs(true), googleSourceCharacters: 125 },
+        { arm: 'google-vi', outputs: resolvedOutputs(true), googleSourceCharacters: 125 },
+        {
+          arm: 'llm-end-to-end',
+          outputs: resolvedOutputs(true),
+          usage: { promptTokens: 100, completionTokens: 50 },
+        },
+        {
+          arm: 'restore-google',
+          outputs: resolvedOutputs(true),
+          usage: { promptTokens: 100, completionTokens: 50 },
+          googleSourceCharacters: 130,
+        },
+      ];
+      expect(mechanicalRows(cases, arms)).to.have.length(48);
+      const changedControl = resolvedOutputs(true);
+      changedControl.find(item => item.id === 'control-main-base')!.english = 'Main Base';
+      const controlMetric = mechanicalRows(cases, [
+        { arm: 'google-auto', outputs: changedControl },
+      ]).find(item => item.id === 'control-main-base')!;
+      expect(controlMetric.noOp).to.equal(true);
+      expect(controlMetric.controlPreserved).to.equal(false);
+      expect(observedCost(arms).complete).to.equal(true);
+      expect(observedCost(arms).usd).to.be.greaterThan(0);
+      const blind = blindResults(cases, arms);
+      expect(Object.keys(blind.mapping)).to.have.members(['A', 'B', 'C', 'D']);
+      expect(blind.review).to.contain('Do not unblind arm labels');
+      expect(blind.review).not.to.contain('google-auto');
+    });
+  });
+
+  function resolvedOutputs(withEnglish: boolean): ArmOutput[] {
+    return cases.map(item => ({
+      id: item.id,
+      status: 'resolved',
+      restoredVi: item.canonicalVietnamese ?? item.asciiInput,
+      ...(withEnglish ? { english: item.acceptableEnglish?.[0] ?? item.asciiInput } : {}),
+      alternatives: [],
+    }));
+  }
+});

--- a/__tests__/api/experiments/diacritic-ab.test.ts
+++ b/__tests__/api/experiments/diacritic-ab.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { ArtifactStore } from '../../../app/api/experiments/diacritic-ab/artifacts';
+import { ArtifactStore, sha256 } from '../../../app/api/experiments/diacritic-ab/artifacts';
 import {
   assertDoRequestWithinCap,
   assertGoogleCharacters,
@@ -33,6 +33,7 @@ import {
   HttpRequest,
   HttpTransport,
 } from '../../../app/api/experiments/diacritic-ab/types';
+import { loadReviewed402Continuation } from '../../../app/api/experiments/translate-diacritic-ab';
 
 describe('diacritic A/B experiment', () => {
   const cases = loadFixture();
@@ -179,6 +180,26 @@ describe('diacritic A/B experiment', () => {
       expect(captured).to.equal(raw);
     });
 
+    it('captures a raw DO error body before failing closed on HTTP 402', async () => {
+      const raw = { id: 'payment_required', message: 'Prepayment required' };
+      const transport: HttpTransport = {
+        async send() {
+          return { status: 402, body: raw };
+        },
+      };
+      let captured: unknown;
+      const client = new DigitalOceanExperimentClient(transport);
+      try {
+        await client.complete(buildDoRequest(cases, 'restore'), cases, 'restore', value => {
+          captured = value;
+        });
+        expect.fail('HTTP 402 should fail');
+      } catch (error) {
+        expect((error as Error).message).to.contain('HTTP 402');
+      }
+      expect(captured).to.equal(raw);
+    });
+
     it('rejects missing, duplicate, unknown, and extra output IDs', () => {
       const base = resolvedOutputs(false);
       expect(() => validateLlmOutputs(base.slice(1), cases, 'restore')).to.throw('exactly 12');
@@ -204,6 +225,53 @@ describe('diacritic A/B experiment', () => {
       store.createReservation({ state: 'reserved', usd: 0.02 });
       expect(store.read('reservation.json')).to.deep.equal({ state: 'reserved', usd: 0.02 });
       expect(() => store.createReservation({ state: 'reserved' })).to.throw('already exists');
+    });
+
+    it('accepts only the exact reviewed 402 continuation artifacts once', () => {
+      directory = fs.mkdtempSync(path.join(os.tmpdir(), 'diacritic-resume-'));
+      const store = new ArtifactStore(directory);
+      const fixtureHash = sha256(
+        fs.readFileSync('app/api/experiments/fixtures/vi-diacritic-cases.json')
+      );
+      const sourceCharacters = cases.reduce((sum, item) => sum + item.asciiInput.length, 0);
+      const googleAuto: ArmResult = {
+        arm: 'google-auto',
+        outputs: resolvedOutputs(true).map(({ restoredVi: _restoredVi, ...output }) => output),
+        googleSourceCharacters: sourceCharacters,
+      };
+      const googleVi: ArmResult = {
+        arm: 'google-vi',
+        outputs: resolvedOutputs(true).map(({ restoredVi: _restoredVi, ...output }) => output),
+        googleSourceCharacters: sourceCharacters,
+      };
+      store.writeJson('reservation.json', {
+        state: 'failed',
+        failure: 'DO completion request failed with HTTP 402',
+        calls: { digitalOcean: 2, google: 3 },
+        manifestFixtureSha256: fixtureHash,
+      });
+      store.writeJson('results.json', {
+        partial: true,
+        arms: [googleAuto, googleVi],
+        operationalFailure: {
+          arm: 'llm-end-to-end',
+          message: 'DO completion request failed with HTTP 402',
+        },
+      });
+      store.writeJson('responses/google-auto.json', { data: {} });
+      store.writeJson('responses/google-vi.json', { data: {} });
+
+      expect(loadReviewed402Continuation(store, cases, fixtureHash).results).to.deep.equal([
+        googleAuto,
+        googleVi,
+      ]);
+      store.writeJson('reservation.json', {
+        ...(store.read('reservation.json') as Record<string, unknown>),
+        resume: { authorizedAt: new Date().toISOString() },
+      });
+      expect(() => loadReviewed402Continuation(store, cases, fixtureHash)).to.throw(
+        'single reviewed HTTP 402 state'
+      );
     });
 
     it('computes mechanical measures/cost and emits a blinded review mapping', () => {

--- a/__tests__/api/experiments/diacritic-ab.test.ts
+++ b/__tests__/api/experiments/diacritic-ab.test.ts
@@ -2,20 +2,25 @@ import { expect } from 'chai';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { ArtifactStore, sha256 } from '../../../app/api/experiments/diacritic-ab/artifacts';
+import { ArtifactStore } from '../../../app/api/experiments/diacritic-ab/artifacts';
 import {
-  assertDoRequestWithinCap,
+  assertGeminiRequestWithinCap,
   assertGoogleCharacters,
   calculateMaximumCost,
   fullReservation,
 } from '../../../app/api/experiments/diacritic-ab/caps';
 import {
-  DigitalOceanExperimentClient,
+  createGeminiFetchTransport,
+  GeminiExperimentClient,
   GoogleExperimentClient,
   GoogleTransport,
   validateLlmOutputs,
 } from '../../../app/api/experiments/diacritic-ab/clients';
-import { DO_ENDPOINT, DO_MODEL } from '../../../app/api/experiments/diacritic-ab/constants';
+import {
+  EXPERIMENT_REVISION,
+  GEMINI_ENDPOINT,
+  GEMINI_MODEL,
+} from '../../../app/api/experiments/diacritic-ab/constants';
 import {
   blindResults,
   mechanicalRows,
@@ -26,14 +31,14 @@ import {
   stripVietnameseDiacritics,
   validateFixture,
 } from '../../../app/api/experiments/diacritic-ab/fixture';
-import { buildDoRequest } from '../../../app/api/experiments/diacritic-ab/prompts';
+import { buildGeminiRequest } from '../../../app/api/experiments/diacritic-ab/prompts';
 import {
   ArmOutput,
   ArmResult,
   HttpRequest,
   HttpTransport,
 } from '../../../app/api/experiments/diacritic-ab/types';
-import { loadReviewed402Continuation } from '../../../app/api/experiments/translate-diacritic-ab';
+import { makeManifest, parseCli } from '../../../app/api/experiments/translate-diacritic-ab';
 
 describe('diacritic A/B experiment', () => {
   const cases = loadFixture();
@@ -69,20 +74,20 @@ describe('diacritic A/B experiment', () => {
 
   describe('caps', () => {
     it('calculates the acknowledged worst case exactly', () => {
-      expect(calculateMaximumCost()).to.equal(0.0175104);
+      expect(calculateMaximumCost()).to.equal(0.0167936);
       expect(fullReservation()).to.deep.include({
-        doCalls: 2,
+        geminiCalls: 2,
         googleCalls: 3,
-        doInputTokens: 8192,
-        doOutputTokens: 1536,
+        geminiInputTokens: 8192,
+        geminiOutputTokens: 1536,
         googleSourceCharacters: 768,
-        maximumUsd: 0.0175104,
+        maximumUsd: 0.0167936,
       });
     });
 
     it('accepts exact per-request boundaries and rejects one unit over', () => {
-      expect(assertDoRequestWithinCap('x'.repeat(4032))).to.equal(4096);
-      expect(() => assertDoRequestWithinCap('x'.repeat(4033))).to.throw('per-call cap');
+      expect(assertGeminiRequestWithinCap('x'.repeat(4032))).to.equal(4096);
+      expect(() => assertGeminiRequestWithinCap('x'.repeat(4033))).to.throw('per-call cap');
       expect(assertGoogleCharacters(['x'.repeat(256)], 256)).to.equal(256);
       expect(() => assertGoogleCharacters(['x'.repeat(257)], 256)).to.throw('source characters');
     });
@@ -91,19 +96,23 @@ describe('diacritic A/B experiment', () => {
   describe('prompt serialization', () => {
     it('pins model/settings and keeps evaluation ground truth out of both requests', () => {
       for (const mode of ['end-to-end', 'restore'] as const) {
-        const request = buildDoRequest(cases, mode);
+        const request = buildGeminiRequest(cases, mode);
         const serialized = JSON.stringify(request);
-        expect(request.model).to.equal(DO_MODEL);
-        expect(request.temperature).to.equal(0);
-        expect(request.max_completion_tokens).to.equal(768);
-        expect(request.response_format.type).to.equal('json_schema');
+        expect(request.generationConfig.temperature).to.equal(0);
+        expect(request.generationConfig.candidateCount).to.equal(1);
+        expect(request.generationConfig.maxOutputTokens).to.equal(768);
+        expect(request.generationConfig.thinkingConfig.thinkingBudget).to.equal(0);
+        expect(request.generationConfig.responseMimeType).to.equal('application/json');
+        expect(request.generationConfig.responseJsonSchema).to.be.an('object');
+        expect(request).not.to.have.property('tools');
+        expect(request).not.to.have.property('cachedContent');
         expect(serialized).not.to.contain('canonicalVietnamese');
         expect(serialized).not.to.contain('acceptableEnglish');
         expect(serialized).not.to.contain('reviewerNote');
         expect(serialized).not.to.contain('Điện phân');
         expect(serialized).not.to.contain('Electrolysis');
         expect(serialized).not.to.contain('Short tone collision');
-        expect(assertDoRequestWithinCap(serialized)).to.be.at.most(4096);
+        expect(assertGeminiRequestWithinCap(serialized)).to.be.at.most(4096);
       }
     });
   });
@@ -132,35 +141,57 @@ describe('diacritic A/B experiment', () => {
       expect(calls[0].texts).to.have.length(12);
     });
 
-    it('pins the DO endpoint/model and validates complete aligned output and usage', async () => {
+    it('pins the Gemini endpoint/model and validates complete aligned output and usage', async () => {
       const requests: HttpRequest[] = [];
       const outputs = resolvedOutputs(false);
       const transport: HttpTransport = {
         async send(request) {
           requests.push(request);
-          if (request.method === 'GET') return { status: 200, body: { data: [{ id: DO_MODEL }] } };
+          if (request.method === 'GET') {
+            return { status: 200, body: { name: `models/${GEMINI_MODEL}` } };
+          }
           return {
             status: 200,
             body: {
-              choices: [{ message: { content: JSON.stringify({ results: outputs }) } }],
-              usage: { prompt_tokens: 400, completion_tokens: 200 },
+              candidates: [
+                {
+                  finishReason: 'STOP',
+                  content: { parts: [{ text: JSON.stringify({ results: outputs }) }] },
+                },
+              ],
+              usageMetadata: {
+                promptTokenCount: 400,
+                candidatesTokenCount: 200,
+                totalTokenCount: 600,
+              },
             },
           };
         },
       };
-      const client = new DigitalOceanExperimentClient(transport);
+      const client = new GeminiExperimentClient(transport);
       await client.assertModelAvailable();
-      const result = await client.complete(buildDoRequest(cases, 'restore'), cases, 'restore');
+      const result = await client.complete(buildGeminiRequest(cases, 'restore'), cases, 'restore');
       expect(result.outputs).to.deep.equal(outputs);
-      expect(result.usage).to.deep.equal({ promptTokens: 400, completionTokens: 200 });
-      expect(requests[0].url).to.equal(`${DO_ENDPOINT}/v1/models`);
-      expect(requests[1].url).to.equal(`${DO_ENDPOINT}/v1/chat/completions`);
-      expect(JSON.parse(requests[1].body!).model).to.equal(DO_MODEL);
+      expect(result.usage).to.deep.equal({
+        promptTokens: 400,
+        completionTokens: 200,
+        thoughtTokens: 0,
+        totalTokens: 600,
+      });
+      expect(requests[0].url).to.equal(`${GEMINI_ENDPOINT}/models/${GEMINI_MODEL}`);
+      expect(requests[1].url).to.equal(`${GEMINI_ENDPOINT}/models/${GEMINI_MODEL}:generateContent`);
+      const body = JSON.parse(requests[1].body!);
+      expect(body.generationConfig.thinkingConfig).to.deep.equal({ thinkingBudget: 0 });
     });
 
-    it('captures a raw DO response before failing closed on missing usage', async () => {
+    it('captures a raw Gemini response before failing closed on missing usage', async () => {
       const raw = {
-        choices: [{ message: { content: JSON.stringify({ results: resolvedOutputs(false) }) } }],
+        candidates: [
+          {
+            finishReason: 'STOP',
+            content: { parts: [{ text: JSON.stringify({ results: resolvedOutputs(false) }) }] },
+          },
+        ],
       };
       const transport: HttpTransport = {
         async send() {
@@ -168,9 +199,9 @@ describe('diacritic A/B experiment', () => {
         },
       };
       let captured: unknown;
-      const client = new DigitalOceanExperimentClient(transport);
+      const client = new GeminiExperimentClient(transport);
       try {
-        await client.complete(buildDoRequest(cases, 'restore'), cases, 'restore', value => {
+        await client.complete(buildGeminiRequest(cases, 'restore'), cases, 'restore', value => {
           captured = value;
         });
         expect.fail('missing usage should fail');
@@ -180,24 +211,79 @@ describe('diacritic A/B experiment', () => {
       expect(captured).to.equal(raw);
     });
 
-    it('captures a raw DO error body before failing closed on HTTP 402', async () => {
-      const raw = { id: 'payment_required', message: 'Prepayment required' };
+    it('captures a raw Gemini error body before failing closed on HTTP errors', async () => {
+      const raw = { error: { code: 429, message: 'Quota exceeded' } };
       const transport: HttpTransport = {
         async send() {
-          return { status: 402, body: raw };
+          return { status: 429, body: raw };
         },
       };
       let captured: unknown;
-      const client = new DigitalOceanExperimentClient(transport);
+      const client = new GeminiExperimentClient(transport);
       try {
-        await client.complete(buildDoRequest(cases, 'restore'), cases, 'restore', value => {
+        await client.complete(buildGeminiRequest(cases, 'restore'), cases, 'restore', value => {
           captured = value;
         });
-        expect.fail('HTTP 402 should fail');
+        expect.fail('HTTP 429 should fail');
       } catch (error) {
-        expect((error as Error).message).to.contain('HTTP 402');
+        expect((error as Error).message).to.contain('HTTP 429');
       }
       expect(captured).to.equal(raw);
+    });
+
+    it('fails closed on blocked or truncated Gemini candidates', async () => {
+      for (const body of [
+        { promptFeedback: { blockReason: 'SAFETY' } },
+        {
+          candidates: [
+            {
+              finishReason: 'MAX_TOKENS',
+              content: { parts: [{ text: JSON.stringify({ results: resolvedOutputs(false) }) }] },
+            },
+          ],
+        },
+      ]) {
+        const client = new GeminiExperimentClient({
+          async send() {
+            return { status: 200, body };
+          },
+        });
+        try {
+          await client.complete(buildGeminiRequest(cases, 'restore'), cases, 'restore');
+          expect.fail('blocked or truncated output should fail');
+        } catch (error) {
+          expect((error as Error).message).to.match(/blocked|did not finish normally/);
+        }
+      }
+    });
+
+    it('puts the Gemini key only in the API-key header', async () => {
+      const originalFetch = global.fetch;
+      let observedUrl: string | undefined;
+      let observedHeaders: Record<string, string> | undefined;
+      global.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        observedUrl = String(input);
+        observedHeaders = init?.headers as Record<string, string>;
+        return {
+          status: 200,
+          async text() {
+            return '{}';
+          },
+        } as Response;
+      }) as typeof fetch;
+      try {
+        await createGeminiFetchTransport('test-secret').send({
+          url: `${GEMINI_ENDPOINT}/models/${GEMINI_MODEL}`,
+          method: 'GET',
+          headers: {},
+          timeoutMs: 100,
+        });
+      } finally {
+        global.fetch = originalFetch;
+      }
+      expect(observedUrl).not.to.contain('test-secret');
+      expect(observedHeaders).to.deep.equal({ 'x-goog-api-key': 'test-secret' });
+      expect(observedHeaders).not.to.have.property('authorization');
     });
 
     it('rejects missing, duplicate, unknown, and extra output IDs', () => {
@@ -227,51 +313,26 @@ describe('diacritic A/B experiment', () => {
       expect(() => store.createReservation({ state: 'reserved' })).to.throw('already exists');
     });
 
-    it('accepts only the exact reviewed 402 continuation artifacts once', () => {
-      directory = fs.mkdtempSync(path.join(os.tmpdir(), 'diacritic-resume-'));
-      const store = new ArtifactStore(directory);
-      const fixtureHash = sha256(
-        fs.readFileSync('app/api/experiments/fixtures/vi-diacritic-cases.json')
-      );
-      const sourceCharacters = cases.reduce((sum, item) => sum + item.asciiInput.length, 0);
-      const googleAuto: ArmResult = {
-        arm: 'google-auto',
-        outputs: resolvedOutputs(true).map(({ restoredVi: _restoredVi, ...output }) => output),
-        googleSourceCharacters: sourceCharacters,
-      };
-      const googleVi: ArmResult = {
-        arm: 'google-vi',
-        outputs: resolvedOutputs(true).map(({ restoredVi: _restoredVi, ...output }) => output),
-        googleSourceCharacters: sourceCharacters,
-      };
-      store.writeJson('reservation.json', {
-        state: 'failed',
-        failure: 'DO completion request failed with HTTP 402',
-        calls: { digitalOcean: 2, google: 3 },
-        manifestFixtureSha256: fixtureHash,
-      });
-      store.writeJson('results.json', {
-        partial: true,
-        arms: [googleAuto, googleVi],
-        operationalFailure: {
-          arm: 'llm-end-to-end',
-          message: 'DO completion request failed with HTTP 402',
-        },
-      });
-      store.writeJson('responses/google-auto.json', { data: {} });
-      store.writeJson('responses/google-vi.json', { data: {} });
+    it('uses a distinct Gemini v2 identity rather than a continuation mode', () => {
+      expect(() => parseCli(['--resume-reviewed-402'], 'development')).to.throw('Unknown argument');
+      const { manifest } = makeManifest(process.cwd(), cases);
+      expect(manifest.experiment).to.equal(EXPERIMENT_REVISION);
+      expect(manifest.provider.gemini.model).to.equal(GEMINI_MODEL);
+      expect(manifest.identities.llmEndToEnd).to.be.a('string').with.length(64);
+      expect(manifest.reservation.maximumUsd).to.equal(0.0167936);
+    });
 
-      expect(loadReviewed402Continuation(store, cases, fixtureHash).results).to.deep.equal([
-        googleAuto,
-        googleVi,
-      ]);
-      store.writeJson('reservation.json', {
-        ...(store.read('reservation.json') as Record<string, unknown>),
-        resume: { authorizedAt: new Date().toISOString() },
-      });
-      expect(() => loadReviewed402Continuation(store, cases, fixtureHash)).to.throw(
-        'single reviewed HTTP 402 state'
+    it('rejects live execution in tests and requires the exact acknowledgement', () => {
+      expect(() => parseCli(['--execute'], 'development')).to.throw('exact acknowledgement');
+      expect(() => parseCli(['--ack-max-usd=0.02'], 'development')).to.throw(
+        'valid only with --execute'
       );
+      expect(() => parseCli(['--execute', '--ack-max-usd=0.02'], 'test')).to.throw(
+        'disabled when NODE_ENV=test'
+      );
+      expect(parseCli(['--execute', '--ack-max-usd=0.02'], 'development')).to.deep.equal({
+        mode: 'execute',
+      });
     });
 
     it('computes mechanical measures/cost and emits a blinded review mapping', () => {
@@ -281,12 +342,12 @@ describe('diacritic A/B experiment', () => {
         {
           arm: 'llm-end-to-end',
           outputs: resolvedOutputs(true),
-          usage: { promptTokens: 100, completionTokens: 50 },
+          usage: { promptTokens: 100, completionTokens: 50, thoughtTokens: 0, totalTokens: 150 },
         },
         {
           arm: 'restore-google',
           outputs: resolvedOutputs(true),
-          usage: { promptTokens: 100, completionTokens: 50 },
+          usage: { promptTokens: 100, completionTokens: 50, thoughtTokens: 0, totalTokens: 150 },
           googleSourceCharacters: 130,
         },
       ];

--- a/__tests__/api/experiments/diacritic-ab.test.ts
+++ b/__tests__/api/experiments/diacritic-ab.test.ts
@@ -6,6 +6,7 @@ import { ArtifactStore } from '../../../app/api/experiments/diacritic-ab/artifac
 import {
   assertGeminiRequestWithinCap,
   assertGoogleCharacters,
+  calculateAccessCheckMaximumCost,
   calculateMaximumCost,
   fullReservation,
 } from '../../../app/api/experiments/diacritic-ab/caps';
@@ -74,14 +75,15 @@ describe('diacritic A/B experiment', () => {
 
   describe('caps', () => {
     it('calculates the acknowledged worst case exactly', () => {
-      expect(calculateMaximumCost()).to.equal(0.0167936);
+      expect(calculateMaximumCost()).to.equal(0.019712);
+      expect(calculateAccessCheckMaximumCost()).to.equal(0.0000055);
       expect(fullReservation()).to.deep.include({
         geminiCalls: 2,
         googleCalls: 3,
         geminiInputTokens: 8192,
         geminiOutputTokens: 1536,
         googleSourceCharacters: 768,
-        maximumUsd: 0.0167936,
+        maximumUsd: 0.019712,
       });
     });
 
@@ -101,7 +103,7 @@ describe('diacritic A/B experiment', () => {
         expect(request.generationConfig.temperature).to.equal(0);
         expect(request.generationConfig.candidateCount).to.equal(1);
         expect(request.generationConfig.maxOutputTokens).to.equal(768);
-        expect(request.generationConfig.thinkingConfig.thinkingBudget).to.equal(0);
+        expect(request.generationConfig.thinkingConfig.thinkingLevel).to.equal('minimal');
         expect(request.generationConfig.responseMimeType).to.equal('application/json');
         expect(request.generationConfig.responseJsonSchema).to.be.an('object');
         expect(request).not.to.have.property('tools');
@@ -147,8 +149,18 @@ describe('diacritic A/B experiment', () => {
       const transport: HttpTransport = {
         async send(request) {
           requests.push(request);
-          if (request.method === 'GET') {
-            return { status: 200, body: { name: `models/${GEMINI_MODEL}` } };
+          if (requests.length === 1) {
+            return {
+              status: 200,
+              body: {
+                candidates: [{ finishReason: 'MAX_TOKENS', content: { parts: [{ text: 'K' }] } }],
+                usageMetadata: {
+                  promptTokenCount: 4,
+                  candidatesTokenCount: 1,
+                  totalTokenCount: 5,
+                },
+              },
+            };
           }
           return {
             status: 200,
@@ -169,7 +181,13 @@ describe('diacritic A/B experiment', () => {
         },
       };
       const client = new GeminiExperimentClient(transport);
-      await client.assertModelAvailable();
+      const accessUsage = await client.checkGenerationAccess();
+      expect(accessUsage).to.deep.equal({
+        promptTokens: 4,
+        completionTokens: 1,
+        thoughtTokens: 0,
+        totalTokens: 5,
+      });
       const result = await client.complete(buildGeminiRequest(cases, 'restore'), cases, 'restore');
       expect(result.outputs).to.deep.equal(outputs);
       expect(result.usage).to.deep.equal({
@@ -178,10 +196,28 @@ describe('diacritic A/B experiment', () => {
         thoughtTokens: 0,
         totalTokens: 600,
       });
-      expect(requests[0].url).to.equal(`${GEMINI_ENDPOINT}/models/${GEMINI_MODEL}`);
+      expect(requests[0].url).to.equal(`${GEMINI_ENDPOINT}/models/${GEMINI_MODEL}:generateContent`);
+      expect(requests[0].method).to.equal('POST');
       expect(requests[1].url).to.equal(`${GEMINI_ENDPOINT}/models/${GEMINI_MODEL}:generateContent`);
       const body = JSON.parse(requests[1].body!);
-      expect(body.generationConfig.thinkingConfig).to.deep.equal({ thinkingBudget: 0 });
+      expect(body.generationConfig.thinkingConfig).to.deep.equal({ thinkingLevel: 'minimal' });
+    });
+
+    it('accepts a successful access check without usage and retains the caller reservation', async () => {
+      const transport: HttpTransport = {
+        async send() {
+          return {
+            status: 200,
+            body: {
+              candidates: [
+                { finishReason: 'MAX_TOKENS', content: { parts: [{ text: 'K' }] } },
+              ],
+            },
+          };
+        },
+      };
+      const client = new GeminiExperimentClient(transport);
+      expect(await client.checkGenerationAccess()).to.equal(undefined);
     });
 
     it('captures a raw Gemini response before failing closed on missing usage', async () => {
@@ -227,6 +263,7 @@ describe('diacritic A/B experiment', () => {
         expect.fail('HTTP 429 should fail');
       } catch (error) {
         expect((error as Error).message).to.contain('HTTP 429');
+        expect((error as Error).message).to.contain('Quota exceeded');
       }
       expect(captured).to.equal(raw);
     });
@@ -273,7 +310,7 @@ describe('diacritic A/B experiment', () => {
       }) as typeof fetch;
       try {
         await createGeminiFetchTransport('test-secret').send({
-          url: `${GEMINI_ENDPOINT}/models/${GEMINI_MODEL}`,
+          url: `${GEMINI_ENDPOINT}/models/${GEMINI_MODEL}:generateContent`,
           method: 'GET',
           headers: {},
           timeoutMs: 100,
@@ -313,13 +350,14 @@ describe('diacritic A/B experiment', () => {
       expect(() => store.createReservation({ state: 'reserved' })).to.throw('already exists');
     });
 
-    it('uses a distinct Gemini v2 identity rather than a continuation mode', () => {
+    it('uses a distinct Gemini 3.1 v3 identity rather than a continuation mode', () => {
       expect(() => parseCli(['--resume-reviewed-402'], 'development')).to.throw('Unknown argument');
       const { manifest } = makeManifest(process.cwd(), cases);
       expect(manifest.experiment).to.equal(EXPERIMENT_REVISION);
       expect(manifest.provider.gemini.model).to.equal(GEMINI_MODEL);
       expect(manifest.identities.llmEndToEnd).to.be.a('string').with.length(64);
-      expect(manifest.reservation.maximumUsd).to.equal(0.0167936);
+      expect(manifest.reservation.maximumUsd).to.equal(0.019712);
+      expect(manifest.accessCheckMaximumUsd).to.equal(0.0000055);
     });
 
     it('rejects live execution in tests and requires the exact acknowledgement', () => {
@@ -328,8 +366,28 @@ describe('diacritic A/B experiment', () => {
         'valid only with --execute'
       );
       expect(() => parseCli(['--execute', '--ack-max-usd=0.02'], 'test')).to.throw(
-        'disabled when NODE_ENV=test'
+        'network access is disabled when NODE_ENV=test'
       );
+      expect(() =>
+        parseCli(['--check-gemini-access', '--ack-access-check-usd=0.0000055'], 'test')
+      ).to.throw('network access is disabled when NODE_ENV=test');
+      expect(() =>
+        parseCli(
+          [
+            '--execute',
+            '--check-gemini-access',
+            '--ack-max-usd=0.02',
+            '--ack-access-check-usd=0.0000055',
+          ],
+          'development'
+        )
+      ).to.throw('mutually exclusive');
+      expect(() => parseCli(['--check-gemini-access'], 'development')).to.throw(
+        'exact acknowledgement'
+      );
+      expect(
+        parseCli(['--check-gemini-access', '--ack-access-check-usd=0.0000055'], 'development')
+      ).to.deep.equal({ mode: 'check-gemini-access' });
       expect(parseCli(['--execute', '--ack-max-usd=0.02'], 'development')).to.deep.equal({
         mode: 'execute',
       });

--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -968,6 +968,10 @@ describe('Search (blueprintsearch)', function () {
     // translating declared-Vietnamese titles that Google handles today.
     it('still uses Google when the Vietnamese gate is switched off', async function () {
       process.env.GEMINI_VI_TITLE_TRANSLATION_ENABLED = 'false';
+      // Stated rather than inherited from the fake's default: this test is
+      // about the gate being bypassed, so the provider's verdict must not be
+      // the variable.
+      fake.detectedSourceLang = 'vi';
       const doc = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
         name: 'Dien phan full',
         data: bpData(['Electrolyzer']),
@@ -979,6 +983,25 @@ describe('Search (blueprintsearch)', function () {
       expect(fake.calls).to.have.length(1);
       expect(fields.origin).to.equal('machine');
       expect(fields.titleOriginal).to.equal('Dien phan full');
+    });
+
+    // Bypassing the gate must not bypass the guard behind it: with our own
+    // detector silent, an English verdict from the provider is the only
+    // evidence there is, and it means leave the title alone.
+    it('keeps the row authored when the gate is off and Google reports English', async function () {
+      process.env.GEMINI_VI_TITLE_TRANSLATION_ENABLED = 'false';
+      fake.detectedSourceLang = 'en';
+      const doc = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Dien phan full',
+        data: bpData(['Electrolyzer']),
+      });
+
+      const fields = await deriveSearchRowWithTranslation(doc, null, 'vi');
+
+      expect(viCalls).to.have.length(0);
+      expect(fake.calls).to.have.length(1);
+      expect(fields.origin).to.equal('authored');
+      expect(fields.title).to.equal('Dien phan full');
     });
 
     it('does not act on a declaration of English', async function () {

--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -24,6 +24,8 @@ import { TranslationUnitModel } from '../../app/api/models/translation-unit';
 import { TranslationBudgetModel } from '../../app/api/models/translation-budget';
 import { SearchQueryModel } from '../../app/api/models/search-query';
 import { FakeTranslationProvider } from '../helpers/fake-translation-provider';
+import { VietnameseTitleTranslationService } from '../../app/api/services/vietnamese-title-translation-service';
+import { VietnameseTitleProvider } from '../../app/api/services/gemini-vietnamese-title-provider';
 
 // Search over blueprintsearch rows (spec/multilingual-search-plan.md Phases
 // 0-1): derivation, retrieval/fusion/ranking, and the getblueprints
@@ -501,7 +503,8 @@ describe('Search (blueprintsearch)', function () {
       // returned — an English query finds a blueprint titled in Vietnamese.
       const englishProvider: TranslationProvider = {
         isConfigured: () => true,
-        translate: async texts => texts.map(() => ({ text: 'Water Filter Farm', detectedSourceLang: 'vi' })),
+        translate: async texts =>
+          texts.map(() => ({ text: 'Water Filter Farm', detectedSourceLang: 'vi' })),
       };
       TranslationService.setInstanceForTest(new TranslationService(englishProvider));
 
@@ -582,7 +585,8 @@ describe('Search (blueprintsearch)', function () {
     it('keeps a translated blueprint findable by its authored title', async function () {
       const englishProvider: TranslationProvider = {
         isConfigured: () => true,
-        translate: async texts => texts.map(() => ({ text: 'Strategic cooking', detectedSourceLang: 'pt' })),
+        translate: async texts =>
+          texts.map(() => ({ text: 'Strategic cooking', detectedSourceLang: 'pt' })),
       };
       TranslationService.setInstanceForTest(new TranslationService(englishProvider));
 
@@ -594,7 +598,9 @@ describe('Search (blueprintsearch)', function () {
       const fields = await deriveSearchRowWithTranslation(doc, null);
       await BlueprintSearchModel.model.updateOne(
         { blueprintId: doc._id, lang: 'en' },
-        { $set: { title: fields.title, titleOriginal: fields.titleOriginal, origin: fields.origin } }
+        {
+          $set: { title: fields.title, titleOriginal: fields.titleOriginal, origin: fields.origin },
+        }
       );
 
       const id = (doc._id as Types.ObjectId).toString();
@@ -693,7 +699,11 @@ describe('Search (blueprintsearch)', function () {
         });
         doc.sourceLang = 'pt';
         await upsertSearchRow(doc);
-        expect((await BlueprintSearchModel.model.find({ blueprintId: doc._id }).lean()).map(r => r.lang).sort()).to.deep.equal(['en', 'pt']);
+        expect(
+          (await BlueprintSearchModel.model.find({ blueprintId: doc._id }).lean())
+            .map(r => r.lang)
+            .sort()
+        ).to.deep.equal(['en', 'pt']);
 
         // The title was re-authored in a different language.
         doc.name = 'Máy lọc nước ba';
@@ -711,7 +721,9 @@ describe('Search (blueprintsearch)', function () {
         });
         doc.sourceLang = 'vi';
         await upsertSearchRow(doc);
-        expect((await BlueprintSearchModel.model.find({ blueprintId: doc._id }).lean())).to.have.length(2);
+        expect(
+          await BlueprintSearchModel.model.find({ blueprintId: doc._id }).lean()
+        ).to.have.length(2);
 
         doc.name = 'Now An English Title';
         doc.sourceLang = 'en';
@@ -778,7 +790,9 @@ describe('Search (blueprintsearch)', function () {
         { blueprintId: doc._id, lang: 'en' },
         { $set: { title: 'Water Filter Farm', origin: 'machine', titleOriginal: null } }
       );
-      const enRow = await BlueprintSearchModel.model.findOne({ blueprintId: doc._id, lang: 'en' }).lean();
+      const enRow = await BlueprintSearchModel.model
+        .findOne({ blueprintId: doc._id, lang: 'en' })
+        .lean();
       await BlueprintSearchModel.model.create({
         blueprintId: doc._id,
         lang: 'vi',
@@ -799,7 +813,9 @@ describe('Search (blueprintsearch)', function () {
       const enOnly = (await searchBlueprintIds('máy lọc')).map(String);
       expect(enOnly).to.not.include(id);
 
-      const withViewerLang = (await searchBlueprintIds('máy lọc', { viewerLang: 'vi' })).map(String);
+      const withViewerLang = (await searchBlueprintIds('máy lọc', { viewerLang: 'vi' })).map(
+        String
+      );
       expect(withViewerLang).to.include(id);
     });
 
@@ -830,7 +846,9 @@ describe('Search (blueprintsearch)', function () {
         name: 'Zephyr Crate Bunker',
         data: bpData(['Ladder']),
       });
-      const enRow = await BlueprintSearchModel.model.findOne({ blueprintId: doc._id, lang: 'en' }).lean();
+      const enRow = await BlueprintSearchModel.model
+        .findOne({ blueprintId: doc._id, lang: 'en' })
+        .lean();
       // A native row carrying the SAME text as the pivot — both rows match
       // the same query, the double-counting shape Part 1 §4 warned about.
       await BlueprintSearchModel.model.create({
@@ -860,40 +878,80 @@ describe('Search (blueprintsearch)', function () {
   // title gets translated at save time rather than waiting for the batch pass.
   describe('declared source language (§2.6)', function () {
     let fake: FakeTranslationProvider;
+    let viCalls: string[];
 
     beforeEach(async function () {
       await TranslationUnitModel.model.deleteMany({});
       await TranslationBudgetModel.model.deleteMany({});
       fake = new FakeTranslationProvider();
       TranslationService.setInstanceForTest(new TranslationService(fake));
+      viCalls = [];
+      const viProvider: VietnameseTitleProvider = {
+        translate: async inputs => {
+          viCalls.push(...inputs.map(input => input.text));
+          return {
+            results: inputs.map(input =>
+              input.text === 'Dien phan full'
+                ? {
+                    id: input.id,
+                    status: 'translated' as const,
+                    restoredVi: 'Điện phân full',
+                    english: 'Electrolysis full',
+                    alternatives: [],
+                  }
+                : {
+                    id: input.id,
+                    status: 'not-vietnamese' as const,
+                    restoredVi: '',
+                    english: '',
+                    alternatives: [],
+                  }
+            ),
+            usage: { inputTokens: 100, outputTokens: 20, thoughtTokens: 0, totalTokens: 120 },
+            latencyMs: 1,
+          };
+        },
+      };
+      VietnameseTitleTranslationService.setInstanceForTest(
+        new VietnameseTitleTranslationService(viProvider)
+      );
+      process.env.GEMINI_VI_TITLE_TRANSLATION_ENABLED = 'true';
+      process.env.GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD = '100000';
+      process.env.GEMINI_API_KEY = 'test-only';
     });
 
     afterEach(async function () {
       TranslationService.setInstanceForTest(null);
+      VietnameseTitleTranslationService.setInstanceForTest(null);
+      delete process.env.GEMINI_VI_TITLE_TRANSLATION_ENABLED;
+      delete process.env.GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD;
+      delete process.env.GEMINI_API_KEY;
       await TranslationUnitModel.model.deleteMany({});
       await TranslationBudgetModel.model.deleteMany({});
     });
 
     // The title our own detector cannot place — the whole point.
     it('translates a title the detector cannot place when the author declared a language', async function () {
-      fake.detectedSourceLang = 'vi';
       const doc = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
         name: 'Dien phan full',
         data: bpData(['Electrolyzer']),
       });
 
-      expect(await deriveSearchRowWithTranslation(doc, null)).to.have.property('origin', 'authored');
+      expect(await deriveSearchRowWithTranslation(doc, null)).to.have.property(
+        'origin',
+        'authored'
+      );
 
       const declared = await deriveSearchRowWithTranslation(doc, null, 'vi');
       expect(declared.origin).to.equal('machine');
-      expect(declared.title).to.equal('[en] Dien phan full');
+      expect(declared.title).to.equal('Electrolysis full');
       expect(declared.titleOriginal).to.equal('Dien phan full');
+      expect(viCalls).to.deep.equal(['Dien phan full']);
     });
 
     // The guard that makes a misdeclaration cheap: a Vietnamese-locale author
     // writing an English title comes back reported as English and stays put.
     it('leaves the row authored when the provider says the text was English', async function () {
-      fake.detectedSourceLang = 'en';
       const doc = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
         name: 'Spom v2 base',
         data: bpData(['Electrolyzer']),
@@ -902,6 +960,25 @@ describe('Search (blueprintsearch)', function () {
       const fields = await deriveSearchRowWithTranslation(doc, null, 'vi');
       expect(fields.origin).to.equal('authored');
       expect(fields.title).to.equal('Spom v2 base');
+    });
+
+    // Regression: the gate declining a title and the gate being switched off
+    // both surface as a non-translated outcome, but only the first is a
+    // verdict. Read as one, the default configuration silently stops
+    // translating declared-Vietnamese titles that Google handles today.
+    it('still uses Google when the Vietnamese gate is switched off', async function () {
+      process.env.GEMINI_VI_TITLE_TRANSLATION_ENABLED = 'false';
+      const doc = await TestDbHelper.createTestBlueprint(testData.users.user1._id, {
+        name: 'Dien phan full',
+        data: bpData(['Electrolyzer']),
+      });
+
+      const fields = await deriveSearchRowWithTranslation(doc, null, 'vi');
+
+      expect(viCalls).to.have.length(0);
+      expect(fake.calls).to.have.length(1);
+      expect(fields.origin).to.equal('machine');
+      expect(fields.titleOriginal).to.equal('Dien phan full');
     });
 
     it('does not act on a declaration of English', async function () {
@@ -1091,7 +1168,8 @@ describe('Search (blueprintsearch)', function () {
       // blueprint, not just that some string came back.
       const englishProvider: TranslationProvider = {
         isConfigured: () => true,
-        translate: async texts => texts.map(() => ({ text: 'water filter', detectedSourceLang: 'vi' })),
+        translate: async texts =>
+          texts.map(() => ({ text: 'water filter', detectedSourceLang: 'vi' })),
       };
       TranslationService.setInstanceForTest(new TranslationService(englishProvider));
 
@@ -1134,17 +1212,23 @@ describe('Search (blueprintsearch)', function () {
     it('falls back to an untranslated (empty) search when the monthly budget is exhausted, without throwing', async function () {
       const month = `${new Date().getUTCFullYear()}-${String(new Date().getUTCMonth() + 1).padStart(2, '0')}`;
       process.env.MONTHLY_CHAR_BUDGET = '1';
-      await TranslationBudgetModel.model.create({ month, userId: null, charCount: 999999, requestCount: 1 });
+      await TranslationBudgetModel.model.create({
+        month,
+        userId: null,
+        charCount: 999999,
+        requestCount: 1,
+      });
 
       const ids = await searchBlueprintIds('máy lọc nước');
       expect(ids).to.deep.equal([]);
       expect(fake.calls).to.have.length(0);
     });
 
-    it('a translation spend counts against the searching user\'s daily cap', async function () {
+    it("a translation spend counts against the searching user's daily cap", async function () {
       const englishProvider: TranslationProvider = {
         isConfigured: () => true,
-        translate: async texts => texts.map(() => ({ text: 'water filter', detectedSourceLang: 'vi' })),
+        translate: async texts =>
+          texts.map(() => ({ text: 'water filter', detectedSourceLang: 'vi' })),
       };
       TranslationService.setInstanceForTest(new TranslationService(englishProvider));
 

--- a/__tests__/api/vietnamese-title-translation-service.test.ts
+++ b/__tests__/api/vietnamese-title-translation-service.test.ts
@@ -26,6 +26,7 @@ import {
 import {
   isVietnameseTitleGateActive,
   normalizeRomanizedVietnamese,
+  vietnameseTitleDryRunCaps,
   VietnameseTitleTranslationService,
 } from '../../app/api/services/vietnamese-title-translation-service';
 import {
@@ -360,9 +361,7 @@ describe('VietnameseTitleTranslationService', function () {
     expect(await TranslationUnitModel.model.countDocuments({ mode: 'vi-romanized-title-v1' })).to.equal(8);
   });
 
-  it('rejects malformed caps and invalid input without constructing a call', async function () {
-    process.env.GEMINI_VI_TITLE_MAX_INPUT_TOKENS = '999999';
-    process.env.GEMINI_VI_TITLE_MAX_OUTPUT_TOKENS = 'not-a-number';
+  it('rejects non-ASCII input without constructing a call', async function () {
     try {
       await service.translateOne('Điện phân', null);
       expect.fail('non-ASCII input must fail');
@@ -370,6 +369,25 @@ describe('VietnameseTitleTranslationService', function () {
       expect((error as Error).message).to.contain('non-empty ASCII');
     }
     expect(fake.calls).to.have.length(0);
+  });
+
+  // The documented guarantee is that env vars can LOWER the token caps and
+  // never raise them. The old combined test set these alongside a non-ASCII
+  // input, so it threw on validation before the caps were ever read and this
+  // path went untested.
+  it('clamps out-of-range and malformed token caps to the code-pinned defaults', async function () {
+    process.env.GEMINI_VI_TITLE_MAX_INPUT_TOKENS = '999999';
+    process.env.GEMINI_VI_TITLE_MAX_OUTPUT_TOKENS = 'not-a-number';
+
+    expect(vietnameseTitleDryRunCaps()).to.include({ inputTokens: 4096, outputTokens: 768 });
+
+    const result = await service.translateOne('Dien phan', null);
+    expect(result.status).to.equal('translated');
+    expect(fake.calls).to.have.length(1);
+
+    // Lowering still works — the cap is a ceiling, not a fixed value.
+    process.env.GEMINI_VI_TITLE_MAX_INPUT_TOKENS = '1024';
+    expect(vietnameseTitleDryRunCaps().inputTokens).to.equal(1024);
   });
 
   it('strips Vietnamese marks and d-with-stroke mechanically', function () {

--- a/__tests__/api/vietnamese-title-translation-service.test.ts
+++ b/__tests__/api/vietnamese-title-translation-service.test.ts
@@ -24,6 +24,7 @@ import {
   VietnameseTitleResult,
 } from '../../app/api/services/vietnamese-title-prompts';
 import {
+  isEligibleVietnameseTitleInput,
   isVietnameseTitleGateActive,
   normalizeRomanizedVietnamese,
   vietnameseTitleDryRunCaps,
@@ -693,6 +694,24 @@ describe('GeminiVietnameseTitleProvider', function () {
       expect(message).not.to.contain('Dien phan');
       expect(message.length).to.be.at.most(300);
     }
+  });
+});
+
+// The census in derive-search uses this predicate to keep ineligible titles
+// out of Gemini batches, because validateInputs rejects the WHOLE batch: one
+// non-ASCII title would otherwise take up to 11 eligible ones down with it on
+// every run. The predicate must therefore agree exactly with validateInputs.
+describe('isEligibleVietnameseTitleInput', function () {
+  it('admits exactly what validateInputs admits', function () {
+    expect(isEligibleVietnameseTitleInput('Dien phan full')).to.equal(true);
+    expect(isEligibleVietnameseTitleInput('a'.repeat(60))).to.equal(true);
+    // Non-ASCII in any form: accented, CJK, emoji.
+    expect(isEligibleVietnameseTitleInput('Điện phân')).to.equal(false);
+    expect(isEligibleVietnameseTitleInput('電解 2')).to.equal(false);
+    expect(isEligibleVietnameseTitleInput('SPOM 🔥')).to.equal(false);
+    // Empty and over the title length cap.
+    expect(isEligibleVietnameseTitleInput('')).to.equal(false);
+    expect(isEligibleVietnameseTitleInput('a'.repeat(61))).to.equal(false);
   });
 });
 

--- a/__tests__/api/vietnamese-title-translation-service.test.ts
+++ b/__tests__/api/vietnamese-title-translation-service.test.ts
@@ -15,6 +15,7 @@ import {
   GeminiVietnameseTitleTransport,
   VietnameseTitleProvider,
   createGeminiVietnameseTitleTransport,
+  isUnrecoverableProviderError,
 } from '../../app/api/services/gemini-vietnamese-title-provider';
 import {
   GEMINI_VI_TITLE_ENDPOINT,
@@ -233,6 +234,43 @@ describe('VietnameseTitleTranslationService', function () {
   // declined it and when it is simply switched off. Callers branch on that
   // difference to decide whether the Google pass behind the gate should still
   // run, so each of the three switches must be visible from the outside.
+  // A rate limit or a bad key is trivially identifiable but not recoverable
+  // without a human. Since budget is reserved BEFORE each provider call, a
+  // caller that treats these as per-batch hiccups and moves on spends the
+  // whole monthly allowance on failures — so they must be distinguishable
+  // from an ordinary one-batch error.
+  it('marks auth and rate-limit failures as needing action, not a retry', async function () {
+    const statuses = [401, 403, 429, 500, 400];
+    const seen: Array<{ status: number; unrecoverable: boolean }> = [];
+
+    for (const status of statuses) {
+      const transport: GeminiVietnameseTitleTransport = {
+        send: async () => ({
+          status,
+          body: { error: { message: `boom ${status}` } },
+        }),
+      };
+      try {
+        await new GeminiVietnameseTitleProvider(transport, 'k').translate([
+          { id: 'a', text: 'Dien phan' },
+        ]);
+        expect.fail(`expected HTTP ${status} to throw`);
+      } catch (error) {
+        expect((error as { status?: number }).status).to.equal(status);
+        seen.push({ status, unrecoverable: isUnrecoverableProviderError(error) });
+      }
+    }
+
+    expect(seen).to.deep.equal([
+      { status: 401, unrecoverable: true },
+      { status: 403, unrecoverable: true },
+      { status: 429, unrecoverable: true },
+      // Transient: one batch is skipped, the pass continues.
+      { status: 500, unrecoverable: false },
+      { status: 400, unrecoverable: false },
+    ]);
+  });
+
   it('reports the gate inactive for each switch that stops it spending', function () {
     expect(isVietnameseTitleGateActive()).to.equal(true);
 
@@ -246,6 +284,59 @@ describe('VietnameseTitleTranslationService', function () {
 
     process.env.GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD = '0';
     expect(isVietnameseTitleGateActive()).to.equal(false);
+  });
+
+  // Regression: staging and production share ONE database, so every migration
+  // is run at least twice over the same data and the second run must be a
+  // no-op, not an error. The first failure was real — Mongoose's autoIndex had
+  // already built the widened key under its own generated name, and the
+  // migration insisted on a different one:
+  //   "Index already exists with a different name:
+  //    textHash_1_sourceLang_1_targetLang_1_mode_1"
+  it('converges whether autoIndex or the migration builds the key first', async function () {
+    // The name Mongo generates for the widened key — what the schema's
+    // unnamed index and the migration must both end up agreeing on.
+    const AUTO_INDEX_NAME = 'textHash_1_sourceLang_1_targetLang_1_mode_1';
+    const collection = mongoose.connection.db!.collection('translationunits');
+    const keyOf = async () =>
+      (await collection.indexes()).find(
+        index =>
+          JSON.stringify(index.key) ===
+          JSON.stringify({ textHash: 1, sourceLang: 1, targetLang: 1, mode: 1 })
+      );
+
+    // Stand the collection up the way a running app does: autoIndex first.
+    await collection.dropIndexes();
+    await collection.createIndex(
+      { textHash: 1, sourceLang: 1, targetLang: 1, mode: 1 },
+      { unique: true }
+    );
+
+    await translationUnitModeMigration.up(mongoose.connection.db);
+    expect((await keyOf())!.name).to.equal(AUTO_INDEX_NAME);
+
+    // A legacy hand-picked name for the same keys is adopted too, not
+    // duplicated — the state a partially-fixed database can be left in.
+    await collection.dropIndexes();
+    await collection.createIndex(
+      { textHash: 1, sourceLang: 1, targetLang: 1, mode: 1 },
+      { unique: true, name: 'translation_unit_mode_key' }
+    );
+    await translationUnitModeMigration.up(mongoose.connection.db);
+    expect((await keyOf())!.name).to.equal(AUTO_INDEX_NAME);
+
+    // The second environment's deploy, over the same database.
+    await translationUnitModeMigration.up(mongoose.connection.db);
+    const settled = await keyOf();
+    expect(settled!.name).to.equal(AUTO_INDEX_NAME);
+    expect(settled!.unique).to.equal(true);
+
+    // And down/up must survive the same double-run.
+    await translationUnitModeMigration.down(mongoose.connection.db);
+    await translationUnitModeMigration.down(mongoose.connection.db);
+    expect(await keyOf()).to.equal(undefined);
+    await translationUnitModeMigration.up(mongoose.connection.db);
+    expect((await keyOf())!.name).to.equal(AUTO_INDEX_NAME);
   });
 
   it('reproduces the reviewed A/B verdicts on the full experiment fixture', async function () {
@@ -325,14 +416,16 @@ describe('VietnameseTitleTranslationService', function () {
     await translationUnitModeMigration.up(db);
 
     expect(await collection.countDocuments({ mode: 'standard' })).to.equal(2);
+    // Located by KEY PATTERN, not by name: the key is the invariant the
+    // collection depends on, and pinning a name here is what let the name
+    // itself drift out of step with the schema's autoIndex.
     const migratedIndexes = await collection.indexes();
-    const migratedIndex = migratedIndexes.find(index => index.name === 'translation_unit_mode_key');
-    expect(migratedIndex!.key).to.deep.equal({
-      textHash: 1,
-      sourceLang: 1,
-      targetLang: 1,
-      mode: 1,
-    });
+    const migratedIndex = migratedIndexes.find(
+      index =>
+        JSON.stringify(index.key) ===
+        JSON.stringify({ textHash: 1, sourceLang: 1, targetLang: 1, mode: 1 })
+    );
+    expect(migratedIndex, 'mode-aware unique index').to.not.equal(undefined);
     expect(migratedIndex!.unique).to.equal(true);
     await collection.insertOne({
       textHash: 'legacy-human',

--- a/__tests__/api/vietnamese-title-translation-service.test.ts
+++ b/__tests__/api/vietnamese-title-translation-service.test.ts
@@ -1,0 +1,590 @@
+import { afterEach, beforeEach, describe, it } from 'mocha';
+import { expect } from 'chai';
+import dotenv from 'dotenv';
+import path from 'path';
+import mongoose from 'mongoose';
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env.test') });
+process.env.NODE_ENV = 'test';
+
+import { TestSetup } from '../setup/testSetup';
+import { TranslationUnitModel } from '../../app/api/models/translation-unit';
+import { TranslationBudgetModel } from '../../app/api/models/translation-budget';
+import {
+  GeminiVietnameseTitleProvider,
+  GeminiVietnameseTitleTransport,
+  VietnameseTitleProvider,
+  createGeminiVietnameseTitleTransport,
+} from '../../app/api/services/gemini-vietnamese-title-provider';
+import {
+  GEMINI_VI_TITLE_ENDPOINT,
+  GEMINI_VI_TITLE_MODEL,
+  GEMINI_VI_TITLE_PROMPT_VERSION,
+  VietnameseTitleResult,
+} from '../../app/api/services/vietnamese-title-prompts';
+import {
+  isVietnameseTitleGateActive,
+  normalizeRomanizedVietnamese,
+  VietnameseTitleTranslationService,
+} from '../../app/api/services/vietnamese-title-translation-service';
+import {
+  hashSourceText,
+  TranslationBudgetExceeded,
+} from '../../app/api/services/translation-service';
+import { batchVietnameseCandidates } from '../../app/api/batch/derive-search';
+
+const translationUnitModeMigration = require('../../migrations/20260805000000_translation-unit-modes.js');
+
+class FakeVietnameseTitleProvider implements VietnameseTitleProvider {
+  public calls: string[][] = [];
+  public status: VietnameseTitleResult['status'] = 'translated';
+  public restoredVi = 'Điện phân';
+  public english = 'Electrolysis';
+  public delayMs = 0;
+
+  async translate(inputs: Array<{ id: string; text: string }>) {
+    this.calls.push(inputs.map(input => input.text));
+    if (this.delayMs) await new Promise(resolve => setTimeout(resolve, this.delayMs));
+    return {
+      results: inputs.map(input => ({
+        id: input.id,
+        status: this.status,
+        restoredVi: this.restoredVi,
+        english: this.english,
+        alternatives: [],
+      })),
+      usage: { inputTokens: 100, outputTokens: 20, thoughtTokens: 0, totalTokens: 120 },
+      latencyMs: 1,
+    };
+  }
+}
+
+// Replays one scripted result per input, so a fixture can drive the accept
+// gate case by case rather than one verdict for the whole batch.
+class ScriptedVietnameseTitleProvider implements VietnameseTitleProvider {
+  public constructor(private readonly script: Map<string, Omit<VietnameseTitleResult, 'id'>>) {}
+
+  async translate(inputs: Array<{ id: string; text: string }>) {
+    return {
+      results: inputs.map(input => ({ id: input.id, ...this.script.get(input.text)! })),
+      usage: { inputTokens: 100, outputTokens: 20, thoughtTokens: 0, totalTokens: 120 },
+      latencyMs: 1,
+    };
+  }
+}
+
+// The exact arm-B ("llm-end-to-end") outputs of the blinded A/B experiment,
+// tmp/llm-diacritic-ab-gemini-3-1 — the run this gate's design was chosen on.
+// Pinned here because the review that cleared it for production reviewed THESE
+// strings: if the gate's accept rules ever drift, the drift shows up as a
+// disagreement with the reviewed verdicts rather than silently in prod.
+const AB_EXPERIMENT_ARM_B: Array<[string, Omit<VietnameseTitleResult, 'id'>, string | null]> = [
+  ['Dien phan', r('Điện phân', 'Electrolysis'), 'Electrolysis'],
+  ['Dien phan 2', r('Điện phân 2', 'Electrolysis 2'), 'Electrolysis 2'],
+  ['Dien phan nuoc', r('Điện phân nước', 'Water electrolysis'), 'Water electrolysis'],
+  ['Loc nuoc ban', r('Lọc nước bẩn', 'Polluted water filtration'), 'Polluted water filtration'],
+  ['Bom khi tu dong', r('Bơm khí tự động', 'Automatic gas pump'), 'Automatic gas pump'],
+  ['Kho chua khi 2', r('Kho chứa khí 2', 'Gas storage 2'), 'Gas storage 2'],
+  ['SPOM tao oxy', r('SPOM tạo oxy', 'Oxygen generating SPOM'), 'Oxygen generating SPOM'],
+  ['Lam mat bang dien', r('Làm mát bằng điện', 'Electric cooling'), 'Electric cooling'],
+  // Genuinely ambiguous without diacritics: the model declined, so does the gate.
+  ['ma', { status: 'ambiguous', restoredVi: 'mã', english: 'code', alternatives: [] }, null],
+  ['khi', { status: 'ambiguous', restoredVi: 'khí', english: 'gas', alternatives: [] }, null],
+  // English controls: a faithful echo is not a translation, so it is refused
+  // rather than rewriting an author's title with itself.
+  ['SPOM v3', r('SPOM v3', 'SPOM v3'), null],
+  ['Main base', r('Main base', 'Main base'), null],
+];
+
+function r(restoredVi: string, english: string): Omit<VietnameseTitleResult, 'id'> {
+  return { status: 'translated', restoredVi, english, alternatives: [] };
+}
+
+describe('VietnameseTitleTranslationService', function () {
+  let fake: FakeVietnameseTitleProvider;
+  let service: VietnameseTitleTranslationService;
+
+  beforeEach(async function () {
+    this.timeout(10000);
+    await TestSetup.beforeEach();
+    await TranslationUnitModel.model.deleteMany({});
+    await TranslationBudgetModel.model.deleteMany({});
+    process.env.GEMINI_VI_TITLE_TRANSLATION_ENABLED = 'true';
+    process.env.GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD = '100000';
+    process.env.GEMINI_API_KEY = 'test-secret';
+    fake = new FakeVietnameseTitleProvider();
+    service = new VietnameseTitleTranslationService(fake);
+  });
+
+  afterEach(async function () {
+    delete process.env.GEMINI_VI_TITLE_TRANSLATION_ENABLED;
+    delete process.env.GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD;
+    delete process.env.GEMINI_VI_TITLE_MAX_INPUT_TOKENS;
+    delete process.env.GEMINI_VI_TITLE_MAX_OUTPUT_TOKENS;
+    delete process.env.GEMINI_API_KEY;
+    await TranslationUnitModel.model.deleteMany({});
+    await TranslationBudgetModel.model.deleteMany({});
+    await TestSetup.afterEach();
+  });
+
+  it('accepts exact mechanical restoration, stores provenance, and reuses its own cache', async function () {
+    const first = await service.translateOne('Dien phan', null);
+    const second = await service.translateOne('Dien phan', null);
+
+    expect(first).to.include({
+      status: 'translated',
+      translatedText: 'Electrolysis',
+      cached: false,
+    });
+    expect(second).to.include({
+      status: 'translated',
+      translatedText: 'Electrolysis',
+      cached: true,
+    });
+    expect(fake.calls).to.have.length(1);
+    const row = await TranslationUnitModel.model.findOne({
+      textHash: hashSourceText('Dien phan'),
+      mode: 'vi-romanized-title-v1',
+    });
+    expect(row).to.include({
+      sourceLang: 'vi',
+      targetLang: 'en',
+      provider: GEMINI_VI_TITLE_MODEL,
+      promptVersion: GEMINI_VI_TITLE_PROMPT_VERSION,
+      restoredSourceText: 'Điện phân',
+      inputTokens: 100,
+      outputTokens: 20,
+    });
+  });
+
+  it('does not cache ambiguous, negative, inconsistent, unchanged, or marker-losing results', async function () {
+    for (const testCase of [
+      { status: 'ambiguous' as const, restored: 'Điện phân', english: '' },
+      { status: 'not-vietnamese' as const, restored: '', english: '' },
+      { status: 'translated' as const, restored: 'Sai', english: 'Wrong' },
+      { status: 'translated' as const, restored: 'Điện phân', english: 'Dien phan' },
+      { status: 'translated' as const, restored: 'Điện phân', english: 'Dien phan!' },
+    ]) {
+      fake.status = testCase.status;
+      fake.restoredVi = testCase.restored;
+      fake.english = testCase.english;
+      const result = await service.translateOne('Dien phan', null);
+      expect(result.status).not.to.equal('translated');
+    }
+    fake.status = 'translated';
+    fake.restoredVi = 'Điện phân v2';
+    fake.english = 'Electrolysis 2';
+    expect((await service.translateOne('Dien phan v2', null)).status).to.equal('invalid');
+    expect(await TranslationUnitModel.model.countDocuments({})).to.equal(0);
+  });
+
+  it('keeps standard Google rows separate and serves Gemini cache after the kill switch is off', async function () {
+    await TranslationUnitModel.model.create({
+      textHash: hashSourceText('Dien phan'),
+      sourceLang: 'vi',
+      targetLang: 'en',
+      mode: 'standard',
+      detectedSourceLang: 'vi',
+      translatedText: 'Bad legacy output',
+      provider: 'google-v2',
+      charCount: 9,
+    });
+    await service.translateOne('Dien phan', null);
+    process.env.GEMINI_VI_TITLE_TRANSLATION_ENABLED = 'false';
+    process.env.GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD = '0';
+
+    const cached = await service.translateOne('Dien phan', null);
+    expect(cached).to.include({ translatedText: 'Electrolysis', cached: true });
+    expect(await TranslationUnitModel.model.countDocuments({})).to.equal(2);
+  });
+
+  it('reserves the maximum before dispatch and pessimistically retains it on provider failure', async function () {
+    const failing: VietnameseTitleProvider = {
+      translate: async () => {
+        throw new Error('provider failed');
+      },
+    };
+    const failingService = new VietnameseTitleTranslationService(failing);
+    try {
+      await failingService.translateOne('Dien phan', null);
+      expect.fail('expected provider failure');
+    } catch (error) {
+      expect((error as Error).message).to.equal('provider failed');
+    }
+    const row = await TranslationBudgetModel.model.findOne({ userId: null });
+    expect(row!.geminiReservedMicroUsd).to.equal(2176);
+    expect(row!.geminiObservedMicroUsd).to.equal(0);
+  });
+
+  it('atomically rejects concurrent reservations above the monthly cap', async function () {
+    process.env.GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD = '2176';
+    fake.delayMs = 20;
+    const results = await Promise.allSettled([
+      service.translateOne('Dien phan', null),
+      service.translateOne('Dien phan 2', null),
+    ]);
+    expect(results.filter(result => result.status === 'fulfilled')).to.have.length(1);
+    const rejected = results.find(result => result.status === 'rejected') as PromiseRejectedResult;
+    expect(rejected.reason).to.be.instanceOf(TranslationBudgetExceeded);
+    expect(fake.calls).to.have.length(1);
+  });
+
+  // Regression: the gate reports 'invalid' both when it judged a title and
+  // declined it and when it is simply switched off. Callers branch on that
+  // difference to decide whether the Google pass behind the gate should still
+  // run, so each of the three switches must be visible from the outside.
+  it('reports the gate inactive for each switch that stops it spending', function () {
+    expect(isVietnameseTitleGateActive()).to.equal(true);
+
+    process.env.GEMINI_VI_TITLE_TRANSLATION_ENABLED = 'false';
+    expect(isVietnameseTitleGateActive()).to.equal(false);
+    process.env.GEMINI_VI_TITLE_TRANSLATION_ENABLED = 'true';
+
+    delete process.env.GEMINI_API_KEY;
+    expect(isVietnameseTitleGateActive()).to.equal(false);
+    process.env.GEMINI_API_KEY = 'test-secret';
+
+    process.env.GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD = '0';
+    expect(isVietnameseTitleGateActive()).to.equal(false);
+  });
+
+  it('reproduces the reviewed A/B verdicts on the full experiment fixture', async function () {
+    const script = new Map(AB_EXPERIMENT_ARM_B.map(([text, result]) => [text, result]));
+    const scripted = new VietnameseTitleTranslationService(
+      new ScriptedVietnameseTitleProvider(script)
+    );
+
+    const outcomes = await scripted.translateMany(
+      AB_EXPERIMENT_ARM_B.map(([text], index) => ({ id: `case-${index}`, text })),
+      null
+    );
+
+    const accepted = outcomes.map(outcome =>
+      outcome.status === 'translated' ? (outcome.translatedText ?? null) : null
+    );
+    expect(accepted).to.deep.equal(AB_EXPERIMENT_ARM_B.map(([, , expected]) => expected));
+
+    // Only the accepted eight reach the cache: an ambiguous answer and an
+    // echoed English control both cost a call but must never be persisted.
+    expect(await TranslationUnitModel.model.countDocuments({ mode: 'vi-romanized-title-v1' })).to.equal(8);
+  });
+
+  it('rejects malformed caps and invalid input without constructing a call', async function () {
+    process.env.GEMINI_VI_TITLE_MAX_INPUT_TOKENS = '999999';
+    process.env.GEMINI_VI_TITLE_MAX_OUTPUT_TOKENS = 'not-a-number';
+    try {
+      await service.translateOne('Điện phân', null);
+      expect.fail('non-ASCII input must fail');
+    } catch (error) {
+      expect((error as Error).message).to.contain('non-empty ASCII');
+    }
+    expect(fake.calls).to.have.length(0);
+  });
+
+  it('strips Vietnamese marks and d-with-stroke mechanically', function () {
+    expect(normalizeRomanizedVietnamese('Điện phân nước ĐẦY')).to.equal('Dien phan nuoc DAY');
+  });
+
+  it('migrates legacy Google/human rows to standard mode and installs the mode-aware key', async function () {
+    const db = mongoose.connection.db!;
+    const collection = db.collection('translationunits');
+    const indexes = await collection.indexes();
+    for (const index of indexes) {
+      if (
+        JSON.stringify(index.key) ===
+        JSON.stringify({ textHash: 1, sourceLang: 1, targetLang: 1, mode: 1 })
+      ) {
+        await collection.dropIndex(index.name!);
+      }
+    }
+    await collection.updateMany({}, { $unset: { mode: '' } });
+    await collection.createIndex(
+      { textHash: 1, sourceLang: 1, targetLang: 1 },
+      { unique: true, name: 'legacy_translation_key' }
+    );
+    await collection.insertMany([
+      {
+        textHash: 'legacy-google',
+        sourceLang: 'auto',
+        targetLang: 'en',
+        translatedText: 'Google',
+        provider: 'google-v2',
+        charCount: 1,
+      },
+      {
+        textHash: 'legacy-human',
+        sourceLang: 'vi',
+        targetLang: 'en',
+        translatedText: 'Human',
+        provider: 'human',
+        charCount: 1,
+      },
+    ]);
+
+    await translationUnitModeMigration.up(db);
+    await translationUnitModeMigration.up(db);
+
+    expect(await collection.countDocuments({ mode: 'standard' })).to.equal(2);
+    const migratedIndexes = await collection.indexes();
+    const migratedIndex = migratedIndexes.find(index => index.name === 'translation_unit_mode_key');
+    expect(migratedIndex!.key).to.deep.equal({
+      textHash: 1,
+      sourceLang: 1,
+      targetLang: 1,
+      mode: 1,
+    });
+    expect(migratedIndex!.unique).to.equal(true);
+    await collection.insertOne({
+      textHash: 'legacy-human',
+      sourceLang: 'vi',
+      targetLang: 'en',
+      mode: 'vi-romanized-title-v1',
+      translatedText: 'Gemini',
+      provider: GEMINI_VI_TITLE_MODEL,
+      charCount: 1,
+    });
+    expect(await collection.countDocuments({ textHash: 'legacy-human' })).to.equal(2);
+  });
+});
+
+describe('GeminiVietnameseTitleProvider', function () {
+  it('batches unique corpus candidates by both count and source characters', function () {
+    const candidates = Array.from({ length: 13 }, (_, index) => [
+      `${index}`.padEnd(60, 'x'),
+      [],
+    ]) as Parameters<typeof batchVietnameseCandidates>[0];
+    const batches = batchVietnameseCandidates(candidates);
+    expect(batches.map(batch => batch.length)).to.deep.equal([12, 1]);
+    expect(
+      batches.every(batch => batch.reduce((sum, [title]) => sum + title.length, 0) <= 720)
+    ).to.equal(true);
+  });
+
+  it('pins the model, prompt, schema, settings, header, timeout, and validates usage', async function () {
+    const requests: Array<{
+      url: string;
+      headers: Record<string, string>;
+      body: string;
+      timeoutMs: number;
+    }> = [];
+    const transport: GeminiVietnameseTitleTransport = {
+      async send(request) {
+        requests.push(request);
+        return {
+          status: 200,
+          body: {
+            candidates: [
+              {
+                finishReason: 'STOP',
+                content: {
+                  parts: [
+                    {
+                      text: JSON.stringify({
+                        results: [
+                          {
+                            id: 'a',
+                            status: 'translated',
+                            restoredVi: 'Điện phân',
+                            english: 'Electrolysis',
+                            alternatives: [],
+                          },
+                        ],
+                      }),
+                    },
+                  ],
+                },
+              },
+            ],
+            usageMetadata: {
+              promptTokenCount: 300,
+              candidatesTokenCount: 20,
+              thoughtsTokenCount: 0,
+              totalTokenCount: 320,
+            },
+          },
+        };
+      },
+    };
+    const provider = new GeminiVietnameseTitleProvider(transport, 'test-secret');
+    await provider.translate([{ id: 'a', text: 'Dien phan' }]);
+
+    expect(requests).to.have.length(1);
+    expect(requests[0].url).to.equal(
+      `${GEMINI_VI_TITLE_ENDPOINT}/models/${GEMINI_VI_TITLE_MODEL}:generateContent`
+    );
+    expect(requests[0].headers).to.deep.equal({ 'content-type': 'application/json' });
+    expect(requests[0].timeoutMs).to.equal(15000);
+    const body = JSON.parse(requests[0].body);
+    expect(body.systemInstruction.parts[0].text).to.contain(GEMINI_VI_TITLE_PROMPT_VERSION);
+    expect(body.generationConfig).to.include({
+      temperature: 0,
+      candidateCount: 1,
+      maxOutputTokens: 768,
+      responseMimeType: 'application/json',
+    });
+    expect(body.generationConfig.thinkingConfig).to.deep.equal({ thinkingLevel: 'minimal' });
+    expect(body.generationConfig.responseJsonSchema).to.be.an('object');
+    expect(body).not.to.have.any.keys('tools', 'toolConfig', 'cachedContent');
+    expect(requests[0].url).not.to.contain('test-secret');
+    expect(requests[0].body).not.to.contain('test-secret');
+  });
+
+  it('fails closed on missing usage, truncation, malformed JSON, and duplicate IDs', async function () {
+    const bodies: unknown[] = [
+      {
+        candidates: [{ finishReason: 'STOP', content: { parts: [{ text: '{"results":[]}' }] } }],
+      },
+      { candidates: [{ finishReason: 'MAX_TOKENS', content: { parts: [{ text: '{}' }] } }] },
+      {
+        candidates: [{ finishReason: 'STOP', content: { parts: [{ text: 'not-json' }] } }],
+        usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+      },
+      {
+        candidates: [
+          {
+            finishReason: 'STOP',
+            content: {
+              parts: [{ text: JSON.stringify({ results: [badResult('a'), badResult('a')] }) }],
+            },
+          },
+        ],
+        usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+      },
+    ];
+    for (const body of bodies) {
+      const provider = new GeminiVietnameseTitleProvider(
+        {
+          async send() {
+            return { status: 200, body };
+          },
+        },
+        'secret'
+      );
+      try {
+        await provider.translate(
+          body === bodies[3]
+            ? [
+                { id: 'a', text: 'A' },
+                { id: 'b', text: 'B' },
+              ]
+            : [{ id: 'a', text: 'A' }]
+        );
+        expect.fail('malformed provider response should fail');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+      }
+    }
+  });
+
+  it('fails closed on blocks, HTTP errors, excessive usage, and oversized requests', async function () {
+    const bodies: Array<{ status: number; body: unknown }> = [
+      { status: 200, body: { promptFeedback: { blockReason: 'SAFETY' } } },
+      { status: 429, body: { error: { message: 'quota denied' } } },
+      {
+        status: 200,
+        body: {
+          candidates: [
+            {
+              finishReason: 'STOP',
+              content: {
+                parts: [{ text: JSON.stringify({ results: [badResult('a')] }) }],
+              },
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 4097,
+            candidatesTokenCount: 1,
+            totalTokenCount: 4098,
+          },
+        },
+      },
+    ];
+    for (const response of bodies) {
+      const provider = new GeminiVietnameseTitleProvider(
+        {
+          async send() {
+            return response;
+          },
+        },
+        'secret'
+      );
+      try {
+        await provider.translate([{ id: 'a', text: 'A' }]);
+        expect.fail('unsafe provider response should fail');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+      }
+    }
+
+    process.env.GEMINI_VI_TITLE_MAX_INPUT_TOKENS = '1';
+    const provider = new GeminiVietnameseTitleProvider(
+      {
+        async send() {
+          throw new Error('must not send');
+        },
+      },
+      'secret'
+    );
+    try {
+      await provider.translate([{ id: 'a', text: 'A' }]);
+      expect.fail('oversized request should fail');
+    } catch (error) {
+      expect((error as Error).message).to.contain('reserves');
+    } finally {
+      delete process.env.GEMINI_VI_TITLE_MAX_INPUT_TOKENS;
+    }
+  });
+
+  it('keeps the API key out of the URL/body and redacts secrets and source text from errors', async function () {
+    const originalFetch = global.fetch;
+    let seenUrl = '';
+    let seenHeaders: Record<string, string> = {};
+    let seenBody = '';
+    global.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      seenUrl = String(input);
+      seenHeaders = init?.headers as Record<string, string>;
+      seenBody = String(init?.body ?? '');
+      return {
+        status: 500,
+        async text() {
+          return '{}';
+        },
+      } as Response;
+    }) as typeof fetch;
+    try {
+      await createGeminiVietnameseTitleTransport('transport-secret').send({
+        url: 'https://example.test/generate',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+        timeoutMs: 100,
+      });
+    } finally {
+      global.fetch = originalFetch;
+    }
+    expect(seenUrl).not.to.contain('transport-secret');
+    expect(seenBody).not.to.contain('transport-secret');
+    expect(seenHeaders['x-goog-api-key']).to.equal('transport-secret');
+
+    const provider = new GeminiVietnameseTitleProvider(
+      {
+        async send() {
+          throw new Error('test-secret Dien phan'.padEnd(500, 'x'));
+        },
+      },
+      'test-secret'
+    );
+    try {
+      await provider.translate([{ id: 'a', text: 'Dien phan' }]);
+      expect.fail('transport failure should propagate safely');
+    } catch (error) {
+      const message = (error as Error).message;
+      expect(message).not.to.contain('test-secret');
+      expect(message).not.to.contain('Dien phan');
+      expect(message.length).to.be.at.most(300);
+    }
+  });
+});
+
+function badResult(id: string): VietnameseTitleResult {
+  return { id, status: 'translated', restoredVi: 'A', english: 'B', alternatives: [] };
+}

--- a/app/api/batch/derive-search.ts
+++ b/app/api/batch/derive-search.ts
@@ -45,6 +45,7 @@ import {
 import { detectLanguageCode } from '../services/language-detection-service';
 import { TranslationService } from '../services/translation-service';
 import {
+  isEligibleVietnameseTitleInput,
   isVietnameseTitleGateActive,
   VietnameseTitleTranslationOutcome,
   VietnameseTitleTranslationService,
@@ -453,6 +454,11 @@ async function detectAmbiguousTitles(
     string,
     Array<{ blueprintId: mongoose.Types.ObjectId; sourceHash: string }>
   >();
+  // Undetectable but not Gemini-eligible (non-ASCII, or over the title length
+  // cap): the service's validateInputs would throw on the WHOLE batch, taking
+  // eligible titles down with it — on every re-run. Google has no such shape
+  // restriction, so these go straight to its continuation instead.
+  const googleOnlyByTitle: typeof byTitle = new Map();
   let skippedResolved = 0;
   let skippedDetected = 0;
   for (const row of rows) {
@@ -470,16 +476,18 @@ async function detectAmbiguousTitles(
       skippedResolved++;
       continue;
     }
-    const group = byTitle.get(title);
+    const bucket = isEligibleVietnameseTitleInput(title) ? byTitle : googleOnlyByTitle;
+    const group = bucket.get(title);
     const target = { blueprintId: row.blueprintId, sourceHash: row.sourceHash };
     if (group != null) group.push(target);
-    else byTitle.set(title, [target]);
+    else bucket.set(title, [target]);
   }
 
   // Batched by UNIQUE title text, same reason as translateTitles: the cache
   // row for a text written earlier in the same call is not visible to
   // findCached yet, so duplicates would each be billed.
   const candidates = [...byTitle.entries()];
+  const googleOnly = [...googleOnlyByTitle.entries()];
   const documentCount = candidates.reduce((n, [, ids]) => n + ids.length, 0);
   const sourceCharacters = candidates.reduce((n, [title]) => n + title.length, 0);
   const geminiBatches = batchVietnameseCandidates(candidates);
@@ -488,6 +496,12 @@ async function detectAmbiguousTitles(
     `\nRomanized Vietnamese census — ${candidates.length} unique candidate titles across ${documentCount} documents` +
       ` (${skippedDetected} already detected locally, ${skippedResolved} fully resolved by the term dictionary)`
   );
+  if (googleOnly.length > 0) {
+    console.log(
+      `  ${googleOnly.length} undetectable title(s) are not Gemini-eligible ` +
+        `(non-ASCII or over-length) and go straight to Google provider-side detection`
+    );
+  }
   console.log(`  source characters: ${sourceCharacters}`);
   console.log(
     `  planned Gemini batches: ${geminiBatches.length} (max ${GEMINI_VI_TITLE_BATCH_SIZE} titles / ` +
@@ -500,7 +514,7 @@ async function detectAmbiguousTitles(
       `${geminiBatches.length * dryRunCaps.maximumMicroUsd} micro-USD maximum`
   );
 
-  if (dryRun || candidates.length === 0) return 0;
+  if (dryRun || (candidates.length === 0 && googleOnly.length === 0)) return 0;
 
   // With the gate off — its default, and the state the README has prod deploy
   // in — every candidate comes back 'invalid' and contributes nothing to
@@ -513,13 +527,13 @@ async function detectAmbiguousTitles(
       '  Gemini romanized-Vietnamese gate inactive (kill switch, GEMINI_API_KEY, or monthly ' +
         'allowance) — continuing every candidate to Google provider-side detection.'
     );
-    return continueNotVietnameseWithGoogle(candidates);
+    return continueNotVietnameseWithGoogle([...candidates, ...googleOnly]);
   }
 
   let done = 0;
   let accepted = 0;
   let failedBatches = 0;
-  const googleCandidates: typeof candidates = [];
+  const googleCandidates: typeof candidates = [...googleOnly];
   for (let i = 0; i < geminiBatches.length; i++) {
     const batch = geminiBatches[i];
     let results: VietnameseTitleTranslationOutcome[];
@@ -587,7 +601,8 @@ async function detectAmbiguousTitles(
   failedBatches += await continueNotVietnameseWithGoogle(googleCandidates);
   console.log(
     `  Gemini accepted ${accepted}/${candidates.length} titles; ` +
-      `${googleCandidates.length} explicit not-vietnamese result(s) continued to Google`
+      `${googleCandidates.length} title(s) continued to Google ` +
+      `(explicit not-vietnamese results plus the ${googleOnly.length} Gemini-ineligible)`
   );
   return failedBatches;
 }

--- a/app/api/batch/derive-search.ts
+++ b/app/api/batch/derive-search.ts
@@ -54,6 +54,8 @@ import {
   GEMINI_VI_TITLE_BATCH_CHARACTERS,
   GEMINI_VI_TITLE_BATCH_SIZE,
 } from '../services/vietnamese-title-prompts';
+import { isUnrecoverableProviderError } from '../services/gemini-vietnamese-title-provider';
+import { TranslationBudgetExceeded } from '../services/translation-service';
 import { getSearchTermDictionary } from '../services/search-term-dictionary';
 import { normalizeContentLocale, resolveTerms, tokenize } from '../../../lib/index';
 import { parseBatchArgs, sampledCursor, describeScope } from './batch-sampling';
@@ -527,10 +529,27 @@ async function detectAmbiguousTitles(
         null
       );
     } catch (err) {
+      failedBatches++;
+      // A bad key, a revoked key, a rate limit, or an exhausted allowance is
+      // not a per-batch hiccup: every remaining batch hits it too, and each
+      // attempt reserves budget BEFORE the provider call. Continuing would
+      // spend the entire monthly allowance on failures. Stop, and say plainly
+      // that this one needs a person.
+      if (err instanceof TranslationBudgetExceeded || isUnrecoverableProviderError(err)) {
+        console.log(
+          `  Gemini pass STOPPED at batch ${i + 1}/${geminiBatches.length} — needs action, ` +
+            `not a retry: ${(err as Error).message}`
+        );
+        console.log(
+          `  ${candidates.length - done} candidate title(s) left unprocessed. Re-running after ` +
+            `the cause is fixed is safe: accepted translations are cached and already-translated ` +
+            `rows are skipped.`
+        );
+        break;
+      }
       console.log(`  Gemini batch ${i + 1}/${geminiBatches.length} error, skipping`);
       console.log(err);
       done += batch.length;
-      failedBatches++;
       continue;
     }
 

--- a/app/api/batch/derive-search.ts
+++ b/app/api/batch/derive-search.ts
@@ -624,7 +624,14 @@ export function batchVietnameseCandidates(
 async function continueNotVietnameseWithGoogle(candidates: AmbiguousCandidate[]): Promise<number> {
   if (candidates.length === 0) return 0;
   if (!TranslationService.instance.isConfigured()) {
-    console.log('  Google continuation — GOOGLE_TRANSLATE_API_KEY not set, leaving authored.');
+    // Return 0 rather than a count: the caller's tally is FAILED BATCHES, and
+    // nothing failed here. The number operators need is the skipped titles, so
+    // say it here where it is unambiguous.
+    const documents = candidates.reduce((n, [, rows]) => n + rows.length, 0);
+    console.log(
+      `  Google continuation — GOOGLE_TRANSLATE_API_KEY not set: ${candidates.length} title(s) ` +
+        `across ${documents} document(s) left authored.`
+    );
     return 0;
   }
   let failures = 0;

--- a/app/api/batch/derive-search.ts
+++ b/app/api/batch/derive-search.ts
@@ -37,9 +37,23 @@ import { BlueprintModel } from '../models/blueprint';
 import { BlueprintSearchModel } from '../models/blueprint-search';
 import { TranslationUnitModel } from '../models/translation-unit';
 import { TranslationBudgetModel } from '../models/translation-budget';
-import { deriveNativeSearchRow, deriveSearchRow, SearchRowFields } from '../services/search-index-service';
+import {
+  deriveNativeSearchRow,
+  deriveSearchRow,
+  SearchRowFields,
+} from '../services/search-index-service';
 import { detectLanguageCode } from '../services/language-detection-service';
 import { TranslationService } from '../services/translation-service';
+import {
+  isVietnameseTitleGateActive,
+  VietnameseTitleTranslationOutcome,
+  VietnameseTitleTranslationService,
+  vietnameseTitleDryRunCaps,
+} from '../services/vietnamese-title-translation-service';
+import {
+  GEMINI_VI_TITLE_BATCH_CHARACTERS,
+  GEMINI_VI_TITLE_BATCH_SIZE,
+} from '../services/vietnamese-title-prompts';
 import { getSearchTermDictionary } from '../services/search-term-dictionary';
 import { normalizeContentLocale, resolveTerms, tokenize } from '../../../lib/index';
 import { parseBatchArgs, sampledCursor, describeScope } from './batch-sampling';
@@ -217,7 +231,11 @@ async function run(dryRun: boolean, limit: number | null, providerDetect: boolea
         if (priorNativeLang === native?.lang) continue;
         pending.push({
           deleteOne: {
-            filter: { blueprintId: doc._id as mongoose.Types.ObjectId, lang: priorNativeLang, origin: 'authored' },
+            filter: {
+              blueprintId: doc._id as mongoose.Types.ObjectId,
+              lang: priorNativeLang,
+              origin: 'authored',
+            },
           },
         });
         nativePruned++;
@@ -233,7 +251,9 @@ async function run(dryRun: boolean, limit: number | null, providerDetect: boolea
     if (originalsBackfilled > 0) {
       console.log(`  titleOriginal backfilled on ${originalsBackfilled} already-translated row(s)`);
     }
-    console.log(`  native-language rows: ${nativeWritten} written, ${nativePruned} pruned (stale sourceLang)`);
+    console.log(
+      `  native-language rows: ${nativeWritten} written, ${nativePruned} pruned (stale sourceLang)`
+    );
 
     let failedBatches = await translateTitles(dryRun, processedIds);
     if (providerDetect) {
@@ -285,17 +305,28 @@ async function translateTitles(
 
   // Chunked so an unlimited run (thousands of blueprints) never issues one
   // $in spanning the whole corpus.
-  const rows: { blueprintId: mongoose.Types.ObjectId; title: string; origin: string }[] = [];
+  const rows: {
+    blueprintId: mongoose.Types.ObjectId;
+    title: string;
+    origin: string;
+    sourceHash: string;
+  }[] = [];
   for (let i = 0; i < blueprintIds.length; i += BULK_BATCH_SIZE) {
     const chunk = blueprintIds.slice(i, i + BULK_BATCH_SIZE);
     const chunkRows = await BlueprintSearchModel.model
       .find({ lang: 'en', blueprintId: { $in: chunk } })
-      .select('blueprintId title origin')
+      .select('blueprintId title origin sourceHash')
       .lean();
-    rows.push(...(chunkRows as { blueprintId: mongoose.Types.ObjectId; title: string; origin: string }[]));
+    rows.push(...(chunkRows as typeof rows));
   }
 
-  const byTitle = new Map<string, { blueprintIds: mongoose.Types.ObjectId[]; sourceLang: string }>();
+  const byTitle = new Map<
+    string,
+    {
+      rows: Array<{ blueprintId: mongoose.Types.ObjectId; sourceHash: string }>;
+      sourceLang: string;
+    }
+  >();
   let alreadyMachine = 0;
   for (const row of rows) {
     if (row.origin === 'machine') {
@@ -305,12 +336,13 @@ async function translateTitles(
     const lang = detectLanguageCode(row.title);
     if (lang == null || lang === 'en') continue;
     const group = byTitle.get(row.title);
-    if (group != null) group.blueprintIds.push(row.blueprintId);
-    else byTitle.set(row.title, { blueprintIds: [row.blueprintId], sourceLang: lang });
+    const target = { blueprintId: row.blueprintId, sourceHash: row.sourceHash };
+    if (group != null) group.rows.push(target);
+    else byTitle.set(row.title, { rows: [target], sourceLang: lang });
   }
 
   const uniqueTitles = [...byTitle.entries()];
-  const documentCount = uniqueTitles.reduce((n, [, group]) => n + group.blueprintIds.length, 0);
+  const documentCount = uniqueTitles.reduce((n, [, group]) => n + group.rows.length, 0);
   console.log(
     `\nTitle translation — ${uniqueTitles.length} unique non-English titles across ${documentCount} documents` +
       ` (${alreadyMachine} rows already machine-translated, left alone)`
@@ -325,7 +357,11 @@ async function translateTitles(
     let results: Awaited<ReturnType<typeof TranslationService.instance.translateMany>>;
     try {
       results = await TranslationService.instance.translateMany(
-        batch.map(([title, group]) => ({ sourceText: title, sourceLang: group.sourceLang, targetLang: 'en' })),
+        batch.map(([title, group]) => ({
+          sourceText: title,
+          sourceLang: group.sourceLang,
+          targetLang: 'en',
+        })),
         null
       );
     } catch (err) {
@@ -347,10 +383,10 @@ async function translateTitles(
       // translation that isn't there while indexing the same string twice
       // (title + titleOriginal).
       if (result.translatedText === originalTitle) continue;
-      for (const blueprintId of group.blueprintIds) {
+      for (const { blueprintId, sourceHash } of group.rows) {
         ops.push({
           updateOne: {
-            filter: { blueprintId, lang: 'en' },
+            filter: { blueprintId, lang: 'en', sourceHash },
             update: {
               $set: {
                 title: result.translatedText,
@@ -378,9 +414,9 @@ async function translateTitles(
 // an English searcher. These titles are absent from the 446 the first backfill
 // found and no amount of re-running the pass above will pick them up.
 //
-// So stop guessing and ask the provider, which is far better than tinyld on
-// short romanized text, and whose answer we already persist
-// (TranslationUnit.detectedSourceLang).
+// Gemini first identifies/restores/translates romanized Vietnamese. Only its
+// explicit not-vietnamese results continue to Google's general provider-side
+// detection; ambiguous or invalid results stay authored.
 //
 // Precision, not cost, is the constraint here (~59K characters one time,
 // against a 500K/month free tier). Three things keep a wrong answer cheap:
@@ -394,24 +430,27 @@ async function detectAmbiguousTitles(
   dryRun: boolean,
   blueprintIds: mongoose.Types.ObjectId[]
 ): Promise<number> {
-  if (!TranslationService.instance.isConfigured()) {
-    console.log('\nProvider-side detection — GOOGLE_TRANSLATE_API_KEY not set, skipping.');
-    return 0;
-  }
-
   const dictionary = getSearchTermDictionary();
 
-  const rows: { blueprintId: mongoose.Types.ObjectId; title: string; origin: string }[] = [];
+  const rows: {
+    blueprintId: mongoose.Types.ObjectId;
+    title: string;
+    origin: string;
+    sourceHash: string;
+  }[] = [];
   for (let i = 0; i < blueprintIds.length; i += BULK_BATCH_SIZE) {
     const chunk = blueprintIds.slice(i, i + BULK_BATCH_SIZE);
     const chunkRows = await BlueprintSearchModel.model
       .find({ lang: 'en', origin: 'authored', blueprintId: { $in: chunk } })
-      .select('blueprintId title origin')
+      .select('blueprintId title origin sourceHash')
       .lean();
-    rows.push(...(chunkRows as { blueprintId: mongoose.Types.ObjectId; title: string; origin: string }[]));
+    rows.push(...(chunkRows as typeof rows));
   }
 
-  const byTitle = new Map<string, mongoose.Types.ObjectId[]>();
+  const byTitle = new Map<
+    string,
+    Array<{ blueprintId: mongoose.Types.ObjectId; sourceHash: string }>
+  >();
   let skippedResolved = 0;
   let skippedDetected = 0;
   for (const row of rows) {
@@ -430,8 +469,9 @@ async function detectAmbiguousTitles(
       continue;
     }
     const group = byTitle.get(title);
-    if (group != null) group.push(row.blueprintId);
-    else byTitle.set(title, [row.blueprintId]);
+    const target = { blueprintId: row.blueprintId, sourceHash: row.sourceHash };
+    if (group != null) group.push(target);
+    else byTitle.set(title, [target]);
   }
 
   // Batched by UNIQUE title text, same reason as translateTitles: the cache
@@ -439,34 +479,55 @@ async function detectAmbiguousTitles(
   // findCached yet, so duplicates would each be billed.
   const candidates = [...byTitle.entries()];
   const documentCount = candidates.reduce((n, [, ids]) => n + ids.length, 0);
+  const sourceCharacters = candidates.reduce((n, [title]) => n + title.length, 0);
+  const geminiBatches = batchVietnameseCandidates(candidates);
+  const dryRunCaps = vietnameseTitleDryRunCaps();
   console.log(
-    `\nProvider-side detection — ${candidates.length} undetectable titles across ${documentCount} documents` +
+    `\nRomanized Vietnamese census — ${candidates.length} unique candidate titles across ${documentCount} documents` +
       ` (${skippedDetected} already detected locally, ${skippedResolved} fully resolved by the term dictionary)`
+  );
+  console.log(`  source characters: ${sourceCharacters}`);
+  console.log(
+    `  planned Gemini batches: ${geminiBatches.length} (max ${GEMINI_VI_TITLE_BATCH_SIZE} titles / ` +
+      `${GEMINI_VI_TITLE_BATCH_CHARACTERS} source characters each, concurrency 1, retries 0)`
+  );
+  console.log(
+    `  reservation: max ${dryRunCaps.inputTokens} input + ${dryRunCaps.outputTokens} output tokens/call; ` +
+      `${geminiBatches.length * dryRunCaps.inputTokens} input + ` +
+      `${geminiBatches.length * dryRunCaps.outputTokens} output tokens total; ` +
+      `${geminiBatches.length * dryRunCaps.maximumMicroUsd} micro-USD maximum`
   );
 
   if (dryRun || candidates.length === 0) return 0;
 
+  // With the gate off — its default, and the state the README has prod deploy
+  // in — every candidate comes back 'invalid' and contributes nothing to
+  // googleCandidates, so the Google detection pass this gate sits in front of
+  // would silently do nothing at all. That is a regression against the shipped
+  // behaviour, not a decision. Send the whole census straight to Google
+  // instead, and say which pass actually ran.
+  if (!isVietnameseTitleGateActive()) {
+    console.log(
+      '  Gemini romanized-Vietnamese gate inactive (kill switch, GEMINI_API_KEY, or monthly ' +
+        'allowance) — continuing every candidate to Google provider-side detection.'
+    );
+    return continueNotVietnameseWithGoogle(candidates);
+  }
+
   let done = 0;
   let accepted = 0;
   let failedBatches = 0;
-  for (let i = 0; i < candidates.length; i += TRANSLATE_BATCH_SIZE) {
-    const batch = candidates.slice(i, i + TRANSLATE_BATCH_SIZE);
-    let results: Awaited<ReturnType<typeof TranslationService.instance.translateMany>>;
+  const googleCandidates: typeof candidates = [];
+  for (let i = 0; i < geminiBatches.length; i++) {
+    const batch = geminiBatches[i];
+    let results: VietnameseTitleTranslationOutcome[];
     try {
-      results = await TranslationService.instance.translateMany(
-        batch.map(([title]) => ({
-          sourceText: title,
-          sourceLang: null,
-          targetLang: 'en',
-          // Without this the ASCII short-circuit returns every one of these
-          // titles untouched with no provider call — the pass would report
-          // success having done nothing at all.
-          forceProviderDetection: true,
-        })),
+      results = await VietnameseTitleTranslationService.instance.translateMany(
+        batch.map(([title], index) => ({ id: `vi-${i}-${index}`, text: title })),
         null
       );
     } catch (err) {
-      console.log(`  batch ${i}-${i + batch.length} detection error, skipping`);
+      console.log(`  Gemini batch ${i + 1}/${geminiBatches.length} error, skipping`);
       console.log(err);
       done += batch.length;
       failedBatches++;
@@ -477,22 +538,23 @@ async function detectAmbiguousTitles(
     for (let b = 0; b < batch.length; b++) {
       const result = results[b];
       const [title, ids] = batch[b];
-      if (result.degraded) continue;
-      const detected = normalizeContentLocale(result.sourceLang);
-      // Both conditions matter. A non-English report with unchanged text means
-      // the provider found nothing to translate; unchanged text with an English
-      // report means it was English all along. Either way the row stays
-      // authored, which is the correct, free outcome.
-      if (detected == null || detected === 'en') continue;
-      if (result.translatedText === title) continue;
+      if (result.status === 'not-vietnamese') {
+        googleCandidates.push(batch[b]);
+        continue;
+      }
+      if (result.status !== 'translated' || result.translatedText == null) continue;
 
       accepted++;
-      for (const blueprintId of ids) {
+      for (const { blueprintId, sourceHash } of ids) {
         ops.push({
           updateOne: {
-            filter: { blueprintId, lang: 'en' },
+            filter: { blueprintId, lang: 'en', sourceHash },
             update: {
-              $set: { title: result.translatedText, titleOriginal: title, origin: 'machine' },
+              $set: {
+                title: result.translatedText,
+                titleOriginal: title,
+                origin: 'machine',
+              },
             },
           },
         });
@@ -500,14 +562,100 @@ async function detectAmbiguousTitles(
     }
     if (ops.length > 0) await BlueprintSearchModel.model.bulkWrite(ops as any);
     done += batch.length;
-    console.log(`  ...${done}/${candidates.length} checked, ${accepted} translated`);
+    console.log(`  ...${done}/${candidates.length} checked by Gemini, ${accepted} translated`);
   }
 
+  failedBatches += await continueNotVietnameseWithGoogle(googleCandidates);
   console.log(
-    `  provider-side detection accepted ${accepted}/${candidates.length} titles ` +
-      `(the rest came back English or unchanged and stay authored)`
+    `  Gemini accepted ${accepted}/${candidates.length} titles; ` +
+      `${googleCandidates.length} explicit not-vietnamese result(s) continued to Google`
   );
   return failedBatches;
+}
+
+type AmbiguousCandidate = [
+  string,
+  Array<{ blueprintId: mongoose.Types.ObjectId; sourceHash: string }>,
+];
+
+export function batchVietnameseCandidates(
+  candidates: AmbiguousCandidate[]
+): AmbiguousCandidate[][] {
+  const batches: AmbiguousCandidate[][] = [];
+  let batch: AmbiguousCandidate[] = [];
+  let characters = 0;
+  for (const candidate of candidates) {
+    const nextCharacters = characters + candidate[0].length;
+    if (
+      batch.length > 0 &&
+      (batch.length >= GEMINI_VI_TITLE_BATCH_SIZE ||
+        nextCharacters > GEMINI_VI_TITLE_BATCH_CHARACTERS)
+    ) {
+      batches.push(batch);
+      batch = [];
+      characters = 0;
+    }
+    batch.push(candidate);
+    characters += candidate[0].length;
+  }
+  if (batch.length > 0) batches.push(batch);
+  return batches;
+}
+
+async function continueNotVietnameseWithGoogle(candidates: AmbiguousCandidate[]): Promise<number> {
+  if (candidates.length === 0) return 0;
+  if (!TranslationService.instance.isConfigured()) {
+    console.log('  Google continuation — GOOGLE_TRANSLATE_API_KEY not set, leaving authored.');
+    return 0;
+  }
+  let failures = 0;
+  for (let i = 0; i < candidates.length; i += TRANSLATE_BATCH_SIZE) {
+    const batch = candidates.slice(i, i + TRANSLATE_BATCH_SIZE);
+    try {
+      const results = await TranslationService.instance.translateMany(
+        batch.map(([title]) => ({
+          sourceText: title,
+          sourceLang: null,
+          targetLang: 'en',
+          forceProviderDetection: true,
+        })),
+        null
+      );
+      const ops: mongoose.AnyBulkWriteOperation[] = [];
+      for (let index = 0; index < batch.length; index++) {
+        const result = results[index];
+        const [title, rows] = batch[index];
+        const detected = normalizeContentLocale(result.sourceLang);
+        if (
+          result.degraded ||
+          detected == null ||
+          detected === 'en' ||
+          result.translatedText === title
+        )
+          continue;
+        for (const { blueprintId, sourceHash } of rows) {
+          ops.push({
+            updateOne: {
+              filter: { blueprintId, lang: 'en', sourceHash },
+              update: {
+                $set: {
+                  title: result.translatedText,
+                  titleOriginal: title,
+                  origin: 'machine',
+                },
+              },
+            },
+          });
+        }
+      }
+      if (ops.length > 0) await BlueprintSearchModel.model.bulkWrite(ops as any);
+    } catch (error) {
+      console.log(`  Google continuation batch ${i}-${i + batch.length} error, skipping`);
+      console.log(error);
+      failures++;
+    }
+  }
+  return failures;
 }
 
 if (require.main === module) {

--- a/app/api/experiments/diacritic-ab/artifacts.ts
+++ b/app/api/experiments/diacritic-ab/artifacts.ts
@@ -1,0 +1,79 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+export function sha256(value: string | Buffer): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function json(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export class ArtifactStore {
+  public readonly responsesDir: string;
+
+  public constructor(public readonly directory: string) {
+    this.responsesDir = path.join(directory, 'responses');
+  }
+
+  public prepare(): void {
+    fs.mkdirSync(this.responsesDir, { recursive: true, mode: 0o700 });
+  }
+
+  public path(name: string): string {
+    return path.join(this.directory, name);
+  }
+
+  public exists(name: string): boolean {
+    return fs.existsSync(this.path(name));
+  }
+
+  public read(name: string): unknown {
+    return JSON.parse(fs.readFileSync(this.path(name), 'utf8')) as unknown;
+  }
+
+  public writeJson(name: string, value: unknown): void {
+    this.atomicReplace(this.path(name), json(value));
+  }
+
+  public writeText(name: string, value: string): void {
+    this.atomicReplace(this.path(name), value);
+  }
+
+  public createReservation(value: unknown): void {
+    this.prepare();
+    const destination = this.path('reservation.json');
+    const temporary = this.writeTemporary(destination, json(value));
+    try {
+      // link is an atomic create-if-absent operation. It cannot overwrite a
+      // reservation left by a crash or an earlier run.
+      fs.linkSync(temporary, destination);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+        throw new Error('A reservation already exists; review the artifact before any rerun');
+      }
+      throw error;
+    } finally {
+      fs.unlinkSync(temporary);
+    }
+  }
+
+  private atomicReplace(destination: string, contents: string): void {
+    this.prepare();
+    const temporary = this.writeTemporary(destination, contents);
+    fs.renameSync(temporary, destination);
+  }
+
+  private writeTemporary(destination: string, contents: string): string {
+    const temporary = `${destination}.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`;
+    const fd = fs.openSync(temporary, 'wx', 0o600);
+    try {
+      fs.writeFileSync(fd, contents, 'utf8');
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    return temporary;
+  }
+}

--- a/app/api/experiments/diacritic-ab/caps.ts
+++ b/app/api/experiments/diacritic-ab/caps.ts
@@ -1,18 +1,18 @@
 import { CAPS, MAX_APPROVED_RATES, RATES } from './constants';
 
 export interface Reservation {
-  doCalls: number;
+  geminiCalls: number;
   googleCalls: number;
-  doInputTokens: number;
-  doOutputTokens: number;
+  geminiInputTokens: number;
+  geminiOutputTokens: number;
   googleSourceCharacters: number;
   maximumUsd: number;
 }
 
 export function calculateMaximumCost(): number {
   return (
-    (CAPS.doInputTokens * RATES.doInputUsdPerMillionTokens) / 1_000_000 +
-    (CAPS.doOutputTokens * RATES.doOutputUsdPerMillionTokens) / 1_000_000 +
+    (CAPS.geminiInputTokens * RATES.geminiInputUsdPerMillionTokens) / 1_000_000 +
+    (CAPS.geminiOutputTokens * RATES.geminiOutputUsdPerMillionTokens) / 1_000_000 +
     (CAPS.googleSourceCharacters * RATES.googleUsdPerMillionCharacters) / 1_000_000
   );
 }
@@ -34,23 +34,23 @@ export function fullReservation(): Reservation {
     throw new Error(`Maximum $${maximumUsd.toFixed(7)} exceeds acknowledged ceiling`);
   }
   return {
-    doCalls: CAPS.doCalls,
+    geminiCalls: CAPS.geminiCalls,
     googleCalls: CAPS.googleCalls,
-    doInputTokens: CAPS.doInputTokens,
-    doOutputTokens: CAPS.doOutputTokens,
+    geminiInputTokens: CAPS.geminiInputTokens,
+    geminiOutputTokens: CAPS.geminiOutputTokens,
     googleSourceCharacters: CAPS.googleSourceCharacters,
     maximumUsd,
   };
 }
 
-export function assertDoRequestWithinCap(serializedBody: string): number {
+export function assertGeminiRequestWithinCap(serializedBody: string): number {
   // Every UTF-8 byte is treated as a token, plus 64 tokens for protocol/message
   // framing. This substantially over-counts this ASCII-heavy prompt and needs no
   // model tokenizer dependency.
   const conservativeTokens = Buffer.byteLength(serializedBody, 'utf8') + 64;
-  if (conservativeTokens > CAPS.doInputTokensPerCall) {
+  if (conservativeTokens > CAPS.geminiInputTokensPerCall) {
     throw new Error(
-      `DO request reserves ${conservativeTokens} input tokens; per-call cap is ${CAPS.doInputTokensPerCall}`
+      `Gemini request reserves ${conservativeTokens} input tokens; per-call cap is ${CAPS.geminiInputTokensPerCall}`
     );
   }
   return conservativeTokens;

--- a/app/api/experiments/diacritic-ab/caps.ts
+++ b/app/api/experiments/diacritic-ab/caps.ts
@@ -17,6 +17,13 @@ export function calculateMaximumCost(): number {
   );
 }
 
+export function calculateAccessCheckMaximumCost(): number {
+  const maximum =
+    (CAPS.geminiAccessCheckInputTokens * RATES.geminiInputUsdPerMillionTokens) / 1_000_000 +
+    (CAPS.geminiAccessCheckOutputTokens * RATES.geminiOutputUsdPerMillionTokens) / 1_000_000;
+  return Number(maximum.toFixed(10));
+}
+
 export function assertApprovedRates(): void {
   for (const key of Object.keys(MAX_APPROVED_RATES) as (keyof typeof MAX_APPROVED_RATES)[]) {
     if (RATES[key] > MAX_APPROVED_RATES[key]) {

--- a/app/api/experiments/diacritic-ab/caps.ts
+++ b/app/api/experiments/diacritic-ab/caps.ts
@@ -1,0 +1,65 @@
+import { CAPS, MAX_APPROVED_RATES, RATES } from './constants';
+
+export interface Reservation {
+  doCalls: number;
+  googleCalls: number;
+  doInputTokens: number;
+  doOutputTokens: number;
+  googleSourceCharacters: number;
+  maximumUsd: number;
+}
+
+export function calculateMaximumCost(): number {
+  return (
+    (CAPS.doInputTokens * RATES.doInputUsdPerMillionTokens) / 1_000_000 +
+    (CAPS.doOutputTokens * RATES.doOutputUsdPerMillionTokens) / 1_000_000 +
+    (CAPS.googleSourceCharacters * RATES.googleUsdPerMillionCharacters) / 1_000_000
+  );
+}
+
+export function assertApprovedRates(): void {
+  for (const key of Object.keys(MAX_APPROVED_RATES) as (keyof typeof MAX_APPROVED_RATES)[]) {
+    if (RATES[key] > MAX_APPROVED_RATES[key]) {
+      throw new Error(
+        `Recorded ${key} exceeds its approved rate; review the plan before executing`
+      );
+    }
+  }
+}
+
+export function fullReservation(): Reservation {
+  assertApprovedRates();
+  const maximumUsd = calculateMaximumCost();
+  if (maximumUsd > CAPS.acknowledgedUsd) {
+    throw new Error(`Maximum $${maximumUsd.toFixed(7)} exceeds acknowledged ceiling`);
+  }
+  return {
+    doCalls: CAPS.doCalls,
+    googleCalls: CAPS.googleCalls,
+    doInputTokens: CAPS.doInputTokens,
+    doOutputTokens: CAPS.doOutputTokens,
+    googleSourceCharacters: CAPS.googleSourceCharacters,
+    maximumUsd,
+  };
+}
+
+export function assertDoRequestWithinCap(serializedBody: string): number {
+  // Every UTF-8 byte is treated as a token, plus 64 tokens for protocol/message
+  // framing. This substantially over-counts this ASCII-heavy prompt and needs no
+  // model tokenizer dependency.
+  const conservativeTokens = Buffer.byteLength(serializedBody, 'utf8') + 64;
+  if (conservativeTokens > CAPS.doInputTokensPerCall) {
+    throw new Error(
+      `DO request reserves ${conservativeTokens} input tokens; per-call cap is ${CAPS.doInputTokensPerCall}`
+    );
+  }
+  return conservativeTokens;
+}
+
+export function assertGoogleCharacters(texts: string[], maximum: number): number {
+  const characters = texts.reduce((sum, text) => sum + text.length, 0);
+  if (characters > maximum) {
+    throw new Error(`Google request has ${characters} source characters; cap is ${maximum}`);
+  }
+  return characters;
+}

--- a/app/api/experiments/diacritic-ab/clients.ts
+++ b/app/api/experiments/diacritic-ab/clients.ts
@@ -1,0 +1,198 @@
+import { TranslateRequest } from '@google-cloud/translate/build/src/v2';
+import { CAPS, DO_ENDPOINT, DO_MODEL, DO_TIMEOUT_MS, GOOGLE_TIMEOUT_MS } from './constants';
+import { assertDoRequestWithinCap, assertGoogleCharacters } from './caps';
+import { DoRequestBody, LlmMode } from './prompts';
+import {
+  ArmOutput,
+  DiacriticCase,
+  HttpRequest,
+  HttpResponse,
+  HttpTransport,
+  TokenUsage,
+} from './types';
+
+interface GoogleMetadata {
+  data?: { translations?: { translatedText?: string; detectedSourceLanguage?: string }[] };
+  [key: string]: unknown;
+}
+
+export interface GoogleTransport {
+  translate(texts: string[], options: TranslateRequest): Promise<[string[], GoogleMetadata]>;
+}
+
+export interface GoogleBatchResult {
+  texts: string[];
+  raw: GoogleMetadata;
+  sourceCharacters: number;
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`Experiment request timed out after ${timeoutMs}ms`)),
+      timeoutMs
+    );
+    promise.then(
+      value => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      error => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}
+
+export class GoogleExperimentClient {
+  public constructor(private readonly transport: GoogleTransport) {}
+
+  public async translate(
+    texts: string[],
+    source: 'auto' | 'vi',
+    captureRaw?: (raw: GoogleMetadata) => void
+  ): Promise<GoogleBatchResult> {
+    const sourceCharacters = assertGoogleCharacters(texts, CAPS.sourceCharacters);
+    const options: TranslateRequest = { to: 'en', format: 'text' };
+    if (source === 'vi') options.from = 'vi';
+    const [translated, raw] = await withTimeout(
+      this.transport.translate(texts, options),
+      GOOGLE_TIMEOUT_MS
+    );
+    captureRaw?.(raw);
+    if (!Array.isArray(translated) || translated.length !== texts.length) {
+      throw new Error(
+        `Google returned ${translated?.length ?? 0} results for ${texts.length} inputs`
+      );
+    }
+    return { texts: translated, raw, sourceCharacters };
+  }
+}
+
+interface ChatCompletionResponse {
+  choices?: { message?: { content?: string } }[];
+  usage?: { prompt_tokens?: number; completion_tokens?: number };
+  [key: string]: unknown;
+}
+
+export interface DoBatchResult {
+  outputs: ArmOutput[];
+  raw: ChatCompletionResponse;
+  usage: TokenUsage;
+}
+
+export class DigitalOceanExperimentClient {
+  public constructor(private readonly transport: HttpTransport) {}
+
+  public async assertModelAvailable(): Promise<void> {
+    const response = await this.transport.send({
+      url: `${DO_ENDPOINT}/v1/models`,
+      method: 'GET',
+      headers: {},
+      timeoutMs: DO_TIMEOUT_MS,
+    });
+    assertSuccess(response, 'DO model-list request');
+    const data = (response.body as { data?: { id?: string }[] })?.data;
+    if (!Array.isArray(data) || !data.some(model => model.id === DO_MODEL)) {
+      throw new Error(`Required model ${DO_MODEL} is unavailable to this key`);
+    }
+  }
+
+  public async complete(
+    requestBody: DoRequestBody,
+    cases: DiacriticCase[],
+    mode: LlmMode,
+    captureRaw?: (raw: ChatCompletionResponse) => void
+  ): Promise<DoBatchResult> {
+    if (requestBody.model !== DO_MODEL) throw new Error(`Unexpected model: ${requestBody.model}`);
+    const serialized = JSON.stringify(requestBody);
+    assertDoRequestWithinCap(serialized);
+    const response = await this.transport.send({
+      url: `${DO_ENDPOINT}/v1/chat/completions`,
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: serialized,
+      timeoutMs: DO_TIMEOUT_MS,
+    });
+    assertSuccess(response, 'DO completion request');
+    const raw = response.body as ChatCompletionResponse;
+    captureRaw?.(raw);
+    const content = raw.choices?.[0]?.message?.content;
+    if (typeof content !== 'string') throw new Error('DO response has no completion content');
+    const promptTokens = raw.usage?.prompt_tokens;
+    const completionTokens = raw.usage?.completion_tokens;
+    if (!Number.isInteger(promptTokens) || !Number.isInteger(completionTokens)) {
+      throw new Error('DO response omitted token usage');
+    }
+    if (
+      promptTokens! > CAPS.doInputTokensPerCall ||
+      completionTokens! > CAPS.doOutputTokensPerCall
+    ) {
+      throw new Error('DO reported usage beyond a per-call cap');
+    }
+    const parsed = JSON.parse(content) as { results?: unknown };
+    return {
+      outputs: validateLlmOutputs(parsed.results, cases, mode),
+      raw,
+      usage: { promptTokens: promptTokens!, completionTokens: completionTokens! },
+    };
+  }
+}
+
+function assertSuccess(response: HttpResponse, operation: string): void {
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(`${operation} failed with HTTP ${response.status}`);
+  }
+}
+
+export function validateLlmOutputs(
+  value: unknown,
+  cases: DiacriticCase[],
+  mode: LlmMode
+): ArmOutput[] {
+  if (!Array.isArray(value) || value.length !== cases.length) {
+    throw new Error(`LLM result must contain exactly ${cases.length} rows`);
+  }
+  const expected = new Set(cases.map(item => item.id));
+  const seen = new Set<string>();
+  for (const raw of value) {
+    const item = raw as Partial<ArmOutput>;
+    if (
+      typeof item.id !== 'string' ||
+      !expected.has(item.id) ||
+      seen.has(item.id) ||
+      (item.status !== 'resolved' && item.status !== 'ambiguous') ||
+      typeof item.restoredVi !== 'string' ||
+      !Array.isArray(item.alternatives) ||
+      item.alternatives.length > 3 ||
+      item.alternatives.some(alt => typeof alt !== 'string') ||
+      (mode === 'end-to-end' && typeof item.english !== 'string')
+    ) {
+      throw new Error('LLM result has an unknown, duplicate, missing, or malformed row');
+    }
+    seen.add(item.id);
+  }
+  if (seen.size !== expected.size) throw new Error('LLM result ID set does not match the fixture');
+  return value as ArmOutput[];
+}
+
+export function createFetchTransport(apiKey: string): HttpTransport {
+  return {
+    async send(request: HttpRequest): Promise<HttpResponse> {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), request.timeoutMs);
+      try {
+        const response = await fetch(request.url, {
+          method: request.method,
+          headers: { ...request.headers, authorization: `Bearer ${apiKey}` },
+          body: request.body,
+          signal: controller.signal,
+        });
+        return { status: response.status, body: (await response.json()) as unknown };
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}

--- a/app/api/experiments/diacritic-ab/clients.ts
+++ b/app/api/experiments/diacritic-ab/clients.ts
@@ -1,7 +1,13 @@
 import { TranslateRequest } from '@google-cloud/translate/build/src/v2';
-import { CAPS, DO_ENDPOINT, DO_MODEL, DO_TIMEOUT_MS, GOOGLE_TIMEOUT_MS } from './constants';
-import { assertDoRequestWithinCap, assertGoogleCharacters } from './caps';
-import { DoRequestBody, LlmMode } from './prompts';
+import {
+  CAPS,
+  GEMINI_ENDPOINT,
+  GEMINI_MODEL,
+  GEMINI_TIMEOUT_MS,
+  GOOGLE_TIMEOUT_MS,
+} from './constants';
+import { assertGeminiRequestWithinCap, assertGoogleCharacters } from './caps';
+import { GeminiRequestBody, LlmMode } from './prompts';
 import {
   ArmOutput,
   DiacriticCase,
@@ -70,74 +76,129 @@ export class GoogleExperimentClient {
   }
 }
 
-interface ChatCompletionResponse {
-  choices?: { message?: { content?: string } }[];
-  usage?: { prompt_tokens?: number; completion_tokens?: number };
+interface GeminiResponse {
+  candidates?: {
+    finishReason?: string;
+    content?: { parts?: { text?: string }[] };
+  }[];
+  promptFeedback?: { blockReason?: string };
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    thoughtsTokenCount?: number;
+    totalTokenCount?: number;
+  };
   [key: string]: unknown;
 }
 
-export interface DoBatchResult {
+export interface GeminiBatchResult {
   outputs: ArmOutput[];
-  raw: ChatCompletionResponse;
+  raw: GeminiResponse;
   usage: TokenUsage;
 }
 
-export class DigitalOceanExperimentClient {
+export class GeminiExperimentClient {
   public constructor(private readonly transport: HttpTransport) {}
 
   public async assertModelAvailable(): Promise<void> {
     const response = await this.transport.send({
-      url: `${DO_ENDPOINT}/v1/models`,
+      url: `${GEMINI_ENDPOINT}/models/${GEMINI_MODEL}`,
       method: 'GET',
       headers: {},
-      timeoutMs: DO_TIMEOUT_MS,
+      timeoutMs: GEMINI_TIMEOUT_MS,
     });
-    assertSuccess(response, 'DO model-list request');
-    const data = (response.body as { data?: { id?: string }[] })?.data;
-    if (!Array.isArray(data) || !data.some(model => model.id === DO_MODEL)) {
-      throw new Error(`Required model ${DO_MODEL} is unavailable to this key`);
+    assertSuccess(response, 'Gemini model metadata request');
+    const name = (response.body as { name?: unknown })?.name;
+    if (name !== `models/${GEMINI_MODEL}`) {
+      throw new Error(`Required model ${GEMINI_MODEL} is unavailable to this key`);
     }
   }
 
   public async complete(
-    requestBody: DoRequestBody,
+    requestBody: GeminiRequestBody,
     cases: DiacriticCase[],
     mode: LlmMode,
-    captureRaw?: (raw: ChatCompletionResponse) => void
-  ): Promise<DoBatchResult> {
-    if (requestBody.model !== DO_MODEL) throw new Error(`Unexpected model: ${requestBody.model}`);
+    captureRaw?: (raw: GeminiResponse) => void
+  ): Promise<GeminiBatchResult> {
+    assertFixedGeminiConfig(requestBody);
     const serialized = JSON.stringify(requestBody);
-    assertDoRequestWithinCap(serialized);
+    assertGeminiRequestWithinCap(serialized);
     const response = await this.transport.send({
-      url: `${DO_ENDPOINT}/v1/chat/completions`,
+      url: `${GEMINI_ENDPOINT}/models/${GEMINI_MODEL}:generateContent`,
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: serialized,
-      timeoutMs: DO_TIMEOUT_MS,
+      timeoutMs: GEMINI_TIMEOUT_MS,
     });
-    const raw = response.body as ChatCompletionResponse;
+    const raw = response.body as GeminiResponse;
     captureRaw?.(raw);
-    assertSuccess(response, 'DO completion request');
-    const content = raw.choices?.[0]?.message?.content;
-    if (typeof content !== 'string') throw new Error('DO response has no completion content');
-    const promptTokens = raw.usage?.prompt_tokens;
-    const completionTokens = raw.usage?.completion_tokens;
-    if (!Number.isInteger(promptTokens) || !Number.isInteger(completionTokens)) {
-      throw new Error('DO response omitted token usage');
+    assertSuccess(response, 'Gemini completion request');
+    if (raw.promptFeedback?.blockReason != null) {
+      throw new Error(`Gemini blocked the prompt: ${raw.promptFeedback.blockReason}`);
     }
-    if (
-      promptTokens! > CAPS.doInputTokensPerCall ||
-      completionTokens! > CAPS.doOutputTokensPerCall
-    ) {
-      throw new Error('DO reported usage beyond a per-call cap');
+    const candidate = raw.candidates?.[0];
+    if (candidate?.finishReason !== 'STOP') {
+      throw new Error(
+        `Gemini completion did not finish normally: ${candidate?.finishReason ?? 'none'}`
+      );
     }
+    const content = candidate.content?.parts
+      ?.map(part => part.text)
+      .filter((text): text is string => typeof text === 'string')
+      .join('');
+    if (content == null || content.length === 0) {
+      throw new Error('Gemini response has no completion content');
+    }
+    const usage = validateGeminiUsage(raw.usageMetadata);
     const parsed = JSON.parse(content) as { results?: unknown };
-    return {
-      outputs: validateLlmOutputs(parsed.results, cases, mode),
-      raw,
-      usage: { promptTokens: promptTokens!, completionTokens: completionTokens! },
-    };
+    return { outputs: validateLlmOutputs(parsed.results, cases, mode), raw, usage };
   }
+}
+
+function assertFixedGeminiConfig(request: GeminiRequestBody): void {
+  const config = request.generationConfig;
+  if (
+    config.temperature !== 0 ||
+    config.candidateCount !== CAPS.geminiCandidates ||
+    config.maxOutputTokens !== CAPS.geminiOutputTokensPerCall ||
+    config.responseMimeType !== 'application/json' ||
+    config.thinkingConfig.thinkingBudget !== CAPS.geminiThinkingBudget
+  ) {
+    throw new Error('Gemini request does not match the fixed experiment configuration');
+  }
+  const forbidden = ['tools', 'toolConfig', 'cachedContent'] as const;
+  for (const key of forbidden) {
+    if (key in (request as unknown as Record<string, unknown>)) {
+      throw new Error(`Gemini request contains forbidden capability: ${key}`);
+    }
+  }
+}
+
+function validateGeminiUsage(value: GeminiResponse['usageMetadata']): TokenUsage {
+  const promptTokens = value?.promptTokenCount;
+  const completionTokens = value?.candidatesTokenCount;
+  const thoughtTokens = value?.thoughtsTokenCount ?? 0;
+  const totalTokens = value?.totalTokenCount;
+  if (
+    !Number.isInteger(promptTokens) ||
+    !Number.isInteger(completionTokens) ||
+    !Number.isInteger(thoughtTokens) ||
+    !Number.isInteger(totalTokens)
+  ) {
+    throw new Error('Gemini response omitted token usage');
+  }
+  if (
+    promptTokens! > CAPS.geminiInputTokensPerCall ||
+    completionTokens! + thoughtTokens > CAPS.geminiOutputTokensPerCall
+  ) {
+    throw new Error('Gemini reported usage beyond a per-call cap');
+  }
+  return {
+    promptTokens: promptTokens!,
+    completionTokens: completionTokens!,
+    thoughtTokens,
+    totalTokens: totalTokens!,
+  };
 }
 
 function assertSuccess(response: HttpResponse, operation: string): void {
@@ -177,7 +238,7 @@ export function validateLlmOutputs(
   return value as ArmOutput[];
 }
 
-export function createFetchTransport(apiKey: string): HttpTransport {
+export function createGeminiFetchTransport(apiKey: string): HttpTransport {
   return {
     async send(request: HttpRequest): Promise<HttpResponse> {
       const controller = new AbortController();
@@ -185,11 +246,18 @@ export function createFetchTransport(apiKey: string): HttpTransport {
       try {
         const response = await fetch(request.url, {
           method: request.method,
-          headers: { ...request.headers, authorization: `Bearer ${apiKey}` },
+          headers: { ...request.headers, 'x-goog-api-key': apiKey },
           body: request.body,
           signal: controller.signal,
         });
-        return { status: response.status, body: (await response.json()) as unknown };
+        const text = await response.text();
+        let body: unknown = text;
+        try {
+          body = JSON.parse(text) as unknown;
+        } catch {
+          // Preserve a non-JSON provider error for the redacted raw artifact.
+        }
+        return { status: response.status, body };
       } finally {
         clearTimeout(timer);
       }

--- a/app/api/experiments/diacritic-ab/clients.ts
+++ b/app/api/experiments/diacritic-ab/clients.ts
@@ -115,9 +115,9 @@ export class DigitalOceanExperimentClient {
       body: serialized,
       timeoutMs: DO_TIMEOUT_MS,
     });
-    assertSuccess(response, 'DO completion request');
     const raw = response.body as ChatCompletionResponse;
     captureRaw?.(raw);
+    assertSuccess(response, 'DO completion request');
     const content = raw.choices?.[0]?.message?.content;
     if (typeof content !== 'string') throw new Error('DO response has no completion content');
     const promptTokens = raw.usage?.prompt_tokens;

--- a/app/api/experiments/diacritic-ab/clients.ts
+++ b/app/api/experiments/diacritic-ab/clients.ts
@@ -1,6 +1,7 @@
 import { TranslateRequest } from '@google-cloud/translate/build/src/v2';
 import {
   CAPS,
+  GEMINI_ACCESS_CHECK_TEXT,
   GEMINI_ENDPOINT,
   GEMINI_MODEL,
   GEMINI_TIMEOUT_MS,
@@ -100,18 +101,36 @@ export interface GeminiBatchResult {
 export class GeminiExperimentClient {
   public constructor(private readonly transport: HttpTransport) {}
 
-  public async assertModelAvailable(): Promise<void> {
+  public async checkGenerationAccess(): Promise<TokenUsage | undefined> {
     const response = await this.transport.send({
-      url: `${GEMINI_ENDPOINT}/models/${GEMINI_MODEL}`,
-      method: 'GET',
-      headers: {},
+      url: `${GEMINI_ENDPOINT}/models/${GEMINI_MODEL}:generateContent`,
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ role: 'user', parts: [{ text: GEMINI_ACCESS_CHECK_TEXT }] }],
+        generationConfig: {
+          temperature: 0,
+          candidateCount: 1,
+          maxOutputTokens: CAPS.geminiAccessCheckOutputTokens,
+          thinkingConfig: { thinkingLevel: CAPS.geminiThinkingLevel },
+        },
+      }),
       timeoutMs: GEMINI_TIMEOUT_MS,
     });
-    assertSuccess(response, 'Gemini model metadata request');
-    const name = (response.body as { name?: unknown })?.name;
-    if (name !== `models/${GEMINI_MODEL}`) {
-      throw new Error(`Required model ${GEMINI_MODEL} is unavailable to this key`);
+    assertSuccess(response, 'Gemini one-token access check');
+    const raw = response.body as GeminiResponse;
+    if (raw.candidates?.length !== 1) {
+      throw new Error('Gemini access check returned invalid or excessive output');
     }
+    if (raw.usageMetadata == null) return undefined;
+    const usage = validateGeminiUsage(raw.usageMetadata);
+    if (
+      usage.promptTokens > CAPS.geminiAccessCheckInputTokens ||
+      usage.completionTokens + usage.thoughtTokens > CAPS.geminiAccessCheckOutputTokens
+    ) {
+      throw new Error('Gemini access check returned invalid or excessive output');
+    }
+    return usage;
   }
 
   public async complete(
@@ -162,7 +181,7 @@ function assertFixedGeminiConfig(request: GeminiRequestBody): void {
     config.candidateCount !== CAPS.geminiCandidates ||
     config.maxOutputTokens !== CAPS.geminiOutputTokensPerCall ||
     config.responseMimeType !== 'application/json' ||
-    config.thinkingConfig.thinkingBudget !== CAPS.geminiThinkingBudget
+    config.thinkingConfig.thinkingLevel !== CAPS.geminiThinkingLevel
   ) {
     throw new Error('Gemini request does not match the fixed experiment configuration');
   }
@@ -203,7 +222,9 @@ function validateGeminiUsage(value: GeminiResponse['usageMetadata']): TokenUsage
 
 function assertSuccess(response: HttpResponse, operation: string): void {
   if (response.status < 200 || response.status >= 300) {
-    throw new Error(`${operation} failed with HTTP ${response.status}`);
+    const providerMessage = (response.body as { error?: { message?: unknown } })?.error?.message;
+    const detail = typeof providerMessage === 'string' ? `: ${providerMessage}` : '';
+    throw new Error(`${operation} failed with HTTP ${response.status}${detail}`);
   }
 }
 

--- a/app/api/experiments/diacritic-ab/constants.ts
+++ b/app/api/experiments/diacritic-ab/constants.ts
@@ -1,0 +1,40 @@
+export const ARTIFACT_DIR = 'tmp/llm-diacritic-ab';
+export const FIXTURE_PATH = 'app/api/experiments/fixtures/vi-diacritic-cases.json';
+
+export const DO_ENDPOINT = 'https://inference.do-ai.run';
+export const DO_MODEL = 'openai-gpt-4o-mini';
+export const DO_TIMEOUT_MS = 30_000;
+export const GOOGLE_TIMEOUT_MS = 15_000;
+
+export const CAPS = Object.freeze({
+  fixtureCases: 12,
+  sourceCharacters: 256,
+  doCalls: 2,
+  googleCalls: 3,
+  doInputTokensPerCall: 4096,
+  doOutputTokensPerCall: 768,
+  doInputTokens: 8192,
+  doOutputTokens: 1536,
+  googleSourceCharacters: 768,
+  retries: 0,
+  concurrency: 1,
+  acknowledgedUsd: 0.02,
+});
+
+export const RATES = Object.freeze({
+  verifiedOn: '2026-08-04',
+  doInputUsdPerMillionTokens: 0.15,
+  doOutputUsdPerMillionTokens: 0.6,
+  googleUsdPerMillionCharacters: 20,
+});
+
+export const MAX_APPROVED_RATES = Object.freeze({
+  doInputUsdPerMillionTokens: 0.15,
+  doOutputUsdPerMillionTokens: 0.6,
+  googleUsdPerMillionCharacters: 20,
+});
+
+export const PROMPT_VERSIONS = Object.freeze({
+  endToEnd: 'vi-diacritic-end-to-end-v1',
+  restore: 'vi-diacritic-restore-v1',
+});

--- a/app/api/experiments/diacritic-ab/constants.ts
+++ b/app/api/experiments/diacritic-ab/constants.ts
@@ -1,10 +1,13 @@
-export const EXPERIMENT_REVISION = 'vi-diacritic-ab-gemini-v2';
-export const ARTIFACT_DIR = 'tmp/llm-diacritic-ab-gemini';
+export const EXPERIMENT_REVISION = 'vi-diacritic-ab-gemini-3-1-v3';
+export const ARTIFACT_DIR = 'tmp/llm-diacritic-ab-gemini-3-1';
 export const V1_ARTIFACT_DIR = 'tmp/llm-diacritic-ab';
+export const V2_ARTIFACT_DIR = 'tmp/llm-diacritic-ab-gemini';
 export const FIXTURE_PATH = 'app/api/experiments/fixtures/vi-diacritic-cases.json';
 
 export const GEMINI_ENDPOINT = 'https://generativelanguage.googleapis.com/v1beta';
-export const GEMINI_MODEL = 'gemini-2.5-flash-lite';
+export const GEMINI_MODEL = 'gemini-3.1-flash-lite';
+export const GEMINI_CREDENTIAL_NAME = 'GEMINI_API_KEY';
+export const GEMINI_ACCESS_CHECK_TEXT = 'Reply with K.';
 export const GEMINI_TIMEOUT_MS = 30_000;
 export const GOOGLE_TIMEOUT_MS = 15_000;
 
@@ -17,9 +20,11 @@ export const CAPS = Object.freeze({
   geminiOutputTokensPerCall: 768,
   geminiInputTokens: 8192,
   geminiOutputTokens: 1536,
+  geminiAccessCheckInputTokens: 16,
+  geminiAccessCheckOutputTokens: 1,
   googleSourceCharacters: 768,
   geminiCandidates: 1,
-  geminiThinkingBudget: 0,
+  geminiThinkingLevel: 'minimal' as const,
   retries: 0,
   concurrency: 1,
   acknowledgedUsd: 0.02,
@@ -27,18 +32,18 @@ export const CAPS = Object.freeze({
 
 export const RATES = Object.freeze({
   verifiedOn: '2026-08-05',
-  geminiInputUsdPerMillionTokens: 0.1,
-  geminiOutputUsdPerMillionTokens: 0.4,
+  geminiInputUsdPerMillionTokens: 0.25,
+  geminiOutputUsdPerMillionTokens: 1.5,
   googleUsdPerMillionCharacters: 20,
 });
 
 export const MAX_APPROVED_RATES = Object.freeze({
-  geminiInputUsdPerMillionTokens: 0.1,
-  geminiOutputUsdPerMillionTokens: 0.4,
+  geminiInputUsdPerMillionTokens: 0.25,
+  geminiOutputUsdPerMillionTokens: 1.5,
   googleUsdPerMillionCharacters: 20,
 });
 
 export const PROMPT_VERSIONS = Object.freeze({
-  endToEnd: 'vi-diacritic-end-to-end-gemini-v2',
-  restore: 'vi-diacritic-restore-gemini-v2',
+  endToEnd: 'vi-diacritic-end-to-end-gemini-3-1-v3',
+  restore: 'vi-diacritic-restore-gemini-3-1-v3',
 });

--- a/app/api/experiments/diacritic-ab/constants.ts
+++ b/app/api/experiments/diacritic-ab/constants.ts
@@ -1,40 +1,44 @@
-export const ARTIFACT_DIR = 'tmp/llm-diacritic-ab';
+export const EXPERIMENT_REVISION = 'vi-diacritic-ab-gemini-v2';
+export const ARTIFACT_DIR = 'tmp/llm-diacritic-ab-gemini';
+export const V1_ARTIFACT_DIR = 'tmp/llm-diacritic-ab';
 export const FIXTURE_PATH = 'app/api/experiments/fixtures/vi-diacritic-cases.json';
 
-export const DO_ENDPOINT = 'https://inference.do-ai.run';
-export const DO_MODEL = 'openai-gpt-4o-mini';
-export const DO_TIMEOUT_MS = 30_000;
+export const GEMINI_ENDPOINT = 'https://generativelanguage.googleapis.com/v1beta';
+export const GEMINI_MODEL = 'gemini-2.5-flash-lite';
+export const GEMINI_TIMEOUT_MS = 30_000;
 export const GOOGLE_TIMEOUT_MS = 15_000;
 
 export const CAPS = Object.freeze({
   fixtureCases: 12,
   sourceCharacters: 256,
-  doCalls: 2,
+  geminiCalls: 2,
   googleCalls: 3,
-  doInputTokensPerCall: 4096,
-  doOutputTokensPerCall: 768,
-  doInputTokens: 8192,
-  doOutputTokens: 1536,
+  geminiInputTokensPerCall: 4096,
+  geminiOutputTokensPerCall: 768,
+  geminiInputTokens: 8192,
+  geminiOutputTokens: 1536,
   googleSourceCharacters: 768,
+  geminiCandidates: 1,
+  geminiThinkingBudget: 0,
   retries: 0,
   concurrency: 1,
   acknowledgedUsd: 0.02,
 });
 
 export const RATES = Object.freeze({
-  verifiedOn: '2026-08-04',
-  doInputUsdPerMillionTokens: 0.15,
-  doOutputUsdPerMillionTokens: 0.6,
+  verifiedOn: '2026-08-05',
+  geminiInputUsdPerMillionTokens: 0.1,
+  geminiOutputUsdPerMillionTokens: 0.4,
   googleUsdPerMillionCharacters: 20,
 });
 
 export const MAX_APPROVED_RATES = Object.freeze({
-  doInputUsdPerMillionTokens: 0.15,
-  doOutputUsdPerMillionTokens: 0.6,
+  geminiInputUsdPerMillionTokens: 0.1,
+  geminiOutputUsdPerMillionTokens: 0.4,
   googleUsdPerMillionCharacters: 20,
 });
 
 export const PROMPT_VERSIONS = Object.freeze({
-  endToEnd: 'vi-diacritic-end-to-end-v1',
-  restore: 'vi-diacritic-restore-v1',
+  endToEnd: 'vi-diacritic-end-to-end-gemini-v2',
+  restore: 'vi-diacritic-restore-gemini-v2',
 });

--- a/app/api/experiments/diacritic-ab/evaluation.ts
+++ b/app/api/experiments/diacritic-ab/evaluation.ts
@@ -1,0 +1,117 @@
+import crypto from 'crypto';
+import { RATES } from './constants';
+import { ArmResult, DiacriticCase, ExperimentArm } from './types';
+
+function normalized(value: string | undefined): string {
+  return (value ?? '').trim().replace(/\s+/g, ' ').toLocaleLowerCase('en');
+}
+
+function whitespaceNormalized(value: string | undefined): string {
+  return (value ?? '').trim().replace(/\s+/g, ' ');
+}
+
+export interface MechanicalRow {
+  arm: ExperimentArm;
+  id: string;
+  noOp: boolean;
+  exactRestoration: boolean | null;
+  restorationDifference: { expected: string; actual: string } | null;
+  controlPreserved: boolean | null;
+}
+
+export function mechanicalRows(cases: DiacriticCase[], arms: ArmResult[]): MechanicalRow[] {
+  const byId = new Map(cases.map(item => [item.id, item]));
+  return arms.flatMap(arm =>
+    arm.outputs.map(output => {
+      const item = byId.get(output.id)!;
+      const candidate = output.english ?? output.restoredVi;
+      const exactRestoration =
+        item.canonicalVietnamese == null || output.restoredVi == null
+          ? null
+          : output.restoredVi === item.canonicalVietnamese;
+      return {
+        arm: arm.arm,
+        id: output.id,
+        noOp:
+          output.status !== 'ambiguous' && normalized(candidate) === normalized(item.asciiInput),
+        exactRestoration,
+        restorationDifference:
+          exactRestoration === false
+            ? { expected: item.canonicalVietnamese!, actual: output.restoredVi! }
+            : null,
+        controlPreserved:
+          item.category === 'control'
+            ? whitespaceNormalized(candidate) === whitespaceNormalized(item.asciiInput)
+            : null,
+      };
+    })
+  );
+}
+
+export function observedCost(arms: ArmResult[]): { usd: number; complete: boolean } {
+  let usd = 0;
+  for (const arm of arms) {
+    if (arm.usage != null) {
+      usd += (arm.usage.promptTokens * RATES.doInputUsdPerMillionTokens) / 1_000_000;
+      usd += (arm.usage.completionTokens * RATES.doOutputUsdPerMillionTokens) / 1_000_000;
+    }
+    if (arm.googleSourceCharacters != null) {
+      usd += (arm.googleSourceCharacters * RATES.googleUsdPerMillionCharacters) / 1_000_000;
+    }
+  }
+  return { usd, complete: arms.length === 4 };
+}
+
+function shuffled<T>(values: T[]): T[] {
+  const result = [...values];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = crypto.randomInt(i + 1);
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+export function blindResults(
+  cases: DiacriticCase[],
+  arms: ArmResult[]
+): { mapping: Record<string, ExperimentArm>; review: string } {
+  const armNames = shuffled(arms.map(arm => arm.arm));
+  const labels = ['A', 'B', 'C', 'D'];
+  const mapping = Object.fromEntries(
+    labels.map((label, index) => [label, armNames[index]])
+  ) as Record<string, ExperimentArm>;
+  const armByName = new Map(arms.map(arm => [arm.arm, arm]));
+  const rows = shuffled(
+    labels.flatMap(label => {
+      const arm = armByName.get(mapping[label])!;
+      return arm.outputs.map(output => ({ label, output }));
+    })
+  );
+  const byId = new Map(cases.map(item => [item.id, item]));
+  const lines = [
+    '# Vietnamese diacritic A/B review',
+    '',
+    'Score each row: 0 wrong, 1 related, 2 correct, 3 natural. Do not unblind arm labels until grading is complete.',
+    '',
+    '| Row | Case | Input | Arm | Restored Vietnamese | English | Status / alternatives | Score | VI acceptable? | EN acceptable? | Ambiguity justified? | Harmful confidence? | Correction |',
+    '| ---: | --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- | --- | --- |',
+  ];
+  rows.forEach(({ label, output }, index) => {
+    const input = byId.get(output.id)!.asciiInput;
+    const status =
+      output.status === 'ambiguous' ? `ambiguous: ${output.alternatives.join('; ')}` : 'resolved';
+    const cells = [
+      index + 1,
+      output.id,
+      input,
+      label,
+      output.restoredVi ?? '—',
+      output.english ?? '—',
+      status,
+    ];
+    lines.push(
+      `| ${cells.map(value => String(value).replace(/\|/g, '\\|')).join(' | ')} |  |  |  |  |  |  |`
+    );
+  });
+  return { mapping, review: `${lines.join('\n')}\n` };
+}

--- a/app/api/experiments/diacritic-ab/evaluation.ts
+++ b/app/api/experiments/diacritic-ab/evaluation.ts
@@ -113,7 +113,12 @@ export function blindResults(
       status,
     ];
     lines.push(
-      `| ${cells.map(value => String(value).replace(/\|/g, '\\|')).join(' | ')} |  |  |  |  |  |  |`
+      // Normalized before escaping: restoredVi/english/alternatives are model
+      // output, and a newline in any of them ends the row early and corrupts
+      // the blinded grading sheet. Pipes are escaped, not stripped.
+      `| ${cells
+        .map(value => whitespaceNormalized(String(value)).replace(/\|/g, '\\|'))
+        .join(' | ')} |  |  |  |  |  |  |`
     );
   });
   return { mapping, review: `${lines.join('\n')}\n` };

--- a/app/api/experiments/diacritic-ab/evaluation.ts
+++ b/app/api/experiments/diacritic-ab/evaluation.ts
@@ -52,8 +52,11 @@ export function observedCost(arms: ArmResult[]): { usd: number; complete: boolea
   let usd = 0;
   for (const arm of arms) {
     if (arm.usage != null) {
-      usd += (arm.usage.promptTokens * RATES.doInputUsdPerMillionTokens) / 1_000_000;
-      usd += (arm.usage.completionTokens * RATES.doOutputUsdPerMillionTokens) / 1_000_000;
+      usd += (arm.usage.promptTokens * RATES.geminiInputUsdPerMillionTokens) / 1_000_000;
+      usd +=
+        ((arm.usage.completionTokens + arm.usage.thoughtTokens) *
+          RATES.geminiOutputUsdPerMillionTokens) /
+        1_000_000;
     }
     if (arm.googleSourceCharacters != null) {
       usd += (arm.googleSourceCharacters * RATES.googleUsdPerMillionCharacters) / 1_000_000;

--- a/app/api/experiments/diacritic-ab/fixture.ts
+++ b/app/api/experiments/diacritic-ab/fixture.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+import { CAPS, FIXTURE_PATH } from './constants';
+import { CaseCategory, DiacriticCase } from './types';
+
+const CATEGORIES = new Set<CaseCategory>(['live', 'synthetic', 'ambiguous', 'control']);
+
+export function stripVietnameseDiacritics(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/đ/g, 'd')
+    .replace(/Đ/g, 'D')
+    .normalize('NFC');
+}
+
+export function validateFixture(value: unknown): DiacriticCase[] {
+  if (!Array.isArray(value) || value.length !== CAPS.fixtureCases) {
+    throw new Error(`Fixture must contain exactly ${CAPS.fixtureCases} cases`);
+  }
+  const cases = value as DiacriticCase[];
+  const ids = new Set<string>();
+  for (const item of cases) {
+    if (
+      item == null ||
+      typeof item.id !== 'string' ||
+      typeof item.asciiInput !== 'string' ||
+      !CATEGORIES.has(item.category)
+    ) {
+      throw new Error('Fixture contains a malformed case');
+    }
+    if (ids.has(item.id)) throw new Error(`Duplicate fixture id: ${item.id}`);
+    ids.add(item.id);
+    if (!/^[\x00-\x7f]*$/.test(item.asciiInput)) {
+      throw new Error(`Fixture input is not ASCII: ${item.id}`);
+    }
+    if (item.category === 'synthetic') {
+      if (item.canonicalVietnamese == null) {
+        throw new Error(`Synthetic case lacks canonicalVietnamese: ${item.id}`);
+      }
+      if (stripVietnameseDiacritics(item.canonicalVietnamese) !== item.asciiInput) {
+        throw new Error(`Synthetic case was not mechanically stripped: ${item.id}`);
+      }
+    }
+  }
+  const characters = cases.reduce((sum, item) => sum + item.asciiInput.length, 0);
+  if (characters > CAPS.sourceCharacters) {
+    throw new Error(`Fixture has ${characters} source characters; cap is ${CAPS.sourceCharacters}`);
+  }
+  return cases;
+}
+
+export function loadFixture(rootDir = process.cwd()): DiacriticCase[] {
+  const raw = fs.readFileSync(path.resolve(rootDir, FIXTURE_PATH), 'utf8');
+  return validateFixture(JSON.parse(raw) as unknown);
+}

--- a/app/api/experiments/diacritic-ab/prompts.ts
+++ b/app/api/experiments/diacritic-ab/prompts.ts
@@ -1,11 +1,11 @@
-import { CAPS, DO_MODEL, PROMPT_VERSIONS } from './constants';
+import { CAPS, PROMPT_VERSIONS } from './constants';
 import { DiacriticCase } from './types';
 
 export type LlmMode = 'end-to-end' | 'restore';
 
 const SHARED_PROMPT = `Inputs are user-authored Oxygen Not Included blueprint titles that may be Vietnamese typed without diacritics. Use ONI context only to disambiguate; never invent absent details. Preserve digits, version markers, punctuation, and ASCII game jargon such as SPOM. Return English or acronym-only controls unchanged. If meaning is genuinely underdetermined, use status "ambiguous" and at most three plausible alternatives instead of guessing. Return only data matching the schema.`;
 
-function responseSchema(mode: LlmMode): Record<string, unknown> {
+export function responseSchema(mode: LlmMode): Record<string, unknown> {
   const properties: Record<string, unknown> = {
     id: { type: 'string' },
     status: { type: 'string', enum: ['resolved', 'ambiguous'] },
@@ -32,20 +32,20 @@ function responseSchema(mode: LlmMode): Record<string, unknown> {
   };
 }
 
-export interface DoRequestBody {
-  model: typeof DO_MODEL;
-  messages: { role: 'system' | 'user'; content: string }[];
-  temperature: 0;
-  max_completion_tokens: number;
-  response_format: {
-    type: 'json_schema';
-    json_schema: { name: string; strict: true; schema: Record<string, unknown> };
+export interface GeminiRequestBody {
+  systemInstruction: { parts: { text: string }[] };
+  contents: { role: 'user'; parts: { text: string }[] }[];
+  generationConfig: {
+    temperature: 0;
+    candidateCount: 1;
+    maxOutputTokens: number;
+    responseMimeType: 'application/json';
+    responseJsonSchema: Record<string, unknown>;
+    thinkingConfig: { thinkingBudget: 0 };
   };
 }
 
-export function buildDoRequest(cases: DiacriticCase[], mode: LlmMode): DoRequestBody {
-  // Only IDs and experiment inputs enter the provider layer. Ground truth and
-  // reviewer notes remain in fixture/evaluation code.
+export function buildGeminiRequest(cases: DiacriticCase[], mode: LlmMode): GeminiRequestBody {
   const inputs = cases.map(item => ({ id: item.id, text: item.asciiInput }));
   const task =
     mode === 'end-to-end'
@@ -53,20 +53,15 @@ export function buildDoRequest(cases: DiacriticCase[], mode: LlmMode): DoRequest
       : 'Restore the intended Vietnamese only; do not translate it to English.';
   const version = mode === 'end-to-end' ? PROMPT_VERSIONS.endToEnd : PROMPT_VERSIONS.restore;
   return {
-    model: DO_MODEL,
-    messages: [
-      { role: 'system', content: `${version}\n${SHARED_PROMPT}\n${task}` },
-      { role: 'user', content: JSON.stringify({ inputs }) },
-    ],
-    temperature: 0,
-    max_completion_tokens: CAPS.doOutputTokensPerCall,
-    response_format: {
-      type: 'json_schema',
-      json_schema: {
-        name: `vi_diacritic_${mode.replace(/-/g, '_')}`,
-        strict: true,
-        schema: responseSchema(mode),
-      },
+    systemInstruction: { parts: [{ text: `${version}\n${SHARED_PROMPT}\n${task}` }] },
+    contents: [{ role: 'user', parts: [{ text: JSON.stringify({ inputs }) }] }],
+    generationConfig: {
+      temperature: 0,
+      candidateCount: CAPS.geminiCandidates,
+      maxOutputTokens: CAPS.geminiOutputTokensPerCall,
+      responseMimeType: 'application/json',
+      responseJsonSchema: responseSchema(mode),
+      thinkingConfig: { thinkingBudget: CAPS.geminiThinkingBudget },
     },
   };
 }

--- a/app/api/experiments/diacritic-ab/prompts.ts
+++ b/app/api/experiments/diacritic-ab/prompts.ts
@@ -1,0 +1,72 @@
+import { CAPS, DO_MODEL, PROMPT_VERSIONS } from './constants';
+import { DiacriticCase } from './types';
+
+export type LlmMode = 'end-to-end' | 'restore';
+
+const SHARED_PROMPT = `Inputs are user-authored Oxygen Not Included blueprint titles that may be Vietnamese typed without diacritics. Use ONI context only to disambiguate; never invent absent details. Preserve digits, version markers, punctuation, and ASCII game jargon such as SPOM. Return English or acronym-only controls unchanged. If meaning is genuinely underdetermined, use status "ambiguous" and at most three plausible alternatives instead of guessing. Return only data matching the schema.`;
+
+function responseSchema(mode: LlmMode): Record<string, unknown> {
+  const properties: Record<string, unknown> = {
+    id: { type: 'string' },
+    status: { type: 'string', enum: ['resolved', 'ambiguous'] },
+    restoredVi: { type: 'string' },
+    alternatives: { type: 'array', items: { type: 'string' }, maxItems: 3 },
+  };
+  const required = ['id', 'status', 'restoredVi', 'alternatives'];
+  if (mode === 'end-to-end') {
+    properties.english = { type: 'string' };
+    required.push('english');
+  }
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      results: {
+        type: 'array',
+        minItems: CAPS.fixtureCases,
+        maxItems: CAPS.fixtureCases,
+        items: { type: 'object', additionalProperties: false, properties, required },
+      },
+    },
+    required: ['results'],
+  };
+}
+
+export interface DoRequestBody {
+  model: typeof DO_MODEL;
+  messages: { role: 'system' | 'user'; content: string }[];
+  temperature: 0;
+  max_completion_tokens: number;
+  response_format: {
+    type: 'json_schema';
+    json_schema: { name: string; strict: true; schema: Record<string, unknown> };
+  };
+}
+
+export function buildDoRequest(cases: DiacriticCase[], mode: LlmMode): DoRequestBody {
+  // Only IDs and experiment inputs enter the provider layer. Ground truth and
+  // reviewer notes remain in fixture/evaluation code.
+  const inputs = cases.map(item => ({ id: item.id, text: item.asciiInput }));
+  const task =
+    mode === 'end-to-end'
+      ? 'Restore the intended Vietnamese and translate its meaning to English.'
+      : 'Restore the intended Vietnamese only; do not translate it to English.';
+  const version = mode === 'end-to-end' ? PROMPT_VERSIONS.endToEnd : PROMPT_VERSIONS.restore;
+  return {
+    model: DO_MODEL,
+    messages: [
+      { role: 'system', content: `${version}\n${SHARED_PROMPT}\n${task}` },
+      { role: 'user', content: JSON.stringify({ inputs }) },
+    ],
+    temperature: 0,
+    max_completion_tokens: CAPS.doOutputTokensPerCall,
+    response_format: {
+      type: 'json_schema',
+      json_schema: {
+        name: `vi_diacritic_${mode.replace(/-/g, '_')}`,
+        strict: true,
+        schema: responseSchema(mode),
+      },
+    },
+  };
+}

--- a/app/api/experiments/diacritic-ab/prompts.ts
+++ b/app/api/experiments/diacritic-ab/prompts.ts
@@ -41,7 +41,7 @@ export interface GeminiRequestBody {
     maxOutputTokens: number;
     responseMimeType: 'application/json';
     responseJsonSchema: Record<string, unknown>;
-    thinkingConfig: { thinkingBudget: 0 };
+    thinkingConfig: { thinkingLevel: 'minimal' };
   };
 }
 
@@ -61,7 +61,7 @@ export function buildGeminiRequest(cases: DiacriticCase[], mode: LlmMode): Gemin
       maxOutputTokens: CAPS.geminiOutputTokensPerCall,
       responseMimeType: 'application/json',
       responseJsonSchema: responseSchema(mode),
-      thinkingConfig: { thinkingBudget: CAPS.geminiThinkingBudget },
+      thinkingConfig: { thinkingLevel: CAPS.geminiThinkingLevel },
     },
   };
 }

--- a/app/api/experiments/diacritic-ab/types.ts
+++ b/app/api/experiments/diacritic-ab/types.ts
@@ -22,6 +22,8 @@ export interface ArmOutput {
 export interface TokenUsage {
   promptTokens: number;
   completionTokens: number;
+  thoughtTokens: number;
+  totalTokens: number;
 }
 
 export interface ArmResult {

--- a/app/api/experiments/diacritic-ab/types.ts
+++ b/app/api/experiments/diacritic-ab/types.ts
@@ -1,0 +1,49 @@
+export type CaseCategory = 'live' | 'synthetic' | 'ambiguous' | 'control';
+export type ExperimentArm = 'google-auto' | 'google-vi' | 'llm-end-to-end' | 'restore-google';
+export type RestorationStatus = 'resolved' | 'ambiguous';
+
+export interface DiacriticCase {
+  id: string;
+  asciiInput: string;
+  canonicalVietnamese?: string;
+  acceptableEnglish?: string[];
+  category: CaseCategory;
+  reviewerNote?: string;
+}
+
+export interface ArmOutput {
+  id: string;
+  status: RestorationStatus;
+  restoredVi?: string;
+  english?: string;
+  alternatives: string[];
+}
+
+export interface TokenUsage {
+  promptTokens: number;
+  completionTokens: number;
+}
+
+export interface ArmResult {
+  arm: ExperimentArm;
+  outputs: ArmOutput[];
+  usage?: TokenUsage;
+  googleSourceCharacters?: number;
+}
+
+export interface HttpRequest {
+  url: string;
+  method: 'GET' | 'POST';
+  headers: Record<string, string>;
+  body?: string;
+  timeoutMs: number;
+}
+
+export interface HttpResponse {
+  status: number;
+  body: unknown;
+}
+
+export interface HttpTransport {
+  send(request: HttpRequest): Promise<HttpResponse>;
+}

--- a/app/api/experiments/fixtures/vi-diacritic-cases.json
+++ b/app/api/experiments/fixtures/vi-diacritic-cases.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "live-dien-phan",
+    "asciiInput": "Dien phan",
+    "canonicalVietnamese": "Điện phân",
+    "acceptableEnglish": ["Electrolysis"],
+    "category": "live"
+  },
+  {
+    "id": "live-dien-phan-2",
+    "asciiInput": "Dien phan 2",
+    "canonicalVietnamese": "Điện phân 2",
+    "acceptableEnglish": ["Electrolysis 2"],
+    "category": "live"
+  },
+  {
+    "id": "synthetic-water-electrolysis",
+    "asciiInput": "Dien phan nuoc",
+    "canonicalVietnamese": "Điện phân nước",
+    "acceptableEnglish": ["Water electrolysis"],
+    "category": "synthetic"
+  },
+  {
+    "id": "synthetic-water-purification",
+    "asciiInput": "Loc nuoc ban",
+    "canonicalVietnamese": "Lọc nước bẩn",
+    "acceptableEnglish": ["Polluted water purification", "Dirty water purification"],
+    "category": "synthetic"
+  },
+  {
+    "id": "synthetic-gas-pump",
+    "asciiInput": "Bom khi tu dong",
+    "canonicalVietnamese": "Bơm khí tự động",
+    "acceptableEnglish": ["Automatic gas pump", "Automated gas pumping"],
+    "category": "synthetic"
+  },
+  {
+    "id": "synthetic-gas-storage",
+    "asciiInput": "Kho chua khi 2",
+    "canonicalVietnamese": "Kho chứa khí 2",
+    "acceptableEnglish": ["Gas storage 2"],
+    "category": "synthetic"
+  },
+  {
+    "id": "synthetic-spom-oxygen",
+    "asciiInput": "SPOM tao oxy",
+    "canonicalVietnamese": "SPOM tạo oxy",
+    "acceptableEnglish": ["SPOM oxygen production", "SPOM makes oxygen"],
+    "category": "synthetic"
+  },
+  {
+    "id": "synthetic-cooling-power",
+    "asciiInput": "Lam mat bang dien",
+    "canonicalVietnamese": "Làm mát bằng điện",
+    "acceptableEnglish": ["Electric cooling", "Cooling with electricity"],
+    "category": "synthetic"
+  },
+  {
+    "id": "ambiguous-ma",
+    "asciiInput": "ma",
+    "acceptableEnglish": ["ghost", "mother", "but", "horse", "code"],
+    "category": "ambiguous",
+    "reviewerNote": "Short tone collision; an ambiguous response is expected."
+  },
+  {
+    "id": "ambiguous-khi",
+    "asciiInput": "khi",
+    "acceptableEnglish": ["gas", "when", "monkey"],
+    "category": "ambiguous",
+    "reviewerNote": "Tone and context can change the meaning; abstention is acceptable."
+  },
+  {
+    "id": "control-spom-v3",
+    "asciiInput": "SPOM v3",
+    "acceptableEnglish": ["SPOM v3"],
+    "category": "control"
+  },
+  {
+    "id": "control-main-base",
+    "asciiInput": "Main base",
+    "acceptableEnglish": ["Main base"],
+    "category": "control"
+  }
+]

--- a/app/api/experiments/translate-diacritic-ab.ts
+++ b/app/api/experiments/translate-diacritic-ab.ts
@@ -6,6 +6,7 @@ import { ArtifactStore, sha256 } from './diacritic-ab/artifacts';
 import {
   assertGeminiRequestWithinCap,
   assertGoogleCharacters,
+  calculateAccessCheckMaximumCost,
   fullReservation,
 } from './diacritic-ab/caps';
 import {
@@ -18,11 +19,13 @@ import {
   CAPS,
   EXPERIMENT_REVISION,
   FIXTURE_PATH,
+  GEMINI_CREDENTIAL_NAME,
   GEMINI_ENDPOINT,
   GEMINI_MODEL,
   PROMPT_VERSIONS,
   RATES,
   V1_ARTIFACT_DIR,
+  V2_ARTIFACT_DIR,
 } from './diacritic-ab/constants';
 import { blindResults, mechanicalRows, observedCost } from './diacritic-ab/evaluation';
 import { loadFixture } from './diacritic-ab/fixture';
@@ -30,25 +33,43 @@ import { buildGeminiRequest } from './diacritic-ab/prompts';
 import { ArmOutput, ArmResult, DiacriticCase, ExperimentArm } from './diacritic-ab/types';
 
 interface CliOptions {
-  mode: 'dry-run' | 'execute';
+  mode: 'dry-run' | 'check-gemini-access' | 'execute';
 }
 
 export function parseCli(argv: string[], nodeEnv = process.env.NODE_ENV): CliOptions {
-  const allowed = new Set(['--execute', '--ack-max-usd=0.02']);
+  const allowed = new Set([
+    '--check-gemini-access',
+    '--ack-access-check-usd=0.0000055',
+    '--execute',
+    '--ack-max-usd=0.02',
+  ]);
   const unknown = argv.filter(arg => !allowed.has(arg));
   if (unknown.length > 0) throw new Error(`Unknown argument(s): ${unknown.join(', ')}`);
   const execute = argv.includes('--execute');
+  const checkGeminiAccess = argv.includes('--check-gemini-access');
   const acknowledged = argv.includes('--ack-max-usd=0.02');
+  const accessCheckAcknowledged = argv.includes('--ack-access-check-usd=0.0000055');
+  if (execute && checkGeminiAccess) {
+    throw new Error('--execute and --check-gemini-access are mutually exclusive');
+  }
   if (!execute && acknowledged) {
     throw new Error('The acknowledgement is valid only with --execute');
+  }
+  if (!checkGeminiAccess && accessCheckAcknowledged) {
+    throw new Error('The access-check acknowledgement is valid only with --check-gemini-access');
+  }
+  if (checkGeminiAccess && !accessCheckAcknowledged) {
+    throw new Error(
+      'Gemini access check requires the exact acknowledgement --ack-access-check-usd=0.0000055'
+    );
   }
   if (execute && !acknowledged) {
     throw new Error('Live execution requires the exact acknowledgement --ack-max-usd=0.02');
   }
-  if (execute && nodeEnv === 'test') {
-    throw new Error('Live experiment execution is disabled when NODE_ENV=test');
+  if ((execute || checkGeminiAccess) && nodeEnv === 'test') {
+    throw new Error('Experiment network access is disabled when NODE_ENV=test');
   }
-  return { mode: execute ? 'execute' : 'dry-run' };
+  return { mode: execute ? 'execute' : checkGeminiAccess ? 'check-gemini-access' : 'dry-run' };
 }
 
 function promptHash(request: ReturnType<typeof buildGeminiRequest>): string {
@@ -79,9 +100,14 @@ export function makeManifest(rootDir: string, cases: DiacriticCase[]) {
   const manifest = {
     experiment: EXPERIMENT_REVISION,
     createdAt: new Date().toISOString(),
-    v1Disposition: fs.existsSync(path.resolve(rootDir, V1_ARTIFACT_DIR))
-      ? 'preserved-local-artifact-present'
-      : 'local-artifact-absent-or-deleted',
+    priorArtifactDisposition: {
+      digitalOceanV1: fs.existsSync(path.resolve(rootDir, V1_ARTIFACT_DIR))
+        ? 'preserved-local-artifact-present'
+        : 'local-artifact-absent-or-deleted',
+      gemini25V2: fs.existsSync(path.resolve(rootDir, V2_ARTIFACT_DIR))
+        ? 'preserved-local-artifact-present'
+        : 'local-artifact-absent-or-deleted',
+    },
     fixture: { path: FIXTURE_PATH, sha256: fixtureHash, cases: cases.length, sourceCharacters },
     prompts: {
       endToEnd: { version: PROMPT_VERSIONS.endToEnd, sha256: promptHash(endToEnd) },
@@ -91,7 +117,7 @@ export function makeManifest(rootDir: string, cases: DiacriticCase[]) {
       gemini: { endpoint: GEMINI_ENDPOINT, model: GEMINI_MODEL, api: 'generateContent-v1beta' },
       google: { api: 'cloud-translation-basic-v2' },
     },
-    credentialNames: ['GEMINI_API_KEY', 'GOOGLE_TRANSLATE_API_KEY'],
+    credentialNames: [GEMINI_CREDENTIAL_NAME, 'GOOGLE_TRANSLATE_API_KEY'],
     requestReservations: {
       geminiEndToEndInputTokens: assertGeminiRequestWithinCap(JSON.stringify(endToEnd)),
       geminiRestoreInputTokens: assertGeminiRequestWithinCap(JSON.stringify(restore)),
@@ -103,7 +129,7 @@ export function makeManifest(rootDir: string, cases: DiacriticCase[]) {
     },
     calls: {
       geminiInference: CAPS.geminiCalls,
-      geminiMetadataPreflight: 1,
+      optionalGeminiAccessCheckInference: 1,
       googleTranslation: CAPS.googleCalls,
       retries: CAPS.retries,
       concurrency: CAPS.concurrency,
@@ -115,6 +141,7 @@ export function makeManifest(rootDir: string, cases: DiacriticCase[]) {
     },
     caps: CAPS,
     reservation,
+    accessCheckMaximumUsd: calculateAccessCheckMaximumCost(),
     identities: {
       googleAuto: cacheIdentity('google-auto', 'google-basic-v2', 'batch-auto-v1', fixtureHash),
       googleVi: cacheIdentity('google-vi', 'google-basic-v2', 'batch-forced-vi-v1', fixtureHash),
@@ -144,10 +171,31 @@ function printPreflight(
     console.log(
       `Live execution acknowledged. Reserving exactly 2 Gemini inference calls, 3 Google translation calls, and $${manifest.reservation.maximumUsd.toFixed(7)} maximum calculated usage ($0.02 fail-closed ledger).`
     );
-  } else {
+  } else if (mode === 'dry-run') {
     console.log(
       'Offline dry run complete. No credential was read, no live client was constructed, and no provider request was sent.'
     );
+  }
+}
+
+async function checkGeminiAccess(): Promise<void> {
+  dotenv.config();
+  const geminiKey = process.env[GEMINI_CREDENTIAL_NAME];
+  if (!geminiKey) throw new Error(`${GEMINI_CREDENTIAL_NAME} is required for the access check`);
+  try {
+    const client = new GeminiExperimentClient(createGeminiFetchTransport(geminiKey));
+    const usage = await client.checkGenerationAccess();
+    if (usage == null) {
+      console.log(
+        `Gemini one-token access check succeeded for ${GEMINI_MODEL}. Gemini omitted usage metadata; conservatively retain the full $${calculateAccessCheckMaximumCost()} access-check ceiling.`
+      );
+    } else {
+      console.log(
+        `Gemini one-token access check succeeded for ${GEMINI_MODEL}. Reported usage: ${usage.promptTokens} input, ${usage.completionTokens + usage.thoughtTokens} output tokens.`
+      );
+    }
+  } catch (error) {
+    throw new Error((error as Error).message.split(geminiKey).join('[REDACTED]'));
   }
 }
 
@@ -186,10 +234,12 @@ async function executeLive(
   }
 
   dotenv.config();
-  const geminiKey = process.env.GEMINI_API_KEY;
+  const geminiKey = process.env[GEMINI_CREDENTIAL_NAME];
   const googleKey = process.env.GOOGLE_TRANSLATE_API_KEY;
   if (!geminiKey || !googleKey) {
-    throw new Error('GEMINI_API_KEY and GOOGLE_TRANSLATE_API_KEY are required for --execute');
+    throw new Error(
+      `${GEMINI_CREDENTIAL_NAME} and GOOGLE_TRANSLATE_API_KEY are required for --execute`
+    );
   }
   const secrets = [geminiKey, googleKey];
   const capture = (name: string) => (raw: unknown) =>
@@ -224,7 +274,7 @@ async function executeLive(
   const googleClient = new GoogleExperimentClient(googleSdk);
   const inputs = cases.map(item => item.asciiInput);
   const results: ArmResult[] = [];
-  let currentOperation = 'model-access';
+  let currentOperation = 'llm-end-to-end';
   const persistPartialResults = () =>
     store.writeJson('results.json', {
       partial: true,
@@ -236,7 +286,14 @@ async function executeLive(
 
   try {
     updateReservation('running');
-    await geminiClient.assertModelAvailable();
+    const llmEndToEnd = await geminiClient.complete(
+      endToEndRequest,
+      cases,
+      'end-to-end',
+      capture('llm-end-to-end')
+    );
+    results.push({ arm: 'llm-end-to-end', outputs: llmEndToEnd.outputs, usage: llmEndToEnd.usage });
+    persistPartialResults();
 
     currentOperation = 'google-auto';
     const googleAuto = await googleClient.translate(inputs, 'auto', capture('google-auto'));
@@ -254,16 +311,6 @@ async function executeLive(
       outputs: googleOutputs(cases, googleVi.texts),
       googleSourceCharacters: googleVi.sourceCharacters,
     });
-    persistPartialResults();
-
-    currentOperation = 'llm-end-to-end';
-    const llmEndToEnd = await geminiClient.complete(
-      endToEndRequest,
-      cases,
-      'end-to-end',
-      capture('llm-end-to-end')
-    );
-    results.push({ arm: 'llm-end-to-end', outputs: llmEndToEnd.outputs, usage: llmEndToEnd.usage });
     persistPartialResults();
 
     currentOperation = 'restore-google';
@@ -331,6 +378,10 @@ export async function main(argv = process.argv.slice(2), rootDir = process.cwd()
   store.writeJson('manifest.json', manifest);
   printPreflight(manifest, options.mode);
   if (options.mode === 'dry-run') return;
+  if (options.mode === 'check-gemini-access') {
+    await checkGeminiAccess();
+    return;
+  }
   await executeLive(store, cases, endToEnd, restore, manifest, reservation);
 }
 

--- a/app/api/experiments/translate-diacritic-ab.ts
+++ b/app/api/experiments/translate-diacritic-ab.ts
@@ -4,60 +4,60 @@ import { Translate } from '@google-cloud/translate/build/src/v2';
 import dotenv from 'dotenv';
 import { ArtifactStore, sha256 } from './diacritic-ab/artifacts';
 import {
-  assertDoRequestWithinCap,
+  assertGeminiRequestWithinCap,
   assertGoogleCharacters,
   fullReservation,
 } from './diacritic-ab/caps';
 import {
-  createFetchTransport,
-  DigitalOceanExperimentClient,
+  createGeminiFetchTransport,
+  GeminiExperimentClient,
   GoogleExperimentClient,
 } from './diacritic-ab/clients';
 import {
   ARTIFACT_DIR,
   CAPS,
-  DO_ENDPOINT,
-  DO_MODEL,
+  EXPERIMENT_REVISION,
   FIXTURE_PATH,
+  GEMINI_ENDPOINT,
+  GEMINI_MODEL,
   PROMPT_VERSIONS,
   RATES,
+  V1_ARTIFACT_DIR,
 } from './diacritic-ab/constants';
 import { blindResults, mechanicalRows, observedCost } from './diacritic-ab/evaluation';
 import { loadFixture } from './diacritic-ab/fixture';
-import { buildDoRequest } from './diacritic-ab/prompts';
+import { buildGeminiRequest } from './diacritic-ab/prompts';
 import { ArmOutput, ArmResult, DiacriticCase, ExperimentArm } from './diacritic-ab/types';
 
 interface CliOptions {
-  mode: 'dry-run' | 'execute' | 'resume-reviewed-402';
-  acknowledged: boolean;
+  mode: 'dry-run' | 'execute';
 }
 
-function parseCli(argv: string[]): CliOptions {
-  const allowed = new Set(['--execute', '--resume-reviewed-402', '--ack-max-usd=0.02']);
+export function parseCli(argv: string[], nodeEnv = process.env.NODE_ENV): CliOptions {
+  const allowed = new Set(['--execute', '--ack-max-usd=0.02']);
   const unknown = argv.filter(arg => !allowed.has(arg));
   if (unknown.length > 0) throw new Error(`Unknown argument(s): ${unknown.join(', ')}`);
   const execute = argv.includes('--execute');
-  const resume = argv.includes('--resume-reviewed-402');
   const acknowledged = argv.includes('--ack-max-usd=0.02');
-  if (execute && resume)
-    throw new Error('--execute and --resume-reviewed-402 are mutually exclusive');
-  if (!execute && !resume && acknowledged) {
-    throw new Error('The acknowledgement is valid only with a live execution mode');
+  if (!execute && acknowledged) {
+    throw new Error('The acknowledgement is valid only with --execute');
   }
-  if ((execute || resume) && !acknowledged) {
+  if (execute && !acknowledged) {
     throw new Error('Live execution requires the exact acknowledgement --ack-max-usd=0.02');
   }
-  return { mode: resume ? 'resume-reviewed-402' : execute ? 'execute' : 'dry-run', acknowledged };
+  if (execute && nodeEnv === 'test') {
+    throw new Error('Live experiment execution is disabled when NODE_ENV=test');
+  }
+  return { mode: execute ? 'execute' : 'dry-run' };
 }
 
-function promptHash(request: ReturnType<typeof buildDoRequest>): string {
-  const withoutInputs = {
-    ...request,
-    messages: request.messages.map(message =>
-      message.role === 'user' ? { ...message, content: '<fixture-inputs>' } : message
-    ),
-  };
-  return sha256(JSON.stringify(withoutInputs));
+function promptHash(request: ReturnType<typeof buildGeminiRequest>): string {
+  return sha256(
+    JSON.stringify({
+      ...request,
+      contents: [{ role: 'user', parts: [{ text: '<fixture-inputs>' }] }],
+    })
+  );
 }
 
 function cacheIdentity(
@@ -66,43 +66,51 @@ function cacheIdentity(
   promptVersion: string,
   fixtureHash: string
 ): string {
-  return sha256(`${arm}\n${provider}\n${promptVersion}\n${fixtureHash}`);
+  return sha256(`${EXPERIMENT_REVISION}\n${arm}\n${provider}\n${promptVersion}\n${fixtureHash}`);
 }
 
-function makeManifest(rootDir: string, cases: DiacriticCase[]) {
+export function makeManifest(rootDir: string, cases: DiacriticCase[]) {
   const fixtureBytes = fs.readFileSync(path.resolve(rootDir, FIXTURE_PATH));
   const fixtureHash = sha256(fixtureBytes);
-  const endToEnd = buildDoRequest(cases, 'end-to-end');
-  const restore = buildDoRequest(cases, 'restore');
-  const serializedEndToEnd = JSON.stringify(endToEnd);
-  const serializedRestore = JSON.stringify(restore);
+  const endToEnd = buildGeminiRequest(cases, 'end-to-end');
+  const restore = buildGeminiRequest(cases, 'restore');
   const sourceCharacters = cases.reduce((sum, item) => sum + item.asciiInput.length, 0);
   const reservation = fullReservation();
   const manifest = {
-    experiment: 'vi-diacritic-ab-v1',
+    experiment: EXPERIMENT_REVISION,
     createdAt: new Date().toISOString(),
+    v1Disposition: fs.existsSync(path.resolve(rootDir, V1_ARTIFACT_DIR))
+      ? 'preserved-local-artifact-present'
+      : 'local-artifact-absent-or-deleted',
     fixture: { path: FIXTURE_PATH, sha256: fixtureHash, cases: cases.length, sourceCharacters },
     prompts: {
       endToEnd: { version: PROMPT_VERSIONS.endToEnd, sha256: promptHash(endToEnd) },
       restore: { version: PROMPT_VERSIONS.restore, sha256: promptHash(restore) },
     },
     provider: {
-      digitalOcean: { endpoint: DO_ENDPOINT, model: DO_MODEL },
-      google: { api: 'basic-v2' },
+      gemini: { endpoint: GEMINI_ENDPOINT, model: GEMINI_MODEL, api: 'generateContent-v1beta' },
+      google: { api: 'cloud-translation-basic-v2' },
     },
+    credentialNames: ['GEMINI_API_KEY', 'GOOGLE_TRANSLATE_API_KEY'],
     requestReservations: {
-      doEndToEndInputTokens: assertDoRequestWithinCap(serializedEndToEnd),
-      doRestoreInputTokens: assertDoRequestWithinCap(serializedRestore),
-      doOutputTokensPerCall: CAPS.doOutputTokensPerCall,
+      geminiEndToEndInputTokens: assertGeminiRequestWithinCap(JSON.stringify(endToEnd)),
+      geminiRestoreInputTokens: assertGeminiRequestWithinCap(JSON.stringify(restore)),
+      geminiOutputTokensPerCall: CAPS.geminiOutputTokensPerCall,
       googleCharactersPerFixtureBatch: assertGoogleCharacters(
         cases.map(item => item.asciiInput),
         CAPS.sourceCharacters
       ),
     },
-    calls: { digitalOceanInference: 2, googleTranslation: 3, retries: 0, concurrency: 1 },
+    calls: {
+      geminiInference: CAPS.geminiCalls,
+      geminiMetadataPreflight: 1,
+      googleTranslation: CAPS.googleCalls,
+      retries: CAPS.retries,
+      concurrency: CAPS.concurrency,
+    },
     rates: RATES,
     rateSources: {
-      digitalOcean: 'https://docs.digitalocean.com/products/inference/details/pricing/',
+      gemini: 'https://ai.google.dev/gemini-api/docs/pricing',
       google: 'https://cloud.google.com/translate/pricing',
     },
     caps: CAPS,
@@ -110,10 +118,15 @@ function makeManifest(rootDir: string, cases: DiacriticCase[]) {
     identities: {
       googleAuto: cacheIdentity('google-auto', 'google-basic-v2', 'batch-auto-v1', fixtureHash),
       googleVi: cacheIdentity('google-vi', 'google-basic-v2', 'batch-forced-vi-v1', fixtureHash),
-      llmEndToEnd: cacheIdentity('llm-end-to-end', DO_MODEL, PROMPT_VERSIONS.endToEnd, fixtureHash),
+      llmEndToEnd: cacheIdentity(
+        'llm-end-to-end',
+        GEMINI_MODEL,
+        PROMPT_VERSIONS.endToEnd,
+        fixtureHash
+      ),
       restoreGoogle: cacheIdentity(
         'restore-google',
-        `${DO_MODEL}+google-basic-v2`,
+        `${GEMINI_MODEL}+google-basic-v2`,
         PROMPT_VERSIONS.restore,
         fixtureHash
       ),
@@ -129,15 +142,11 @@ function printPreflight(
   console.log(JSON.stringify(manifest, null, 2));
   if (mode === 'execute') {
     console.log(
-      `Live execution acknowledged. Reserving exactly 2 DO calls, 3 Google calls, and $${manifest.reservation.maximumUsd.toFixed(7)} maximum calculated usage ($0.02 fail-closed ledger).`
-    );
-  } else if (mode === 'resume-reviewed-402') {
-    console.log(
-      'Reviewed HTTP 402 continuation acknowledged. Reusing 2 captured Google arms and reserving only the remaining 2 DO calls plus 1 Google call.'
+      `Live execution acknowledged. Reserving exactly 2 Gemini inference calls, 3 Google translation calls, and $${manifest.reservation.maximumUsd.toFixed(7)} maximum calculated usage ($0.02 fail-closed ledger).`
     );
   } else {
     console.log(
-      'Offline dry run complete. No live client was constructed and no provider request was sent.'
+      'Offline dry run complete. No credential was read, no live client was constructed, and no provider request was sent.'
     );
   }
 }
@@ -151,139 +160,49 @@ function googleOutputs(cases: DiacriticCase[], texts: string[]): ArmOutput[] {
   }));
 }
 
-function armGoogleCharacters(...values: number[]): number {
-  return values.reduce((sum, value) => sum + value, 0);
-}
-
-interface Reviewed402Reservation {
-  state?: unknown;
-  failure?: unknown;
-  calls?: { digitalOcean?: unknown; google?: unknown };
-  manifestFixtureSha256?: unknown;
-  resume?: unknown;
-  [key: string]: unknown;
-}
-
-interface PartialResultsArtifact {
-  partial?: unknown;
-  arms?: unknown;
-  operationalFailure?: { arm?: unknown; message?: unknown };
-}
-
-function validateCapturedGoogleArm(
-  value: unknown,
-  expectedArm: 'google-auto' | 'google-vi',
-  cases: DiacriticCase[]
-): ArmResult {
-  const arm = value as Partial<ArmResult>;
-  const expectedIds = new Set(cases.map(item => item.id));
-  const outputs = arm.outputs;
-  if (
-    arm.arm !== expectedArm ||
-    !Array.isArray(outputs) ||
-    outputs.length !== cases.length ||
-    arm.googleSourceCharacters !== cases.reduce((sum, item) => sum + item.asciiInput.length, 0)
-  ) {
-    throw new Error(`Captured ${expectedArm} arm does not match the reviewed fixture`);
-  }
-  const seen = new Set<string>();
-  for (const output of outputs) {
-    if (
-      typeof output.id !== 'string' ||
-      !expectedIds.has(output.id) ||
-      seen.has(output.id) ||
-      output.status !== 'resolved' ||
-      typeof output.english !== 'string' ||
-      !Array.isArray(output.alternatives) ||
-      output.alternatives.length !== 0
-    ) {
-      throw new Error(`Captured ${expectedArm} output is incomplete or misaligned`);
-    }
-    seen.add(output.id);
-  }
-  return arm as ArmResult;
-}
-
-export function loadReviewed402Continuation(
-  store: ArtifactStore,
-  cases: DiacriticCase[],
-  fixtureHash: string
-): { reservation: Reviewed402Reservation; results: ArmResult[] } {
-  if (!store.exists('reservation.json') || !store.exists('results.json')) {
-    throw new Error('Reviewed HTTP 402 continuation requires reservation.json and results.json');
-  }
-  const reservation = store.read('reservation.json') as Reviewed402Reservation;
-  const partial = store.read('results.json') as PartialResultsArtifact;
-  if (
-    reservation.state !== 'failed' ||
-    reservation.failure !== 'DO completion request failed with HTTP 402' ||
-    reservation.calls?.digitalOcean !== CAPS.doCalls ||
-    reservation.calls?.google !== CAPS.googleCalls ||
-    reservation.manifestFixtureSha256 !== fixtureHash ||
-    reservation.resume != null
-  ) {
-    throw new Error(
-      'Reservation is not the single reviewed HTTP 402 state authorized for continuation'
-    );
-  }
-  if (
-    partial.partial !== true ||
-    partial.operationalFailure?.arm !== 'llm-end-to-end' ||
-    partial.operationalFailure.message !== 'DO completion request failed with HTTP 402' ||
-    !Array.isArray(partial.arms) ||
-    partial.arms.length !== 2
-  ) {
-    throw new Error('Partial results are not the reviewed two-Google-arm HTTP 402 artifact');
-  }
-  for (const name of ['llm-end-to-end.json', 'llm-restore.json', 'restore-google.json']) {
-    if (fs.existsSync(path.join(store.responsesDir, name))) {
-      throw new Error(`Cannot continue because responses/${name} already exists`);
-    }
-  }
-  for (const name of ['google-auto.json', 'google-vi.json']) {
-    if (!fs.existsSync(path.join(store.responsesDir, name))) {
-      throw new Error(`Cannot continue without responses/${name}`);
-    }
-  }
-  return {
-    reservation,
-    results: [
-      validateCapturedGoogleArm(partial.arms[0], 'google-auto', cases),
-      validateCapturedGoogleArm(partial.arms[1], 'google-vi', cases),
-    ],
-  };
+function redactSecrets(value: unknown, secrets: string[]): unknown {
+  const serialized = JSON.stringify(value);
+  if (serialized == null) return value;
+  return JSON.parse(
+    secrets.reduce((result, secret) => result.split(secret).join('[REDACTED]'), serialized)
+  ) as unknown;
 }
 
 async function executeLive(
   store: ArtifactStore,
   cases: DiacriticCase[],
-  endToEndRequest: ReturnType<typeof buildDoRequest>,
-  restoreRequest: ReturnType<typeof buildDoRequest>,
+  endToEndRequest: ReturnType<typeof buildGeminiRequest>,
+  restoreRequest: ReturnType<typeof buildGeminiRequest>,
   manifest: ReturnType<typeof makeManifest>['manifest'],
   reservation: ReturnType<typeof fullReservation>
 ): Promise<void> {
   if (store.exists('reservation.json')) {
     console.log(JSON.stringify(store.read('reservation.json'), null, 2));
-    if (store.exists('results.json')) {
+    if (store.exists('results.json'))
       console.log(JSON.stringify(store.read('results.json'), null, 2));
-    }
     throw new Error(
       'Reservation already exists; captured or partial results require manual review'
     );
   }
+
   dotenv.config();
-  const doKey = process.env.DO_INFERENCE_API_KEY;
+  const geminiKey = process.env.GEMINI_API_KEY;
   const googleKey = process.env.GOOGLE_TRANSLATE_API_KEY;
-  if (!doKey || !googleKey) {
-    throw new Error('DO_INFERENCE_API_KEY and GOOGLE_TRANSLATE_API_KEY are required for --execute');
+  if (!geminiKey || !googleKey) {
+    throw new Error('GEMINI_API_KEY and GOOGLE_TRANSLATE_API_KEY are required for --execute');
   }
+  const secrets = [geminiKey, googleKey];
+  const capture = (name: string) => (raw: unknown) =>
+    store.writeJson(`responses/${name}.json`, redactSecrets(raw, secrets));
+
   const now = new Date().toISOString();
   store.createReservation({
+    experiment: EXPERIMENT_REVISION,
     state: 'reserved',
     reservedAt: now,
     updatedAt: now,
-    calls: { digitalOcean: reservation.doCalls, google: reservation.googleCalls },
-    tokens: { input: reservation.doInputTokens, output: reservation.doOutputTokens },
+    calls: { gemini: reservation.geminiCalls, google: reservation.googleCalls },
+    tokens: { input: reservation.geminiInputTokens, output: reservation.geminiOutputTokens },
     googleSourceCharacters: reservation.googleSourceCharacters,
     usd: CAPS.acknowledgedUsd,
     calculatedMaximumUsd: reservation.maximumUsd,
@@ -300,7 +219,7 @@ async function executeLive(
       ...extra,
     });
 
-  const doClient = new DigitalOceanExperimentClient(createFetchTransport(doKey));
+  const geminiClient = new GeminiExperimentClient(createGeminiFetchTransport(geminiKey));
   const googleSdk = new Translate({ key: googleKey, autoRetry: false, maxRetries: 0 });
   const googleClient = new GoogleExperimentClient(googleSdk);
   const inputs = cases.map(item => item.asciiInput);
@@ -314,14 +233,13 @@ async function executeLive(
       mechanical: mechanicalRows(cases, results),
       observedCost: observedCost(results),
     });
+
   try {
     updateReservation('running');
-    await doClient.assertModelAvailable();
+    await geminiClient.assertModelAvailable();
 
     currentOperation = 'google-auto';
-    const googleAuto = await googleClient.translate(inputs, 'auto', raw =>
-      store.writeJson('responses/google-auto.json', raw)
-    );
+    const googleAuto = await googleClient.translate(inputs, 'auto', capture('google-auto'));
     results.push({
       arm: 'google-auto',
       outputs: googleOutputs(cases, googleAuto.texts),
@@ -330,9 +248,7 @@ async function executeLive(
     persistPartialResults();
 
     currentOperation = 'google-vi';
-    const googleVi = await googleClient.translate(inputs, 'vi', raw =>
-      store.writeJson('responses/google-vi.json', raw)
-    );
+    const googleVi = await googleClient.translate(inputs, 'vi', capture('google-vi'));
     results.push({
       arm: 'google-vi',
       outputs: googleOutputs(cases, googleVi.texts),
@@ -341,130 +257,26 @@ async function executeLive(
     persistPartialResults();
 
     currentOperation = 'llm-end-to-end';
-    const llmEndToEnd = await doClient.complete(endToEndRequest, cases, 'end-to-end', raw =>
-      store.writeJson('responses/llm-end-to-end.json', raw)
+    const llmEndToEnd = await geminiClient.complete(
+      endToEndRequest,
+      cases,
+      'end-to-end',
+      capture('llm-end-to-end')
     );
     results.push({ arm: 'llm-end-to-end', outputs: llmEndToEnd.outputs, usage: llmEndToEnd.usage });
     persistPartialResults();
 
     currentOperation = 'restore-google';
-    const restored = await doClient.complete(restoreRequest, cases, 'restore', raw =>
-      store.writeJson('responses/llm-restore.json', raw)
+    const restored = await geminiClient.complete(
+      restoreRequest,
+      cases,
+      'restore',
+      capture('llm-restore')
     );
-    const restoredTexts = restored.outputs.map(output => output.restoredVi!);
-    const restoreGoogle = await googleClient.translate(restoredTexts, 'vi', raw =>
-      store.writeJson('responses/restore-google.json', raw)
-    );
-    const combined = restored.outputs.map((output, index) => ({
-      ...output,
-      english: restoreGoogle.texts[index],
-    }));
-    results.push({
-      arm: 'restore-google',
-      outputs: combined,
-      usage: restored.usage,
-      googleSourceCharacters: restoreGoogle.sourceCharacters,
-    });
-    persistPartialResults();
-
-    const blind = blindResults(cases, results);
-    store.writeJson('results.json', {
-      completedAt: new Date().toISOString(),
-      partial: false,
-      arms: results,
-      mechanical: mechanicalRows(cases, results),
-      observedCost: observedCost(results),
-      blindMapping: blind.mapping,
-      googleCharacters: armGoogleCharacters(
-        googleAuto.sourceCharacters,
-        googleVi.sourceCharacters,
-        restoreGoogle.sourceCharacters
-      ),
-    });
-    store.writeText('review.md', blind.review);
-    updateReservation('complete', { completedAt: new Date().toISOString() });
-  } catch (error) {
-    const message = (error as Error).message
-      .split(doKey)
-      .join('[REDACTED]')
-      .split(googleKey)
-      .join('[REDACTED]');
-    store.writeJson('results.json', {
-      partial: true,
-      updatedAt: new Date().toISOString(),
-      arms: results,
-      mechanical: mechanicalRows(cases, results),
-      observedCost: observedCost(results),
-      operationalFailure: { arm: currentOperation, message },
-    });
-    updateReservation('failed', { failure: message });
-    throw new Error(message);
-  }
-}
-
-async function resumeReviewed402(
-  store: ArtifactStore,
-  cases: DiacriticCase[],
-  endToEndRequest: ReturnType<typeof buildDoRequest>,
-  restoreRequest: ReturnType<typeof buildDoRequest>,
-  manifest: ReturnType<typeof makeManifest>['manifest']
-): Promise<void> {
-  const reviewed = loadReviewed402Continuation(store, cases, manifest.fixture.sha256);
-  dotenv.config();
-  const doKey = process.env.DO_INFERENCE_API_KEY;
-  const googleKey = process.env.GOOGLE_TRANSLATE_API_KEY;
-  if (!doKey || !googleKey) {
-    throw new Error(
-      'DO_INFERENCE_API_KEY and GOOGLE_TRANSLATE_API_KEY are required for the continuation'
-    );
-  }
-  const updateReservation = (state: string, extra: Record<string, unknown> = {}) =>
-    store.writeJson('reservation.json', {
-      ...(store.read('reservation.json') as Record<string, unknown>),
-      state,
-      updatedAt: new Date().toISOString(),
-      ...extra,
-    });
-  updateReservation('resume-running', {
-    resume: {
-      authorizedAt: new Date().toISOString(),
-      reason: 'manually-reviewed-http-402-before-inference',
-      consumedBeforeResume: { digitalOcean: 0, google: 2 },
-      remainingCalls: { digitalOcean: 2, google: 1 },
-    },
-  });
-
-  const doClient = new DigitalOceanExperimentClient(createFetchTransport(doKey));
-  const googleSdk = new Translate({ key: googleKey, autoRetry: false, maxRetries: 0 });
-  const googleClient = new GoogleExperimentClient(googleSdk);
-  const results = [...reviewed.results];
-  let currentOperation = 'model-access';
-  const persistPartialResults = () =>
-    store.writeJson('results.json', {
-      partial: true,
-      updatedAt: new Date().toISOString(),
-      arms: results,
-      mechanical: mechanicalRows(cases, results),
-      observedCost: observedCost(results),
-      continuation: 'reviewed-http-402',
-    });
-  try {
-    await doClient.assertModelAvailable();
-
-    currentOperation = 'llm-end-to-end';
-    const llmEndToEnd = await doClient.complete(endToEndRequest, cases, 'end-to-end', raw =>
-      store.writeJson('responses/llm-end-to-end.json', raw)
-    );
-    results.push({ arm: 'llm-end-to-end', outputs: llmEndToEnd.outputs, usage: llmEndToEnd.usage });
-    persistPartialResults();
-
-    currentOperation = 'restore-google';
-    const restored = await doClient.complete(restoreRequest, cases, 'restore', raw =>
-      store.writeJson('responses/llm-restore.json', raw)
-    );
-    const restoredTexts = restored.outputs.map(output => output.restoredVi!);
-    const restoreGoogle = await googleClient.translate(restoredTexts, 'vi', raw =>
-      store.writeJson('responses/restore-google.json', raw)
+    const restoreGoogle = await googleClient.translate(
+      restored.outputs.map(output => output.restoredVi!),
+      'vi',
+      capture('restore-google')
     );
     results.push({
       arm: 'restore-google',
@@ -489,19 +301,14 @@ async function resumeReviewed402(
         (sum, result) => sum + (result.googleSourceCharacters ?? 0),
         0
       ),
-      continuation: 'reviewed-http-402',
     });
     store.writeText('review.md', blind.review);
-    updateReservation('complete', {
-      completedAt: new Date().toISOString(),
-      resumeCompletedAt: new Date().toISOString(),
-    });
+    updateReservation('complete', { completedAt: new Date().toISOString() });
   } catch (error) {
-    const message = (error as Error).message
-      .split(doKey)
-      .join('[REDACTED]')
-      .split(googleKey)
-      .join('[REDACTED]');
+    const message = secrets.reduce(
+      (result, secret) => result.split(secret).join('[REDACTED]'),
+      (error as Error).message
+    );
     store.writeJson('results.json', {
       partial: true,
       updatedAt: new Date().toISOString(),
@@ -509,9 +316,8 @@ async function resumeReviewed402(
       mechanical: mechanicalRows(cases, results),
       observedCost: observedCost(results),
       operationalFailure: { arm: currentOperation, message },
-      continuation: 'reviewed-http-402',
     });
-    updateReservation('failed', { resumeFailure: message });
+    updateReservation('failed', { failure: message });
     throw new Error(message);
   }
 }
@@ -525,11 +331,7 @@ export async function main(argv = process.argv.slice(2), rootDir = process.cwd()
   store.writeJson('manifest.json', manifest);
   printPreflight(manifest, options.mode);
   if (options.mode === 'dry-run') return;
-  if (options.mode === 'resume-reviewed-402') {
-    await resumeReviewed402(store, cases, endToEnd, restore, manifest);
-  } else {
-    await executeLive(store, cases, endToEnd, restore, manifest, reservation);
-  }
+  await executeLive(store, cases, endToEnd, restore, manifest, reservation);
 }
 
 if (require.main === module) {

--- a/app/api/experiments/translate-diacritic-ab.ts
+++ b/app/api/experiments/translate-diacritic-ab.ts
@@ -1,0 +1,310 @@
+import fs from 'fs';
+import path from 'path';
+import { Translate } from '@google-cloud/translate/build/src/v2';
+import dotenv from 'dotenv';
+import { ArtifactStore, sha256 } from './diacritic-ab/artifacts';
+import {
+  assertDoRequestWithinCap,
+  assertGoogleCharacters,
+  fullReservation,
+} from './diacritic-ab/caps';
+import {
+  createFetchTransport,
+  DigitalOceanExperimentClient,
+  GoogleExperimentClient,
+} from './diacritic-ab/clients';
+import {
+  ARTIFACT_DIR,
+  CAPS,
+  DO_ENDPOINT,
+  DO_MODEL,
+  FIXTURE_PATH,
+  PROMPT_VERSIONS,
+  RATES,
+} from './diacritic-ab/constants';
+import { blindResults, mechanicalRows, observedCost } from './diacritic-ab/evaluation';
+import { loadFixture } from './diacritic-ab/fixture';
+import { buildDoRequest } from './diacritic-ab/prompts';
+import { ArmOutput, ArmResult, DiacriticCase, ExperimentArm } from './diacritic-ab/types';
+
+interface CliOptions {
+  execute: boolean;
+  acknowledged: boolean;
+}
+
+function parseCli(argv: string[]): CliOptions {
+  const allowed = new Set(['--execute', '--ack-max-usd=0.02']);
+  const unknown = argv.filter(arg => !allowed.has(arg));
+  if (unknown.length > 0) throw new Error(`Unknown argument(s): ${unknown.join(', ')}`);
+  const execute = argv.includes('--execute');
+  const acknowledged = argv.includes('--ack-max-usd=0.02');
+  if (!execute && acknowledged) throw new Error('The acknowledgement is valid only with --execute');
+  if (execute && !acknowledged) {
+    throw new Error('Live execution requires the exact acknowledgement --ack-max-usd=0.02');
+  }
+  return { execute, acknowledged };
+}
+
+function promptHash(request: ReturnType<typeof buildDoRequest>): string {
+  const withoutInputs = {
+    ...request,
+    messages: request.messages.map(message =>
+      message.role === 'user' ? { ...message, content: '<fixture-inputs>' } : message
+    ),
+  };
+  return sha256(JSON.stringify(withoutInputs));
+}
+
+function cacheIdentity(
+  arm: ExperimentArm,
+  provider: string,
+  promptVersion: string,
+  fixtureHash: string
+): string {
+  return sha256(`${arm}\n${provider}\n${promptVersion}\n${fixtureHash}`);
+}
+
+function makeManifest(rootDir: string, cases: DiacriticCase[]) {
+  const fixtureBytes = fs.readFileSync(path.resolve(rootDir, FIXTURE_PATH));
+  const fixtureHash = sha256(fixtureBytes);
+  const endToEnd = buildDoRequest(cases, 'end-to-end');
+  const restore = buildDoRequest(cases, 'restore');
+  const serializedEndToEnd = JSON.stringify(endToEnd);
+  const serializedRestore = JSON.stringify(restore);
+  const sourceCharacters = cases.reduce((sum, item) => sum + item.asciiInput.length, 0);
+  const reservation = fullReservation();
+  const manifest = {
+    experiment: 'vi-diacritic-ab-v1',
+    createdAt: new Date().toISOString(),
+    fixture: { path: FIXTURE_PATH, sha256: fixtureHash, cases: cases.length, sourceCharacters },
+    prompts: {
+      endToEnd: { version: PROMPT_VERSIONS.endToEnd, sha256: promptHash(endToEnd) },
+      restore: { version: PROMPT_VERSIONS.restore, sha256: promptHash(restore) },
+    },
+    provider: {
+      digitalOcean: { endpoint: DO_ENDPOINT, model: DO_MODEL },
+      google: { api: 'basic-v2' },
+    },
+    requestReservations: {
+      doEndToEndInputTokens: assertDoRequestWithinCap(serializedEndToEnd),
+      doRestoreInputTokens: assertDoRequestWithinCap(serializedRestore),
+      doOutputTokensPerCall: CAPS.doOutputTokensPerCall,
+      googleCharactersPerFixtureBatch: assertGoogleCharacters(
+        cases.map(item => item.asciiInput),
+        CAPS.sourceCharacters
+      ),
+    },
+    calls: { digitalOceanInference: 2, googleTranslation: 3, retries: 0, concurrency: 1 },
+    rates: RATES,
+    rateSources: {
+      digitalOcean: 'https://docs.digitalocean.com/products/inference/details/pricing/',
+      google: 'https://cloud.google.com/translate/pricing',
+    },
+    caps: CAPS,
+    reservation,
+    identities: {
+      googleAuto: cacheIdentity('google-auto', 'google-basic-v2', 'batch-auto-v1', fixtureHash),
+      googleVi: cacheIdentity('google-vi', 'google-basic-v2', 'batch-forced-vi-v1', fixtureHash),
+      llmEndToEnd: cacheIdentity('llm-end-to-end', DO_MODEL, PROMPT_VERSIONS.endToEnd, fixtureHash),
+      restoreGoogle: cacheIdentity(
+        'restore-google',
+        `${DO_MODEL}+google-basic-v2`,
+        PROMPT_VERSIONS.restore,
+        fixtureHash
+      ),
+    },
+  };
+  return { manifest, endToEnd, restore, reservation };
+}
+
+function printPreflight(
+  manifest: ReturnType<typeof makeManifest>['manifest'],
+  execute: boolean
+): void {
+  console.log(JSON.stringify(manifest, null, 2));
+  console.log(
+    execute
+      ? `Live execution acknowledged. Reserving exactly 2 DO calls, 3 Google calls, and $${manifest.reservation.maximumUsd.toFixed(7)} maximum calculated usage ($0.02 fail-closed ledger).`
+      : 'Offline dry run complete. No live client was constructed and no provider request was sent.'
+  );
+}
+
+function googleOutputs(cases: DiacriticCase[], texts: string[]): ArmOutput[] {
+  return cases.map((item, index) => ({
+    id: item.id,
+    status: 'resolved',
+    english: texts[index],
+    alternatives: [],
+  }));
+}
+
+function armGoogleCharacters(...values: number[]): number {
+  return values.reduce((sum, value) => sum + value, 0);
+}
+
+async function executeLive(
+  store: ArtifactStore,
+  cases: DiacriticCase[],
+  endToEndRequest: ReturnType<typeof buildDoRequest>,
+  restoreRequest: ReturnType<typeof buildDoRequest>,
+  manifest: ReturnType<typeof makeManifest>['manifest'],
+  reservation: ReturnType<typeof fullReservation>
+): Promise<void> {
+  if (store.exists('reservation.json')) {
+    console.log(JSON.stringify(store.read('reservation.json'), null, 2));
+    if (store.exists('results.json')) {
+      console.log(JSON.stringify(store.read('results.json'), null, 2));
+    }
+    throw new Error(
+      'Reservation already exists; captured or partial results require manual review'
+    );
+  }
+  dotenv.config();
+  const doKey = process.env.DO_INFERENCE_API_KEY;
+  const googleKey = process.env.GOOGLE_TRANSLATE_API_KEY;
+  if (!doKey || !googleKey) {
+    throw new Error('DO_INFERENCE_API_KEY and GOOGLE_TRANSLATE_API_KEY are required for --execute');
+  }
+  const now = new Date().toISOString();
+  store.createReservation({
+    state: 'reserved',
+    reservedAt: now,
+    updatedAt: now,
+    calls: { digitalOcean: reservation.doCalls, google: reservation.googleCalls },
+    tokens: { input: reservation.doInputTokens, output: reservation.doOutputTokens },
+    googleSourceCharacters: reservation.googleSourceCharacters,
+    usd: CAPS.acknowledgedUsd,
+    calculatedMaximumUsd: reservation.maximumUsd,
+    manifestFixtureSha256: manifest.fixture.sha256,
+  });
+  const updateReservation = (
+    state: 'running' | 'complete' | 'failed',
+    extra: Record<string, unknown> = {}
+  ) =>
+    store.writeJson('reservation.json', {
+      ...(store.read('reservation.json') as Record<string, unknown>),
+      state,
+      updatedAt: new Date().toISOString(),
+      ...extra,
+    });
+
+  const doClient = new DigitalOceanExperimentClient(createFetchTransport(doKey));
+  const googleSdk = new Translate({ key: googleKey, autoRetry: false, maxRetries: 0 });
+  const googleClient = new GoogleExperimentClient(googleSdk);
+  const inputs = cases.map(item => item.asciiInput);
+  const results: ArmResult[] = [];
+  let currentOperation = 'model-access';
+  const persistPartialResults = () =>
+    store.writeJson('results.json', {
+      partial: true,
+      updatedAt: new Date().toISOString(),
+      arms: results,
+      mechanical: mechanicalRows(cases, results),
+      observedCost: observedCost(results),
+    });
+  try {
+    updateReservation('running');
+    await doClient.assertModelAvailable();
+
+    currentOperation = 'google-auto';
+    const googleAuto = await googleClient.translate(inputs, 'auto', raw =>
+      store.writeJson('responses/google-auto.json', raw)
+    );
+    results.push({
+      arm: 'google-auto',
+      outputs: googleOutputs(cases, googleAuto.texts),
+      googleSourceCharacters: googleAuto.sourceCharacters,
+    });
+    persistPartialResults();
+
+    currentOperation = 'google-vi';
+    const googleVi = await googleClient.translate(inputs, 'vi', raw =>
+      store.writeJson('responses/google-vi.json', raw)
+    );
+    results.push({
+      arm: 'google-vi',
+      outputs: googleOutputs(cases, googleVi.texts),
+      googleSourceCharacters: googleVi.sourceCharacters,
+    });
+    persistPartialResults();
+
+    currentOperation = 'llm-end-to-end';
+    const llmEndToEnd = await doClient.complete(endToEndRequest, cases, 'end-to-end', raw =>
+      store.writeJson('responses/llm-end-to-end.json', raw)
+    );
+    results.push({ arm: 'llm-end-to-end', outputs: llmEndToEnd.outputs, usage: llmEndToEnd.usage });
+    persistPartialResults();
+
+    currentOperation = 'restore-google';
+    const restored = await doClient.complete(restoreRequest, cases, 'restore', raw =>
+      store.writeJson('responses/llm-restore.json', raw)
+    );
+    const restoredTexts = restored.outputs.map(output => output.restoredVi!);
+    const restoreGoogle = await googleClient.translate(restoredTexts, 'vi', raw =>
+      store.writeJson('responses/restore-google.json', raw)
+    );
+    const combined = restored.outputs.map((output, index) => ({
+      ...output,
+      english: restoreGoogle.texts[index],
+    }));
+    results.push({
+      arm: 'restore-google',
+      outputs: combined,
+      usage: restored.usage,
+      googleSourceCharacters: restoreGoogle.sourceCharacters,
+    });
+    persistPartialResults();
+
+    const blind = blindResults(cases, results);
+    store.writeJson('results.json', {
+      completedAt: new Date().toISOString(),
+      partial: false,
+      arms: results,
+      mechanical: mechanicalRows(cases, results),
+      observedCost: observedCost(results),
+      blindMapping: blind.mapping,
+      googleCharacters: armGoogleCharacters(
+        googleAuto.sourceCharacters,
+        googleVi.sourceCharacters,
+        restoreGoogle.sourceCharacters
+      ),
+    });
+    store.writeText('review.md', blind.review);
+    updateReservation('complete', { completedAt: new Date().toISOString() });
+  } catch (error) {
+    const message = (error as Error).message
+      .split(doKey)
+      .join('[REDACTED]')
+      .split(googleKey)
+      .join('[REDACTED]');
+    store.writeJson('results.json', {
+      partial: true,
+      updatedAt: new Date().toISOString(),
+      arms: results,
+      mechanical: mechanicalRows(cases, results),
+      observedCost: observedCost(results),
+      operationalFailure: { arm: currentOperation, message },
+    });
+    updateReservation('failed', { failure: message });
+    throw new Error(message);
+  }
+}
+
+export async function main(argv = process.argv.slice(2), rootDir = process.cwd()): Promise<void> {
+  const options = parseCli(argv);
+  const cases = loadFixture(rootDir);
+  const { manifest, endToEnd, restore, reservation } = makeManifest(rootDir, cases);
+  const store = new ArtifactStore(path.resolve(rootDir, ARTIFACT_DIR));
+  store.prepare();
+  store.writeJson('manifest.json', manifest);
+  printPreflight(manifest, options.execute);
+  if (!options.execute) return;
+  await executeLive(store, cases, endToEnd, restore, manifest, reservation);
+}
+
+if (require.main === module) {
+  main().catch(error => {
+    process.stderr.write(`${(error as Error).message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/app/api/experiments/translate-diacritic-ab.ts
+++ b/app/api/experiments/translate-diacritic-ab.ts
@@ -28,21 +28,26 @@ import { buildDoRequest } from './diacritic-ab/prompts';
 import { ArmOutput, ArmResult, DiacriticCase, ExperimentArm } from './diacritic-ab/types';
 
 interface CliOptions {
-  execute: boolean;
+  mode: 'dry-run' | 'execute' | 'resume-reviewed-402';
   acknowledged: boolean;
 }
 
 function parseCli(argv: string[]): CliOptions {
-  const allowed = new Set(['--execute', '--ack-max-usd=0.02']);
+  const allowed = new Set(['--execute', '--resume-reviewed-402', '--ack-max-usd=0.02']);
   const unknown = argv.filter(arg => !allowed.has(arg));
   if (unknown.length > 0) throw new Error(`Unknown argument(s): ${unknown.join(', ')}`);
   const execute = argv.includes('--execute');
+  const resume = argv.includes('--resume-reviewed-402');
   const acknowledged = argv.includes('--ack-max-usd=0.02');
-  if (!execute && acknowledged) throw new Error('The acknowledgement is valid only with --execute');
-  if (execute && !acknowledged) {
+  if (execute && resume)
+    throw new Error('--execute and --resume-reviewed-402 are mutually exclusive');
+  if (!execute && !resume && acknowledged) {
+    throw new Error('The acknowledgement is valid only with a live execution mode');
+  }
+  if ((execute || resume) && !acknowledged) {
     throw new Error('Live execution requires the exact acknowledgement --ack-max-usd=0.02');
   }
-  return { execute, acknowledged };
+  return { mode: resume ? 'resume-reviewed-402' : execute ? 'execute' : 'dry-run', acknowledged };
 }
 
 function promptHash(request: ReturnType<typeof buildDoRequest>): string {
@@ -119,14 +124,22 @@ function makeManifest(rootDir: string, cases: DiacriticCase[]) {
 
 function printPreflight(
   manifest: ReturnType<typeof makeManifest>['manifest'],
-  execute: boolean
+  mode: CliOptions['mode']
 ): void {
   console.log(JSON.stringify(manifest, null, 2));
-  console.log(
-    execute
-      ? `Live execution acknowledged. Reserving exactly 2 DO calls, 3 Google calls, and $${manifest.reservation.maximumUsd.toFixed(7)} maximum calculated usage ($0.02 fail-closed ledger).`
-      : 'Offline dry run complete. No live client was constructed and no provider request was sent.'
-  );
+  if (mode === 'execute') {
+    console.log(
+      `Live execution acknowledged. Reserving exactly 2 DO calls, 3 Google calls, and $${manifest.reservation.maximumUsd.toFixed(7)} maximum calculated usage ($0.02 fail-closed ledger).`
+    );
+  } else if (mode === 'resume-reviewed-402') {
+    console.log(
+      'Reviewed HTTP 402 continuation acknowledged. Reusing 2 captured Google arms and reserving only the remaining 2 DO calls plus 1 Google call.'
+    );
+  } else {
+    console.log(
+      'Offline dry run complete. No live client was constructed and no provider request was sent.'
+    );
+  }
 }
 
 function googleOutputs(cases: DiacriticCase[], texts: string[]): ArmOutput[] {
@@ -140,6 +153,105 @@ function googleOutputs(cases: DiacriticCase[], texts: string[]): ArmOutput[] {
 
 function armGoogleCharacters(...values: number[]): number {
   return values.reduce((sum, value) => sum + value, 0);
+}
+
+interface Reviewed402Reservation {
+  state?: unknown;
+  failure?: unknown;
+  calls?: { digitalOcean?: unknown; google?: unknown };
+  manifestFixtureSha256?: unknown;
+  resume?: unknown;
+  [key: string]: unknown;
+}
+
+interface PartialResultsArtifact {
+  partial?: unknown;
+  arms?: unknown;
+  operationalFailure?: { arm?: unknown; message?: unknown };
+}
+
+function validateCapturedGoogleArm(
+  value: unknown,
+  expectedArm: 'google-auto' | 'google-vi',
+  cases: DiacriticCase[]
+): ArmResult {
+  const arm = value as Partial<ArmResult>;
+  const expectedIds = new Set(cases.map(item => item.id));
+  const outputs = arm.outputs;
+  if (
+    arm.arm !== expectedArm ||
+    !Array.isArray(outputs) ||
+    outputs.length !== cases.length ||
+    arm.googleSourceCharacters !== cases.reduce((sum, item) => sum + item.asciiInput.length, 0)
+  ) {
+    throw new Error(`Captured ${expectedArm} arm does not match the reviewed fixture`);
+  }
+  const seen = new Set<string>();
+  for (const output of outputs) {
+    if (
+      typeof output.id !== 'string' ||
+      !expectedIds.has(output.id) ||
+      seen.has(output.id) ||
+      output.status !== 'resolved' ||
+      typeof output.english !== 'string' ||
+      !Array.isArray(output.alternatives) ||
+      output.alternatives.length !== 0
+    ) {
+      throw new Error(`Captured ${expectedArm} output is incomplete or misaligned`);
+    }
+    seen.add(output.id);
+  }
+  return arm as ArmResult;
+}
+
+export function loadReviewed402Continuation(
+  store: ArtifactStore,
+  cases: DiacriticCase[],
+  fixtureHash: string
+): { reservation: Reviewed402Reservation; results: ArmResult[] } {
+  if (!store.exists('reservation.json') || !store.exists('results.json')) {
+    throw new Error('Reviewed HTTP 402 continuation requires reservation.json and results.json');
+  }
+  const reservation = store.read('reservation.json') as Reviewed402Reservation;
+  const partial = store.read('results.json') as PartialResultsArtifact;
+  if (
+    reservation.state !== 'failed' ||
+    reservation.failure !== 'DO completion request failed with HTTP 402' ||
+    reservation.calls?.digitalOcean !== CAPS.doCalls ||
+    reservation.calls?.google !== CAPS.googleCalls ||
+    reservation.manifestFixtureSha256 !== fixtureHash ||
+    reservation.resume != null
+  ) {
+    throw new Error(
+      'Reservation is not the single reviewed HTTP 402 state authorized for continuation'
+    );
+  }
+  if (
+    partial.partial !== true ||
+    partial.operationalFailure?.arm !== 'llm-end-to-end' ||
+    partial.operationalFailure.message !== 'DO completion request failed with HTTP 402' ||
+    !Array.isArray(partial.arms) ||
+    partial.arms.length !== 2
+  ) {
+    throw new Error('Partial results are not the reviewed two-Google-arm HTTP 402 artifact');
+  }
+  for (const name of ['llm-end-to-end.json', 'llm-restore.json', 'restore-google.json']) {
+    if (fs.existsSync(path.join(store.responsesDir, name))) {
+      throw new Error(`Cannot continue because responses/${name} already exists`);
+    }
+  }
+  for (const name of ['google-auto.json', 'google-vi.json']) {
+    if (!fs.existsSync(path.join(store.responsesDir, name))) {
+      throw new Error(`Cannot continue without responses/${name}`);
+    }
+  }
+  return {
+    reservation,
+    results: [
+      validateCapturedGoogleArm(partial.arms[0], 'google-auto', cases),
+      validateCapturedGoogleArm(partial.arms[1], 'google-vi', cases),
+    ],
+  };
 }
 
 async function executeLive(
@@ -290,6 +402,120 @@ async function executeLive(
   }
 }
 
+async function resumeReviewed402(
+  store: ArtifactStore,
+  cases: DiacriticCase[],
+  endToEndRequest: ReturnType<typeof buildDoRequest>,
+  restoreRequest: ReturnType<typeof buildDoRequest>,
+  manifest: ReturnType<typeof makeManifest>['manifest']
+): Promise<void> {
+  const reviewed = loadReviewed402Continuation(store, cases, manifest.fixture.sha256);
+  dotenv.config();
+  const doKey = process.env.DO_INFERENCE_API_KEY;
+  const googleKey = process.env.GOOGLE_TRANSLATE_API_KEY;
+  if (!doKey || !googleKey) {
+    throw new Error(
+      'DO_INFERENCE_API_KEY and GOOGLE_TRANSLATE_API_KEY are required for the continuation'
+    );
+  }
+  const updateReservation = (state: string, extra: Record<string, unknown> = {}) =>
+    store.writeJson('reservation.json', {
+      ...(store.read('reservation.json') as Record<string, unknown>),
+      state,
+      updatedAt: new Date().toISOString(),
+      ...extra,
+    });
+  updateReservation('resume-running', {
+    resume: {
+      authorizedAt: new Date().toISOString(),
+      reason: 'manually-reviewed-http-402-before-inference',
+      consumedBeforeResume: { digitalOcean: 0, google: 2 },
+      remainingCalls: { digitalOcean: 2, google: 1 },
+    },
+  });
+
+  const doClient = new DigitalOceanExperimentClient(createFetchTransport(doKey));
+  const googleSdk = new Translate({ key: googleKey, autoRetry: false, maxRetries: 0 });
+  const googleClient = new GoogleExperimentClient(googleSdk);
+  const results = [...reviewed.results];
+  let currentOperation = 'model-access';
+  const persistPartialResults = () =>
+    store.writeJson('results.json', {
+      partial: true,
+      updatedAt: new Date().toISOString(),
+      arms: results,
+      mechanical: mechanicalRows(cases, results),
+      observedCost: observedCost(results),
+      continuation: 'reviewed-http-402',
+    });
+  try {
+    await doClient.assertModelAvailable();
+
+    currentOperation = 'llm-end-to-end';
+    const llmEndToEnd = await doClient.complete(endToEndRequest, cases, 'end-to-end', raw =>
+      store.writeJson('responses/llm-end-to-end.json', raw)
+    );
+    results.push({ arm: 'llm-end-to-end', outputs: llmEndToEnd.outputs, usage: llmEndToEnd.usage });
+    persistPartialResults();
+
+    currentOperation = 'restore-google';
+    const restored = await doClient.complete(restoreRequest, cases, 'restore', raw =>
+      store.writeJson('responses/llm-restore.json', raw)
+    );
+    const restoredTexts = restored.outputs.map(output => output.restoredVi!);
+    const restoreGoogle = await googleClient.translate(restoredTexts, 'vi', raw =>
+      store.writeJson('responses/restore-google.json', raw)
+    );
+    results.push({
+      arm: 'restore-google',
+      outputs: restored.outputs.map((output, index) => ({
+        ...output,
+        english: restoreGoogle.texts[index],
+      })),
+      usage: restored.usage,
+      googleSourceCharacters: restoreGoogle.sourceCharacters,
+    });
+    persistPartialResults();
+
+    const blind = blindResults(cases, results);
+    store.writeJson('results.json', {
+      completedAt: new Date().toISOString(),
+      partial: false,
+      arms: results,
+      mechanical: mechanicalRows(cases, results),
+      observedCost: observedCost(results),
+      blindMapping: blind.mapping,
+      googleCharacters: results.reduce(
+        (sum, result) => sum + (result.googleSourceCharacters ?? 0),
+        0
+      ),
+      continuation: 'reviewed-http-402',
+    });
+    store.writeText('review.md', blind.review);
+    updateReservation('complete', {
+      completedAt: new Date().toISOString(),
+      resumeCompletedAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    const message = (error as Error).message
+      .split(doKey)
+      .join('[REDACTED]')
+      .split(googleKey)
+      .join('[REDACTED]');
+    store.writeJson('results.json', {
+      partial: true,
+      updatedAt: new Date().toISOString(),
+      arms: results,
+      mechanical: mechanicalRows(cases, results),
+      observedCost: observedCost(results),
+      operationalFailure: { arm: currentOperation, message },
+      continuation: 'reviewed-http-402',
+    });
+    updateReservation('failed', { resumeFailure: message });
+    throw new Error(message);
+  }
+}
+
 export async function main(argv = process.argv.slice(2), rootDir = process.cwd()): Promise<void> {
   const options = parseCli(argv);
   const cases = loadFixture(rootDir);
@@ -297,9 +523,13 @@ export async function main(argv = process.argv.slice(2), rootDir = process.cwd()
   const store = new ArtifactStore(path.resolve(rootDir, ARTIFACT_DIR));
   store.prepare();
   store.writeJson('manifest.json', manifest);
-  printPreflight(manifest, options.execute);
-  if (!options.execute) return;
-  await executeLive(store, cases, endToEnd, restore, manifest, reservation);
+  printPreflight(manifest, options.mode);
+  if (options.mode === 'dry-run') return;
+  if (options.mode === 'resume-reviewed-402') {
+    await resumeReviewed402(store, cases, endToEnd, restore, manifest);
+  } else {
+    await executeLive(store, cases, endToEnd, restore, manifest, reservation);
+  }
 }
 
 if (require.main === module) {

--- a/app/api/models/translation-budget.ts
+++ b/app/api/models/translation-budget.ts
@@ -14,6 +14,11 @@ export interface TranslationBudget extends Document {
   userId?: mongoose.Types.ObjectId | null;
   charCount: number;
   requestCount: number;
+  geminiReservedMicroUsd: number;
+  geminiObservedMicroUsd: number;
+  geminiInputTokens: number;
+  geminiOutputTokens: number;
+  geminiRequestCount: number;
 }
 
 export class TranslationBudgetModel {
@@ -26,6 +31,11 @@ export class TranslationBudgetModel {
       userId: { type: Schema.Types.ObjectId, ref: 'User', default: null },
       charCount: { type: Number, default: 0 },
       requestCount: { type: Number, default: 0 },
+      geminiReservedMicroUsd: { type: Number, default: 0 },
+      geminiObservedMicroUsd: { type: Number, default: 0 },
+      geminiInputTokens: { type: Number, default: 0 },
+      geminiOutputTokens: { type: Number, default: 0 },
+      geminiRequestCount: { type: Number, default: 0 },
     });
 
     // Site row: { month, userId: null, day: null }; per-user row: { month,

--- a/app/api/models/translation-unit.ts
+++ b/app/api/models/translation-unit.ts
@@ -80,6 +80,12 @@ export class TranslationUnitModel {
       { timestamps: true }
     );
 
+    // Unnamed on purpose: Mongo's generated name is what
+    // migrations/20260805000000_translation-unit-modes.js creates too, so
+    // autoIndex and the migration cannot disagree about it. Pinning a
+    // friendlier name here means pinning the identical string there as well,
+    // or whichever runs second dies with "Index already exists with a
+    // different name".
     translationUnitSchema.index(
       { textHash: 1, sourceLang: 1, targetLang: 1, mode: 1 },
       { unique: true }

--- a/app/api/models/translation-unit.ts
+++ b/app/api/models/translation-unit.ts
@@ -9,8 +9,14 @@ import { TRANSLATION_TARGET_LANGS } from '../../../lib/index';
 // rebuild. This collection replaces the earlier per-document `translations`
 // cache, which never shipped (empty in prod), so the re-key is a schema edit
 // rather than a migration.
-export type TranslationProviderName = 'google-v2' | 'human';
-const TRANSLATION_PROVIDERS: TranslationProviderName[] = ['google-v2', 'human'];
+export type TranslationProviderName = 'google-v2' | 'gemini-3.1-flash-lite' | 'human';
+const TRANSLATION_PROVIDERS: TranslationProviderName[] = [
+  'google-v2',
+  'gemini-3.1-flash-lite',
+  'human',
+];
+export type TranslationMode = 'standard' | 'vi-romanized-title-v1';
+export const STANDARD_TRANSLATION_MODE: TranslationMode = 'standard';
 
 // sourceLang key value written while the provider auto-detects. Today EVERY
 // row uses it: the Google provider never sees the caller's declared source
@@ -19,7 +25,7 @@ const TRANSLATION_PROVIDERS: TranslationProviderName[] = ['google-v2', 'human'];
 // writing real codes — new keys, no migration.
 export const AUTO_SOURCE_LANG = 'auto';
 
-export interface TranslationUnit extends Document {
+export interface TranslationUnit extends Omit<Document, 'model'> {
   // sha256 of the source text, first 16 hex chars — the cache key. Freshness
   // needs no separate field: a source edit changes the hash, which is a new
   // key, so a stale row is simply never found again.
@@ -27,12 +33,18 @@ export interface TranslationUnit extends Document {
   // Declared source language at translate time, or 'auto' when unknown.
   sourceLang: string;
   targetLang: string;
+  mode: TranslationMode;
   // What the provider reported the source actually was (null for human rows
   // and providers that don't detect).
   detectedSourceLang: string | null;
   translatedText: string;
   provider: TranslationProviderName;
   charCount: number;
+  promptVersion?: string | null;
+  model?: string | null;
+  restoredSourceText?: string | null;
+  inputTokens?: number | null;
+  outputTokens?: number | null;
   // Phase 4 (deferred): human-submitted corrections. null = machine.
   reviewedBy?: mongoose.Types.ObjectId | null;
   createdAt: Date;
@@ -48,16 +60,30 @@ export class TranslationUnitModel {
         textHash: { type: String, required: true },
         sourceLang: { type: String, required: true },
         targetLang: { type: String, enum: TRANSLATION_TARGET_LANGS, required: true },
+        mode: {
+          type: String,
+          enum: ['standard', 'vi-romanized-title-v1'],
+          default: STANDARD_TRANSLATION_MODE,
+          required: true,
+        },
         detectedSourceLang: { type: String, default: null },
         translatedText: { type: String, required: true },
         provider: { type: String, enum: TRANSLATION_PROVIDERS, required: true },
         charCount: { type: Number, required: true },
+        promptVersion: { type: String, default: null },
+        model: { type: String, default: null },
+        restoredSourceText: { type: String, default: null },
+        inputTokens: { type: Number, default: null },
+        outputTokens: { type: Number, default: null },
         reviewedBy: { type: Schema.Types.ObjectId, ref: 'User', default: null },
       },
       { timestamps: true }
     );
 
-    translationUnitSchema.index({ textHash: 1, sourceLang: 1, targetLang: 1 }, { unique: true });
+    translationUnitSchema.index(
+      { textHash: 1, sourceLang: 1, targetLang: 1, mode: 1 },
+      { unique: true }
+    );
 
     TranslationUnitModel.model =
       (mongoose.models['TranslationUnit'] as Model<TranslationUnit>) ??

--- a/app/api/services/gemini-vietnamese-title-provider.ts
+++ b/app/api/services/gemini-vietnamese-title-provider.ts
@@ -1,0 +1,236 @@
+import {
+  buildVietnameseTitleRequest,
+  conservativeGeminiInputTokens,
+  GEMINI_VI_TITLE_ENDPOINT,
+  GEMINI_VI_TITLE_MODEL,
+  GEMINI_VI_TITLE_TIMEOUT_MS,
+  geminiVietnameseTitleCaps,
+  VietnameseTitleInput,
+  VietnameseTitleResult,
+} from './vietnamese-title-prompts';
+
+export interface GeminiVietnameseTitleUsage {
+  inputTokens: number;
+  outputTokens: number;
+  thoughtTokens: number;
+  totalTokens: number;
+}
+
+export interface GeminiVietnameseTitleBatchResult {
+  results: VietnameseTitleResult[];
+  usage: GeminiVietnameseTitleUsage;
+  latencyMs: number;
+}
+
+export interface GeminiVietnameseTitleTransport {
+  send(request: {
+    url: string;
+    headers: Record<string, string>;
+    body: string;
+    timeoutMs: number;
+  }): Promise<{ status: number; body: unknown }>;
+}
+
+interface GeminiResponse {
+  candidates?: Array<{
+    finishReason?: string;
+    content?: { parts?: Array<{ text?: string }> };
+  }>;
+  promptFeedback?: { blockReason?: string };
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    thoughtsTokenCount?: number;
+    totalTokenCount?: number;
+  };
+}
+
+export interface VietnameseTitleProvider {
+  translate(inputs: VietnameseTitleInput[]): Promise<GeminiVietnameseTitleBatchResult>;
+}
+
+function sanitizeProviderError(error: unknown, key?: string, sensitiveTexts: string[] = []): Error {
+  let message = error instanceof Error ? error.message : String(error);
+  if (key) message = message.split(key).join('[REDACTED]');
+  for (const text of sensitiveTexts) message = message.split(text).join('[REDACTED]');
+  return new Error(message.slice(0, 300));
+}
+
+export function createGeminiVietnameseTitleTransport(
+  apiKey: string
+): GeminiVietnameseTitleTransport {
+  return {
+    async send(request) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), request.timeoutMs);
+      try {
+        const response = await fetch(request.url, {
+          method: 'POST',
+          headers: { ...request.headers, 'x-goog-api-key': apiKey },
+          body: request.body,
+          signal: controller.signal,
+        });
+        const raw = await response.text();
+        let body: unknown = raw;
+        try {
+          body = JSON.parse(raw) as unknown;
+        } catch {
+          // The caller turns the bounded provider message into a sanitized error.
+        }
+        return { status: response.status, body };
+      } catch (error) {
+        throw sanitizeProviderError(error, apiKey);
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}
+
+export class GeminiVietnameseTitleProvider implements VietnameseTitleProvider {
+  public constructor(
+    private readonly transport?: GeminiVietnameseTitleTransport,
+    private readonly apiKey: string | undefined = process.env.GEMINI_API_KEY
+  ) {}
+
+  public async translate(
+    inputs: VietnameseTitleInput[]
+  ): Promise<GeminiVietnameseTitleBatchResult> {
+    const caps = geminiVietnameseTitleCaps();
+    const request = buildVietnameseTitleRequest(inputs, caps.outputTokens);
+    const serialized = JSON.stringify(request);
+    const reservedInput = conservativeGeminiInputTokens(serialized);
+    if (reservedInput > caps.inputTokens) {
+      throw new Error(
+        `Gemini Vietnamese-title request reserves ${reservedInput} input tokens; cap is ${caps.inputTokens}`
+      );
+    }
+    if (!this.transport && !this.apiKey) {
+      throw new Error('Gemini Vietnamese-title translation is not configured');
+    }
+
+    const startedAt = Date.now();
+    let response: { status: number; body: unknown };
+    try {
+      response = await (this.transport ?? createGeminiVietnameseTitleTransport(this.apiKey!)).send({
+        url: `${GEMINI_VI_TITLE_ENDPOINT}/models/${GEMINI_VI_TITLE_MODEL}:generateContent`,
+        headers: { 'content-type': 'application/json' },
+        body: serialized,
+        timeoutMs: GEMINI_VI_TITLE_TIMEOUT_MS,
+      });
+    } catch (error) {
+      throw sanitizeProviderError(
+        error,
+        this.apiKey,
+        inputs.map(input => input.text)
+      );
+    }
+    const latencyMs = Date.now() - startedAt;
+    const raw = response.body as GeminiResponse;
+    if (response.status < 200 || response.status >= 300) {
+      const detail = (response.body as { error?: { message?: unknown } })?.error?.message;
+      throw sanitizeProviderError(
+        `Gemini Vietnamese-title request failed with HTTP ${response.status}${
+          typeof detail === 'string' ? `: ${detail}` : ''
+        }`,
+        this.apiKey,
+        inputs.map(input => input.text)
+      );
+    }
+    if (raw.promptFeedback?.blockReason) {
+      throw new Error(
+        `Gemini Vietnamese-title request was blocked: ${raw.promptFeedback.blockReason}`
+      );
+    }
+    if (raw.candidates?.length !== 1 || raw.candidates[0].finishReason !== 'STOP') {
+      throw new Error(
+        `Gemini Vietnamese-title request did not finish normally: ${
+          raw.candidates?.[0]?.finishReason ?? 'none'
+        }`
+      );
+    }
+    const completion = raw.candidates[0].content?.parts
+      ?.map(part => part.text)
+      .filter((text): text is string => typeof text === 'string')
+      .join('');
+    if (!completion) throw new Error('Gemini Vietnamese-title response has no content');
+
+    const usage = this.validateUsage(raw.usageMetadata, caps.inputTokens, caps.outputTokens);
+    let parsed: { results?: unknown };
+    try {
+      parsed = JSON.parse(completion) as { results?: unknown };
+    } catch {
+      throw new Error('Gemini Vietnamese-title response was not valid JSON');
+    }
+    const results = this.validateResults(parsed.results, inputs);
+    console.log(
+      `[vi-title] model=${GEMINI_VI_TITLE_MODEL} inputs=${inputs.length} latencyMs=${latencyMs} ` +
+        `inputTokens=${usage.inputTokens} outputTokens=${usage.outputTokens}`
+    );
+    return { results, usage, latencyMs };
+  }
+
+  private validateUsage(
+    raw: GeminiResponse['usageMetadata'],
+    inputCap: number,
+    outputCap: number
+  ): GeminiVietnameseTitleUsage {
+    const inputTokens = raw?.promptTokenCount;
+    const completionTokens = raw?.candidatesTokenCount;
+    const thoughtTokens = raw?.thoughtsTokenCount ?? 0;
+    const totalTokens = raw?.totalTokenCount;
+    if (
+      !Number.isInteger(inputTokens) ||
+      !Number.isInteger(completionTokens) ||
+      !Number.isInteger(thoughtTokens) ||
+      !Number.isInteger(totalTokens) ||
+      inputTokens! < 0 ||
+      completionTokens! < 0 ||
+      thoughtTokens < 0 ||
+      totalTokens! < inputTokens! + completionTokens! + thoughtTokens
+    ) {
+      throw new Error('Gemini Vietnamese-title response omitted complete token usage');
+    }
+    const outputTokens = completionTokens! + thoughtTokens;
+    if (inputTokens! > inputCap || outputTokens > outputCap) {
+      throw new Error('Gemini Vietnamese-title response reported usage beyond a per-call cap');
+    }
+    return { inputTokens: inputTokens!, outputTokens, thoughtTokens, totalTokens: totalTokens! };
+  }
+
+  private validateResults(value: unknown, inputs: VietnameseTitleInput[]): VietnameseTitleResult[] {
+    if (!Array.isArray(value) || value.length !== inputs.length) {
+      throw new Error(
+        `Gemini Vietnamese-title response must contain exactly ${inputs.length} results`
+      );
+    }
+    const expected = new Set(inputs.map(input => input.id));
+    const seen = new Set<string>();
+    for (const raw of value) {
+      const item = raw as Partial<VietnameseTitleResult>;
+      if (
+        typeof item.id !== 'string' ||
+        !expected.has(item.id) ||
+        seen.has(item.id) ||
+        (item.status !== 'translated' &&
+          item.status !== 'ambiguous' &&
+          item.status !== 'not-vietnamese') ||
+        typeof item.restoredVi !== 'string' ||
+        typeof item.english !== 'string' ||
+        !Array.isArray(item.alternatives) ||
+        item.alternatives.length > 3 ||
+        item.alternatives.some(value => typeof value !== 'string')
+      ) {
+        throw new Error(
+          'Gemini Vietnamese-title response has an unknown, duplicate, or malformed result'
+        );
+      }
+      seen.add(item.id);
+    }
+    if (seen.size !== expected.size) {
+      throw new Error('Gemini Vietnamese-title response ID set is incomplete');
+    }
+    const byId = new Map((value as VietnameseTitleResult[]).map(result => [result.id, result]));
+    return inputs.map(input => byId.get(input.id)!);
+  }
+}

--- a/app/api/services/gemini-vietnamese-title-provider.ts
+++ b/app/api/services/gemini-vietnamese-title-provider.ts
@@ -49,11 +49,42 @@ export interface VietnameseTitleProvider {
   translate(inputs: VietnameseTitleInput[]): Promise<GeminiVietnameseTitleBatchResult>;
 }
 
-function sanitizeProviderError(error: unknown, key?: string, sensitiveTexts: string[] = []): Error {
+// Carries the HTTP status through the sanitizer so callers can tell a
+// per-batch hiccup from a condition every later batch will hit too.
+export class GeminiVietnameseTitleHttpError extends Error {
+  public constructor(
+    message: string,
+    public readonly status: number
+  ) {
+    super(message);
+    this.name = 'GeminiVietnameseTitleHttpError';
+  }
+}
+
+function sanitizeProviderError(
+  error: unknown,
+  key?: string,
+  sensitiveTexts: string[] = [],
+  status?: number
+): Error {
   let message = error instanceof Error ? error.message : String(error);
   if (key) message = message.split(key).join('[REDACTED]');
   for (const text of sensitiveTexts) message = message.split(text).join('[REDACTED]');
-  return new Error(message.slice(0, 300));
+  const sanitized = message.slice(0, 300);
+  return status == null
+    ? new Error(sanitized)
+    : new GeminiVietnameseTitleHttpError(sanitized, status);
+}
+
+// 401/403 mean the key is wrong, revoked, or lacks access to the model; 429
+// means rate-limited or out of quota. None of them clear up by moving on to
+// the next batch, and every attempt reserves budget BEFORE the call — so
+// marching through the rest of the census would burn the whole monthly
+// allowance without producing a single translation. These need a human, so
+// the caller stops and says so rather than retrying into the cap.
+export function isUnrecoverableProviderError(error: unknown): boolean {
+  const status = (error as { status?: unknown })?.status;
+  return status === 401 || status === 403 || status === 429;
 }
 
 export function createGeminiVietnameseTitleTransport(
@@ -134,7 +165,8 @@ export class GeminiVietnameseTitleProvider implements VietnameseTitleProvider {
           typeof detail === 'string' ? `: ${detail}` : ''
         }`,
         this.apiKey,
-        inputs.map(input => input.text)
+        inputs.map(input => input.text),
+        response.status
       );
     }
     if (raw.promptFeedback?.blockReason) {

--- a/app/api/services/search-index-service.ts
+++ b/app/api/services/search-index-service.ts
@@ -6,6 +6,10 @@ import { BlueprintSearchModel, mongoTextLang, SearchRowOrigin } from '../models/
 import { getSearchTermDictionary } from './search-term-dictionary';
 import { detectLanguageCode } from './language-detection-service';
 import { TranslationService } from './translation-service';
+import {
+  isVietnameseTitleGateActive,
+  VietnameseTitleTranslationService,
+} from './vietnamese-title-translation-service';
 
 // Derives and upserts blueprintsearch rows (spec/multilingual-search-plan.md
 // §2.1). Phase 0 scope: the authored 'en' pivot row only — every blueprint
@@ -21,7 +25,11 @@ import { TranslationService } from './translation-service';
 // hash is used as a content-pin (the backfill's freshness check, and phase
 // 5's concurrent-save guard below).
 function computeSourceHash(parts: readonly unknown[]): string {
-  return crypto.createHash('sha256').update(JSON.stringify(parts), 'utf8').digest('hex').slice(0, 16);
+  return crypto
+    .createHash('sha256')
+    .update(JSON.stringify(parts), 'utf8')
+    .digest('hex')
+    .slice(0, 16);
 }
 
 export interface SearchRowFields {
@@ -198,7 +206,13 @@ export function deriveNativeSearchRow(
     // title was edited, or a later, better-informed detection disagrees —
     // is recognized as stale by the same freshness check every other row
     // uses, not just by the cleanup delete below.
-    sourceHash: computeSourceHash([pivot.title, pivot.description, pivot.termIds, pivot.clusterKey, lang]),
+    sourceHash: computeSourceHash([
+      pivot.title,
+      pivot.description,
+      pivot.termIds,
+      pivot.clusterKey,
+      lang,
+    ]),
   };
 }
 
@@ -282,12 +296,39 @@ export async function deriveSearchRowWithTranslation(
   const base = deriveSearchRow(blueprint);
   const detected = confidentTitleLang(base.title);
   const declared =
-    declaredLang != null && declaredLang !== 'en' && declaredLang !== detected ? declaredLang : null;
+    declaredLang != null && declaredLang !== 'en' && declaredLang !== detected
+      ? declaredLang
+      : null;
   const sourceLang = detected ?? declared;
   if (sourceLang == null) return base;
-  if (!TranslationService.instance.isConfigured()) return base;
 
   try {
+    const declaredNormalized = normalizeContentLocale(declaredLang);
+    const isAsciiVietnamese =
+      /^[\x20-\x7e]+$/.test(base.title) && (detected === 'vi' || declaredNormalized === 'vi');
+    // Gate ACTIVE and this looks Vietnamese: its verdict is final, including
+    // its refusals. An 'ambiguous' or 'not-vietnamese' answer means the gate
+    // looked and declined, and handing the title to Google to guess instead is
+    // the outcome the gate exists to prevent.
+    //
+    // Gate INACTIVE is a different thing entirely and must not be read as a
+    // refusal: without this check the default configuration would silently stop
+    // translating declared-Vietnamese titles that Google handles today.
+    if (isAsciiVietnamese && isVietnameseTitleGateActive()) {
+      const result = await VietnameseTitleTranslationService.instance.translateOne(
+        base.title,
+        userId
+      );
+      if (result.status !== 'translated' || result.translatedText == null) return base;
+      return {
+        ...base,
+        title: result.translatedText,
+        titleOriginal: base.title,
+        origin: 'machine',
+      };
+    }
+
+    if (!TranslationService.instance.isConfigured()) return base;
     const result = await TranslationService.instance.translateOne(
       { sourceText: base.title, sourceLang, targetLang: 'en' },
       userId
@@ -346,7 +387,9 @@ export function syncMachineTitle(
           lang: fields.lang,
           sourceHash: fields.sourceHash,
         },
-        { $set: { title: fields.title, titleOriginal: fields.titleOriginal, origin: fields.origin } }
+        {
+          $set: { title: fields.title, titleOriginal: fields.titleOriginal, origin: fields.origin },
+        }
       );
     })
     .catch(err => {
@@ -362,15 +405,22 @@ export function syncMachineTitle(
 export function syncSearchRowStatus(
   blueprintId: string | mongoose.Types.ObjectId,
   patch: Partial<
-    Pick<SearchRowFields, 'isPublished' | 'deletedAt' | 'ratingAverage' | 'ratingCount' | 'hotScore' | 'downloadCount' | 'forkCount'>
+    Pick<
+      SearchRowFields,
+      | 'isPublished'
+      | 'deletedAt'
+      | 'ratingAverage'
+      | 'ratingCount'
+      | 'hotScore'
+      | 'downloadCount'
+      | 'forkCount'
+    >
   >
 ): void {
-  BlueprintSearchModel.model
-    .updateMany({ blueprintId }, { $set: patch })
-    .catch(err => {
-      console.log('search index status sync error');
-      console.log(err);
-    });
+  BlueprintSearchModel.model.updateMany({ blueprintId }, { $set: patch }).catch(err => {
+    console.log('search index status sync error');
+    console.log(err);
+  });
 }
 
 // Phase 5 (spec/multilingual-search-plan.md — lazy accretion): a reader who
@@ -423,7 +473,10 @@ export async function upsertTranslatedSearchRow(params: {
 
   let translatedTitle = title;
   try {
-    const result = await TranslationService.instance.translateOne({ sourceText: title, sourceLang, targetLang }, userId);
+    const result = await TranslationService.instance.translateOne(
+      { sourceText: title, sourceLang, targetLang },
+      userId
+    );
     if (!result.degraded) translatedTitle = result.translatedText;
   } catch (err) {
     console.log('lazy accretion title translation error');
@@ -439,14 +492,22 @@ export async function upsertTranslatedSearchRow(params: {
   // the next reader translate click (or the next save's own derivation)
   // will re-derive against the fresh state.
   if (base != null) {
-    const fresh = await BlueprintSearchModel.model.findOne({ blueprintId, lang: 'en' }).select('sourceHash').lean();
+    const fresh = await BlueprintSearchModel.model
+      .findOne({ blueprintId, lang: 'en' })
+      .select('sourceHash')
+      .lean();
     if (fresh?.sourceHash !== base.sourceHash) return;
   }
 
   const termIds = base?.termIds ?? [];
   const terms = base?.terms ?? [];
   const clusterKey = base?.clusterKey ?? null;
-  const sourceHash = computeSourceHash([translatedTitle, translatedDescription, termIds, clusterKey]);
+  const sourceHash = computeSourceHash([
+    translatedTitle,
+    translatedDescription,
+    termIds,
+    clusterKey,
+  ]);
 
   await BlueprintSearchModel.model.updateOne(
     { blueprintId, lang: targetLang },

--- a/app/api/services/translation-service.ts
+++ b/app/api/services/translation-service.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import {
   AUTO_SOURCE_LANG,
+  STANDARD_TRANSLATION_MODE,
   TranslationUnit,
   TranslationUnitModel,
 } from '../models/translation-unit';
@@ -151,14 +152,22 @@ export class TranslationService {
     requestCount: number
   ): Promise<void> {
     try {
-      await TranslationBudgetModel.model.updateOne(filter, { $inc: { charCount, requestCount } }, { upsert: true });
+      await TranslationBudgetModel.model.updateOne(
+        filter,
+        { $inc: { charCount, requestCount } },
+        { upsert: true }
+      );
     } catch (err) {
       if ((err as { code?: number })?.code !== 11000) throw err;
       await TranslationBudgetModel.model.updateOne(filter, { $inc: { charCount, requestCount } });
     }
   }
 
-  private async recordSpend(charCount: number, requestCount: number, userId: string | null): Promise<void> {
+  private async recordSpend(
+    charCount: number,
+    requestCount: number,
+    userId: string | null
+  ): Promise<void> {
     const month = this.monthKey();
     await this.incrementBudget({ month, userId: null }, charCount, requestCount);
     if (userId != null) {
@@ -175,14 +184,22 @@ export class TranslationService {
     sourceLangKey: string,
     targetLang: string
   ): Promise<TranslationUnit | null> {
-    return TranslationUnitModel.model.findOne({ textHash, sourceLang: sourceLangKey, targetLang });
+    return TranslationUnitModel.model.findOne({
+      textHash,
+      sourceLang: sourceLangKey,
+      targetLang,
+      mode: STANDARD_TRANSLATION_MODE,
+    });
   }
 
   // Translates a batch of inputs sharing one targetLang in as few provider
   // calls as possible (comment "translate all" is naturally a batch; a single
   // blueprint description is a batch of one). userId drives the per-user
   // daily cap — pass null for anonymous/system callers.
-  public async translateMany(inputs: TranslateInput[], userId: string | null): Promise<TranslateResult[]> {
+  public async translateMany(
+    inputs: TranslateInput[],
+    userId: string | null
+  ): Promise<TranslateResult[]> {
     const results: (TranslateResult | undefined)[] = new Array(inputs.length);
     const misses: {
       index: number;
@@ -278,7 +295,12 @@ export class TranslationService {
 
         const detectedSourceLang = raw.detectedSourceLang ?? input.sourceLang ?? null;
         await TranslationUnitModel.model.updateOne(
-          { textHash, sourceLang: sourceLangKey, targetLang: input.targetLang },
+          {
+            textHash,
+            sourceLang: sourceLangKey,
+            targetLang: input.targetLang,
+            mode: STANDARD_TRANSLATION_MODE,
+          },
           {
             $set: {
               detectedSourceLang,
@@ -304,7 +326,10 @@ export class TranslationService {
     return results as TranslateResult[];
   }
 
-  public async translateOne(input: TranslateInput, userId: string | null): Promise<TranslateResult> {
+  public async translateOne(
+    input: TranslateInput,
+    userId: string | null
+  ): Promise<TranslateResult> {
     const [result] = await this.translateMany([input], userId);
     return result;
   }

--- a/app/api/services/vietnamese-title-prompts.ts
+++ b/app/api/services/vietnamese-title-prompts.ts
@@ -1,0 +1,128 @@
+export const GEMINI_VI_TITLE_MODEL = 'gemini-3.1-flash-lite';
+export const GEMINI_VI_TITLE_PROMPT_VERSION = 'vi-romanized-title-gemini-3.1-flash-lite-v1';
+export const GEMINI_VI_TITLE_MODE = 'vi-romanized-title-v1' as const;
+export const GEMINI_VI_TITLE_ENDPOINT = 'https://generativelanguage.googleapis.com/v1beta';
+export const GEMINI_VI_TITLE_TIMEOUT_MS = 15_000;
+export const GEMINI_VI_TITLE_BATCH_SIZE = 12;
+export const GEMINI_VI_TITLE_BATCH_CHARACTERS = 720;
+export const GEMINI_VI_TITLE_DEFAULT_MAX_INPUT_TOKENS = 4096;
+export const GEMINI_VI_TITLE_DEFAULT_MAX_OUTPUT_TOKENS = 768;
+
+export type VietnameseTitleStatus = 'translated' | 'ambiguous' | 'not-vietnamese';
+
+export interface VietnameseTitleInput {
+  id: string;
+  text: string;
+}
+
+export interface VietnameseTitleResult {
+  id: string;
+  status: VietnameseTitleStatus;
+  restoredVi: string;
+  english: string;
+  alternatives: string[];
+}
+
+export interface GeminiVietnameseTitleRequest {
+  systemInstruction: { parts: { text: string }[] };
+  contents: { role: 'user'; parts: { text: string }[] }[];
+  generationConfig: {
+    temperature: 0;
+    candidateCount: 1;
+    maxOutputTokens: number;
+    responseMimeType: 'application/json';
+    responseJsonSchema: Record<string, unknown>;
+    thinkingConfig: { thinkingLevel: 'minimal' };
+  };
+}
+
+const SYSTEM_PROMPT = `Inputs are user-authored Oxygen Not Included blueprint titles that may be Vietnamese typed without diacritics. For each input, decide whether it is romanized Vietnamese. If it is, restore the intended Vietnamese and translate its meaning to English. Use ONI context only to disambiguate; never invent absent details. Preserve digits, version markers, punctuation, and ASCII game jargon such as SPOM. Use status "not-vietnamese" for English, acronyms, and other languages. If Vietnamese meaning is genuinely underdetermined, use status "ambiguous" and at most three plausible alternatives instead of guessing. Return exactly one result per input and only data matching the schema.`;
+
+export function vietnameseTitleResponseSchema(count: number): Record<string, unknown> {
+  return {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      results: {
+        type: 'array',
+        minItems: count,
+        maxItems: count,
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            id: { type: 'string' },
+            status: {
+              type: 'string',
+              enum: ['translated', 'ambiguous', 'not-vietnamese'],
+            },
+            restoredVi: { type: 'string' },
+            english: { type: 'string' },
+            alternatives: {
+              type: 'array',
+              items: { type: 'string' },
+              maxItems: 3,
+            },
+          },
+          required: ['id', 'status', 'restoredVi', 'english', 'alternatives'],
+        },
+      },
+    },
+    required: ['results'],
+  };
+}
+
+export function buildVietnameseTitleRequest(
+  inputs: VietnameseTitleInput[],
+  maxOutputTokens: number
+): GeminiVietnameseTitleRequest {
+  return {
+    systemInstruction: {
+      parts: [{ text: `${GEMINI_VI_TITLE_PROMPT_VERSION}\n${SYSTEM_PROMPT}` }],
+    },
+    contents: [{ role: 'user', parts: [{ text: JSON.stringify({ inputs }) }] }],
+    generationConfig: {
+      temperature: 0,
+      candidateCount: 1,
+      maxOutputTokens,
+      responseMimeType: 'application/json',
+      responseJsonSchema: vietnameseTitleResponseSchema(inputs.length),
+      thinkingConfig: { thinkingLevel: 'minimal' },
+    },
+  };
+}
+
+function boundedPositiveInt(value: string | undefined, maximum: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 && parsed <= maximum ? parsed : maximum;
+}
+
+export function geminiVietnameseTitleCaps(): {
+  inputTokens: number;
+  outputTokens: number;
+} {
+  return {
+    inputTokens: boundedPositiveInt(
+      process.env.GEMINI_VI_TITLE_MAX_INPUT_TOKENS,
+      GEMINI_VI_TITLE_DEFAULT_MAX_INPUT_TOKENS
+    ),
+    outputTokens: boundedPositiveInt(
+      process.env.GEMINI_VI_TITLE_MAX_OUTPUT_TOKENS,
+      GEMINI_VI_TITLE_DEFAULT_MAX_OUTPUT_TOKENS
+    ),
+  };
+}
+
+export function conservativeGeminiInputTokens(serialized: string): number {
+  return Buffer.byteLength(serialized, 'utf8') + 64;
+}
+
+export function geminiMaximumMicroUsd(inputTokens: number, outputTokens: number): number {
+  // Verified 2026-08-05: $0.25/M input and $1.50/M output. In micro-USD,
+  // those rates are 0.25 and 1.5 per token respectively.
+  return Math.ceil(inputTokens * 0.25 + outputTokens * 1.5);
+}
+
+export function geminiObservedMicroUsd(inputTokens: number, outputTokens: number): number {
+  return geminiMaximumMicroUsd(inputTokens, outputTokens);
+}

--- a/app/api/services/vietnamese-title-translation-service.ts
+++ b/app/api/services/vietnamese-title-translation-service.ts
@@ -267,8 +267,15 @@ export class VietnameseTitleTranslationService {
 
   private acceptedEnglish(source: string, restoredVi: string, english: string): string | null {
     const normalizedEnglish = normalizeBlueprintName(english);
+    // Case-folded: this check proves the model restored DIACRITICS on the very
+    // text we sent rather than inventing a different phrase, and letter case
+    // carries no diacritic information. A hallucinated phrase still fails it;
+    // a title-cased restoration of the right phrase no longer does.
+    const restoredMatchesSource =
+      normalizeRomanizedVietnamese(restoredVi).toLocaleLowerCase('en') ===
+      source.replace(/\s+/g, ' ').trim().toLocaleLowerCase('en');
     const accepted =
-      normalizeRomanizedVietnamese(restoredVi) === source.replace(/\s+/g, ' ').trim() &&
+      restoredMatchesSource &&
       normalizedEnglish.length <= MAX_BLUEPRINT_NAME_LENGTH &&
       checkNormalizedBlueprintName(normalizedEnglish).ok &&
       !sameMeaninglessForm(source, normalizedEnglish) &&

--- a/app/api/services/vietnamese-title-translation-service.ts
+++ b/app/api/services/vietnamese-title-translation-service.ts
@@ -1,0 +1,373 @@
+import mongoose from 'mongoose';
+import {
+  checkNormalizedBlueprintName,
+  MAX_BLUEPRINT_NAME_LENGTH,
+  normalizeBlueprintName,
+} from '../../../lib/index';
+import { TranslationUnitModel } from '../models/translation-unit';
+import { TranslationBudgetModel } from '../models/translation-budget';
+import { hashSourceText, TranslationBudgetExceeded } from './translation-service';
+import {
+  GeminiVietnameseTitleProvider,
+  VietnameseTitleProvider,
+} from './gemini-vietnamese-title-provider';
+import {
+  conservativeGeminiInputTokens,
+  GEMINI_VI_TITLE_BATCH_CHARACTERS,
+  GEMINI_VI_TITLE_BATCH_SIZE,
+  GEMINI_VI_TITLE_MODE,
+  GEMINI_VI_TITLE_MODEL,
+  GEMINI_VI_TITLE_PROMPT_VERSION,
+  geminiMaximumMicroUsd,
+  geminiObservedMicroUsd,
+  geminiVietnameseTitleCaps,
+  buildVietnameseTitleRequest,
+  VietnameseTitleInput,
+  VietnameseTitleStatus,
+} from './vietnamese-title-prompts';
+
+const ASCII_NONEMPTY = /^[\x20-\x7e]+$/;
+
+export interface VietnameseTitleTranslationOutcome {
+  id: string;
+  status: VietnameseTitleStatus | 'invalid';
+  translatedText?: string;
+  restoredVi?: string;
+  cached: boolean;
+}
+
+function monthKey(date = new Date()): string {
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+function dayKey(date = new Date()): string {
+  return `${monthKey(date)}-${String(date.getUTCDate()).padStart(2, '0')}`;
+}
+
+function nonNegativeEnvInt(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+export function normalizeRomanizedVietnamese(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/đ/g, 'd')
+    .replace(/Đ/g, 'D')
+    .normalize('NFC')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function sameMeaninglessForm(left: string, right: string): boolean {
+  const normalize = (value: string) =>
+    value
+      .normalize('NFKC')
+      .toLocaleLowerCase('en')
+      .replace(/[^\p{L}\p{N}]+/gu, ' ')
+      .trim();
+  return normalize(left) === normalize(right);
+}
+
+function preservesNumbersAndVersions(source: string, english: string): boolean {
+  const numbers = (value: string) => value.match(/\d+(?:\.\d+)*/g) ?? [];
+  if (JSON.stringify(numbers(source)) !== JSON.stringify(numbers(english))) return false;
+  const markers = source.match(/\b(?:v|ver|version|mk)\s*\d+(?:\.\d+)*/gi) ?? [];
+  const normalizedEnglish = english.toLocaleLowerCase('en').replace(/\s+/g, '');
+  return markers.every(marker =>
+    normalizedEnglish.includes(marker.toLocaleLowerCase('en').replace(/\s+/g, ''))
+  );
+}
+
+export function isVietnameseTitleFeatureEnabled(): boolean {
+  return process.env.GEMINI_VI_TITLE_TRANSLATION_ENABLED === 'true';
+}
+
+// The three conditions translateMany itself requires before it will spend.
+// Exported because callers need to tell "the gate looked and declined this
+// title" apart from "the gate is switched off" — both surface as an 'invalid'
+// outcome, but only the second means some other pass should still run.
+export function isVietnameseTitleGateActive(): boolean {
+  return (
+    isVietnameseTitleFeatureEnabled() &&
+    !!process.env.GEMINI_API_KEY &&
+    nonNegativeEnvInt(process.env.GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD, 0) > 0
+  );
+}
+
+export function vietnameseTitleDryRunCaps(): {
+  inputTokens: number;
+  outputTokens: number;
+  maximumMicroUsd: number;
+} {
+  const caps = geminiVietnameseTitleCaps();
+  return {
+    ...caps,
+    maximumMicroUsd: geminiMaximumMicroUsd(caps.inputTokens, caps.outputTokens),
+  };
+}
+
+export class VietnameseTitleTranslationService {
+  private static _instance: VietnameseTitleTranslationService | null = null;
+  public static get instance(): VietnameseTitleTranslationService {
+    if (this._instance == null) this._instance = new VietnameseTitleTranslationService();
+    return this._instance;
+  }
+  public static setInstanceForTest(instance: VietnameseTitleTranslationService | null): void {
+    this._instance = instance;
+  }
+
+  public constructor(
+    private readonly provider: VietnameseTitleProvider = new GeminiVietnameseTitleProvider()
+  ) {}
+
+  public async translateOne(
+    sourceText: string,
+    userId: string | null
+  ): Promise<VietnameseTitleTranslationOutcome> {
+    const [result] = await this.translateMany([{ id: 'title', text: sourceText }], userId);
+    return result;
+  }
+
+  public async translateMany(
+    inputs: VietnameseTitleInput[],
+    userId: string | null
+  ): Promise<VietnameseTitleTranslationOutcome[]> {
+    this.validateInputs(inputs);
+    const outcomes: Array<VietnameseTitleTranslationOutcome | undefined> = new Array(inputs.length);
+    const misses: Array<{ index: number; input: VietnameseTitleInput; textHash: string }> = [];
+
+    for (let index = 0; index < inputs.length; index++) {
+      const input = inputs[index];
+      const textHash = hashSourceText(input.text);
+      const cached = await TranslationUnitModel.model.findOne({
+        textHash,
+        sourceLang: 'vi',
+        targetLang: 'en',
+        mode: GEMINI_VI_TITLE_MODE,
+        provider: GEMINI_VI_TITLE_MODEL,
+        promptVersion: GEMINI_VI_TITLE_PROMPT_VERSION,
+        model: GEMINI_VI_TITLE_MODEL,
+      });
+      if (cached != null) {
+        outcomes[index] = {
+          id: input.id,
+          status: 'translated',
+          translatedText: cached.translatedText,
+          restoredVi: cached.restoredSourceText ?? undefined,
+          cached: true,
+        };
+      } else {
+        misses.push({ index, input, textHash });
+      }
+    }
+    if (misses.length === 0) return outcomes as VietnameseTitleTranslationOutcome[];
+
+    if (!isVietnameseTitleGateActive()) return this.declineMisses(outcomes, misses);
+    const monthlyCap = nonNegativeEnvInt(process.env.GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD, 0);
+
+    const caps = geminiVietnameseTitleCaps();
+    const request = buildVietnameseTitleRequest(
+      misses.map(miss => miss.input),
+      caps.outputTokens
+    );
+    if (conservativeGeminiInputTokens(JSON.stringify(request)) > caps.inputTokens) {
+      throw new Error('Gemini Vietnamese-title request exceeds the fixed input ceiling');
+    }
+    const reservation = geminiMaximumMicroUsd(caps.inputTokens, caps.outputTokens);
+    await this.reserveBudget(reservation, monthlyCap, userId);
+
+    const batch = await this.provider.translate(misses.map(miss => miss.input));
+    await TranslationBudgetModel.model.updateOne(
+      { month: monthKey(), userId: null, day: null },
+      {
+        $inc: {
+          geminiObservedMicroUsd: geminiObservedMicroUsd(
+            batch.usage.inputTokens,
+            batch.usage.outputTokens
+          ),
+          geminiInputTokens: batch.usage.inputTokens,
+          geminiOutputTokens: batch.usage.outputTokens,
+        },
+      }
+    );
+
+    for (let i = 0; i < misses.length; i++) {
+      const miss = misses[i];
+      const result = batch.results[i];
+      const acceptedEnglish =
+        result.status === 'translated'
+          ? this.acceptedEnglish(miss.input.text, result.restoredVi, result.english)
+          : null;
+      if (acceptedEnglish == null) {
+        outcomes[miss.index] = {
+          id: miss.input.id,
+          status: result.status === 'translated' ? 'invalid' : result.status,
+          cached: false,
+        };
+        continue;
+      }
+      await TranslationUnitModel.model.updateOne(
+        {
+          textHash: miss.textHash,
+          sourceLang: 'vi',
+          targetLang: 'en',
+          mode: GEMINI_VI_TITLE_MODE,
+        },
+        {
+          $set: {
+            detectedSourceLang: 'vi',
+            translatedText: acceptedEnglish,
+            provider: GEMINI_VI_TITLE_MODEL,
+            charCount: miss.input.text.length,
+            promptVersion: GEMINI_VI_TITLE_PROMPT_VERSION,
+            model: GEMINI_VI_TITLE_MODEL,
+            restoredSourceText: result.restoredVi,
+            inputTokens: batch.usage.inputTokens,
+            outputTokens: batch.usage.outputTokens,
+          },
+        },
+        { upsert: true }
+      );
+      outcomes[miss.index] = {
+        id: miss.input.id,
+        status: 'translated',
+        translatedText: acceptedEnglish,
+        restoredVi: result.restoredVi,
+        cached: false,
+      };
+    }
+    return outcomes as VietnameseTitleTranslationOutcome[];
+  }
+
+  private validateInputs(inputs: VietnameseTitleInput[]): void {
+    if (inputs.length === 0 || inputs.length > GEMINI_VI_TITLE_BATCH_SIZE) {
+      throw new Error(`Vietnamese-title batch must contain 1-${GEMINI_VI_TITLE_BATCH_SIZE} inputs`);
+    }
+    const ids = new Set<string>();
+    let characters = 0;
+    for (const input of inputs) {
+      if (!input.id || ids.has(input.id))
+        throw new Error('Vietnamese-title input IDs must be unique');
+      ids.add(input.id);
+      if (!ASCII_NONEMPTY.test(input.text) || input.text.length > MAX_BLUEPRINT_NAME_LENGTH) {
+        throw new Error(
+          'Vietnamese-title input must be non-empty ASCII within the title length policy'
+        );
+      }
+      characters += input.text.length;
+    }
+    if (characters > GEMINI_VI_TITLE_BATCH_CHARACTERS) {
+      throw new Error(
+        `Vietnamese-title batch exceeds ${GEMINI_VI_TITLE_BATCH_CHARACTERS} source characters`
+      );
+    }
+  }
+
+  private acceptedEnglish(source: string, restoredVi: string, english: string): string | null {
+    const normalizedEnglish = normalizeBlueprintName(english);
+    const accepted =
+      normalizeRomanizedVietnamese(restoredVi) === source.replace(/\s+/g, ' ').trim() &&
+      normalizedEnglish.length <= MAX_BLUEPRINT_NAME_LENGTH &&
+      checkNormalizedBlueprintName(normalizedEnglish).ok &&
+      !sameMeaninglessForm(source, normalizedEnglish) &&
+      preservesNumbersAndVersions(source, normalizedEnglish);
+    return accepted ? normalizedEnglish : null;
+  }
+
+  private declineMisses(
+    outcomes: Array<VietnameseTitleTranslationOutcome | undefined>,
+    misses: Array<{ index: number; input: VietnameseTitleInput }>
+  ): VietnameseTitleTranslationOutcome[] {
+    for (const miss of misses) {
+      outcomes[miss.index] = { id: miss.input.id, status: 'invalid', cached: false };
+    }
+    return outcomes as VietnameseTitleTranslationOutcome[];
+  }
+
+  private async reserveBudget(
+    reservation: number,
+    cap: number,
+    userId: string | null
+  ): Promise<void> {
+    const month = monthKey();
+    const filter = {
+      month,
+      userId: null,
+      day: null,
+      $expr: {
+        $lte: [{ $add: [{ $ifNull: ['$geminiReservedMicroUsd', 0] }, reservation] }, cap],
+      },
+    };
+    const update = {
+      $inc: {
+        geminiReservedMicroUsd: reservation,
+        geminiRequestCount: 1,
+      },
+    };
+    let reserved = await TranslationBudgetModel.model.updateOne(filter, update);
+    if (reserved.modifiedCount === 0) {
+      const exists = await TranslationBudgetModel.model.exists({ month, userId: null, day: null });
+      if (exists == null && reservation <= cap) {
+        try {
+          await TranslationBudgetModel.model.create({
+            month,
+            userId: null,
+            day: null,
+            geminiReservedMicroUsd: reservation,
+            geminiRequestCount: 1,
+          });
+          reserved = { ...reserved, modifiedCount: 1 } as typeof reserved;
+        } catch (error) {
+          if ((error as { code?: number }).code !== 11000) throw error;
+          reserved = await TranslationBudgetModel.model.updateOne(filter, update);
+        }
+      }
+    }
+    if (reserved.modifiedCount === 0) {
+      throw new TranslationBudgetExceeded('Monthly Gemini Vietnamese-title budget exceeded');
+    }
+
+    if (userId != null) await this.reserveUserRequest(userId, month);
+  }
+
+  private async reserveUserRequest(userId: string, month: string): Promise<void> {
+    const cap = nonNegativeEnvInt(process.env.MAX_TRANSLATIONS_PER_USER_PER_DAY, 200);
+    if (cap === 0)
+      throw new TranslationBudgetExceeded('Daily translation limit exceeded for this user');
+    const day = dayKey();
+    const objectId = new mongoose.Types.ObjectId(userId);
+    const filter = {
+      month,
+      userId: objectId,
+      day,
+      requestCount: { $lt: cap },
+    };
+    let reserved = await TranslationBudgetModel.model.updateOne(filter, {
+      $inc: { requestCount: 1 },
+    });
+    if (reserved.modifiedCount === 0) {
+      const exists = await TranslationBudgetModel.model.exists({ month, userId: objectId, day });
+      if (exists == null) {
+        try {
+          await TranslationBudgetModel.model.create({
+            month,
+            userId: objectId,
+            day,
+            requestCount: 1,
+          });
+          reserved = { ...reserved, modifiedCount: 1 } as typeof reserved;
+        } catch (error) {
+          if ((error as { code?: number }).code !== 11000) throw error;
+          reserved = await TranslationBudgetModel.model.updateOne(filter, {
+            $inc: { requestCount: 1 },
+          });
+        }
+      }
+    }
+    if (reserved.modifiedCount === 0) {
+      throw new TranslationBudgetExceeded('Daily translation limit exceeded for this user');
+    }
+  }
+}

--- a/app/api/services/vietnamese-title-translation-service.ts
+++ b/app/api/services/vietnamese-title-translation-service.ts
@@ -28,6 +28,14 @@ import {
 
 const ASCII_NONEMPTY = /^[\x20-\x7e]+$/;
 
+// The per-title shape validateInputs enforces, exported so the census in
+// derive-search can route ineligible titles (non-ASCII, over-length) straight
+// to the Google continuation instead of poisoning a whole Gemini batch with
+// a validation throw.
+export function isEligibleVietnameseTitleInput(text: string): boolean {
+  return ASCII_NONEMPTY.test(text) && text.length <= MAX_BLUEPRINT_NAME_LENGTH;
+}
+
 export interface VietnameseTitleTranslationOutcome {
   id: string;
   status: VietnameseTitleStatus | 'invalid';
@@ -251,7 +259,7 @@ export class VietnameseTitleTranslationService {
       if (!input.id || ids.has(input.id))
         throw new Error('Vietnamese-title input IDs must be unique');
       ids.add(input.id);
-      if (!ASCII_NONEMPTY.test(input.text) || input.text.length > MAX_BLUEPRINT_NAME_LENGTH) {
+      if (!isEligibleVietnameseTitleInput(input.text)) {
         throw new Error(
           'Vietnamese-title input must be non-empty ASCII within the title length policy'
         );

--- a/app/server.ts
+++ b/app/server.ts
@@ -25,6 +25,19 @@ if (!process.env.GOOGLE_TRANSLATE_API_KEY) {
   );
 }
 
+const viTitleEnabled = process.env.GEMINI_VI_TITLE_TRANSLATION_ENABLED === 'true';
+const viTitleBudget = Number(process.env.GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD ?? 0);
+console.log(
+  `[vi-title] ${
+    viTitleEnabled &&
+    process.env.GEMINI_API_KEY &&
+    Number.isFinite(viTitleBudget) &&
+    viTitleBudget > 0
+      ? `ENABLED (monthly cap ${viTitleBudget} micro-USD)`
+      : 'DISABLED (requires kill switch, GEMINI_API_KEY, and a positive monthly budget)'
+  }`
+);
+
 const PORT = 3000;
 const server = app.listen(PORT, () => {
   console.log(`Example app listening on port ${PORT}!`);
@@ -45,7 +58,9 @@ for (const signal of ['SIGTERM', 'SIGINT'] as const) {
 
 server.on('error', (err: NodeJS.ErrnoException) => {
   if (err.code === 'EADDRINUSE') {
-    console.error(`Error: port ${PORT} is already in use. Is another server or Docker container running?`);
+    console.error(
+      `Error: port ${PORT} is already in use. Is another server or Docker container running?`
+    );
     process.exit(1);
   }
   throw err;

--- a/app/server.ts
+++ b/app/server.ts
@@ -8,6 +8,7 @@ import app from './app';
 import { PreviewImageService } from './api/services/preview-image-service';
 import { BlueprintCounterService } from './api/services/blueprint-counter-service';
 import { startMemoryHeartbeat } from './api/services/memory-heartbeat';
+import { isVietnameseTitleGateActive } from './api/services/vietnamese-title-translation-service';
 
 // Loud, unmissable startup check — avatar endpoints answer 503 until the key
 // exists, but the server still boots so a missing key can't take the site down.
@@ -25,16 +26,14 @@ if (!process.env.GOOGLE_TRANSLATE_API_KEY) {
   );
 }
 
-const viTitleEnabled = process.env.GEMINI_VI_TITLE_TRANSLATION_ENABLED === 'true';
-const viTitleBudget = Number(process.env.GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD ?? 0);
+// Same predicate the batch pass and save path spend against, so the banner
+// cannot report a state the code disagrees with.
 console.log(
   `[vi-title] ${
-    viTitleEnabled &&
-    process.env.GEMINI_API_KEY &&
-    Number.isFinite(viTitleBudget) &&
-    viTitleBudget > 0
-      ? `ENABLED (monthly cap ${viTitleBudget} micro-USD)`
-      : 'DISABLED (requires kill switch, GEMINI_API_KEY, and a positive monthly budget)'
+    isVietnameseTitleGateActive()
+      ? `ENABLED (monthly cap ${process.env.GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD} micro-USD)`
+      : 'DISABLED (requires GEMINI_VI_TITLE_TRANSLATION_ENABLED=true, GEMINI_API_KEY, and a ' +
+        'positive GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD)'
   }`
 );
 

--- a/migrations/20260805000000_translation-unit-modes.js
+++ b/migrations/20260805000000_translation-unit-modes.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const COLLECTION = 'translationunits';
+const OLD_INDEX = { textHash: 1, sourceLang: 1, targetLang: 1 };
+const NEW_INDEX = { textHash: 1, sourceLang: 1, targetLang: 1, mode: 1 };
+
+async function hasCollection(db) {
+  return (await db.listCollections({ name: COLLECTION }).toArray()).length > 0;
+}
+
+async function dropMatchingIndex(db, keys) {
+  if (!(await hasCollection(db))) return;
+  const indexes = await db.collection(COLLECTION).indexes();
+  const match = indexes.find(index => JSON.stringify(index.key) === JSON.stringify(keys));
+  if (match) await db.collection(COLLECTION).dropIndex(match.name);
+}
+
+module.exports = {
+  async up(db) {
+    if (!(await hasCollection(db))) return;
+    await db
+      .collection(COLLECTION)
+      .updateMany({ mode: { $exists: false } }, { $set: { mode: 'standard' } });
+    await dropMatchingIndex(db, OLD_INDEX);
+    await db.collection(COLLECTION).createIndex(NEW_INDEX, {
+      unique: true,
+      name: 'translation_unit_mode_key',
+    });
+  },
+
+  async down(db) {
+    if (!(await hasCollection(db))) return;
+    await db.collection(COLLECTION).deleteMany({ mode: 'vi-romanized-title-v1' });
+    await dropMatchingIndex(db, NEW_INDEX);
+    await db.collection(COLLECTION).updateMany({}, { $unset: { mode: '' } });
+    await db.collection(COLLECTION).createIndex(OLD_INDEX, {
+      unique: true,
+      name: 'translation_unit_text_key',
+    });
+  },
+};

--- a/migrations/20260805000000_translation-unit-modes.js
+++ b/migrations/20260805000000_translation-unit-modes.js
@@ -1,41 +1,87 @@
 'use strict';
 
+// Adds `mode` to translationunits and widens the unique key to include it, so
+// a Gemini romanized-Vietnamese row and a Google row for the same text hash
+// can coexist instead of colliding.
+//
+// Indexes are matched by KEY PATTERN, never by name. Mongoose's autoIndex
+// races this migration on every deploy: whichever runs first creates the
+// index, and if the two disagree about its NAME the loser dies with
+// "Index already exists with a different name". That is not hypothetical —
+// it is how this migration first failed. Matching on the key pattern makes
+// the migration converge from any starting state:
+//
+//   - fresh database                  -> creates it
+//   - autoIndex got there first       -> adopts it, no data touched
+//   - migration already ran           -> no-op
+//
+// which is what "idempotent" has to mean here, because staging and production
+// share one database: every migration is run at least twice against the same
+// data, and the second run must be a no-op rather than an error.
+
 const COLLECTION = 'translationunits';
 const OLD_INDEX = { textHash: 1, sourceLang: 1, targetLang: 1 };
+// Both names are the ones Mongo GENERATES for these key patterns, which is
+// also what Mongoose's autoIndex produces from the schema — the convention
+// the other index migrations in this directory follow. Inventing a friendlier
+// name is what broke this migration: the schema declares no name, so autoIndex
+// built the auto-named index and the migration then demanded a different one
+// for the same keys.
+const OLD_INDEX_NAME = 'textHash_1_sourceLang_1_targetLang_1';
 const NEW_INDEX = { textHash: 1, sourceLang: 1, targetLang: 1, mode: 1 };
+const NEW_INDEX_NAME = 'textHash_1_sourceLang_1_targetLang_1_mode_1';
 
 async function hasCollection(db) {
   return (await db.listCollections({ name: COLLECTION }).toArray()).length > 0;
 }
 
-async function dropMatchingIndex(db, keys) {
-  if (!(await hasCollection(db))) return;
+// Mongo preserves index key order, and so does JSON.stringify over an object
+// literal, so comparing the serialized key is an exact match on the compound
+// index — not merely on the set of fields.
+async function indexByKey(db, keys) {
   const indexes = await db.collection(COLLECTION).indexes();
-  const match = indexes.find(index => JSON.stringify(index.key) === JSON.stringify(keys));
+  return indexes.find(index => JSON.stringify(index.key) === JSON.stringify(keys));
+}
+
+async function dropIndexByKey(db, keys) {
+  const match = await indexByKey(db, keys);
   if (match) await db.collection(COLLECTION).dropIndex(match.name);
+}
+
+async function ensureUniqueIndex(db, keys, name) {
+  const existing = await indexByKey(db, keys);
+  if (existing) {
+    // Right keys, right options, right name: nothing to do — this is the
+    // autoIndex-got-there-first case, and the common one. Anything else (a
+    // non-unique variant, or a legacy hand-picked name) is replaced, since
+    // Mongo cannot alter an index in place.
+    if (existing.name === name && existing.unique === true) return;
+    await db.collection(COLLECTION).dropIndex(existing.name);
+  }
+  await db.collection(COLLECTION).createIndex(keys, { unique: true, name });
 }
 
 module.exports = {
   async up(db) {
     if (!(await hasCollection(db))) return;
+    // Backfill before the key widens: the old index does not include `mode`,
+    // so this cannot collide, and the new one is never built over rows
+    // missing the field.
     await db
       .collection(COLLECTION)
       .updateMany({ mode: { $exists: false } }, { $set: { mode: 'standard' } });
-    await dropMatchingIndex(db, OLD_INDEX);
-    await db.collection(COLLECTION).createIndex(NEW_INDEX, {
-      unique: true,
-      name: 'translation_unit_mode_key',
-    });
+    await dropIndexByKey(db, OLD_INDEX);
+    await ensureUniqueIndex(db, NEW_INDEX, NEW_INDEX_NAME);
   },
 
   async down(db) {
     if (!(await hasCollection(db))) return;
+    // Gemini rows must go before the key narrows — they are cache entries,
+    // rebuildable at the cost of re-asking the provider. Standard rows keep
+    // their text and are untouched.
     await db.collection(COLLECTION).deleteMany({ mode: 'vi-romanized-title-v1' });
-    await dropMatchingIndex(db, NEW_INDEX);
+    await dropIndexByKey(db, NEW_INDEX);
     await db.collection(COLLECTION).updateMany({}, { $unset: { mode: '' } });
-    await db.collection(COLLECTION).createIndex(OLD_INDEX, {
-      unique: true,
-      name: 'translation_unit_text_key',
-    });
+    await ensureUniqueIndex(db, OLD_INDEX, OLD_INDEX_NAME);
   },
 };


### PR DESCRIPTION
## What ships

Blueprint titles like `Dien phan full` are Vietnamese typed without diacritics. Our own detector can't place them and Google mistranslates them outright, so they've been unreachable to an English searcher no matter how often the existing passes re-run. This adds a Gemini gate that identifies, restores and translates them, in front of the existing Google provider-side detection.

New: `gemini-vietnamese-title-provider.ts`, `vietnamese-title-prompts.ts`, `vietnamese-title-translation-service.ts`, migration `20260805000000_translation-unit-modes.js`. Wired into `derive-search.ts` and `search-index-service.ts`. Also closes out the offline A/B experiment that motivated the design (local-only tooling, never wired into the app).

## Why it refuses more than it accepts

A result is taken only when **all** of these hold: the restored Vietnamese strips mechanically back to the *exact* input (the anti-hallucination guard), the English differs from the input by more than punctuation and case, numbers and version markers survive, and the text passes the shared blueprint-name policy. Ambiguous answers and faithful echoes of English titles are discarded and **never cached**, so a re-run can't accumulate a bad answer.

The downside is bounded independently of any of that: `titleOriginal` keeps the authored text in the index, so a wrong translation can only ever *add* a spurious match, never remove a correct one.

## Spend guardrails

Fail-closed on three independent switches — the kill switch (`GEMINI_VI_TITLE_TRANSLATION_ENABLED`, literal `'true'`), the shared `GEMINI_API_KEY`, and a positive monthly micro-USD allowance defaulting to `0`. Token caps are code-pinned; env vars can only *lower* them. Budget is reserved at the per-call maximum before dispatch and never released back down, so a provider failure costs its reservation rather than going unrecorded; observed spend is tracked separately.

**Sizing note:** because reservations are ceilings, the allowance bounds *calls*, not dollars — each reserves 2,176 micro-USD regardless of batch size.

## Review findings — two defects found and fixed

Neither was caught by the existing tests.

1. **The Google detection pass silently stopped running when the gate was off.** With the kill switch unset — the default, and exactly the state prod deploys in — every candidate came back `invalid`, nothing reached `googleCandidates`, and the Google pass that ships on master did nothing at all, while logging `Gemini accepted 0/N` as though the gate had merely declined. Root cause: `invalid` conflated "the gate judged this and refused" with "the gate is switched off". Fixed by exporting `isVietnameseTitleGateActive()` (one source of truth, shared with the service's own spend check) and branching on it in both callers. While the gate *is* active its refusals stay final — re-asking Google about an `ambiguous` title is the guess the gate exists to prevent.
2. **`.env.test` never blanked `GEMINI_API_KEY`**, so the batch scripts' bare `dotenv.config()` would load a real key into the test process. Same leak this repo has been burned by before.

Also hardened: bulk updates now filter on the `sourceHash` they were read at, so a title re-authored mid-run isn't overwritten with a translation of the old text.

## The A/B review, now scored

The blinded native-speaker review sheet from the offline experiment had never been scored. It is now — all 48 rows, arms unblinded only after grading. Substantive cases only (10 of 12; English controls excluded):

| Arm | Provider | EN-acceptable | Unflagged wrong assertions |
| --- | --- | ---: | ---: |
| B `llm-end-to-end` (**shipped**) | Gemini restores + translates | **10/10** | 0 |
| D `restore-google` | Gemini restores, Google translates | **10/10** | 0 |
| C `google-vi` | Google, source forced `vi` | 2/10 | 3 |
| A `google-auto` | Google, auto-detect | 1/10 | 3 |

Scored by Claude, **not** by a native speaker — recorded honestly in the sheet. The fixture is elementary domain vocabulary and the arms separate by a margin far wider than the judgment involved (Google returns `Bơm khí tự động` → "Automatic gas bomb", `Kho chứa khí 2` → "Sourdough when 2"). Ordering is settled; individual scores are ±1.

**The specific worry going in was inverted by the data.** The concern was that the gate would silently resolve `ma` → `mã` with no ambiguity flag. It doesn't: on both deliberately ambiguous fixtures it returned status `ambiguous` with alternatives, and production rejects any non-`translated` status. The unflagged confident answers on those rows are *Google's* — `ma` → "and", `ma` → "ghost". The behaviour worth worrying about belongs to the arm this change replaces.

Replayed through the real accept rules: **8 accepted and correct, 2 refused as ambiguous, 2 refused as English echoes, 0 wrong acceptances.** That replay is now a test, so future drift in the accept rules fails against the reviewed run instead of surfacing in prod.

## Verification

- `npm run tsc` clean.
- Backend suite **1067 passing / 0 failing** (1064 baseline verified independently on a clean run before any changes — the prior report of a flaky avatar timeout did not reproduce; +3 new tests).
- Migration reviewed for idempotency in both directions; sets `mode` before touching the index, and `down` deletes vi-mode rows before restoring the narrower unique key.
- No network in tests: fakes for both providers, all keys blanked in `.env.test`.

## Rollout (ops, after merge)

Deploy has the gate off. Order matters:

1. DB backup, then `npm run migrate:up`.
2. `npm run derive-search:dry-run` — constructs no Gemini client, reports the exact census and maximum reservation.
3. Set `GEMINI_VI_TITLE_TRANSLATION_ENABLED=true` and an allowance chosen from that maximum, restart, then `npm run derive-search` once.

Rollback is switch-off plus allowance-zero; accepted cache rows stay usable and `Blueprint.name` is never modified.

## Known, deliberate

Only *accepted* translations are cached, so a re-run re-asks Gemini about every ambiguous and not-Vietnamese title. Bounded and documented; it's why a routine re-run isn't free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)