### PR TITLE
Run several checkouts side by side, in containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,49 @@
+# Development image. This is NOT the deploy image — that is deploy.Dockerfile,
+# which builds the app; this one only supplies the toolchain and then gets out
+# of the way. The source arrives as a bind mount at /app, so nothing is COPYed
+# in and the build context is this directory alone.
+#
+# Node matches .nvmrc / package.json engines. Bump all three together.
+ARG NODE_VERSION=20.19.4
+FROM node:${NODE_VERSION}-bookworm
+
+# canvas and sharp are native modules. Both publish prebuilt binaries for
+# linux-x64-glibc, so the toolchain below is usually unused — but the moment a
+# prebuild is missing (a new node minor, an arm64 host) node-gyp needs cairo's
+# headers, and an npm ci that fails only on someone else's machine is a bad
+# trade for a few hundred megabytes here. netcat-openbsd is what
+# scripts/test-db-setup.sh probes the database with.
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+      build-essential python3 pkg-config \
+      libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev \
+      ca-certificates curl git less vim netcat-openbsd \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI — `gh pr create` from inside the container is the normal way a
+# task ends, so it belongs in the image rather than in a setup step.
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends gh \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Installed globally so it survives a container rebuild rather than being
+# reinstalled into a bind-mounted node_modules on every create.
+RUN npm install -g @anthropic-ai/claude-code
+
+RUN git config --system core.editor vi
+
+# The node image already ships a `node` user at uid/gid 1000, which is the uid
+# a Linux workstation hands out first — so bind-mounted files are owned
+# correctly without any remapping. Pre-create the named-volume mount points as
+# that user: a volume's ownership is seeded from the image's directory the
+# first time it is created, and a root-owned one is unwritable afterwards.
+RUN mkdir -p /app/node_modules /app/frontend/node_modules /app/log /home/node/.npm \
+ && chown -R node:node /app /home/node/.npm
+
+WORKDIR /app
+USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "name": "blueprintnotincluded",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/app",
+  // The node image's own uid-1000 user. updateRemoteUserUID reconciles it with
+  // the host user at create time, which is what keeps bind-mounted files
+  // writable on Linux; on macOS Docker Desktop maps uids anyway and it is a
+  // no-op.
+  "remoteUser": "node",
+  "updateRemoteUserUID": true,
+  // Angular's dev server and the backend. Both are compose services (`web`,
+  // `api`) that start themselves once the install below finishes — see README.
+  "forwardPorts": [4200, 3000, 8025],
+  "portsAttributes": {
+    "4200": { "label": "Angular dev server", "onAutoForward": "notify" },
+    "3000": { "label": "Backend API", "onAutoForward": "silent" },
+    "8025": { "label": "Mailpit", "onAutoForward": "silent" }
+  },
+  // Bind the host's Claude Code state so auth and history survive a rebuild.
+  "mounts": [
+    "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.gitconfig,target=/home/node/.gitconfig,type=bind,consistency=cached"
+  ],
+  // The .env.test.local line is what points the suite at the container's
+  // Mongo; the committed .env.test says 127.0.0.1, which is nothing in here.
+  "postCreateCommand": "[ -f .env.test.local ] || echo 'DB_URI=mongodb://database:27017/blueprintnotincluded_test' > .env.test.local; npm ci --no-audit --no-fund && (cd frontend && npm ci --no-audit --no-fund) && npm run build:lib",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "anthropic.claude-code",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "angular.ng-template"
+      ]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,13 +18,18 @@
     "8025": { "label": "Mailpit", "onAutoForward": "silent" }
   },
   // Bind the host's Claude Code state so auth and history survive a rebuild.
+  // A type=bind source must already exist — unlike -v, Docker will not create
+  // one and refuses to start the container — and postCreateCommand runs too
+  // late to help. initializeCommand runs on the HOST before creation, the only
+  // hook early enough, so a machine with neither path still comes up.
+  "initializeCommand": "mkdir -p \"${localEnv:HOME}/.claude\" && touch \"${localEnv:HOME}/.gitconfig\"",
   "mounts": [
     "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.gitconfig,target=/home/node/.gitconfig,type=bind,consistency=cached"
   ],
   // The .env.test.local line is what points the suite at the container's
   // Mongo; the committed .env.test says 127.0.0.1, which is nothing in here.
