### PR TITLE
feat(editor): read and edit automation building settings (BlueprintsV2 buildingData)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -684,6 +684,70 @@ content — users no longer set these manually. `multiplayerSafe` has been remov
   runs** — no document written before the field existed has a set at all (prod: `cd /bpni/build
 && npm run derive-metadata`, dry-run first).
 
+### Building settings (buildingData)
+
+`spec/building-settings-plan.md`. A blueprint's per-component settings — timer durations,
+switch state, logic gate delays, threshold values, ... — written by the BlueprintsV2 mod as
+`buildings[].buildingData: {Key, Value}[]` (`Key` is the ONI component class name). Previously
+dropped on import and never written back; now round-trips, displays, and (for a curated set)
+edits.
+
+- **Round-trip** — `BlueprintItem.buildingData?: BniBuildingData[]` and the matching
+  `MdbBuilding.buildingData` field carry the array end-to-end (import/export/clone/undo),
+  deep-copied at every model boundary via `structuredClone` so undo snapshots never alias the
+  live item. `MdbBuilding` omits the field when empty, so every pre-existing stored
+  blueprint's MDB fingerprint (and therefore `rawSource` freshness) is unaffected — same
+  reasoning as `worldNotes`. `bpv2-sanitize.ts`'s position shift mutates building objects in
+  place and never touches `buildingData`, so a sanitized export keeps settings attached for
+  free.
+- **Catalogue** — `lib/src/blueprint/building-settings/settings-catalog.ts` is a curated,
+  hand-authored table (`SETTINGS_CATALOG`) of the automation-relevant keys (`Switch`,
+  `LogicTimerSensor`, `LogicTimeOfDaySensor`, `LogicCounter`, `LogicGateBuffer`/`Filter`,
+  `LogicRibbonReader`/`Writer`, `LogicCritterCountSensor`, `LogicAlarm`, `IThresholdSwitch`,
+  `IActivationRangeTarget`, `BuildingEnabledButton`, `Automatable`) with per-field type/unit/
+  bounds — cross-checked against the mod's real `DataTransferHelpers.cs`/`API_Methods.cs`
+  source (available locally as an additional working directory), not just the import spec's
+  summary table. Every other key (`Door`, `Valve`, filters, `AccessControl`, `PixelPack`,
+  skins, ...) is preserved opaquely and never rendered as anything but a count.
+  `format-setting.ts` formats known fields for display (durations show seconds plus a cycle
+  count once ≥600s; `LogicTimeOfDaySensor` fractions show as % of cycle, matching the game's
+  own side screen).
+- **Display + edit** — `BuildingSettingsComponent`
+  (`frontend/.../side-bar/building-settings/`), mounted in `item-collection-info` next to the
+  dormant `app-ui-screen-container` (the old website's own settings model, `uiScreens`/
+  `uiSaveSettings` — untouched, has no data source since the 2024 export ships empty
+  `uiScreens` for every building). Renders one row per known field (checkbox/number/text
+  input), a count line for unrecognized keys ("N other stored settings (preserved)", raw
+  `Key` names only in the tooltip — never dumped as JSON), and an "Add automation settings"
+  button when the selected building can create a currently-absent key from scratch.
+  `BlueprintItem.setBuildingSetting(key, field, value)` replaces one field on an
+  already-present key, keeping every other field verbatim — required because the mod's
+  `TryApplyData` bails on the **whole** Value object if even one expected field is missing
+  (confirmed against real mod source; the one exception found is `LogicAlarm`, which applies
+  each field independently). `addBuildingSetting(key)` constructs a complete Value object from
+  scratch using hand-verified defaults.
+- **Creatable-from-scratch is deliberately narrow** — `CREATABLE_SETTINGS` in
+  `settings-catalog.ts` currently has only `LogicTimerSensor` (`onDuration`/`offDuration`:
+  10s each; `timeElapsedInCurrentState`: 0, definitionally correct for a fresh component;
+  `displayCyclesMode`: false, a display-only toggle with no simulation effect even if wrong).
+  Every other key, including `LogicCounter` (whose `resetCountAtMax`/`advancedMode` real
+  defaults aren't confirmed), stays edit-only-when-the-file-already-has-it: synthesizing an
+  incomplete or wrong default for a gameplay-affecting field would silently change build
+  behaviour on export. Extend the list only once a key's real in-game defaults are verified.
+- **Edits commit on blur/Enter/change** (one undo step per completed edit, not per keystroke),
+  matching the world-notes editor pattern — `blueprintService.blueprint.emitBlueprintChanged()`.
+  Editing a setting invalidates `rawSource` through the same fingerprint comparison phase 1's
+  round-trip already wired into `toMdbBuilding` — no new invalidation code needed (see
+  `spec/blueprintsv2-followups.md` task 5, "editor UX gap").
+  **Gotcha**: a `*ngFor` over a getter-backed array with no `trackBy` breaks live typing —
+  `rows` rebuilds fresh objects on every change-detection cycle (which fires on every
+  keystroke because the `(keydown.enter)` binding registers a real `keydown` listener), and
+  without `trackBy` Angular's default identity diffing tears down and rebuilds the `<input>`
+  DOM nodes mid-edit, discarding whatever was just typed. Fixed with
+  `trackBy: trackByRow` keyed on `Key:field`; a regression spec (re-queries the DOM after a
+  simulated mid-edit change-detection tick rather than reusing a captured node reference)
+  fails without the fix and passes with it.
+
 ### Session Management Files
 
 Check these files in `agent/` directory for current status:

--- a/__tests__/fixtures/time-sensors.blueprint
+++ b/__tests__/fixtures/time-sensors.blueprint
@@ -1,0 +1,85 @@
+{
+  "blueprintVersion": 3,
+  "friendlyname": "Time Sensors",
+  "buildings": [
+    {
+      "offset": {
+        "x": 1,
+        "y": 1
+      },
+      "buildingdef": "LogicTimerSensor",
+      "selected_elements": [
+        -1725038055
+      ],
+      "buildingData": [
+        {
+          "Key": "Switch",
+          "Value": {
+            "switchedOn": true
+          }
+        },
+        {
+          "Key": "LogicTimerSensor",
+          "Value": {
+            "onDuration": 5.0,
+            "offDuration": 5.0,
+            "timeElapsedInCurrentState": 3.099925,
+            "displayCyclesMode": false
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 2,
+        "y": 1
+      },
+      "buildingdef": "LogicTimerSensor",
+      "selected_elements": [
+        -1725038055
+      ],
+      "buildingData": [
+        {
+          "Key": "Switch",
+          "Value": {
+            "switchedOn": true
+          }
+        },
+        {
+          "Key": "LogicTimerSensor",
+          "Value": {
+            "onDuration": 6.0,
+            "offDuration": 6000.0,
+            "timeElapsedInCurrentState": 0.78333354,
+            "displayCyclesMode": true
+          }
+        }
+      ]
+    },
+    {
+      "offset": {
+        "x": 3,
+        "y": 1
+      },
+      "buildingdef": "LogicTimeOfDaySensor",
+      "selected_elements": [
+        -1725038055
+      ],
+      "buildingData": [
+        {
+          "Key": "Switch",
+          "Value": {
+            "switchedOn": false
+          }
+        },
+        {
+          "Key": "LogicTimeOfDaySensor",
+          "Value": {
+            "startTime": 0.249224767,
+            "duration": 0.000996187
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/__tests__/lib/bpv2-import.test.ts
+++ b/__tests__/lib/bpv2-import.test.ts
@@ -10,8 +10,11 @@ import {
   decodeBniShareString,
   encodeBniShareString,
   looksLikeBniShareString,
+  Vector2,
 } from '../../lib';
 import { loadGameDatabase } from '../helpers/roomFixtures';
+
+const TIME_SENSORS_FIXTURE_PATH = path.join(__dirname, '../fixtures/time-sensors.blueprint');
 
 // BlueprintsV2 v3 import coverage (spec/blueprintsv2-import-spec.md), driven
 // by a real mod export: 71 buildings, material overrides, custom icon, both
@@ -85,6 +88,14 @@ describe('BlueprintsV2 import', function () {
       // Unknown hash -> default element, not a crash or an empty slot
       expect(tile!.buildableElements[0]).to.not.equal(undefined);
       expect(tile!.buildableElements[0].id).to.equal(tile!.oniItem.defaultElement[0].id);
+    });
+
+    it('carries every buildingData entry onto the imported items (Q4)', () => {
+      let count = 0;
+      for (const item of blueprint.blueprintItems)
+        if (item.buildingData != null) count += item.buildingData.length;
+      // Matches the raw fixture: 26 buildings carry 37 buildingData entries.
+      expect(count).to.equal(37);
     });
 
     it('keeps the v3 metadata available on the parsed blueprint (P0)', () => {
@@ -205,6 +216,100 @@ describe('BlueprintsV2 import', function () {
 
       expect(bottomRightAfter.x).to.equal(farNote.x);
       expect(bottomRightAfter.y).to.equal(farNote.y);
+    });
+  });
+
+  describe('buildingData persistence (spec/building-settings-plan.md, phase 1)', function () {
+    let timeSensorsText: string;
+    let timeSensorsFixture: BniBlueprint;
+
+    before(function () {
+      timeSensorsText = fs.readFileSync(TIME_SENSORS_FIXTURE_PATH, 'utf8');
+      timeSensorsFixture = JSON.parse(timeSensorsText);
+    });
+
+    it('round-trips buildingData through bni -> Blueprint -> mdb -> Blueprint -> bni verbatim', () => {
+      const source = new Blueprint();
+      source.importFromBni(timeSensorsFixture);
+      expect(source.blueprintItems).to.have.length(3);
+      expect(source.blueprintItems.map(item => item.buildingData)).to.deep.equal(
+        timeSensorsFixture.buildings.map(b => b.buildingData)
+      );
+
+      const mdb = source.toMdbBlueprint();
+      const reimported = new Blueprint();
+      reimported.importFromMdb(mdb);
+      expect(reimported.blueprintItems.map(item => item.buildingData)).to.deep.equal(
+        source.blueprintItems.map(item => item.buildingData)
+      );
+
+      const bni = reimported.toBniBlueprint('roundtrip');
+      expect(bni.buildings.map(b => b.buildingData)).to.deep.equal(
+        timeSensorsFixture.buildings.map(b => b.buildingData)
+      );
+    });
+
+    it('a sanitized export keeps settings attached to the shifted building', () => {
+      // Shift the fixture into negative territory so toBniBlueprint's own
+      // SanitizePositions-equivalent pass actually fires.
+      const shifted: BniBlueprint = {
+        ...timeSensorsFixture,
+        buildings: timeSensorsFixture.buildings.map(b => ({
+          ...b,
+          offset: new Vector2(b.offset!.x - 10, b.offset!.y - 10),
+        })),
+      };
+      const source = new Blueprint();
+      source.importFromBni(shifted);
+
+      const bni = source.toBniBlueprint('sanitized');
+      expect(bni.buildings.map(b => b.buildingData)).to.deep.equal(
+        timeSensorsFixture.buildings.map(b => b.buildingData)
+      );
+    });
+
+    it('omits buildingData from toMdbBuilding/toBniBuilding for a building placed in the editor', () => {
+      const empty = new Blueprint();
+      empty.importFromBni({ friendlyname: '', buildings: [], digcommands: [] });
+      // No blueprintItems to place through the editor API directly here, but
+      // the empty-fixture check below proves the omit-when-empty path: a
+      // blueprint with no buildingData produces no buildingData key anywhere.
+      const mdb = empty.toMdbBlueprint();
+      expect(JSON.stringify(mdb)).to.not.include('buildingData');
+      const bni = empty.toBniBlueprint('no-settings');
+      expect(JSON.stringify(bni)).to.not.include('buildingData');
+    });
+
+    it('undo simulation: mutating the live item after snapshotting does not affect the restored settings', () => {
+      const source = new Blueprint();
+      source.importFromBni(timeSensorsFixture);
+      const snapshot = source.toMdbBlueprint();
+
+      // Mutate the live item's buildingData directly (as an in-place edit would).
+      const liveItem = source.blueprintItems[0];
+      const liveSwitch = liveItem.buildingData!.find(entry => entry.Key == 'Switch')!;
+      liveSwitch.Value.switchedOn = false;
+
+      const restored = new Blueprint();
+      restored.importFromMdb(snapshot);
+      const restoredSwitch = restored.blueprintItems[0].buildingData!.find(
+        entry => entry.Key == 'Switch'
+      )!;
+      // Snapshot was taken before the mutation, so it must still read true.
+      expect(restoredSwitch.Value.switchedOn).to.equal(true);
+      expect(restored.blueprintItems[0].buildingData).to.not.equal(liveItem.buildingData);
+    });
+
+    it('clone() carries buildingData', () => {
+      const source = new Blueprint();
+      source.importFromBni(timeSensorsFixture);
+      const cloned = source.clone();
+      expect(cloned.blueprintItems.map(item => item.buildingData)).to.deep.equal(
+        source.blueprintItems.map(item => item.buildingData)
+      );
+      expect(cloned.blueprintItems[0].buildingData).to.not.equal(
+        source.blueprintItems[0].buildingData
+      );
     });
   });
 

--- a/__tests__/lib/building-settings.test.ts
+++ b/__tests__/lib/building-settings.test.ts
@@ -1,11 +1,14 @@
-import { describe, it } from 'mocha';
+import { describe, it, before } from 'mocha';
 import { expect } from 'chai';
 import {
+  Blueprint,
+  BlueprintHelpers,
   BniBuildingData,
   formatBuildingDataEntry,
   isKnownSettingsKey,
   SETTINGS_CATALOG,
 } from '../../lib/index';
+import { loadGameDatabase } from '../helpers/roomFixtures';
 
 // Catalogue + formatter unit coverage (spec/building-settings-plan.md phase 2).
 // Pure, no game database needed.
@@ -126,5 +129,158 @@ describe('formatBuildingDataEntry', function () {
       Value: { maxCount: 3 },
     })!;
     expect(rows).to.deep.equal([{ field: 'maxCount', label: 'Target count', text: '3' }]);
+  });
+});
+
+// Write path (spec/building-settings-plan.md phase 3 step 1). Needs the real
+// game database so BlueprintHelpers.createInstance can build real items.
+describe('BlueprintItem.setBuildingSetting / addBuildingSetting', function () {
+  before(function () {
+    loadGameDatabase();
+  });
+
+  it('replaces one field on an already-present Key, keeping every other field verbatim', () => {
+    const item = BlueprintHelpers.createInstance('LogicTimerSensor')!;
+    item.buildingData = [
+      { Key: 'Switch', Value: { switchedOn: true } },
+      {
+        Key: 'LogicTimerSensor',
+        Value: {
+          onDuration: 5.0,
+          offDuration: 5.0,
+          timeElapsedInCurrentState: 3.099925,
+          displayCyclesMode: false,
+        },
+      },
+    ];
+
+    item.setBuildingSetting('LogicTimerSensor', 'onDuration', 42);
+
+    const entry = item.buildingData.find(e => e.Key == 'LogicTimerSensor')!;
+    expect(entry.Value).to.deep.equal({
+      onDuration: 42,
+      offDuration: 5.0,
+      timeElapsedInCurrentState: 3.099925,
+      displayCyclesMode: false,
+    });
+    // Untouched sibling Key survives.
+    expect(item.buildingData.find(e => e.Key == 'Switch')!.Value).to.deep.equal({
+      switchedOn: true,
+    });
+  });
+
+  it('creates a complete Value object from catalogue defaults when the Key is absent', () => {
+    const item = BlueprintHelpers.createInstance('LogicTimerSensor')!;
+    expect(item.buildingData).to.equal(undefined);
+
+    item.setBuildingSetting('LogicTimerSensor', 'onDuration', 42);
+
+    expect(item.buildingData).to.have.length(1);
+    expect(item.buildingData![0]).to.deep.equal({
+      Key: 'LogicTimerSensor',
+      Value: {
+        onDuration: 42,
+        offDuration: 10,
+        timeElapsedInCurrentState: 0,
+        displayCyclesMode: false,
+      },
+    });
+  });
+
+  it('addBuildingSetting creates every default field without an explicit edit', () => {
+    const item = BlueprintHelpers.createInstance('LogicTimerSensor')!;
+    const created = item.addBuildingSetting('LogicTimerSensor');
+
+    expect(created).to.equal(true);
+    expect(item.buildingData![0].Value).to.deep.equal({
+      onDuration: 10,
+      offDuration: 10,
+      timeElapsedInCurrentState: 0,
+      displayCyclesMode: false,
+    });
+  });
+
+  it('addBuildingSetting is a no-op (still true) when the Key is already present', () => {
+    const item = BlueprintHelpers.createInstance('LogicTimerSensor')!;
+    item.buildingData = [{ Key: 'LogicTimerSensor', Value: { onDuration: 99 } }];
+
+    expect(item.addBuildingSetting('LogicTimerSensor')).to.equal(true);
+    // Existing entry is untouched, not replaced with defaults.
+    expect(item.buildingData).to.have.length(1);
+    expect(item.buildingData[0].Value).to.deep.equal({ onDuration: 99 });
+  });
+
+  it('rejects creating a Key with no verified defaults on this building', () => {
+    // LogicCounter's resetCountAtMax/advancedMode defaults are not verified
+    // (settings-catalog.ts), so it must not be creatable from scratch.
+    const item = BlueprintHelpers.createInstance('LogicCounter')!;
+    expect(item.addBuildingSetting('LogicCounter')).to.equal(false);
+    expect(() => item.setBuildingSetting('LogicCounter', 'maxCount', 5)).to.throw(
+      /is not present.*no creatable defaults/
+    );
+  });
+
+  it('rejects creating a Key on a building where it is not the hand-checked creatable one', () => {
+    // LogicTimerSensor's own Key is creatable on that building, but a Key
+    // that has no defaults entry at all for this prefab must still reject.
+    const item = BlueprintHelpers.createInstance('LogicTimerSensor')!;
+    expect(() => item.setBuildingSetting('LogicCounter', 'maxCount', 5)).to.throw();
+  });
+
+  it('does not share the created Value object with the catalogue defaults or another item', () => {
+    const itemA = BlueprintHelpers.createInstance('LogicTimerSensor')!;
+    const itemB = BlueprintHelpers.createInstance('LogicTimerSensor')!;
+    itemA.addBuildingSetting('LogicTimerSensor');
+    itemB.addBuildingSetting('LogicTimerSensor');
+
+    itemA.setBuildingSetting('LogicTimerSensor', 'onDuration', 1);
+    itemB.setBuildingSetting('LogicTimerSensor', 'onDuration', 2);
+
+    expect(itemA.buildingData![0].Value.onDuration).to.equal(1);
+    expect(itemB.buildingData![0].Value.onDuration).to.equal(2);
+
+    // A third creation still gets the pristine default, proving the module
+    // constant itself was never mutated by the two edits above.
+    const itemC = BlueprintHelpers.createInstance('LogicTimerSensor')!;
+    itemC.addBuildingSetting('LogicTimerSensor');
+    expect(itemC.buildingData![0].Value.onDuration).to.equal(10);
+  });
+
+  it('full loop: editing a duration reaches toBniBlueprint as a complete LogicTimerSensor object', () => {
+    const blueprint = new Blueprint();
+    blueprint.importFromBni({
+      friendlyname: '',
+      buildings: [
+        {
+          offset: { x: 1, y: 1 },
+          buildingdef: 'LogicTimerSensor',
+          selected_elements: [-1725038055],
+          buildingData: [
+            { Key: 'Switch', Value: { switchedOn: true } },
+            {
+              Key: 'LogicTimerSensor',
+              Value: {
+                onDuration: 5.0,
+                offDuration: 5.0,
+                timeElapsedInCurrentState: 3.099925,
+                displayCyclesMode: false,
+              },
+            },
+          ],
+        },
+      ],
+      digcommands: [],
+    } as any);
+
+    blueprint.blueprintItems[0].setBuildingSetting('LogicTimerSensor', 'onDuration', 30);
+
+    const bni = blueprint.toBniBlueprint('edited');
+    const timerEntry = bni.buildings[0].buildingData!.find(e => e.Key == 'LogicTimerSensor')!;
+    expect(timerEntry.Value).to.deep.equal({
+      onDuration: 30,
+      offDuration: 5.0,
+      timeElapsedInCurrentState: 3.099925,
+      displayCyclesMode: false,
+    });
   });
 });

--- a/__tests__/lib/building-settings.test.ts
+++ b/__tests__/lib/building-settings.test.ts
@@ -130,6 +130,40 @@ describe('formatBuildingDataEntry', function () {
     })!;
     expect(rows).to.deep.equal([{ field: 'maxCount', label: 'Target count', text: '3' }]);
   });
+
+  it('does not eat a real trailing zero on a whole-number int field (CodeRabbit #212)', () => {
+    // formatNumber(10, 0) previously stripped the trailing zero as if it were
+    // decimal-formatting noise, displaying "1" for a target count of 10.
+    const rows = formatBuildingDataEntry({
+      Key: 'LogicCounter',
+      Value: { maxCount: 10 },
+    })!;
+    expect(rows).to.deep.equal([{ field: 'maxCount', label: 'Target count', text: '10' }]);
+  });
+
+  it('does not eat trailing zeroes on other whole-number int fields (100, 20)', () => {
+    const rows100 = formatBuildingDataEntry({
+      Key: 'LogicCritterCountSensor',
+      Value: {
+        countThreshold: 100,
+        activateOnGreaterThan: true,
+        countCritters: true,
+        countEggs: false,
+      },
+    })!;
+    expect(rows100.find(r => r.field == 'countThreshold')!.text).to.equal('100');
+
+    const rows20 = formatBuildingDataEntry({
+      Key: 'LogicCritterCountSensor',
+      Value: {
+        countThreshold: 20,
+        activateOnGreaterThan: true,
+        countCritters: true,
+        countEggs: false,
+      },
+    })!;
+    expect(rows20.find(r => r.field == 'countThreshold')!.text).to.equal('20');
+  });
 });
 
 // Write path (spec/building-settings-plan.md phase 3 step 1). Needs the real
@@ -225,6 +259,14 @@ describe('BlueprintItem.setBuildingSetting / addBuildingSetting', function () {
     // that has no defaults entry at all for this prefab must still reject.
     const item = BlueprintHelpers.createInstance('LogicTimerSensor')!;
     expect(() => item.setBuildingSetting('LogicCounter', 'maxCount', 5)).to.throw();
+  });
+
+  it('repairs a null/malformed Value on an already-present Key instead of crashing (CodeRabbit #212)', () => {
+    const item = BlueprintHelpers.createInstance('LogicTimerSensor')!;
+    item.buildingData = [{ Key: 'Switch', Value: null as any }];
+
+    expect(() => item.setBuildingSetting('Switch', 'switchedOn', true)).to.not.throw();
+    expect(item.buildingData[0].Value).to.deep.equal({ switchedOn: true });
   });
 
   it('does not share the created Value object with the catalogue defaults or another item', () => {

--- a/__tests__/lib/building-settings.test.ts
+++ b/__tests__/lib/building-settings.test.ts
@@ -1,0 +1,130 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import {
+  BniBuildingData,
+  formatBuildingDataEntry,
+  isKnownSettingsKey,
+  SETTINGS_CATALOG,
+} from '../../lib/index';
+
+// Catalogue + formatter unit coverage (spec/building-settings-plan.md phase 2).
+// Pure, no game database needed.
+describe('building-settings catalogue', function () {
+  it('recognizes every key from the plan\'s automation table', () => {
+    const expectedKeys = [
+      'Switch',
+      'LogicTimerSensor',
+      'LogicTimeOfDaySensor',
+      'LogicCounter',
+      'LogicGateBuffer',
+      'LogicGateFilter',
+      'LogicRibbonReader',
+      'LogicRibbonWriter',
+      'LogicCritterCountSensor',
+      'LogicAlarm',
+      'IThresholdSwitch',
+      'IActivationRangeTarget',
+      'BuildingEnabledButton',
+      'Automatable',
+    ];
+    for (const key of expectedKeys) expect(isKnownSettingsKey(key)).to.equal(true);
+  });
+
+  it('does not know keys outside the curated set', () => {
+    for (const key of ['Door', 'Valve', 'PixelPack', 'AccessControl', 'Filterable'])
+      expect(isKnownSettingsKey(key)).to.equal(false);
+  });
+
+  it('marks LogicTimerSensor.timeElapsedInCurrentState hidden', () => {
+    const descriptor = SETTINGS_CATALOG.LogicTimerSensor.find(
+      d => d.field == 'timeElapsedInCurrentState'
+    )!;
+    expect(descriptor.hidden).to.equal(true);
+  });
+});
+
+describe('formatBuildingDataEntry', function () {
+  it('returns null for a Key outside the curated catalogue', () => {
+    const entry: BniBuildingData = { Key: 'Door', Value: { requestedState: 1 } };
+    expect(formatBuildingDataEntry(entry)).to.equal(null);
+  });
+
+  it('formats a Switch entry', () => {
+    const rows = formatBuildingDataEntry({ Key: 'Switch', Value: { switchedOn: true } });
+    expect(rows).to.deep.equal([{ field: 'switchedOn', label: 'On', text: 'On' }]);
+  });
+
+  it('omits the hidden runtime field and formats the rest of LogicTimerSensor', () => {
+    const rows = formatBuildingDataEntry({
+      Key: 'LogicTimerSensor',
+      Value: {
+        onDuration: 5.0,
+        offDuration: 5.0,
+        timeElapsedInCurrentState: 3.099925,
+        displayCyclesMode: false,
+      },
+    })!;
+    expect(rows.map(r => r.field)).to.deep.equal(['onDuration', 'offDuration', 'displayCyclesMode']);
+    expect(rows.find(r => r.field == 'onDuration')!.text).to.equal('5 s');
+    expect(rows.find(r => r.field == 'displayCyclesMode')!.text).to.equal('Off');
+  });
+
+  it('appends a cycle count once a duration crosses 600s', () => {
+    const rows = formatBuildingDataEntry({
+      Key: 'LogicTimerSensor',
+      Value: {
+        onDuration: 6.0,
+        offDuration: 6000.0,
+        timeElapsedInCurrentState: 0.78333354,
+        displayCyclesMode: true,
+      },
+    })!;
+    // Below the threshold, but displayCyclesMode still forces the cycle suffix.
+    expect(rows.find(r => r.field == 'onDuration')!.text).to.equal('6 s (~0.01 cycles)');
+    expect(rows.find(r => r.field == 'offDuration')!.text).to.equal('6000 s (~10 cycles)');
+  });
+
+  it('renders LogicTimeOfDaySensor fractions as a percentage of the cycle', () => {
+    const rows = formatBuildingDataEntry({
+      Key: 'LogicTimeOfDaySensor',
+      Value: { startTime: 0.249224767, duration: 0.000996187 },
+    })!;
+    expect(rows.find(r => r.field == 'startTime')!.text).to.equal('24.92% of cycle');
+    expect(rows.find(r => r.field == 'duration')!.text).to.equal('0.1% of cycle');
+  });
+
+  it('renders selectedBit with the bit unit', () => {
+    const rows = formatBuildingDataEntry({
+      Key: 'LogicRibbonReader',
+      Value: { selectedBit: 2 },
+    })!;
+    expect(rows).to.deep.equal([{ field: 'selectedBit', label: 'Bit', text: 'Bit 2' }]);
+  });
+
+  it('renders an empty string field as an em dash', () => {
+    const rows = formatBuildingDataEntry({
+      Key: 'LogicAlarm',
+      Value: {
+        notificationName: '',
+        notificationTooltip: 'Something happened',
+        notificationType: 0,
+        pauseOnNotify: false,
+        zoomOnNotify: true,
+        cooldown: 12.5,
+      },
+    })!;
+    expect(rows.find(r => r.field == 'notificationName')!.text).to.equal('—');
+    expect(rows.find(r => r.field == 'notificationTooltip')!.text).to.equal('Something happened');
+    expect(rows.find(r => r.field == 'cooldown')!.text).to.equal('12.5 s');
+  });
+
+  it('skips fields the stored Value is missing rather than failing the whole entry', () => {
+    // An older/partial file might not carry every field the catalogue knows
+    // about — the formatter must be forgiving on the read-only display path.
+    const rows = formatBuildingDataEntry({
+      Key: 'LogicCounter',
+      Value: { maxCount: 3 },
+    })!;
+    expect(rows).to.deep.equal([{ field: 'maxCount', label: 'Target count', text: '3' }]);
+  });
+});

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.css
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.css
@@ -1,12 +1,38 @@
 .building-setting-row {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   gap: 8px;
   padding: 2px 0;
 }
 
 .building-setting-label {
   color: var(--p-text-muted-color);
+}
+
+.building-setting-control {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.building-setting-number {
+  width: 70px;
+}
+
+.building-setting-text {
+  width: 140px;
+}
+
+.building-setting-unit,
+.building-setting-hint {
+  color: var(--p-text-muted-color);
+  font-size: smaller;
+}
+
+.building-setting-add {
+  width: 100%;
+  margin-top: 6px;
 }
 
 .building-setting-other {

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.css
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.css
@@ -1,0 +1,17 @@
+.building-setting-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 2px 0;
+}
+
+.building-setting-label {
+  color: var(--p-text-muted-color);
+}
+
+.building-setting-other {
+  margin-top: 6px;
+  font-size: smaller;
+  color: var(--p-text-muted-color);
+  cursor: default;
+}

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
@@ -9,7 +9,10 @@
     <span class="ui-fieldset-legend-text" i18n>Building settings</span>
   </legend>
 
-  <div class="building-setting-row" *ngFor="let row of rows">
+  <div
+    class="building-setting-row"
+    *ngFor="let row of rows; trackBy: trackByRow"
+  >
     <span class="building-setting-label">{{ row.label }}</span>
 
     <span class="building-setting-control">

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
@@ -1,0 +1,29 @@
+<fieldset
+  *ngIf="hasSettings"
+  legend="Settings"
+  class="ui-fieldset ui-widget ui-widget-content ui-corner-all"
+>
+  <legend
+    class="ui-fieldset-legend ui-corner-all ui-state-default ui-unselectable-text"
+  >
+    <span class="ui-fieldset-legend-text" i18n>Building settings</span>
+  </legend>
+
+  <div class="building-setting-row" *ngFor="let row of rows">
+    <span class="building-setting-label">{{ row.label }}</span>
+    <span class="building-setting-value">{{ row.text }}</span>
+  </div>
+
+  <div
+    *ngIf="otherKeys.length > 0"
+    class="building-setting-other"
+    [pTooltip]="otherKeysTooltip"
+    tooltipEvent="both"
+  >
+    {{ otherKeys.length }} other stored setting<span
+      *ngIf="otherKeys.length !== 1"
+      >s</span
+    >
+    (preserved)
+  </div>
+</fieldset>

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
@@ -52,6 +52,7 @@
         type="text"
         class="building-setting-text"
         [value]="row.displayValue"
+        [attr.maxlength]="row.displayMax"
         (blur)="onFieldInput(row, textInput.value)"
         (keydown.enter)="onFieldInput(row, textInput.value); textInput.blur()"
       />

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
@@ -11,8 +11,60 @@
 
   <div class="building-setting-row" *ngFor="let row of rows">
     <span class="building-setting-label">{{ row.label }}</span>
-    <span class="building-setting-value">{{ row.text }}</span>
+
+    <span class="building-setting-control">
+      <input
+        *ngIf="row.type === 'bool'"
+        type="checkbox"
+        [checked]="row.displayValue"
+        (change)="onFieldInput(row, $any($event.target).checked)"
+      />
+
+      <ng-container *ngIf="row.type === 'int' || row.type === 'float'">
+        <input
+          #numInput
+          type="number"
+          class="building-setting-number"
+          [value]="row.displayValue"
+          [attr.min]="row.displayMin"
+          [attr.max]="row.displayMax"
+          [attr.step]="row.type === 'int' ? 1 : 0.1"
+          (blur)="onFieldInput(row, numInput.value)"
+          (keydown.enter)="onFieldInput(row, numInput.value); numInput.blur()"
+        />
+        <span class="building-setting-unit" *ngIf="row.unit === 's'">s</span>
+        <span
+          class="building-setting-unit"
+          *ngIf="row.unit === 'cycleFraction' || row.unit === '%'"
+          >%</span
+        >
+        <span class="building-setting-hint" *ngIf="row.cycleHint">
+          ({{ row.cycleHint }})
+        </span>
+      </ng-container>
+
+      <input
+        *ngIf="row.type === 'string'"
+        #textInput
+        type="text"
+        class="building-setting-text"
+        [value]="row.displayValue"
+        (blur)="onFieldInput(row, textInput.value)"
+        (keydown.enter)="onFieldInput(row, textInput.value); textInput.blur()"
+      />
+    </span>
   </div>
+
+  <button
+    *ngFor="let key of creatableKeys"
+    pButton
+    type="button"
+    class="ui-button building-setting-add"
+    (click)="addSetting(key)"
+    i18n
+  >
+    Add automation settings
+  </button>
 
   <div
     *ngIf="otherKeys.length > 0"

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
@@ -234,4 +234,48 @@ describe("BuildingSettingsComponent", () => {
       fixture.nativeElement.querySelector(".building-setting-add"),
     ).toBeNull();
   });
+
+  it("renders no editable row for a null Value, without crashing (CodeRabbit #212)", () => {
+    // A hand-edited file or a mod version we don't know about could leave a
+    // known Key with a null/malformed Value. rows() must skip it rather than
+    // render a blank editable control backed by nothing.
+    setItem("SomeBuilding", [{ Key: "Switch", Value: null as any }]);
+
+    expect(() => fixture.detectChanges()).not.toThrow();
+    expect(fixture.nativeElement.querySelector("fieldset")).toBeNull();
+    expect(component.blueprintItem.setBuildingSetting).not.toHaveBeenCalled();
+  });
+
+  it("caps a string field at the catalogue's max length, in the template and the handler", () => {
+    setItem("LogicAlarm", [
+      {
+        Key: "LogicAlarm",
+        Value: {
+          notificationName: "short",
+          notificationTooltip: "t",
+          notificationType: 0,
+          pauseOnNotify: false,
+          zoomOnNotify: false,
+          cooldown: 1,
+        },
+      },
+    ]);
+
+    const nameInput = fixture.nativeElement.querySelector(
+      "input[type=text]",
+    ) as HTMLInputElement;
+    // notificationName's catalogue max is 200.
+    expect(nameInput.maxLength).toBe(200);
+
+    // A programmatic value (e.g. a paste) can still exceed maxlength; the
+    // handler must clamp it before it reaches setBuildingSetting.
+    nameInput.value = "x".repeat(250);
+    nameInput.dispatchEvent(new Event("blur"));
+
+    expect(component.blueprintItem.setBuildingSetting).toHaveBeenCalledWith(
+      "LogicAlarm",
+      "notificationName",
+      "x".repeat(200),
+    );
+  });
 });

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
@@ -2,36 +2,69 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
+import { BlueprintService } from "src/app/module-blueprint/services/blueprint-service";
 import { BlueprintItem } from "../../../../../../../lib/index";
 import { BuildingSettingsComponent } from "./building-settings.component";
 
 describe("BuildingSettingsComponent", () => {
   let component: BuildingSettingsComponent;
   let fixture: ComponentFixture<BuildingSettingsComponent>;
+  let emitBlueprintChanged: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
+    emitBlueprintChanged = vi.fn();
+
     await TestBed.configureTestingModule({
       declarations: [BuildingSettingsComponent],
       imports: [CommonModule],
       schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        {
+          provide: BlueprintService,
+          useValue: { blueprint: { emitBlueprintChanged } },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(BuildingSettingsComponent);
     component = fixture.componentInstance;
   });
 
-  function setBuildingData(buildingData: BlueprintItem["buildingData"]) {
-    component.blueprintItem = { buildingData } as unknown as BlueprintItem;
+  function makeItem(id: string, buildingData: BlueprintItem["buildingData"]) {
+    return {
+      id,
+      buildingData,
+      setBuildingSetting: vi.fn(function (
+        this: any,
+        key: string,
+        field: string,
+        value: unknown,
+      ) {
+        const entry = this.buildingData.find((e: any) => e.Key == key);
+        entry.Value[field] = value;
+      }),
+      addBuildingSetting: vi.fn(function (this: any, key: string) {
+        this.buildingData = [
+          ...(this.buildingData ?? []),
+          { Key: key, Value: { onDuration: 10, offDuration: 10 } },
+        ];
+        return true;
+      }),
+    } as unknown as BlueprintItem;
+  }
+
+  function setItem(id: string, buildingData: BlueprintItem["buildingData"]) {
+    component.blueprintItem = makeItem(id, buildingData);
     fixture.detectChanges();
   }
 
-  it("renders nothing for a building with no settings", () => {
-    setBuildingData(undefined);
+  it("renders nothing for a building with no settings and no creatable keys", () => {
+    setItem("TestBuilding", undefined);
     expect(fixture.nativeElement.querySelector("fieldset")).toBeNull();
   });
 
-  it("renders labeled rows for known keys, matching the Time Sensors fixture shape", () => {
-    setBuildingData([
+  it("renders editable rows for known keys, matching the Time Sensors fixture shape", () => {
+    setItem("LogicTimerSensor", [
       { Key: "Switch", Value: { switchedOn: true } },
       {
         Key: "LogicTimerSensor",
@@ -44,17 +77,25 @@ describe("BuildingSettingsComponent", () => {
       },
     ]);
 
+    const numberInputs = fixture.nativeElement.querySelectorAll(
+      "input[type=number]",
+    ) as NodeListOf<HTMLInputElement>;
+    const values = Array.from(numberInputs).map((i) => i.value);
+    expect(values).toContain("5");
+
+    const checkbox = fixture.nativeElement.querySelector(
+      "input[type=checkbox]",
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+
+    // The hidden runtime field never reaches the DOM as an input or label.
     const text = fixture.nativeElement.textContent as string;
-    expect(text).toContain("On");
-    expect(text).toContain("5 s");
-    expect(text).toContain("Off duration");
-    // The hidden runtime field never reaches the DOM.
     expect(text).not.toContain("3.0999");
-    expect(fixture.nativeElement.querySelector("fieldset")).not.toBeNull();
+    expect(text).not.toContain("Time elapsed");
   });
 
   it("renders a preserved-count line for a key outside the curated catalogue", () => {
-    setBuildingData([{ Key: "Door", Value: { requestedState: 1 } }]);
+    setItem("Door", [{ Key: "Door", Value: { requestedState: 1 } }]);
 
     const text = fixture.nativeElement.textContent as string;
     expect(text).toContain("1 other stored setting");
@@ -62,7 +103,7 @@ describe("BuildingSettingsComponent", () => {
   });
 
   it("mixes known rows and an other-settings count in the same panel", () => {
-    setBuildingData([
+    setItem("SomeBuilding", [
       { Key: "BuildingEnabledButton", Value: { IsEnabled: true } },
       { Key: "PixelPack", Value: { colorSettings: "{}" } },
       { Key: "AccessControl", Value: { defaultPermissionByTag: "{}" } },
@@ -71,5 +112,92 @@ describe("BuildingSettingsComponent", () => {
     const text = fixture.nativeElement.textContent as string;
     expect(text).toContain("Enabled");
     expect(text).toContain("2 other stored settings");
+  });
+
+  it("commits a number field on blur: setBuildingSetting then emitBlueprintChanged", () => {
+    setItem("LogicTimerSensor", [
+      {
+        Key: "LogicTimerSensor",
+        Value: {
+          onDuration: 5.0,
+          offDuration: 5.0,
+          timeElapsedInCurrentState: 0,
+          displayCyclesMode: false,
+        },
+      },
+    ]);
+
+    const numberInput = fixture.nativeElement.querySelector(
+      "input[type=number]",
+    ) as HTMLInputElement;
+    numberInput.value = "42";
+    numberInput.dispatchEvent(new Event("blur"));
+
+    expect(component.blueprintItem.setBuildingSetting).toHaveBeenCalledWith(
+      "LogicTimerSensor",
+      "onDuration",
+      42,
+    );
+    expect(emitBlueprintChanged).toHaveBeenCalled();
+  });
+
+  it("clamps a number field to the catalogue's soft bounds on commit", () => {
+    setItem("LogicRibbonReader", [
+      { Key: "LogicRibbonReader", Value: { selectedBit: 1 } },
+    ]);
+
+    const numberInput = fixture.nativeElement.querySelector(
+      "input[type=number]",
+    ) as HTMLInputElement;
+    numberInput.value = "99";
+    numberInput.dispatchEvent(new Event("blur"));
+
+    expect(component.blueprintItem.setBuildingSetting).toHaveBeenCalledWith(
+      "LogicRibbonReader",
+      "selectedBit",
+      3,
+    );
+  });
+
+  it("commits a checkbox field immediately on change", () => {
+    setItem("LogicTimerSensor", [
+      { Key: "Switch", Value: { switchedOn: true } },
+    ]);
+
+    const checkbox = fixture.nativeElement.querySelector(
+      "input[type=checkbox]",
+    ) as HTMLInputElement;
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event("change"));
+
+    expect(component.blueprintItem.setBuildingSetting).toHaveBeenCalledWith(
+      "Switch",
+      "switchedOn",
+      false,
+    );
+    expect(emitBlueprintChanged).toHaveBeenCalled();
+  });
+
+  it("offers to add automation settings on a building with no data yet, and commits on click", () => {
+    setItem("LogicTimerSensor", undefined);
+
+    const addButton = fixture.nativeElement.querySelector(
+      ".building-setting-add",
+    ) as HTMLButtonElement;
+    expect(addButton).not.toBeNull();
+
+    addButton.click();
+
+    expect(component.blueprintItem.addBuildingSetting).toHaveBeenCalledWith(
+      "LogicTimerSensor",
+    );
+    expect(emitBlueprintChanged).toHaveBeenCalled();
+  });
+
+  it("does not offer to add settings for a building with no creatable keys", () => {
+    setItem("Door", [{ Key: "Door", Value: { requestedState: 1 } }]);
+    expect(
+      fixture.nativeElement.querySelector(".building-setting-add"),
+    ).toBeNull();
   });
 });

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
@@ -1,0 +1,75 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { CommonModule } from "@angular/common";
+
+import { BlueprintItem } from "../../../../../../../lib/index";
+import { BuildingSettingsComponent } from "./building-settings.component";
+
+describe("BuildingSettingsComponent", () => {
+  let component: BuildingSettingsComponent;
+  let fixture: ComponentFixture<BuildingSettingsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BuildingSettingsComponent],
+      imports: [CommonModule],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BuildingSettingsComponent);
+    component = fixture.componentInstance;
+  });
+
+  function setBuildingData(buildingData: BlueprintItem["buildingData"]) {
+    component.blueprintItem = { buildingData } as unknown as BlueprintItem;
+    fixture.detectChanges();
+  }
+
+  it("renders nothing for a building with no settings", () => {
+    setBuildingData(undefined);
+    expect(fixture.nativeElement.querySelector("fieldset")).toBeNull();
+  });
+
+  it("renders labeled rows for known keys, matching the Time Sensors fixture shape", () => {
+    setBuildingData([
+      { Key: "Switch", Value: { switchedOn: true } },
+      {
+        Key: "LogicTimerSensor",
+        Value: {
+          onDuration: 5.0,
+          offDuration: 5.0,
+          timeElapsedInCurrentState: 3.099925,
+          displayCyclesMode: false,
+        },
+      },
+    ]);
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain("On");
+    expect(text).toContain("5 s");
+    expect(text).toContain("Off duration");
+    // The hidden runtime field never reaches the DOM.
+    expect(text).not.toContain("3.0999");
+    expect(fixture.nativeElement.querySelector("fieldset")).not.toBeNull();
+  });
+
+  it("renders a preserved-count line for a key outside the curated catalogue", () => {
+    setBuildingData([{ Key: "Door", Value: { requestedState: 1 } }]);
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain("1 other stored setting");
+    expect(text).not.toContain("requestedState");
+  });
+
+  it("mixes known rows and an other-settings count in the same panel", () => {
+    setBuildingData([
+      { Key: "BuildingEnabledButton", Value: { IsEnabled: true } },
+      { Key: "PixelPack", Value: { colorSettings: "{}" } },
+      { Key: "AccessControl", Value: { defaultPermissionByTag: "{}" } },
+    ]);
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain("Enabled");
+    expect(text).toContain("2 other stored settings");
+  });
+});

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
@@ -141,6 +141,40 @@ describe("BuildingSettingsComponent", () => {
     expect(emitBlueprintChanged).toHaveBeenCalled();
   });
 
+  it("keeps a typed value across a change-detection cycle mid-edit (trackBy regression)", () => {
+    // Reported bug: the editor's global zone.js hooks re-run change
+    // detection on every keystroke (the (keydown.enter) binding registers a
+    // real keydown listener). Without a stable trackBy, *ngFor's identity
+    // diffing tore down and rebuilt the <input> DOM node on every such
+    // cycle, discarding whatever had just been typed but not yet committed.
+    setItem("LogicTimerSensor", [
+      {
+        Key: "LogicTimerSensor",
+        Value: {
+          onDuration: 5.0,
+          offDuration: 5.0,
+          timeElapsedInCurrentState: 0,
+          displayCyclesMode: false,
+        },
+      },
+    ]);
+
+    let numberInput = fixture.nativeElement.querySelector(
+      "input[type=number]",
+    ) as HTMLInputElement;
+    numberInput.value = "42";
+    // Simulate an incidental app-wide change-detection tick firing while the
+    // field still holds an uncommitted keystroke.
+    fixture.detectChanges();
+    // Re-query rather than reuse the captured reference: a torn-down/rebuilt
+    // node would leave `numberInput` pointing at a detached element, masking
+    // the bug from a naive assertion on the stale reference.
+    numberInput = fixture.nativeElement.querySelector(
+      "input[type=number]",
+    ) as HTMLInputElement;
+    expect(numberInput.value).toBe("42");
+  });
+
   it("clamps a number field to the catalogue's soft bounds on commit", () => {
     setItem("LogicRibbonReader", [
       { Key: "LogicRibbonReader", Value: { selectedBit: 1 } },

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.ts
@@ -114,6 +114,16 @@ export class BuildingSettingsComponent {
     this.commit();
   }
 
+  // `rows` is a getter that rebuilds a fresh array of fresh objects on every
+  // change-detection cycle (which fires on every keystroke, since the
+  // (keydown.enter) binding registers a real keydown listener zone.js wakes
+  // up for). Without a stable trackBy, *ngFor's default identity diffing
+  // treats every row as removed-and-re-added on each cycle and tears down
+  // the <input> DOM nodes mid-edit, discarding whatever the user just typed.
+  trackByRow(_index: number, row: EditableSettingRow): string {
+    return `${row.key}:${row.field}`;
+  }
+
   onFieldInput(row: EditableSettingRow, rawInput: string | boolean) {
     let value: any = rawInput;
     if (row.type == "bool") {

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.ts
@@ -1,18 +1,41 @@
 import { Component, Input } from "@angular/core";
+import { BlueprintService } from "src/app/module-blueprint/services/blueprint-service";
 import {
   BlueprintItem,
+  creatableSettingsKeysFor,
   formatBuildingDataEntry,
-  FormattedSettingRow,
+  SETTINGS_CATALOG,
+  SettingFieldType,
+  SettingUnit,
 } from "../../../../../../../lib/index";
 
-interface DisplayedSettingRow extends FormattedSettingRow {
-  key: string;
+// A percentage unit is stored as a 0-1 fraction (LogicTimeOfDaySensor's
+// startTime/duration) but edited as a 0-100 number, matching the game's own
+// side screen. Every other unit round-trips 1:1.
+function displayScale(unit: SettingUnit | undefined): number {
+  return unit == "cycleFraction" || unit == "%" ? 100 : 1;
 }
 
-// Read-only display of a building's BlueprintsV2 buildingData (timer
-// durations, switch state, logic gate delays, ...) — spec/building-settings-plan.md
-// phase 2. Curated keys render as labeled rows; every other stored Key is
-// preserved but shown only as a count, never dumped as raw JSON.
+interface EditableSettingRow {
+  key: string;
+  field: string;
+  label: string;
+  type: SettingFieldType;
+  unit?: SettingUnit;
+  displayValue: any;
+  displayMin?: number;
+  displayMax?: number;
+  cycleHint: string | null;
+}
+
+const CYCLE_SECONDS = 600;
+
+// Editable display of a building's BlueprintsV2 buildingData (timer
+// durations, switch state, logic gate delays, ...) —
+// spec/building-settings-plan.md phase 3. Curated keys render as editable
+// rows; every other stored Key is preserved but shown only as a count, never
+// dumped as raw JSON. Edits commit on blur/Enter/change, one undo step per
+// completed edit, matching the world-notes editor pattern.
 @Component({
   selector: "app-building-settings",
   templateUrl: "./building-settings.component.html",
@@ -22,16 +45,45 @@ interface DisplayedSettingRow extends FormattedSettingRow {
 export class BuildingSettingsComponent {
   @Input() blueprintItem!: BlueprintItem;
 
+  constructor(private blueprintService: BlueprintService) {}
+
   get hasSettings(): boolean {
-    return (this.blueprintItem.buildingData?.length ?? 0) > 0;
+    return (
+      this.rows.length > 0 ||
+      this.otherKeys.length > 0 ||
+      this.creatableKeys.length > 0
+    );
   }
 
-  get rows(): DisplayedSettingRow[] {
-    const rows: DisplayedSettingRow[] = [];
+  get rows(): EditableSettingRow[] {
+    const rows: EditableSettingRow[] = [];
     for (const entry of this.blueprintItem.buildingData ?? []) {
-      const formatted = formatBuildingDataEntry(entry);
-      if (formatted == null) continue;
-      for (const row of formatted) rows.push({ ...row, key: entry.Key });
+      const descriptors = SETTINGS_CATALOG[entry.Key];
+      if (descriptors == null) continue;
+
+      for (const descriptor of descriptors) {
+        if (descriptor.hidden) continue;
+        const scale = displayScale(descriptor.unit);
+        const raw = entry.Value?.[descriptor.field];
+        rows.push({
+          key: entry.Key,
+          field: descriptor.field,
+          label: descriptor.labelKey,
+          type: descriptor.type,
+          unit: descriptor.unit,
+          displayValue: typeof raw == "number" ? raw * scale : raw,
+          displayMin:
+            descriptor.min != null ? descriptor.min * scale : undefined,
+          displayMax:
+            descriptor.max != null ? descriptor.max * scale : undefined,
+          cycleHint:
+            descriptor.unit == "s" &&
+            typeof raw == "number" &&
+            raw >= CYCLE_SECONDS
+              ? `~${(raw / CYCLE_SECONDS).toFixed(2)} cycles`
+              : null,
+        });
+      }
     }
     return rows;
   }
@@ -44,5 +96,44 @@ export class BuildingSettingsComponent {
 
   get otherKeysTooltip(): string {
     return this.otherKeys.join(", ");
+  }
+
+  // Keys this specific building can create from scratch (hand-checked
+  // catalogue defaults) that it does not already have.
+  get creatableKeys(): string[] {
+    const existing = new Set(
+      (this.blueprintItem.buildingData ?? []).map((entry) => entry.Key),
+    );
+    return creatableSettingsKeysFor(this.blueprintItem.id).filter(
+      (key) => !existing.has(key),
+    );
+  }
+
+  addSetting(key: string) {
+    this.blueprintItem.addBuildingSetting(key);
+    this.commit();
+  }
+
+  onFieldInput(row: EditableSettingRow, rawInput: string | boolean) {
+    let value: any = rawInput;
+    if (row.type == "bool") {
+      value = Boolean(rawInput);
+    } else if (row.type == "int" || row.type == "float") {
+      let num = Number(rawInput);
+      if (Number.isNaN(num)) return;
+      if (row.displayMin != null && num < row.displayMin) num = row.displayMin;
+      if (row.displayMax != null && num > row.displayMax) num = row.displayMax;
+      value = num / displayScale(row.unit);
+      if (row.type == "int") value = Math.round(value);
+    } else if (row.type == "string") {
+      value = String(rawInput);
+    }
+
+    this.blueprintItem.setBuildingSetting(row.key, row.field, value);
+    this.commit();
+  }
+
+  private commit() {
+    this.blueprintService.blueprint.emitBlueprintChanged();
   }
 }

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.ts
@@ -61,10 +61,18 @@ export class BuildingSettingsComponent {
       const descriptors = SETTINGS_CATALOG[entry.Key];
       if (descriptors == null) continue;
 
+      const value = entry.Value;
+      if (value == null || typeof value !== "object") continue;
+
       for (const descriptor of descriptors) {
         if (descriptor.hidden) continue;
+        // Mirrors formatBuildingDataEntry: a missing field means this entry
+        // is incomplete/malformed (or from a newer mod version) — skip it
+        // rather than rendering an editable row backed by nothing, which
+        // would crash setBuildingSetting the moment the user touched it.
+        if (!(descriptor.field in value)) continue;
         const scale = displayScale(descriptor.unit);
-        const raw = entry.Value?.[descriptor.field];
+        const raw = value[descriptor.field];
         rows.push({
           key: entry.Key,
           field: descriptor.field,
@@ -137,6 +145,10 @@ export class BuildingSettingsComponent {
       if (row.type == "int") value = Math.round(value);
     } else if (row.type == "string") {
       value = String(rawInput);
+      // The template's [attr.maxlength] stops interactive typing, but not a
+      // paste or a value set programmatically, so enforce the catalogue
+      // bound here too before it reaches storage/export.
+      if (row.displayMax != null) value = value.slice(0, row.displayMax);
     }
 
     this.blueprintItem.setBuildingSetting(row.key, row.field, value);

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.ts
@@ -1,0 +1,48 @@
+import { Component, Input } from "@angular/core";
+import {
+  BlueprintItem,
+  formatBuildingDataEntry,
+  FormattedSettingRow,
+} from "../../../../../../../lib/index";
+
+interface DisplayedSettingRow extends FormattedSettingRow {
+  key: string;
+}
+
+// Read-only display of a building's BlueprintsV2 buildingData (timer
+// durations, switch state, logic gate delays, ...) — spec/building-settings-plan.md
+// phase 2. Curated keys render as labeled rows; every other stored Key is
+// preserved but shown only as a count, never dumped as raw JSON.
+@Component({
+  selector: "app-building-settings",
+  templateUrl: "./building-settings.component.html",
+  styleUrls: ["./building-settings.component.css"],
+  standalone: false,
+})
+export class BuildingSettingsComponent {
+  @Input() blueprintItem!: BlueprintItem;
+
+  get hasSettings(): boolean {
+    return (this.blueprintItem.buildingData?.length ?? 0) > 0;
+  }
+
+  get rows(): DisplayedSettingRow[] {
+    const rows: DisplayedSettingRow[] = [];
+    for (const entry of this.blueprintItem.buildingData ?? []) {
+      const formatted = formatBuildingDataEntry(entry);
+      if (formatted == null) continue;
+      for (const row of formatted) rows.push({ ...row, key: entry.Key });
+    }
+    return rows;
+  }
+
+  get otherKeys(): string[] {
+    return (this.blueprintItem.buildingData ?? [])
+      .filter((entry) => formatBuildingDataEntry(entry) == null)
+      .map((entry) => entry.Key);
+  }
+
+  get otherKeysTooltip(): string {
+    return this.otherKeys.join(", ");
+  }
+}

--- a/frontend/src/app/module-blueprint/components/side-bar/item-collection-info/item-collection-info.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/item-collection-info/item-collection-info.component.html
@@ -44,6 +44,12 @@
     [blueprintItem]="itemCollection.items[0]"
   >
   </app-ui-screen-container>
+
+  <app-building-settings
+    *ngIf="itemCollection.items.length === 1"
+    [blueprintItem]="itemCollection.items[0]"
+  >
+  </app-building-settings>
 </div>
 
 <div *ngIf="showPipeContent">

--- a/frontend/src/app/module-blueprint/module-blueprint.module.ts
+++ b/frontend/src/app/module-blueprint/module-blueprint.module.ts
@@ -72,6 +72,7 @@ import { BuildableElementPickerComponent } from "./components/side-bar/buildable
 import { ElementReport } from "./common/tools/element-report";
 import { ElementReportToolComponent } from "./components/side-bar/element-report-tool/element-report-tool.component";
 import { UiScreenContainerComponent } from "./components/side-bar/ui-screens/ui-screen-container/ui-screen-container.component";
+import { BuildingSettingsComponent } from "./components/side-bar/building-settings/building-settings.component";
 import { SingleSliderScreenComponent } from "./components/side-bar/ui-screens/single-slider-screen/single-slider-screen.component";
 import { ThresholdSwhitchScreenComponent } from "./components/side-bar/ui-screens/threshold-switch-screen/threshold-switch-screen.component";
 import { ActiveRangeScreenComponent } from "./components/side-bar/ui-screens/active-range-screen/active-range-screen.component";
@@ -140,6 +141,7 @@ import { TerrainToolComponent } from "./components/side-bar/terrain-tool/terrain
     BuildableElementPickerComponent,
     ElementReportToolComponent,
     UiScreenContainerComponent,
+    BuildingSettingsComponent,
     SingleSliderScreenComponent,
     ThresholdSwhitchScreenComponent,
     ActiveRangeScreenComponent,

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -54,6 +54,8 @@ export * from './src/blueprint/terrain-metadata';
 export * from './src/blueprint/note-conversion';
 export * from './src/blueprint/bpv2-sanitize';
 export * from './src/blueprint/translation';
+export * from './src/blueprint/building-settings/settings-catalog';
+export * from './src/blueprint/building-settings/format-setting';
 export * from './src/search/query-normalize';
 export * from './src/search/term-resolve';
 export * from './src/search/rrf';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -60,6 +60,8 @@ export * from './src/blueprint/terrain-metadata';
 export * from './src/blueprint/note-conversion';
 export * from './src/blueprint/bpv2-sanitize';
 export * from './src/blueprint/translation';
+export * from './src/blueprint/building-settings/settings-catalog';
+export * from './src/blueprint/building-settings/format-setting';
 export * from './src/search/query-normalize';
 export * from './src/search/term-resolve';
 export * from './src/search/rrf';

--- a/lib/src/blueprint/blueprint-item.d.ts
+++ b/lib/src/blueprint/blueprint-item.d.ts
@@ -24,6 +24,8 @@ export declare class BlueprintItem {
     get header(): string;
     buildableElements: BuildableElement[];
     buildingData?: BniBuildingData[];
+    addBuildingSetting(key: string): boolean;
+    setBuildingSetting(key: string, field: string, value: any): void;
     uiSaveSettings: UiSaveSettings[];
     getUiSettings(id: string): UiSaveSettings | undefined;
     setElement(elementId: string, index: number): void;

--- a/lib/src/blueprint/blueprint-item.d.ts
+++ b/lib/src/blueprint/blueprint-item.d.ts
@@ -6,7 +6,7 @@ import { Orientation } from '../enums/orientation';
 import { OniItem } from '../oni-item';
 import { DrawPart } from '../drawing/draw-part';
 import { OniBuilding } from '../io/oni/oni-building';
-import { BniBuilding } from '../io/bni/bni-building';
+import { BniBuilding, BniBuildingData } from '../io/bni/bni-building';
 import { MdbBuilding } from '../io/mdb/mdb-building';
 import { CameraService } from '../drawing/camera-service';
 import { PixiUtil } from '../drawing/pixi-util';
@@ -23,6 +23,7 @@ export declare class BlueprintItem {
     set temperatureScale(value: number);
     get header(): string;
     buildableElements: BuildableElement[];
+    buildingData?: BniBuildingData[];
     uiSaveSettings: UiSaveSettings[];
     getUiSettings(id: string): UiSaveSettings | undefined;
     setElement(elementId: string, index: number): void;

--- a/lib/src/blueprint/blueprint-item.ts
+++ b/lib/src/blueprint/blueprint-item.ts
@@ -88,6 +88,11 @@ export class BlueprintItem {
       );
 
     const entry = this.buildingData!.find(entry => entry.Key == key)!;
+    // A pre-existing entry can have a null/malformed Value (hand-edited file,
+    // a mod version we don't know about) — repair rather than crash on the
+    // write. The editor UI itself never offers a field for that case (see
+    // BuildingSettingsComponent.rows), so this only guards a direct caller.
+    if (entry.Value == null || typeof entry.Value !== 'object') entry.Value = {};
     entry.Value[field] = value;
   }
 

--- a/lib/src/blueprint/blueprint-item.ts
+++ b/lib/src/blueprint/blueprint-item.ts
@@ -7,7 +7,7 @@ import { Orientation } from '../enums/orientation';
 import { OniItem } from '../oni-item';
 import { DrawPart } from '../drawing/draw-part';
 import { OniBuilding } from '../io/oni/oni-building';
-import { BniBuilding } from '../io/bni/bni-building';
+import { BniBuilding, BniBuildingData } from '../io/bni/bni-building';
 import { MdbBuilding } from '../io/mdb/mdb-building';
 import { SpriteTag } from '../enums/sprite-tag';
 import { CameraService } from '../drawing/camera-service';
@@ -52,6 +52,12 @@ export class BlueprintItem {
   }
 
   public buildableElements: BuildableElement[] = [];
+
+  // BlueprintsV2 per-component settings (§3 of the import spec: timer
+  // durations, switch state, logic gate delays, ...). Opaque passthrough —
+  // undefined/empty for buildings placed in the editor (the mod applies its
+  // own defaults on load), preserved verbatim for anything read from a file.
+  public buildingData?: BniBuildingData[];
 
   public uiSaveSettings: UiSaveSettings[] = [];
   public getUiSettings(id: string): UiSaveSettings | undefined {
@@ -202,6 +208,13 @@ export class BlueprintItem {
 
     this.changeOrientation(building.orientation);
 
+    // Deep-copied: undo snapshots and the live item must never share
+    // references into the same Value objects.
+    this.buildingData =
+      building.buildingData != null && building.buildingData.length > 0
+        ? structuredClone(building.buildingData)
+        : undefined;
+
     // Construction materials: each entry is a Klei tag hash in recipe order
     // (BlueprintsV2 §2.3). Unknown hashes or surplus slots keep the default
     // material — cleanUp() backfills every unset slot.
@@ -236,6 +249,11 @@ export class BlueprintItem {
       for (let setting of original.settings)
         this.uiSaveSettings.push(UiSaveSettings.clone(setting));
     }
+
+    this.buildingData =
+      original.buildingData != null && original.buildingData.length > 0
+        ? structuredClone(original.buildingData)
+        : undefined;
 
     // TODO default temperature
     if (original.temperature == undefined) this.temperature = BlueprintItem.defaultTemperature;
@@ -402,6 +420,9 @@ export class BlueprintItem {
       }
     }
 
+    if (this.buildingData != null && this.buildingData.length > 0)
+      returnValue.buildingData = structuredClone(this.buildingData);
+
     if (this.orientation != Orientation.Neutral) returnValue.orientation = this.orientation;
 
     return returnValue;
@@ -415,6 +436,9 @@ export class BlueprintItem {
       orientation: this.orientation,
       selected_elements: this.getSelectedElementsTag(),
     };
+
+    if (this.buildingData != null && this.buildingData.length > 0)
+      returnValue.buildingData = structuredClone(this.buildingData);
 
     return returnValue;
   }

--- a/lib/src/blueprint/blueprint-item.ts
+++ b/lib/src/blueprint/blueprint-item.ts
@@ -8,6 +8,7 @@ import { OniItem } from '../oni-item';
 import { DrawPart } from '../drawing/draw-part';
 import { OniBuilding } from '../io/oni/oni-building';
 import { BniBuilding, BniBuildingData } from '../io/bni/bni-building';
+import { getCreatableSettingDefaults } from './building-settings/settings-catalog';
 import { MdbBuilding } from '../io/mdb/mdb-building';
 import { SpriteTag } from '../enums/sprite-tag';
 import { CameraService } from '../drawing/camera-service';
@@ -58,6 +59,37 @@ export class BlueprintItem {
   // undefined/empty for buildings placed in the editor (the mod applies its
   // own defaults on load), preserved verbatim for anything read from a file.
   public buildingData?: BniBuildingData[];
+
+  // Creates a Key from scratch using its hand-checked catalogue defaults
+  // (settings-catalog.ts CREATABLE_SETTINGS). No-op if the Key is already
+  // present. Returns whether an entry now exists (already-present counts).
+  public addBuildingSetting(key: string): boolean {
+    if (this.buildingData?.some(entry => entry.Key == key)) return true;
+
+    const defaults = getCreatableSettingDefaults(this.id, key);
+    if (defaults == null) return false;
+
+    if (this.buildingData == null) this.buildingData = [];
+    this.buildingData.push({ Key: key, Value: structuredClone(defaults) });
+    return true;
+  }
+
+  // Sets one field of one buildingData Key, matching the mod's own edit
+  // contract: every other field of that Key's Value object is left verbatim
+  // (TryApplyData requires the whole object present, and most components
+  // bail on the whole thing if even one expected field is missing — spec
+  // §3). Throws if the Key is absent and not creatable from scratch on this
+  // building; the editor UI must only offer fields it has already gated
+  // through addBuildingSetting/creatableSettingsKeysFor.
+  public setBuildingSetting(key: string, field: string, value: any) {
+    if (!this.buildingData?.some(entry => entry.Key == key) && !this.addBuildingSetting(key))
+      throw new Error(
+        `BlueprintItem.setBuildingSetting: '${key}' is not present on '${this.id}' and has no creatable defaults`
+      );
+
+    const entry = this.buildingData!.find(entry => entry.Key == key)!;
+    entry.Value[field] = value;
+  }
 
   public uiSaveSettings: UiSaveSettings[] = [];
   public getUiSettings(id: string): UiSaveSettings | undefined {

--- a/lib/src/blueprint/building-settings/format-setting.d.ts
+++ b/lib/src/blueprint/building-settings/format-setting.d.ts
@@ -1,0 +1,8 @@
+import { BniBuildingData } from '../../io/bni/bni-building';
+export interface FormattedSettingRow {
+    field: string;
+    label: string;
+    text: string;
+}
+export declare function formatBuildingDataEntry(entry: BniBuildingData): FormattedSettingRow[] | null;
+//# sourceMappingURL=format-setting.d.ts.map

--- a/lib/src/blueprint/building-settings/format-setting.ts
+++ b/lib/src/blueprint/building-settings/format-setting.ts
@@ -12,7 +12,11 @@ export interface FormattedSettingRow {
 // Trims a fixed-decimal string down to its meaningful digits: 5.00 -> "5",
 // 5.10 -> "5.1". toFixed alone would print every trailing zero.
 function formatNumber(value: number, decimals: number): string {
-  return value.toFixed(decimals).replace(/\.?0+$/, '') || '0';
+  const text = value.toFixed(decimals);
+  // decimals === 0 never produces a decimal point, so every trailing zero is
+  // a real digit (10 -> "10", not "1") — only trim when there's a fractional
+  // part to strip.
+  return decimals === 0 ? text : text.replace(/\.?0+$/, '') || '0';
 }
 
 function formatDuration(seconds: number, displayCyclesMode: boolean | undefined): string {

--- a/lib/src/blueprint/building-settings/format-setting.ts
+++ b/lib/src/blueprint/building-settings/format-setting.ts
@@ -1,0 +1,81 @@
+import { BniBuildingData } from '../../io/bni/bni-building';
+import { SETTINGS_CATALOG, SettingFieldDescriptor } from './settings-catalog';
+
+const CYCLE_SECONDS = 600;
+
+export interface FormattedSettingRow {
+  field: string;
+  label: string;
+  text: string;
+}
+
+// Trims a fixed-decimal string down to its meaningful digits: 5.00 -> "5",
+// 5.10 -> "5.1". toFixed alone would print every trailing zero.
+function formatNumber(value: number, decimals: number): string {
+  return value.toFixed(decimals).replace(/\.?0+$/, '') || '0';
+}
+
+function formatDuration(seconds: number, displayCyclesMode: boolean | undefined): string {
+  const base = `${formatNumber(seconds, 2)} s`;
+  if (displayCyclesMode || seconds >= CYCLE_SECONDS)
+    return `${base} (~${formatNumber(seconds / CYCLE_SECONDS, 2)} cycles)`;
+  return base;
+}
+
+function formatFieldValue(
+  descriptor: SettingFieldDescriptor,
+  raw: any,
+  value: Record<string, any>
+): string {
+  switch (descriptor.type) {
+    case 'bool':
+      return raw ? 'On' : 'Off';
+    case 'string':
+      return raw == null || raw === '' ? '—' : String(raw);
+    case 'enum':
+      return descriptor.enumLabels?.[raw] ?? String(raw);
+    case 'int':
+    case 'float':
+      if (typeof raw !== 'number' || Number.isNaN(raw)) return String(raw);
+      switch (descriptor.unit) {
+        case 's':
+          return formatDuration(raw, value.displayCyclesMode);
+        case 'cycleFraction':
+          return `${formatNumber(raw * 100, 2)}% of cycle`;
+        case 'bit':
+          return `Bit ${raw}`;
+        case '%':
+          return `${formatNumber(raw * 100, 2)}%`;
+        default:
+          return formatNumber(raw, descriptor.type === 'int' ? 0 : 2);
+      }
+  }
+}
+
+// Formats one buildingData entry's known fields for display. Returns null
+// when the Key is not in the curated catalogue — the caller falls back to
+// the "N other stored settings (preserved)" line for those, and for any
+// entry whose shape this throws on (mods can register their own Keys through
+// the ModAPI, and a game update can add fields we don't know about yet).
+export function formatBuildingDataEntry(entry: BniBuildingData): FormattedSettingRow[] | null {
+  const descriptors = SETTINGS_CATALOG[entry.Key];
+  if (descriptors == null) return null;
+
+  const value = entry.Value ?? {};
+  const rows: FormattedSettingRow[] = [];
+  for (const descriptor of descriptors) {
+    if (descriptor.hidden) continue;
+    if (!(descriptor.field in value)) continue;
+    try {
+      rows.push({
+        field: descriptor.field,
+        label: descriptor.labelKey,
+        text: formatFieldValue(descriptor, value[descriptor.field], value),
+      });
+    } catch {
+      // Unrecognized shape for this field — skip it rather than fail the
+      // whole panel.
+    }
+  }
+  return rows;
+}

--- a/lib/src/blueprint/building-settings/settings-catalog.d.ts
+++ b/lib/src/blueprint/building-settings/settings-catalog.d.ts
@@ -1,0 +1,15 @@
+export type SettingUnit = 's' | 'cycleFraction' | 'bit' | '%';
+export type SettingFieldType = 'bool' | 'float' | 'int' | 'string' | 'enum';
+export interface SettingFieldDescriptor {
+    field: string;
+    labelKey: string;
+    type: SettingFieldType;
+    unit?: SettingUnit;
+    min?: number;
+    max?: number;
+    enumLabels?: Record<number, string>;
+    hidden?: boolean;
+}
+export declare const SETTINGS_CATALOG: Record<string, SettingFieldDescriptor[]>;
+export declare function isKnownSettingsKey(key: string): boolean;
+//# sourceMappingURL=settings-catalog.d.ts.map

--- a/lib/src/blueprint/building-settings/settings-catalog.d.ts
+++ b/lib/src/blueprint/building-settings/settings-catalog.d.ts
@@ -12,4 +12,7 @@ export interface SettingFieldDescriptor {
 }
 export declare const SETTINGS_CATALOG: Record<string, SettingFieldDescriptor[]>;
 export declare function isKnownSettingsKey(key: string): boolean;
+export declare const CREATABLE_SETTINGS: Record<string, Record<string, Record<string, any>>>;
+export declare function creatableSettingsKeysFor(prefabId: string): string[];
+export declare function getCreatableSettingDefaults(prefabId: string, key: string): Record<string, any> | undefined;
 //# sourceMappingURL=settings-catalog.d.ts.map

--- a/lib/src/blueprint/building-settings/settings-catalog.ts
+++ b/lib/src/blueprint/building-settings/settings-catalog.ts
@@ -1,0 +1,112 @@
+// Curated catalogue of the BlueprintsV2 `buildingData` component keys we
+// know how to display (and, from phase 3, edit) — spec/building-settings-plan.md
+// "Automation keys in scope" table, verified against
+// spec/blueprintsv2-import-spec.md §3. Every other `Key` a file may carry
+// (`Door`, `Valve`, filters, `AccessControl`, `PixelPack`, skins, ...) is
+// preserved opaquely and never reaches this table in v1.
+
+// 'cycleFraction': a 0-1 fraction of a 600s in-game cycle (LogicTimeOfDaySensor),
+// displayed as a percentage. 's': seconds, with a cycle count appended for long
+// durations. 'bit': a 0-3 ribbon bit index. '%': a plain percentage, reserved.
+export type SettingUnit = 's' | 'cycleFraction' | 'bit' | '%';
+
+export type SettingFieldType = 'bool' | 'float' | 'int' | 'string' | 'enum';
+
+export interface SettingFieldDescriptor {
+  // Property name inside the component's `Value` object.
+  field: string;
+  // Display label. Plain English text in v1 — the site's chrome (this
+  // included) ships English-only; see spec/search-followups.md's "UI
+  // localization state".
+  labelKey: string;
+  type: SettingFieldType;
+  unit?: SettingUnit;
+  min?: number;
+  max?: number;
+  // type: 'enum' only. Keyed by the raw stored integer.
+  enumLabels?: Record<number, string>;
+  // Preserved and round-tripped, never shown or offered for edit. Only
+  // `LogicTimerSensor.timeElapsedInCurrentState` today — a runtime value the
+  // mod's TryApplyData still requires present in a written Value object.
+  hidden?: boolean;
+}
+
+// Keyed by the component `Key` (nameof the ONI component class — the mod's
+// own registry, API_Methods.cs RegisterVanillaBuildings()).
+export const SETTINGS_CATALOG: Record<string, SettingFieldDescriptor[]> = {
+  Switch: [{ field: 'switchedOn', labelKey: 'On', type: 'bool' }],
+
+  LogicTimerSensor: [
+    { field: 'onDuration', labelKey: 'On duration', type: 'float', unit: 's', min: 0 },
+    { field: 'offDuration', labelKey: 'Off duration', type: 'float', unit: 's', min: 0 },
+    {
+      field: 'timeElapsedInCurrentState',
+      labelKey: 'Time elapsed in current state',
+      type: 'float',
+      unit: 's',
+      hidden: true,
+    },
+    { field: 'displayCyclesMode', labelKey: 'Display in cycles', type: 'bool' },
+  ],
+
+  LogicTimeOfDaySensor: [
+    { field: 'startTime', labelKey: 'Start time', type: 'float', unit: 'cycleFraction', min: 0, max: 1 },
+    { field: 'duration', labelKey: 'Duration', type: 'float', unit: 'cycleFraction', min: 0, max: 1 },
+  ],
+
+  LogicCounter: [
+    { field: 'maxCount', labelKey: 'Target count', type: 'int', min: 1, max: 10 },
+    { field: 'resetCountAtMax', labelKey: 'Reset at target', type: 'bool' },
+    { field: 'advancedMode', labelKey: 'Advanced mode', type: 'bool' },
+  ],
+
+  LogicGateBuffer: [
+    { field: 'DelayAmount', labelKey: 'Delay', type: 'float', unit: 's', min: 0 },
+  ],
+  LogicGateFilter: [
+    { field: 'DelayAmount', labelKey: 'Delay', type: 'float', unit: 's', min: 0 },
+  ],
+
+  LogicRibbonReader: [
+    { field: 'selectedBit', labelKey: 'Bit', type: 'int', unit: 'bit', min: 0, max: 3 },
+  ],
+  LogicRibbonWriter: [
+    { field: 'selectedBit', labelKey: 'Bit', type: 'int', unit: 'bit', min: 0, max: 3 },
+  ],
+
+  LogicCritterCountSensor: [
+    { field: 'countThreshold', labelKey: 'Threshold', type: 'int', min: 0 },
+    { field: 'activateOnGreaterThan', labelKey: 'Activate above threshold', type: 'bool' },
+    { field: 'countCritters', labelKey: 'Count critters', type: 'bool' },
+    { field: 'countEggs', labelKey: 'Count eggs', type: 'bool' },
+  ],
+
+  LogicAlarm: [
+    { field: 'notificationName', labelKey: 'Name', type: 'string', max: 200 },
+    { field: 'notificationTooltip', labelKey: 'Tooltip', type: 'string', max: 400 },
+    // Klei's NotificationType enum values are unverified here (spec §6 Q5) —
+    // shown as a raw integer rather than guessing labels.
+    { field: 'notificationType', labelKey: 'Notification type', type: 'int' },
+    { field: 'pauseOnNotify', labelKey: 'Pause on notify', type: 'bool' },
+    { field: 'zoomOnNotify', labelKey: 'Zoom on notify', type: 'bool' },
+    { field: 'cooldown', labelKey: 'Cooldown', type: 'float', unit: 's', min: 0 },
+  ],
+
+  IThresholdSwitch: [
+    { field: 'Threshold', labelKey: 'Threshold', type: 'float' },
+    { field: 'ActivateAboveThreshold', labelKey: 'Activate above threshold', type: 'bool' },
+  ],
+
+  IActivationRangeTarget: [
+    { field: 'ActivateValue', labelKey: 'Activate value', type: 'float' },
+    { field: 'DeactivateValue', labelKey: 'Deactivate value', type: 'float' },
+  ],
+
+  BuildingEnabledButton: [{ field: 'IsEnabled', labelKey: 'Enabled', type: 'bool' }],
+
+  Automatable: [{ field: 'automationOnly', labelKey: 'Automation only', type: 'bool' }],
+};
+
+export function isKnownSettingsKey(key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(SETTINGS_CATALOG, key);
+}

--- a/lib/src/blueprint/building-settings/settings-catalog.ts
+++ b/lib/src/blueprint/building-settings/settings-catalog.ts
@@ -110,3 +110,44 @@ export const SETTINGS_CATALOG: Record<string, SettingFieldDescriptor[]> = {
 export function isKnownSettingsKey(key: string): boolean {
   return Object.prototype.hasOwnProperty.call(SETTINGS_CATALOG, key);
 }
+
+// Editing an already-present Key is offered for every entry in
+// SETTINGS_CATALOG above. *Creating* a Key from scratch (a building placed in
+// the editor, or an uploaded file that omitted it because it was all-default)
+// is a narrower, hand-checked set: TryApplyData bails on the whole Value
+// object if any one field is missing, so a synthesized object must supply
+// every field with the real in-game default or it silently does nothing —
+// and worse, a wrong guess for a gameplay-affecting field changes the
+// building's behaviour versus leaving it absent.
+//
+// v1 ships only LogicTimerSensor, whose four fields are all either given
+// (onDuration/offDuration: spec/building-settings-plan.md phase 3 step 1) or
+// definitionally safe (timeElapsedInCurrentState: 0 for a fresh component;
+// displayCyclesMode: a display-only toggle with no simulation effect even if
+// the guessed default is wrong). Every other automation key — including
+// LogicCounter, whose resetCountAtMax/advancedMode defaults are not
+// confirmed — stays edit-only-when-present until its real defaults are
+// verified in-game. Extend CREATABLE_SETTINGS then, per building prefab id.
+export const CREATABLE_SETTINGS: Record<string, Record<string, Record<string, any>>> = {
+  LogicTimerSensor: {
+    LogicTimerSensor: {
+      onDuration: 10,
+      offDuration: 10,
+      timeElapsedInCurrentState: 0,
+      displayCyclesMode: false,
+    },
+  },
+};
+
+// The Keys creatable from scratch on a specific building prefab id.
+export function creatableSettingsKeysFor(prefabId: string): string[] {
+  const forPrefab = CREATABLE_SETTINGS[prefabId];
+  return forPrefab == null ? [] : Object.keys(forPrefab);
+}
+
+export function getCreatableSettingDefaults(
+  prefabId: string,
+  key: string
+): Record<string, any> | undefined {
+  return CREATABLE_SETTINGS[prefabId]?.[key];
+}

--- a/lib/src/io/mdb/mdb-building.d.ts
+++ b/lib/src/io/mdb/mdb-building.d.ts
@@ -1,12 +1,14 @@
 import { Vector2 } from '../../vector2';
 import { UiSaveSettings } from '../../b-export/b-ui-screen';
 import { InfoIcon } from '../../blueprint/note-conversion';
+import { BniBuildingData } from '../bni/bni-building';
 export interface MdbBuilding {
     id: string;
     temperature?: number;
     position?: Vector2;
     elements?: string[];
     settings?: UiSaveSettings[];
+    buildingData?: BniBuildingData[];
     connections?: number;
     pipeElement?: string;
     orientation?: number;

--- a/lib/src/io/mdb/mdb-building.ts
+++ b/lib/src/io/mdb/mdb-building.ts
@@ -1,6 +1,7 @@
 import { Vector2 } from '../../vector2';
 import { UiSaveSettings } from '../../b-export/b-ui-screen';
 import { InfoIcon } from '../../blueprint/note-conversion';
+import { BniBuildingData } from '../bni/bni-building';
 
 export interface MdbBuilding {
   id: string;
@@ -8,6 +9,12 @@ export interface MdbBuilding {
   position?: Vector2;
   elements?: string[];
   settings?: UiSaveSettings[];
+
+  // BlueprintsV2 per-component settings (§3 of the import spec). Opaque
+  // passthrough — Value shapes are component-specific and version-fragile.
+  // Omitted when empty so the fingerprint of every pre-existing stored
+  // blueprint stays byte-identical (same reasoning as worldNotes).
+  buildingData?: BniBuildingData[];
 
   // Utilities
   connections?: number;


### PR DESCRIPTION
## Summary

A blueprint like the one at `spec/Time Sensors.blueprint` carries per-building component settings written by the BlueprintsV2 mod — timer durations, switch state, logic gate delays, threshold values, etc. (`buildings[].buildingData: {Key, Value}[]`). The editor previously dropped this data silently on import and never wrote it back, so there was no way to see or change a sensor's configuration on the site. This PR makes it (a) survive every path through the editor, (b) visible on the selected-building panel, and (c) editable for a curated set of automation components.

Ships as three build-order commits on one branch, matching the plan at `spec/building-settings-plan.md` (local, gitignored — not part of this diff):

- **`feat(lib): round-trip BlueprintsV2 buildingData through the editor model`** — `BlueprintItem.buildingData` and the matching `MdbBuilding.buildingData` field carry the mod's `{Key, Value}[]` array through import/export/clone/undo, deep-copied at every model boundary. Omitted when empty in the MDB model, so every pre-existing stored blueprint's fingerprint (and therefore `rawSource` freshness) is unaffected.
- **`feat(editor): display automation building settings`** — a pure catalogue + formatter (`lib/src/blueprint/building-settings/`) covering the curated automation keys (`Switch`, `LogicTimerSensor`, `LogicTimeOfDaySensor`, `LogicCounter`, `LogicGateBuffer`/`Filter`, `LogicRibbonReader`/`Writer`, `LogicCritterCountSensor`, `LogicAlarm`, `IThresholdSwitch`, `IActivationRangeTarget`, `BuildingEnabledButton`, `Automatable`), plus a read-only panel mounted in the item info sidebar. Every other key is preserved opaquely and folded into an "N other stored settings (preserved)" line — raw `Key` names only in a tooltip, never dumped as JSON.
- **`feat(editor): edit automation building settings`** — `BlueprintItem.setBuildingSetting`/`addBuildingSetting` on the write side, checkbox/number/text inputs on the panel, committing on blur/Enter/change (one undo step per edit). Cross-checked the mod's real `DataTransferHelpers.cs`/`API_Methods.cs` source (available locally) rather than relying only on the import spec's summary table, which surfaced that most components bail on the *whole* Value object if any one field is missing on write, except `LogicAlarm`, which applies each field independently.

Plus a follow-up commit fixing a real bug found in manual testing (missing `trackBy` on the settings rows `*ngFor` caused every keystroke's change-detection cycle to tear down and rebuild the `<input>` DOM nodes, discarding what had just been typed), and a docs commit recording the feature in `CLAUDE.md`.

## Design decisions worth flagging

- **Creating a setting from scratch is deliberately narrow.** The mod's `TryApplyData` silently no-ops if a synthesized Value object is missing even one expected field, so creating one from nothing requires the *real* in-game default for every field — a wrong guess on a gameplay-affecting field would silently change build behaviour on export. `CREATABLE_SETTINGS` currently has only `LogicTimerSensor` (durations: 10s, given; the other two fields are either definitionally correct for a fresh component or purely cosmetic). Everything else, including `LogicCounter` (whose `resetCountAtMax`/`advancedMode` real defaults aren't confirmed), is edit-only-when-the-file-already-carries-the-key. Extending the creatable set is a follow-up once more defaults are verified in-game.
- **rawSource invalidation needed no new code** — `setBuildingSetting` mutates the same field phase 1 already wired into `toMdbBuilding`, so the existing fingerprint comparison (`BlueprintService.getValidRawSource`) already catches an edit.
- The old website's own settings model (`uiScreens`/`uiSaveSettings`, mounted as `app-ui-screen-container`) is untouched — it has no data source since the 2024 export ships empty `uiScreens` for every building. Removing that dead machinery is out of scope here.

## Test plan

- [x] `npm run tsc` clean
- [x] Backend suite green — 1097 passing locally (repeated runs surface a rotating set of unrelated DB-timeout flakes on this machine under load, documented in `CLAUDE.md`; none in `bpv2-import.test.ts` or `building-settings.test.ts` across many runs)
- [x] Frontend suite green — 1242/1244 (2 pre-existing skips), `cd frontend && npm run lint` clean
- [x] New coverage: lib round-trip (`__tests__/lib/bpv2-import.test.ts`, `__tests__/lib/building-settings.test.ts` — catalogue, formatter, write-path incl. deep-copy safety and a full `toBniBlueprint` loop), frontend component spec (read-only rows, editable inputs, add-from-scratch button, and a regression spec proving the trackBy fix)
- [x] Manually verified in the live editor: imported `Time Sensors.blueprint`, edited timer durations and the switch state, confirmed the panel showed the right rows, edits persisted through save/reload
- [ ] **In-game verification not yet done** — the plan calls for pushing an edited blueprint back to a real ONI install to confirm the mod accepts the written JSON and applies the edited durations, validating the all-fields-required contract against the real mod rather than just this repo's reading of it. Opening this PR now for CodeRabbit + review feedback in parallel; will report back before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)