### PR TITLE
fix: exclude rawSource from getFeed's blueprint select

### DIFF
--- a/__tests__/api/social.test.ts
+++ b/__tests__/api/social.test.ts
@@ -10,7 +10,8 @@ process.env.NODE_ENV = 'test';
 import { TestSetup } from '../setup/testSetup';
 import { BlueprintModel } from '../../app/api/models/blueprint';
 import { FollowModel } from '../../app/api/models/follow';
-import { Types } from 'mongoose';
+import mongoose, { Types } from 'mongoose';
+import sinon from 'sinon';
 
 describe('Profile, Follow, Feed API', function () {
   let testData: any;
@@ -395,6 +396,43 @@ describe('Profile, Follow, Feed API', function () {
         .set('Authorization', `Bearer ${token}`);
 
       expect(response.body.blueprints).to.deep.equal([]);
+    });
+
+    it('excludes rawSource from the underlying feed blueprint query', async function () {
+      // buildListItem already field-picks the response explicitly, so
+      // rawSource never reaches response JSON regardless of the Mongo
+      // select() — the actual risk is pulling up to ~2MB of verbatim
+      // blueprint text per row across the wire from Mongo. Assert on the
+      // query itself (every other list/feed query in app/api uses
+      // '-data -thumbnail -rawSource'; this one was the sole outlier).
+      await FollowModel.model.create({
+        followerId: testData.users.user2._id,
+        followeeId: testData.users.user1._id,
+      });
+      await BlueprintModel.model.updateOne(
+        { _id: testData.blueprints.popularBlueprint._id },
+        { rawSource: '{"friendlyname":"x"}', rawSourceFormat: 'bpv2-json' }
+      );
+
+      const selectSpy = sinon.spy(mongoose.Query.prototype, 'select');
+      try {
+        const token = testData.users.user2.generateJwt();
+        const response = await TestSetup.request()
+          .get('/api/feed')
+          .query({ olderthan: Date.now() })
+          .set('Authorization', `Bearer ${token}`);
+
+        expect(response.status).to.equal(200);
+
+        const blueprintSelectCall = selectSpy
+          .getCalls()
+          .find(call => typeof call.args[0] === 'string' && call.args[0].includes('-data'));
+        expect(blueprintSelectCall, 'expected the feed blueprint query to call .select()').to
+          .exist;
+        expect(blueprintSelectCall!.args[0]).to.include('-rawSource');
+      } finally {
+        selectSpy.restore();
+      }
     });
 
     it('paginates with the olderthan cursor', async function () {

--- a/app/api/user-controller.ts
+++ b/app/api/user-controller.ts
@@ -422,7 +422,7 @@ export class UserController {
           })
           .sort({ createdAt: -1 })
           .limit(browseIncrement * 2)
-          .select('-data -thumbnail')
+          .select('-data -thumbnail -rawSource')
           .populate('owner')
           .then(blueprints => {
             return BlueprintController.handleGetBlueprint(req, res, blueprints);


### PR DESCRIPTION
## Summary
- `getFeed` (`app/api/user-controller.ts:425`) was the sole list/feed query in `app/api` not excluding `rawSource` from its Mongo `select()` — every other list query uses `'-data -thumbnail -rawSource'` (documented convention in `spec/blueprintsv2-followups.md`'s BPv2 gotcha list).
- Fixed the select to match convention: `'-data -thumbnail -rawSource'`.

## Note on scope
`buildListItem` already constructs the response object with explicit fields (no spread), so `rawSource` never actually reached the `/api/feed` JSON body regardless of this select — verified empirically. The real cost was pulling up to ~2MB of verbatim blueprint text per feed row across the wire from Mongo unnecessarily, and the inconsistency with the other 6 call sites. The regression test spies on the underlying Mongoose query (`mongoose.Query.prototype.select`) rather than asserting on the response body, since the response shape can't actually expose this field — confirmed the test fails against the old select and passes against the new one.

## Test plan
- [x] New spec in `__tests__/api/social.test.ts` — verified it fails on the old select, passes on the new one
- [x] Full backend suite: 1101 passing
- [x] `npm run tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)