-  "postCreateCommand": "[ -f .env.test.local ] || echo 'DB_URI=mongodb://database:27017/blueprintnotincluded_test' > .env.test.local; npm ci --no-audit --no-fund && (cd frontend && npm ci --no-audit --no-fund) && npm run build:lib",
+  "postCreateCommand": "[ -f .env.test.local ] || echo 'DB_URI=mongodb://database:27017/blueprintnotincluded_test' > .env.test.local; npm ci --no-audit --no-fund && (cd frontend && npm ci --no-audit --no-fund) && npm run build:lib && npm run migrate:up",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,123 @@
+# The development stack: toolchain, servers and services in containers, so a
+# checkout needs nothing on the host but a container runtime. Deploying is a
+# separate concern and a separate pair of files (../docker-compose.yml,
+# deploy.Dockerfile).
+#
+# Compose reads `.env` from the directory of the *first* compose file, which is
+# this one — so the repo-root .env, the same file dotenv reads, has to be named:
+#
+#   docker compose --env-file .env -f .devcontainer/docker-compose.yml up -d
+#
+# Several checkouts run side by side: each gives its own .env a
+# COMPOSE_PROJECT_NAME and its own *_PORT values. With nothing set you get one
+# project on the well-known ports. In-container ports never move — the backend
+# is always 3000 and Angular always 4200 — so only the host side of a publish
+# varies and nothing inside a container has to know which checkout it is.
+name: ${COMPOSE_PROJECT_NAME:-bpni-dev}
+
+# Everything that runs project code runs the same image off the same volumes.
+x-node: &node
+  build:
+    # This directory, not the repo root: nothing is COPYed into the image (the
+    # source is the bind mount below), so there is no reason to hand the
+    # daemon a gigabyte of blueprints and node_modules.
+    context: .
+    dockerfile: Dockerfile
+    args:
+      NODE_VERSION: '20.19.4'
+  environment: &node-env
+    NODE_ENV: development
+    npm_config_cache: /home/node/.npm
+  volumes:
+    - ..:/app:cached
+    # Named volumes, not part of the bind mount: canvas and sharp are built for
+    # the platform that installed them, so a host-side node_modules must never
+    # be what a container runs — and vice versa.
+    - node_modules:/app/node_modules
+    - frontend_node_modules:/app/frontend/node_modules
+    - npm_cache:/home/node/.npm
+  depends_on:
+    database:
+      condition: service_healthy
+    mailhog:
+      condition: service_started
+
+services:
+
+  # Where a shell, an agent, and one-off commands live. Owns nothing at
+  # runtime, so restarting a server never disturbs a session in here.
+  app:
+    <<: *node
+    command: sleep infinity
+    stdin_open: true
+    tty: true
+
+  api:
+    <<: *node
+    # The wait loop is the handshake with provisioning: npm writes
+    # node_modules/.package-lock.json only after a *successful* install, so
+    # this starts when the dependencies are actually there and not before.
+    # `docker compose exec app npm ci` in another shell is all it takes.
+    command: >
+      bash -lc 'while [ ! -f /app/node_modules/.package-lock.json ]; do
+                  echo "waiting for dependencies — run npm ci in the app container"; sleep 5;
+                done;
+                npm run dev 2>&1 | tee -a /app/log/api.log'
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:${API_PORT:-3000}:3000"
+
+  web:
+    <<: *node
+    working_dir: /app/frontend
+    environment:
+      <<: *node-env
+      # frontend/proxy.conf.js. `api`, not localhost: the dev server is its own
+      # container now, so the backend is a service name away.
+      BACKEND_HOST: api
+      BACKEND_PORT: '3000'
+    # Also waits on lib/index.js — `npm run build:lib` output, which the
+    # frontend imports and cannot compile without.
+    command: >
+      bash -lc 'while [ ! -f /app/frontend/node_modules/.package-lock.json ] || [ ! -f /app/lib/index.js ]; do
+                  echo "waiting for dependencies — run npm ci and npm run build:lib in the app container"; sleep 5;
+                done;
+                npm start -- --host 0.0.0.0 --port 4200 --allowed-hosts 2>&1 | tee -a /app/log/web.log'
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:${WEB_PORT:-4200}:4200"
+
+  database:
+    # MONGO_TAG: the 8.0 line (8.0.29 checked) refuses to start on Linux
+    # kernels 6.19 and newer (SERVER-121912); 8.2 does. Set MONGO_TAG=8.2 in
+    # .env on such a host rather than editing the default, which CI shares.
+    image: mongo:${MONGO_TAG:-8.0.23}
+    environment:
+      - "MONGO_INITDB_DATABASE=blueprintnotincluded"
+    volumes:
+      - ../mongo/docker-entrypoint-initdb.d/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+      - mongodb_data:/data/db
+    ports:
+      # Loopback only: nothing on the LAN has business with a dev database.
+      # Published at all so host tools (mongosh, Compass) can still reach it.
+      - "127.0.0.1:${MONGO_PORT:-27017}:27017"
+    healthcheck:
+      # Everything else waits on this. Without it the first migrate:up of a
+      # cold stack races the database's own initdb and dies on a refused
+      # connection.
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  mailhog:
+    image: axllent/mailpit
+    ports:
+      - "127.0.0.1:${MAILPIT_SMTP_PORT:-1025}:1025"
+      - "127.0.0.1:${MAILPIT_UI_PORT:-8025}:8025"
+
+volumes:
+  mongodb_data:
+  node_modules:
+  frontend_node_modules:
+  npm_cache:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -32,6 +32,13 @@ x-node: &node
   environment: &node-env
     NODE_ENV: development
     npm_config_cache: /home/node/.npm
+    # The database and mail are sibling services in here, never localhost.
+    # Set on the container rather than left to .env so the sample file can
+    # keep the host answer: app/server.ts calls plain dotenv.config(), which
+    # does not overwrite an already-set variable, so these win over the .env
+    # the bind mount carries.
+    DB_URI: mongodb://database:27017/blueprintnotincluded
+    SMTP_HOST: mailhog
   volumes:
     - ..:/app:cached
     # Named volumes, not part of the bind mount: canvas and sharp are built for

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,7 +16,11 @@
 name: ${COMPOSE_PROJECT_NAME:-bpni-dev}
 
 # Everything that runs project code runs the same image off the same volumes.
+# `image:` names it explicitly so app, api and web share one build instead of
+# tagging three copies — and so a second checkout on the same machine reuses
+# it. It holds no checkout-specific state; the source is a bind mount.
 x-node: &node
+  image: blueprintnotincluded-dev:local
   build:
     # This directory, not the repo root: nothing is COPYed into the image (the
     # source is the bind mount below), so there is no reason to hand the

--- a/.env.sample
+++ b/.env.sample
@@ -9,11 +9,13 @@ BROWSE_INCREMENT="10"
 # "false" to revert filterName to the legacy name-substring regex without a
 # code revert. Any other value (or unset) is enabled.
 # SEARCH_V2_ENABLED="false"
-# Inside the dev container the database and Mailpit are reachable by compose
-# service name, so this is "database" and SMTP_HOST is "mailhog". Running the
-# app straight on the host instead, they are localhost and the published
-# MONGO_PORT / MAILPIT_SMTP_PORT.
-DB_URI="mongodb://database:27017/blueprintnotincluded"
+# The host answer: running the app straight on the host, the database and
+# Mailpit are localhost on the published MONGO_PORT / MAILPIT_SMTP_PORT. In
+# the dev container they are compose services, and
+# .devcontainer/docker-compose.yml sets DB_URI and SMTP_HOST to those service
+# names on the container itself — so a plain `cp .env.sample .env` is correct
+# for both paths and neither needs editing.
+DB_URI="mongodb://localhost:27017/blueprintnotincluded"
 # Ports. Leave these alone for a single checkout.
 #
 # PORT and BACKEND_PORT are *listen* ports, inside whatever is running the
@@ -30,12 +32,13 @@ DB_URI="mongodb://database:27017/blueprintnotincluded"
 # WEB_PORT="4200"
 # API_PORT="3000"
 # MONGO_PORT="27017"
