### PR TITLE
docs(agent): record the completed prod activation and the jargon-guard follow-up

### DIFF
--- a/agent/SESSION_NOTES.md
+++ b/agent/SESSION_NOTES.md
@@ -1,3 +1,42 @@
+# Session Notes - 2026-08-26/27
+
+## What We Accomplished ✅
+
+### Prod activation of the multilingual-search + Vietnamese-title-gate work
+
+The full rollout, runbook-driven (`spec/archive/rollout-vi-gate.md`, local): three local
+rehearsals against a prod restore, two blockers found and fixed before prod spent a cent,
+then migrations, promotion, backfill, and verification.
+
+- **PR #211** — the 768 Gemini output-token cap truncated 113/199 batches with MAX_TOKENS
+  (output counts completion + thought; a full 12-title batch measures ~716–800). Default
+  raised to 2048; per-call reservation is now 4,096 micro-USD.
+- **Google Cloud quotas** — three console quotas were at deliberately-tiny 1,000
+  (chars/day, chars/min/user, req/min). Quota 403s are invisibly retried inside the v2
+  client's gax layer until the app's 15s timer fires, so exhaustion logs as "Translation
+  request timed out". All raised; the app-side `MONTHLY_CHAR_BUDGET` (400k chars ≈ $8/mo)
+  is the binding cost guard.
+- **Changelog wipe** — prod's `migrations` tracking collection was found empty despite 15
+  recorded runs in the previous day's dump. Restored from the dump; both new migrations
+  validated by DB fingerprints (index keys/weights, backfilled fields), which is the
+  trustworthy check when `migrate:status` claims "all pending".
+- **Pre-guard no-op cleanup** — 645 machine rows from the 2026-08-05 backfill were
+  byte-identical to their authored titles (written before the "provider must change the
+  text" guard); flipped back to authored so the run re-considered them properly.
+- **The run** — 2,378 titles / 199 Gemini calls / 26 accepted (all correct) / 2,248
+  continued to Google / 0 failed batches / ~$0.24 observed against a $1.50 cap. Precision
+  audit: zero unchanged-title machine rows. Verified live both directions ("full
+  electrolysis" ↔ `Dien Phan Z`).
+- **Post-activation incident, fixed same day** — Google mangled short jargon titles
+  (`drecko` → "Shit", `10 dupe SPOM` → "10 ass SPOM"; 52 titles / 89 rows). Reverted and
+  cache-pinned to source text so re-derives can't re-apply them. Systemic guard is the new
+  top open item in TODO.md.
+
+PRs: #211 (token cap), #213 (CLAUDE.md), this one (agent docs). Docs archived:
+`spec/rollout-vi-gate.md` and the vi-gate `next-session-prompt.md` → `spec/archive/`.
+
+---
+
 # Session Notes - 2026-08-04
 
 ## What We Accomplished ✅

--- a/agent/TODO.md
+++ b/agent/TODO.md
@@ -1,47 +1,36 @@
 # Agent TODO - Blueprint Not Included
 
 ## Current Status
-- **Phase**: Multilingual search + content locale — search plan phases 0–5 shipped, plus
-  `spec/search-followups.md` Part 1 §1/§2 and all of Part 2 (PR #206)
-- **Date**: 2026-08-04
+- **Phase**: Multilingual search + content locale — fully shipped AND activated in prod
+  (2026-08-27): migrations, Vietnamese-title gate (PR #210 + #211), full derive-search
+  backfill, precision audit clean
+- **Date**: 2026-08-27
 - **Branch**: `master`
 - **Stack**: Node 20.19.4 · TypeScript 5.9.3 strict · Mongoose 8.24 · Express 5.2 · Canvas 3.2.3 · Angular 20 · PrimeNG 20
-- **Tests**: 1022 backend (Mocha + Chai) · 1226 frontend (Vitest, 2 skipped) — all green
+- **Tests**: 1072 backend (Mocha + Chai) · 1226 frontend (Vitest, 2 skipped) — all green
 - **Enforcement**: zero-warning flags enabled backend, lib, and frontend (`strict` + `strictTemplates`); CI improvements all complete (mongo:8.0.23 + mongosh health check)
 
-## ⚠️ Blocking: activate the content-locale work in prod
+## Prod activation — DONE 2026-08-27
 
-PR #206 is merged but **inert until two commands run, in this order**:
-
-```bash
-cd /bpni/build
-npm run migrate:up        # 20260804000000_search-title-original — rebuilds the text index
-npm run derive-search     # backfills titleOriginal + runs provider-side detection
-```
-
-Take a DB backup first (DO dashboard → Backups → Create backup now), per the migration
-runbook. `derive-search` is rerunnable; do a `derive-search:dry-run` first to see the
-candidate counts. The detection pass spends real money against `GOOGLE_TRANSLATE_API_KEY`
-(one-time, ~59K characters, inside the 500K/month free tier) — re-runs are cache reads.
-
-Until this runs: no row has a `titleOriginal` (so a machine-translated blueprint is still
-unfindable by its authored title), and romanized non-English titles are still untranslated.
+Migrations applied (validated by DB fingerprints — the `migrations` changelog collection was
+found inexplicably empty and had to be restored from a dump; if `migrate:status` ever shows
+"all pending" again, check the collection before believing it). Gate enabled, full backfill
+run: 2,378 titles / 199 Gemini calls / 26 accepted / 0 failed batches / ~$0.24 observed.
+Precision audit (`search-followups.md` Part 1 §5): zero unchanged-title machine rows.
+Verified live in both query directions. Rollout trail: `spec/archive/rollout-vi-gate.md`
+(local).
 
 ## Multilingual search — what's left
 
 Full detail in `spec/multilingual-search-plan.md` §4.5 and `spec/search-followups.md`.
 
-- **Retrieval never reads the non-English rows** (followups Part 1 §4). Phase 5 accretes
-  rows in the reader's language, but `lexicalRetrieval`/`structuralRetrieval` still
-  hard-code `lang: 'en'`. They cost nothing and buy nothing until a viewer-language signal
-  is threaded in — which `?lang=` now supplies for the first time, so this is unblocked.
-- **`changed: false` precision audit** (followups Part 1 §5). Cheap aggregate; measures
-  whether `confidentTitleLang` over-fires. Worth running against prod **after** the
-  activation above, since the new detection pass adds to the population.
-- **Native-language search rows** (followups §2.9). Now that `sourceLang` can be declared,
-  writing a row with `lang: sourceLang` holding the authored text verbatim is free — no API
-  call. It overlaps `titleOriginal`; design them together or there will be two mechanisms
-  for one job.
+- **Guard game jargon from the Google translation passes** — found in prod 2026-08-27:
+  Google confidently mistranslates short all-jargon titles it misreads as another language
+  (`drecko` → "Shit", `10 dupe SPOM` → "10 ass SPOM", SPOM → "memory", pacu → "race"; 89
+  rows reverted and cache-pinned). The term-dictionary fully-resolved filter only guards the
+  Gemini census — extend it to the Google continuation and phase-3b passes, and consider
+  adding `drecko`/`pacu`/`dupe`/`puft` to `assets/search-aliases.json`. **Do before any full
+  re-derive** — the cache pins protect the 52 known titles, not the class.
 - **Sticky "always show original titles"** (followups §2.12) — does an English reader ever
   want the authored title instead? Product question, not mechanical.
 - **Phase 6 — semantic retrieval**, only if `searchqueries` telemetry justifies it. It held


### PR DESCRIPTION
TODO.md still carried the 2026-08-04 "blocking: activate in prod" section; the activation completed 2026-08-27. Replaces it with the outcome, prunes the shipped items from the multilingual what's-left list (Part 1 §4/§5, native rows §2.9), and adds the new top open item: extending the term-dictionary guard to the Google translation passes after the drecko→"Shit" jargon-mistranslation incident (89 rows, fixed and cache-pinned same day). SESSION_NOTES gets the 2026-08-26/27 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)