### PR TITLE
fix(search): raise the vi-title Gemini output-token cap to 2048

### DIFF
--- a/__tests__/api/vietnamese-title-translation-service.test.ts
+++ b/__tests__/api/vietnamese-title-translation-service.test.ts
@@ -215,12 +215,12 @@ describe('VietnameseTitleTranslationService', function () {
       expect((error as Error).message).to.equal('provider failed');
     }
     const row = await TranslationBudgetModel.model.findOne({ userId: null });
-    expect(row!.geminiReservedMicroUsd).to.equal(2176);
+    expect(row!.geminiReservedMicroUsd).to.equal(4096);
     expect(row!.geminiObservedMicroUsd).to.equal(0);
   });
 
   it('atomically rejects concurrent reservations above the monthly cap', async function () {
-    process.env.GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD = '2176';
+    process.env.GEMINI_VI_TITLE_MONTHLY_BUDGET_MICRO_USD = '4096';
     fake.delayMs = 20;
     const results = await Promise.allSettled([
       service.translateOne('Dien phan', null),
@@ -380,7 +380,7 @@ describe('VietnameseTitleTranslationService', function () {
     process.env.GEMINI_VI_TITLE_MAX_INPUT_TOKENS = '999999';
     process.env.GEMINI_VI_TITLE_MAX_OUTPUT_TOKENS = 'not-a-number';
 
-    expect(vietnameseTitleDryRunCaps()).to.include({ inputTokens: 4096, outputTokens: 768 });
+    expect(vietnameseTitleDryRunCaps()).to.include({ inputTokens: 4096, outputTokens: 2048 });
 
     const result = await service.translateOne('Dien phan', null);
     expect(result.status).to.equal('translated');
@@ -531,7 +531,7 @@ describe('GeminiVietnameseTitleProvider', function () {
     expect(body.generationConfig).to.include({
       temperature: 0,
       candidateCount: 1,
-      maxOutputTokens: 768,
+      maxOutputTokens: 2048,
       responseMimeType: 'application/json',
     });
     expect(body.generationConfig.thinkingConfig).to.deep.equal({ thinkingLevel: 'minimal' });

--- a/app/api/services/vietnamese-title-prompts.ts
+++ b/app/api/services/vietnamese-title-prompts.ts
@@ -6,7 +6,12 @@ export const GEMINI_VI_TITLE_TIMEOUT_MS = 15_000;
 export const GEMINI_VI_TITLE_BATCH_SIZE = 12;
 export const GEMINI_VI_TITLE_BATCH_CHARACTERS = 720;
 export const GEMINI_VI_TITLE_DEFAULT_MAX_INPUT_TOKENS = 4096;
-export const GEMINI_VI_TITLE_DEFAULT_MAX_OUTPUT_TOKENS = 768;
+// Output usage counts completion + thought tokens (validateUsage). Measured on
+// the 2026-08-26 prod-restore rehearsal: a full 12-title batch spends 716-740
+// output tokens even at thinkingLevel minimal, so the previous 768 cap
+// truncated 113 of 199 batches with MAX_TOKENS. 2048 leaves ~3x headroom; the
+// env override (boundedPositiveInt) can only lower this, never raise it.
+export const GEMINI_VI_TITLE_DEFAULT_MAX_OUTPUT_TOKENS = 2048;
 
 export type VietnameseTitleStatus = 'translated' | 'ambiguous' | 'not-vietnamese';
 


### PR DESCRIPTION
## What

Raises `GEMINI_VI_TITLE_DEFAULT_MAX_OUTPUT_TOKENS` from 768 to 2048, with test expectations updated for the new per-call max reservation (2,176 → 4,096 micro-USD).

## Why

Phase 1b of the rollout runbook (`spec/rollout-vi-gate.md`) — the supervised paid rehearsal against a fresh prod restore — failed 113 of 199 Gemini batches with `MAX_TOKENS`. Output usage counts completion **plus thought** tokens (`validateUsage`), and a full 12-title batch measures 716–740 output tokens even at `thinkingLevel: minimal`, so the 768 ceiling truncated most full batches. The env override can't fix it: `boundedPositiveInt` treats values above the default as the default, so the cap can only be lowered from env, never raised.

## Cost impact

Per-call max reservation becomes 4096×0.25 + 2048×1.5 = 4,096 micro-USD. A full 199-batch backfill reserves ~$0.82 at the ceiling; observed spend on the rehearsal was ~$0.10 for the whole corpus. The runbook cap formula becomes `4096 × (batches + headroom)`.

## Verified

- Full backend suite in this branch's tree: 1072 passing.
- Rehearsal evidence: successful batches at 716–740 output tokens; the 13 accepted translations were all correct ONI-domain English (Điện phân → Electrolysis, Cửa nước → Liquid lock, …).

## Not addressed here

The rehearsal's second blocker — Google Translate returning 403 `userRateLimitExceeded` (masked as 15s timeouts by gax's internal retries) — is a quota/console matter, not a code change. Tracked in the rollout runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)