+# APP_PORT="3000"      # host side of ../docker-compose.yml (the deploy stack) only
 # MONGO_TAG="8.0.23"   # 8.2 on Linux kernels >= 6.19 — 8.0.x cannot start there (SERVER-121912)
 # MAILPIT_SMTP_PORT="1025"
 # MAILPIT_UI_PORT="8025"
 # COMPOSE_PROJECT_NAME="bpni-dev"
 JWT_SECRET="anylongstringhere"
-SMTP_HOST="mailhog"
+SMTP_HOST="localhost"
 SMTP_PORT="1025"
 
 # WorkOS Configuration (for authentication)

--- a/.env.sample
+++ b/.env.sample
@@ -9,21 +9,33 @@ BROWSE_INCREMENT="10"
 # "false" to revert filterName to the legacy name-substring regex without a
 # code revert. Any other value (or unset) is enabled.
 # SEARCH_V2_ENABLED="false"
-DB_URI="mongodb://localhost:27017/blueprintnotincluded"
-# Ports. Leave these alone for a single checkout. To run several checkouts side
-# by side give each its own values: PORT is the backend's listen port (links
-# still come from HOST / SITE_URL); the *_PORT trio is what docker compose
-# publishes the database and Mailpit on; COMPOSE_PROJECT_NAME keeps their
-# containers and volumes apart. The frontend proxy follows BACKEND_PORT
-# (`BACKEND_PORT=3001 npm start`) and its own port is `npm start -- --port N`.
+# Inside the dev container the database and Mailpit are reachable by compose
+# service name, so this is "database" and SMTP_HOST is "mailhog". Running the
+# app straight on the host instead, they are localhost and the published
+# MONGO_PORT / MAILPIT_SMTP_PORT.
+DB_URI="mongodb://database:27017/blueprintnotincluded"
+# Ports. Leave these alone for a single checkout.
+#
+# PORT and BACKEND_PORT are *listen* ports, inside whatever is running the
+# code: PORT is the backend's (links still come from HOST / SITE_URL) and the
+# frontend proxy targets BACKEND_PORT. In the dev container both stay at their
+# defaults forever — nothing in there needs to know which checkout it is.
+#
+# The rest are the *host* side of what .devcontainer/docker-compose.yml
+# publishes, and they are what several checkouts running side by side actually
+# vary, together with COMPOSE_PROJECT_NAME, which keeps their containers and
+# volumes apart. WEB_PORT is the one you open in a browser.
 # PORT="3000"
+# BACKEND_PORT="3000"
+# WEB_PORT="4200"
+# API_PORT="3000"
 # MONGO_PORT="27017"
 # MONGO_TAG="8.0.23"   # 8.2 on Linux kernels >= 6.19 — 8.0.x cannot start there (SERVER-121912)
 # MAILPIT_SMTP_PORT="1025"
 # MAILPIT_UI_PORT="8025"
-# COMPOSE_PROJECT_NAME="bpni"
+# COMPOSE_PROJECT_NAME="bpni-dev"
 JWT_SECRET="anylongstringhere"
-SMTP_HOST="localhost"
+SMTP_HOST="mailhog"
 SMTP_PORT="1025"
 
 # WorkOS Configuration (for authentication)

--- a/.env.sample
+++ b/.env.sample
@@ -37,7 +37,7 @@ DB_URI="mongodb://localhost:27017/blueprintnotincluded"
 # BACKEND_PORT="3000"
 # WEB_PORT="4200"
 # API_PORT="3000"
-# MONGO_PORT="27017"
+# MONGO_PORT="27017"   # on the host path, change DB_URI above to match — nothing derives it
 # APP_PORT="3000"      # host side of ../docker-compose.yml (the deploy stack) only
 # MONGO_TAG="8.0.23"   # 8.2 on Linux kernels >= 6.19 — 8.0.x cannot start there (SERVER-121912)
 # MAILPIT_SMTP_PORT="1025"

--- a/.env.sample
+++ b/.env.sample
@@ -10,6 +10,18 @@ BROWSE_INCREMENT="10"
 # code revert. Any other value (or unset) is enabled.
 # SEARCH_V2_ENABLED="false"
 DB_URI="mongodb://localhost:27017/blueprintnotincluded"
+# Ports. Leave these alone for a single checkout. To run several checkouts side
+# by side give each its own values: PORT is the backend's listen port (links
+# still come from HOST / SITE_URL); the *_PORT trio is what docker compose
+# publishes the database and Mailpit on; COMPOSE_PROJECT_NAME keeps their
+# containers and volumes apart. The frontend proxy follows BACKEND_PORT
+# (`BACKEND_PORT=3001 npm start`) and its own port is `npm start -- --port N`.
+# PORT="3000"
+# MONGO_PORT="27017"
+# MONGO_TAG="8.0.23"   # 8.2 on Linux kernels >= 6.19 — 8.0.x cannot start there (SERVER-121912)
+# MAILPIT_SMTP_PORT="1025"
+# MAILPIT_UI_PORT="8025"
+# COMPOSE_PROJECT_NAME="bpni"
 JWT_SECRET="anylongstringhere"
 SMTP_HOST="localhost"
 SMTP_PORT="1025"

--- a/.env.sample
+++ b/.env.sample
@@ -13,8 +13,14 @@ BROWSE_INCREMENT="10"
 # Mailpit are localhost on the published MONGO_PORT / MAILPIT_SMTP_PORT. In
 # the dev container they are compose services, and
 # .devcontainer/docker-compose.yml sets DB_URI and SMTP_HOST to those service
-# names on the container itself — so a plain `cp .env.sample .env` is correct
-# for both paths and neither needs editing.
+# names on the container itself — so this line is right for both paths on the
+# default ports.
+#
+# Two things a copy does not get right on its own. Change MONGO_PORT for a
+# second host checkout and the port below has to change with it by hand:
+# dotenv does no variable expansion (16.6.1 checked), so "${MONGO_PORT}" here
+# would be stored and used literally. And JWT_SECRET further down is a known
+# placeholder.
 DB_URI="mongodb://localhost:27017/blueprintnotincluded"
 # Ports. Leave these alone for a single checkout.
 #
@@ -37,6 +43,8 @@ DB_URI="mongodb://localhost:27017/blueprintnotincluded"
 # MAILPIT_SMTP_PORT="1025"
 # MAILPIT_UI_PORT="8025"
 # COMPOSE_PROJECT_NAME="bpni-dev"
+# Placeholder, and predictable: anything reachable by anyone else needs its
+# own value here before it starts, or JWTs can be forged against it.
 JWT_SECRET="anylongstringhere"
 SMTP_HOST="localhost"
 SMTP_PORT="1025"

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,14 @@
 /node_modules
 /.env
 /.env.migration
+# Per-checkout test overrides (see __tests__/hooks.ts)
+/.env.test.local
 /prod-dump
 
 /build
 /.claude
+# Dev-server logs written by tooling that runs the servers in the background
+/log
 
 # TypeScript build artifacts (keep .d.ts for development)
 *.d.ts.map

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,13 +36,18 @@ app container**; the host needs only a container runtime.
 
 - `docker compose --env-file .env -f .devcontainer/docker-compose.yml up -d` - Bring up the whole stack. `--env-file` is required: compose looks for `.env` beside the compose file, not at the repo root
 - `... exec app bash` - A shell in the container, where every command below runs. `app` runs no servers, so nothing you do in it disturbs one
-- `npm ci && (cd frontend && npm ci) && npm run build:lib` - First run only. The `api` and `web` services poll for the result and start serving on their own; do **not** run `npm run dev` or `npm start` by hand
+- `npm ci && (cd frontend && npm ci) && npm run build:lib && npm run migrate:up` - First run only. The migration is part of it: the schema the code expects is not the schema a fresh database has. The `api` and `web` services poll for the result and start serving on their own; do **not** run `npm run dev` or `npm start` by hand
 - `... logs -f api web` / `... restart api` - Watch or bounce a server
 - Frontend: http://localhost:4200, Backend: http://localhost:3000
 - From inside, the database is `database:27017` and mail is `mailhog:1025` — service names, not localhost
 
 To run on the host instead (Node 20.19.4 per `.nvmrc`): `./dev-setup.sh` starts
-just the database and mail, and `DB_URI` / `SMTP_HOST` become `localhost`.
+just the database and mail, and `DB_URI` / `SMTP_HOST` are already `localhost`
+in `.env.sample`. The *test* database is separate: the suite reads
+`.env.test.local` before the committed `.env.test`, so a checkout on a
+non-default `MONGO_PORT` — or one that ran in the container first, leaving a
+`.env.test.local` pointing at `database:27017` — needs that file to say
+`DB_URI=mongodb://localhost:${MONGO_PORT}/blueprintnotincluded_test`.
 
 ### Production Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,8 @@ Copy `.env.sample` to `.env` and configure:
 - `SMTP_HOST`/`SMTP_PORT` - Mail server for dev/test (defaults to localhost:1025)
 - `MAILJET_API_KEY`/`MAILJET_SECRET_KEY`/`MAILJET_FROM_EMAIL` - Required in production for email
 - `SITE_URL` - Base URL included in password reset links
+- `PORT` - Backend listen port (default 3000). Links never derive from it — they use `HOST` / `SITE_URL` — so several checkouts can listen on different ports behind one hostname each
+- `MONGO_PORT` / `MAILPIT_SMTP_PORT` / `MAILPIT_UI_PORT` / `COMPOSE_PROJECT_NAME` - Read by `docker compose` from `.env` to publish the database and Mailpit on other host ports and keep one checkout's containers and volumes apart from another's. `BACKEND_PORT` steers the frontend's API proxy (`frontend/proxy.conf.js`). `MONGO_TAG` picks the compose image (default `8.0.23`; `8.2` on Linux kernels ≥ 6.19, where 8.0.x will not start — SERVER-121912). Details in README "Several checkouts side by side"
 
 ## Database
 
@@ -178,6 +180,7 @@ Uses MongoDB 8.0.23 locally and in CI (prod upgrade from 7.0.34 pending) with Mo
 - **Framework**: Mocha with Chai — do not introduce Jest
 - **Maintenance**: When removing large dependency sets, regenerate package-lock.json with `rm package-lock.json && npm install` to prevent corruption
 - **Email in tests**: `emailService.ts` skips SMTP when `NODE_ENV=test` — no mail server needed
+- **Test database location**: `__tests__/hooks.ts` loads a gitignored `.env.test.local` before `.env.test`, and a `DB_URI` already in the environment beats both (CI sets it as a job var). `scripts/test-db-setup.sh` resolves `DB_URI` the same way, so it checks and starts the Mongo the tests will actually use
 
 **Frontend**: Vitest with jsdom (no real browser). Runner: `@angular/build:unit-test`. Coverage via `@vitest/coverage-v8`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,11 @@ just the database and mail, and `DB_URI` / `SMTP_HOST` are already `localhost`
 in `.env.sample`. The *test* database is separate: the suite reads
 `.env.test.local` before the committed `.env.test`, so a checkout on a
 non-default `MONGO_PORT` — or one that ran in the container first, leaving a
-`.env.test.local` pointing at `database:27017` — needs that file to say
-`DB_URI=mongodb://localhost:${MONGO_PORT}/blueprintnotincluded_test`.
+`.env.test.local` pointing at `database:27017` — needs that file rewritten. It takes the port as a *number*: dotenv does no
+variable expansion (16.6.1), so a `${MONGO_PORT}` written there is stored and
+used literally, and `scripts/test-db-setup.sh` would then probe the
+placeholder. From a shell that has the value —
+`echo "DB_URI=mongodb://localhost:$MONGO_PORT/blueprintnotincluded_test" > .env.test.local`.
 
 ### Production Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,19 @@ This is the source repository for blueprintnotincluded.org, a web application fo
 
 ### Development (Recommended)
 
-- `./dev-setup.sh` - Start dependencies (database + mail)
-- `npm run dev` - Start backend with live reloading
-- `cd frontend && npm start` - Start frontend with live reloading
+The toolchain lives in `.devcontainer/` — Node, the native build deps for
+`canvas` and `sharp`, MongoDB and Mailpit. Everything below runs **inside the
+app container**; the host needs only a container runtime.
+
+- `docker compose --env-file .env -f .devcontainer/docker-compose.yml up -d` - Bring up the whole stack. `--env-file` is required: compose looks for `.env` beside the compose file, not at the repo root
+- `... exec app bash` - A shell in the container, where every command below runs. `app` runs no servers, so nothing you do in it disturbs one
+- `npm ci && (cd frontend && npm ci) && npm run build:lib` - First run only. The `api` and `web` services poll for the result and start serving on their own; do **not** run `npm run dev` or `npm start` by hand
+- `... logs -f api web` / `... restart api` - Watch or bounce a server
 - Frontend: http://localhost:4200, Backend: http://localhost:3000
+- From inside, the database is `database:27017` and mail is `mailhog:1025` — service names, not localhost
+
+To run on the host instead (Node 20.19.4 per `.nvmrc`): `./dev-setup.sh` starts
+just the database and mail, and `DB_URI` / `SMTP_HOST` become `localhost`.
 
 ### Production Testing
 
@@ -151,11 +160,11 @@ Copy `.env.sample` to `.env` and configure:
 - `DB_URI` - MongoDB connection string
 - `JWT_SECRET` - Secret key for JWT tokens
 - `ENV_NAME` - Environment identifier (`production` enables Mailjet; otherwise nodemailer/SMTP)
-- `SMTP_HOST`/`SMTP_PORT` - Mail server for dev/test (defaults to localhost:1025)
+- `SMTP_HOST`/`SMTP_PORT` - Mail server for dev/test (`mailhog:1025` in the dev container, `localhost:1025` on the host)
 - `MAILJET_API_KEY`/`MAILJET_SECRET_KEY`/`MAILJET_FROM_EMAIL` - Required in production for email
 - `SITE_URL` - Base URL included in password reset links
 - `PORT` - Backend listen port (default 3000). Links never derive from it — they use `HOST` / `SITE_URL` — so several checkouts can listen on different ports behind one hostname each
-- `MONGO_PORT` / `MAILPIT_SMTP_PORT` / `MAILPIT_UI_PORT` / `COMPOSE_PROJECT_NAME` - Read by `docker compose` from `.env` to publish the database and Mailpit on other host ports and keep one checkout's containers and volumes apart from another's. `BACKEND_PORT` steers the frontend's API proxy (`frontend/proxy.conf.js`). `MONGO_TAG` picks the compose image (default `8.0.23`; `8.2` on Linux kernels ≥ 6.19, where 8.0.x will not start — SERVER-121912). Details in README "Several checkouts side by side"
+- `WEB_PORT` / `API_PORT` / `MONGO_PORT` / `MAILPIT_SMTP_PORT` / `MAILPIT_UI_PORT` / `COMPOSE_PROJECT_NAME` - Read by `docker compose` from `.env` to publish the container's ports on other **host** ports and keep one checkout's containers and volumes apart from another's. Inside the container the ports never move (4200 and 3000), so `PORT` and `BACKEND_PORT` matter only for a host-side run. `MONGO_TAG` picks the database image (default `8.0.23`; `8.2` on Linux kernels ≥ 6.19, where 8.0.x will not start — SERVER-121912). Details in README "Several checkouts side by side"
 
 ## Database
 

--- a/README.md
+++ b/README.md
@@ -8,39 +8,64 @@ It is a combined curated version of the original blueprintnotincluded web app.
 
 ### Development (Recommended)
 
-For ARM64 Macs and local development with live reloading:
+The whole toolchain — Node, the native build deps for `canvas` and `sharp`,
+MongoDB, Mailpit — is in `.devcontainer/`, so a checkout needs nothing on the
+host but a container runtime. Open the folder in a devcontainer-aware editor
+and it builds itself, or drive it by hand:
 
 ```bash
 # One-time setup: copy environment configuration
 cp .env.sample .env
 
-# Start dependencies only (database + mail)
-./dev-setup.sh
+# Bring the stack up. --env-file is not optional: compose looks for .env
+# beside the compose file, not at the repo root.
+dc() { docker compose --env-file .env -f .devcontainer/docker-compose.yml "$@"; }
+dc up -d
 
-# In separate terminals:
-npm run dev              # Backend with live reloading
-cd frontend && npm start # Frontend with live reloading
+# First run only: install and build, from inside the app container
+dc exec app bash -lc 'npm ci && (cd frontend && npm ci) && npm run build:lib && npm run migrate:up'
 ```
+
+That is the whole setup. `api` and `web` are services, not something you start
+by hand — they poll for `node_modules` and `lib/index.js` and begin serving the
+moment the install above finishes, live-reloading from the bind-mounted source
+after that. `dc logs -f api web` to watch them, `dc restart api` to bounce one.
 
 - **Frontend**: http://localhost:4200 (Angular dev server with API proxy)
 - **Backend API**: http://localhost:3000 (Express with ts-node-dev)
-- **Database**: mongodb://localhost:27017
+- **Database**: mongodb://localhost:27017 (`database:27017` from inside)
 - **Mail testing**: http://localhost:8025 (Mailpit web UI)
+
+`dc exec app bash` is the shell for everything else — tests, migrations, batch
+scripts, `git`, `gh`. The `app` container runs no servers, so nothing you do in
+there disturbs one.
+
+To run the app straight on the host instead — Node 20.19.4 per `.nvmrc` —
+`./dev-setup.sh` starts just the database and mail from the production compose
+file, and `DB_URI` / `SMTP_HOST` in `.env` become `localhost` rather than the
+`database` / `mailhog` service names the sample ships.
 
 ### Several checkouts side by side
 
-Every port is a knob, so two worktrees can run at once on one machine without
-touching each other's database or mail. Per checkout, in `.env`: `PORT` (the
-backend's listen port; links still come from `HOST` / `SITE_URL`), the
-`MONGO_PORT` / `MAILPIT_SMTP_PORT` / `MAILPIT_UI_PORT` trio that `docker
-compose` publishes, `COMPOSE_PROJECT_NAME` so the containers and volumes stay
-apart, and `DB_URI` pointing at that Mongo. The frontend follows
-`BACKEND_PORT=<PORT> npm start -- --port <N>`. Tests read a gitignored
-`.env.test.local` before `.env.test`, so `DB_URI` there points them at the same
-Mongo. `.env.sample` has the block, commented out; the defaults above are what
-you get when it stays that way. One more knob lives beside them: `MONGO_TAG`,
-because the MongoDB 8.0 images refuse to start on Linux kernels 6.19 and
-newer (SERVER-121912) — set it to `8.2` on such a host.
+Every port is a knob, so two checkouts can run at once on one machine without
+touching each other's database or mail. Only the *host* side moves: inside the
+container the backend is always on 3000 and Angular always on 4200, so nothing
+in there has to know which checkout it is.
+
+Per checkout, in `.env`: `WEB_PORT` (the Angular dev server — the one you open),
+`API_PORT`, `MONGO_PORT`, `MAILPIT_SMTP_PORT`, `MAILPIT_UI_PORT`, and
+`COMPOSE_PROJECT_NAME` so the containers and volumes stay apart. `.env.sample`
+has the block, commented out; the defaults above are what you get when it stays
+that way.
+
+Tests read a gitignored `.env.test.local` before `.env.test`, which is how the
+suite is pointed at the container's Mongo (`mongodb://database:27017/
+blueprintnotincluded_test`) rather than the committed `127.0.0.1` default.
+
+Two knobs are about the host rather than the checkout: `MONGO_TAG`, because no
+MongoDB 8.0 image starts on Linux kernels 6.19 and newer (SERVER-121912) — set
+it to `8.2` on such a host — and `PORT` / `BACKEND_PORT`, which matter only if
+you are running the app outside the container on a machine where 3000 is taken.
 
 ### Production Testing
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cp .env.sample .env
 # Bring the stack up. --env-file is not optional: compose looks for .env
 # beside the compose file, not at the repo root.
 dc() { docker compose --env-file .env -f .devcontainer/docker-compose.yml "$@"; }
-dc up -d
+dc up -d          # add --build after editing .devcontainer/Dockerfile
 
 # First run only: install and build, from inside the app container
 dc exec app bash -lc 'npm ci && (cd frontend && npm ci) && npm run build:lib && npm run migrate:up'

--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ cd frontend && npm start # Frontend with live reloading
 - **Database**: mongodb://localhost:27017
 - **Mail testing**: http://localhost:8025 (Mailpit web UI)
 
+### Several checkouts side by side
+
+Every port is a knob, so two worktrees can run at once on one machine without
+touching each other's database or mail. Per checkout, in `.env`: `PORT` (the
+backend's listen port; links still come from `HOST` / `SITE_URL`), the
+`MONGO_PORT` / `MAILPIT_SMTP_PORT` / `MAILPIT_UI_PORT` trio that `docker
+compose` publishes, `COMPOSE_PROJECT_NAME` so the containers and volumes stay
+apart, and `DB_URI` pointing at that Mongo. The frontend follows
+`BACKEND_PORT=<PORT> npm start -- --port <N>`. Tests read a gitignored
+`.env.test.local` before `.env.test`, so `DB_URI` there points them at the same
+Mongo. `.env.sample` has the block, commented out; the defaults above are what
+you get when it stays that way. One more knob lives beside them: `MONGO_TAG`,
+because the MongoDB 8.0 images refuse to start on Linux kernels 6.19 and
+newer (SERVER-121912) — set it to `8.2` on such a host.
+
 ### Production Testing
 
 Test with pre-built images (may require AMD64 emulation on ARM64 Macs):

--- a/__tests__/hooks.ts
+++ b/__tests__/hooks.ts
@@ -7,6 +7,9 @@ import mongoose from 'mongoose';
 // hooks.ts is loaded via .mocharc's `require` entries, before any test file,
 // so DB_URI isn't set yet locally (CI sets it directly as a job env var, but
 // dotenv won't override that either way — it skips already-set keys).
+// .env.test.local (gitignored) first: dotenv keeps the first value it sees, so
+// a per-checkout override (a MongoDB on another port) beats the committed file.
+dotenv.config({ path: path.resolve(__dirname, '../.env.test.local') });
 dotenv.config({ path: path.resolve(__dirname, '../.env.test') });
 process.env.NODE_ENV = 'test';
 

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import { before, after } from 'mocha';
 
 // Load test environment variables before any tests run
+dotenv.config({ path: path.resolve(__dirname, '../.env.test.local') });
 dotenv.config({ path: path.resolve(__dirname, '../.env.test') });
 
 // Set test flag to suppress initialization logs

--- a/app/server.ts
+++ b/app/server.ts
@@ -37,7 +37,9 @@ console.log(
   }`
 );
 
-const PORT = 3000;
+// PORT is a listen port only: links and og:url come from HOST / SITE_URL, so
+// several checkouts can run side by side on one machine (see README).
+const PORT = Number(process.env.PORT) || 3000;
 const server = app.listen(PORT, () => {
   console.log(`Example app listening on port ${PORT}!`);
   startMemoryHeartbeat('api');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,10 @@ services:
       - database
       - mailhog
     ports:
-      - "3000:3000"
+      # Host side parameterised like every other port here: the file claims
+      # several checkouts can run side by side, and a fixed 3000 made the
+      # second one fail on port allocation. The container side never moves.
+      - "${APP_PORT:-3000}:3000"
 
   database:
     # MONGO_TAG: the 8.0 line (8.0.29 checked) refuses to start on Linux

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,19 @@
 # Default: pulls pre-built image from Docker Hub.
 # To build and run from local source instead:
 #   docker compose up --build
+#
+# Several checkouts can run side by side: each one sets COMPOSE_PROJECT_NAME
+# and the *_PORT variables in its own .env (compose reads that file for the
+# ${...} values below). With nothing set you get the classic single-checkout
+# layout — one project, the well-known ports.
+name: ${COMPOSE_PROJECT_NAME:-bpni}
+
 services:
   app:
     image: racefpv/bpni:latest
     build:
       context: .
       dockerfile: deploy.Dockerfile
-    container_name: bpni-prod
     environment:
       - ENV_NAME=development
       - BROWSE_INCREMENT=100
@@ -33,22 +39,24 @@ services:
       - "3000:3000"
 
   database:
-    image: mongo:8.0.23
-    container_name: bpni-mongodb
+    # MONGO_TAG: the 8.0 line (8.0.29 checked) refuses to start on Linux
+    # kernels 6.19 and newer (SERVER-121912); 8.2 does. Set MONGO_TAG=8.2 in
+    # .env on such a host rather than editing the default, which CI shares.
+    image: mongo:${MONGO_TAG:-8.0.23}
     environment:
       - "MONGO_INITDB_DATABASE=blueprintnotincluded"
     volumes:
       - ./mongo/docker-entrypoint-initdb.d/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
       - mongodb_data:/data/db
     ports:
-      - "27017:27017"
+      # Loopback only: nothing on the LAN has business with a dev database.
+      - "127.0.0.1:${MONGO_PORT:-27017}:27017"
 
   mailhog:
     image: axllent/mailpit
-    container_name: bpni-mailhog
     ports:
-      - "1025:1025"
-      - "8025:8025"
+      - "127.0.0.1:${MAILPIT_SMTP_PORT:-1025}:1025"
+      - "127.0.0.1:${MAILPIT_UI_PORT:-8025}:8025"
 
 volumes:
   mongodb_data:

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -90,7 +90,7 @@
           "builder": "@ngx-env/builder:dev-server",
           "options": {
             "buildTarget": "blueprintnotincluded:build",
-            "proxyConfig": "proxy.conf.json"
+            "proxyConfig": "proxy.conf.js"
           },
           "configurations": {
             "production": {
@@ -199,7 +199,7 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
             "buildTarget": "blueprintnotincluded-admin:build:development",
-            "proxyConfig": "proxy.conf.json"
+            "proxyConfig": "proxy.conf.js"
           },
           "configurations": {
             "production": {

--- a/frontend/proxy.conf.js
+++ b/frontend/proxy.conf.js
@@ -1,0 +1,13 @@
+// BACKEND_PORT lets several checkouts run side by side, each with its own
+// backend (`PORT` in the root .env) — `BACKEND_PORT=3001 npm start`. Unset,
+// this is the same proxy the old proxy.conf.json declared.
+const backendPort = process.env.BACKEND_PORT || 3000;
+
+module.exports = {
+  '/api/**': {
+    target: `http://localhost:${backendPort}`,
+    secure: false,
+    logLevel: 'debug',
+    changeOrigin: true,
+  },
+};

--- a/frontend/proxy.conf.js
+++ b/frontend/proxy.conf.js
@@ -1,11 +1,14 @@
-// BACKEND_PORT lets several checkouts run side by side, each with its own
-// backend (`PORT` in the root .env) — `BACKEND_PORT=3001 npm start`. Unset,
-// this is the same proxy the old proxy.conf.json declared.
+// Where the dev server sends /api. BACKEND_HOST and BACKEND_PORT let several
+// checkouts run side by side, each with its own backend, and let the dev
+// server live in a different container from the backend (`BACKEND_HOST=api`,
+// the compose service name). Unset, this is the same proxy the old
+// proxy.conf.json declared.
+const backendHost = process.env.BACKEND_HOST || 'localhost';
 const backendPort = process.env.BACKEND_PORT || 3000;
 
 module.exports = {
   '/api/**': {
-    target: `http://localhost:${backendPort}`,
+    target: `http://${backendHost}:${backendPort}`,
     secure: false,
     logLevel: 'debug',
     changeOrigin: true,

--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -1,8 +1,0 @@
-{
-  "/api/**": {
-    "target": "http://localhost:3000",
-    "secure": false,
-    "logLevel": "debug",
-    "changeOrigin": true
-  }
-}

--- a/scripts/test-db-setup.sh
+++ b/scripts/test-db-setup.sh
@@ -1,26 +1,38 @@
 #!/bin/bash
+# Make sure the MongoDB the tests will use is reachable, starting it when it
+# is not. The tests read DB_URI from the environment, then .env.test.local,
+# then .env.test (see __tests__/hooks.ts) — resolve it the same way here so
+# this script checks the server the tests will actually connect to.
+set -e
 
-# Check if MongoDB is running on port 27017
-if ! nc -z localhost 27017; then
-    echo "MongoDB is not running on localhost:27017"
-    echo "Starting MongoDB via Docker..."
+uri="${DB_URI:-}"
+for f in .env.test.local .env.test; do
+  [ -n "$uri" ] && break
+  [ -f "$f" ] && uri=$(sed -n 's/^DB_URI=//p' "$f" | head -1 | tr -d '"'"'")
+done
+# mongodb://[user:pass@]host[:port]/db → host and port
+hostport=${uri#*://}; hostport=${hostport##*@}; hostport=${hostport%%/*}
+host=${hostport%%:*}; port=${hostport##*:}
+[ "$port" = "$host" ] && port=27017
+host=${host:-localhost}
 
-    # Use docker compose (v2) instead of docker-compose (v1)
-    docker compose up -d mongodb-bpni
-
-    # Wait for MongoDB to be ready
-    echo "Waiting for MongoDB to be ready..."
-    timeout=30
-    while ! nc -z localhost 27017; do
-        timeout=$((timeout - 1))
-        if [ $timeout -eq 0 ]; then
-            echo "Timeout waiting for MongoDB to start"
-            exit 1
-        fi
-        sleep 1
-    done
-
-    echo "MongoDB is ready!"
-else
-    echo "MongoDB is already running on localhost:27017"
+if nc -z "$host" "$port"; then
+    echo "MongoDB is already running on $host:$port"
+    exit 0
 fi
+
+echo "MongoDB is not running on $host:$port"
+echo "Starting MongoDB via Docker..."
+docker compose up -d database
+
+echo "Waiting for MongoDB to be ready..."
+timeout=30
+while ! nc -z "$host" "$port"; do
+    timeout=$((timeout - 1))
+    if [ $timeout -eq 0 ]; then
+        echo "Timeout waiting for MongoDB to start"
+        exit 1
+    fi
+    sleep 1
+done
+echo "MongoDB is ready!"

--- a/scripts/test-db-setup.sh
+++ b/scripts/test-db-setup.sh
@@ -22,6 +22,14 @@ if nc -z "$host" "$port"; then
 fi
 
 echo "MongoDB is not running on $host:$port"
+# Inside the dev container there is no docker, and the database is a sibling
+# service that compose already started — so an unreachable one here is a real
+# fault to report, not something to paper over by starting another.
+if ! command -v docker >/dev/null 2>&1; then
+    echo "No docker client here. If you are in the dev container, the 'database'"
+    echo "service is down or DB_URI ($uri) does not name it."
+    exit 1
+fi
 echo "Starting MongoDB via Docker..."
 docker compose up -d database
 

--- a/scripts/test-db-setup.sh
+++ b/scripts/test-db-setup.sh
@@ -27,7 +27,7 @@ echo "MongoDB is not running on $host:$port"
 # fault to report, not something to paper over by starting another.
 if ! command -v docker >/dev/null 2>&1; then
     echo "No docker client here. If you are in the dev container, the 'database'"
-    echo "service is down or DB_URI ($uri) does not name it."
+    echo "service is down or DB_URI ($host:$port) does not name it."
     exit 1
 fi
 echo "Starting MongoDB via Docker..."


### PR DESCRIPTION
**Safe to merge as is.** Every port keeps its old default and running on the host still works, so a single checkout on the old path (`cp .env.sample .env`, `./dev-setup.sh`, `npm run dev`, `cd frontend && npm start`) sees the same strings it saw before. CI is untouched and still sets `DB_URI` as a job env var, which wins over both dotenv files.

One decision is *flagged*, not blocking (see MongoDB below).

## What this does

Lets several worktrees of this repo run at once on one machine, each with its own database, mail sink and ports — and then moves the toolchain into a container so a checkout needs a container runtime and nothing else. Three commits, in order:

### `b789fca5` — ports as knobs

Everything the dev setup used to assume is now a variable with the old value as its default:

- `app/server.ts` listens on `PORT` (links still come from `HOST` / `SITE_URL`)
- `frontend/proxy.conf.json` → `frontend/proxy.conf.js`; the API target follows `BACKEND_PORT`
- `docker-compose.yml` gains a `name:` (`COMPOSE_PROJECT_NAME`), publishes the database and Mailpit on `MONGO_PORT` / `MAILPIT_SMTP_PORT` / `MAILPIT_UI_PORT` (loopback only), and drops the fixed `container_name`s — those are what made a second checkout collide. **Line endings normalised to LF** (it was the only CRLF file in the repo), so review that file with whitespace ignored; the real diff is ~17 lines
- tests load a gitignored `.env.test.local` before `.env.test`; `scripts/test-db-setup.sh` resolves `DB_URI` the same way. It also now starts the `database` service — the `mongodb-bpni` it referenced never existed in the compose file
- `/log` gitignored for tooling that runs the servers in the background

### `b633810f` — put development in a container

The toolchain was the host's problem and it should not have been. No Node, no fnm, no cairo headers for `canvas`, no MongoDB.

- `.devcontainer/Dockerfile`: node 20.19.4 (matching `.nvmrc` and `engines`) plus the native build deps `canvas` and `sharp` fall back on, `gh`, and Claude Code. Nothing is `COPY`ed in — the source is a bind mount, so the build context is `.devcontainer/` alone rather than a gigabyte of blueprints
- `.devcontainer/docker-compose.yml`: `app` for shells, agents and one-off commands, `api` and `web` for the two dev servers, plus `database` and `mailhog`. The servers being services means restarting one is a compose verb, not a hunt for a pid. They poll for `node_modules/.package-lock.json` and `lib/index.js`, which is what lets `up -d` and `npm ci` happen in either order
- In-container ports never move — 3000 and 4200 — so only the host side of a publish varies between checkouts. `WEB_PORT` / `API_PORT` join the `*_PORT` set and are that host side; `PORT` and `BACKEND_PORT` go back to meaning what they say, a listen port and a proxy target, and sit at 3000 in every checkout's containers. They vary only on the host path, where two checkouts genuinely cannot share a listen port
- `frontend/proxy.conf.js` takes `BACKEND_HOST`, because the dev server and the backend are no longer the same localhost
- `scripts/test-db-setup.sh` says so plainly when there is no docker client to start a database with, instead of failing on `docker: not found`

Single-checkout use is a two-liner: `cp .env.sample .env`, then `docker compose --env-file .env -f .devcontainer/docker-compose.yml up -d` — which builds the image on a cold machine, and takes `--build` after a `.devcontainer/Dockerfile` edit, as `README` says. Running on the host still works and `README` says how.

### `ea3dcd61` — one dev image for the three code services

Without an explicit image name compose tags a copy per service, so `app`, `api` and `web` each got their own and a second checkout rebuilt all three. The image holds no checkout-specific state — the source is a bind mount — so one shared tag is correct, and it makes the second worktree free.

## MongoDB — the flagged decision

No `mongo:8.0.x` image starts on Linux kernels 6.19 and newer (`SERVER-121912`; `8.0.29` checked, it refuses at boot). `8.2` starts. This PR leaves the default at `8.0.23` for parity with CI and the pending prod upgrade, and adds `MONGO_TAG` so a host on a new kernel can set `8.2` in `.env`. Bumping the default and CI together is the alternative; Docker Desktop's VM kernel will cross 6.19 at some point and the Mac path will hit the same wall.

## Verified

On Linux, with podman 4.9.3 / crun 1.14.1:

- Backend suite green **in the container: 1083 passing, 0 failing**. Earlier, on the host path, the same 1083 passed against a Mongo on port 42012 via `.env.test.local`, with nothing listening on 27017 — so it could not have used the old default
- Cold worktree to green preview in one command; warm re-up 29s with installs skipped; restart 12s
- **Two stacks side by side** on host ports 42010 and 42020, each with its own Mongo, Mailpit, backend and Angular dev server: both previews answered 200 with their own branch in `/api/version`, and a document inserted in one Mongo was absent from the other

That last test found and fixed two real bugs in the surrounding tooling (not in this diff): podman wedges a container in `Created` when two stacks come up at once, and seeding keyed on "does the mongo volume exist", which a failed first attempt made a lie.

## Not verified

- The plain single-checkout path on a Mac was not run end to end; it was exercised only through the parameterised path on Linux. The defaults are the same strings as before, but say so rather than imply it
- Frontend `npm test` / `npm run lint` — no frontend source changed, only `proxy.conf.js` and `angular.json`'s pointer to it
- `devcontainer.json` driven by a real devcontainer CLI or VS Code. Plain compose is what runs here, and plain compose ignores that file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmmSaim3iEut5ZtjPbb6S8
