### PR TITLE
fix: gate feedback dialog behind sign-in before typing

### DIFF
--- a/frontend/src/app/module-blueprint/components/dialogs/feedback-dialog/feedback-dialog.component.html
+++ b/frontend/src/app/module-blueprint/components/dialogs/feedback-dialog/feedback-dialog.component.html
@@ -6,7 +6,13 @@
   [breakpoints]="{ '560px': '92vw' }"
   [draggable]="false"
 >
-  <ng-container *ngIf="state !== 'success'">
+  <!-- Sending feedback needs an account (spam guard). Prompt to sign in before
+       the visitor types anything, rather than failing on submit. -->
+  <p *ngIf="!authService.isLoggedIn()" style="margin: 1rem 0">
+    Please sign in to send feedback — it keeps out spam and only takes a moment.
+  </p>
+
+  <ng-container *ngIf="authService.isLoggedIn() && state !== 'success'">
     <textarea
       pTextarea
       [(ngModel)]="message"
@@ -35,7 +41,15 @@
   </p>
 
   <ng-template pTemplate="footer">
-    <ng-container *ngIf="state !== 'success'">
+    <ng-container *ngIf="!authService.isLoggedIn()">
+      <p-button
+        label="Cancel"
+        severity="secondary"
+        (onClick)="visible = false"
+      ></p-button>
+      <p-button label="Sign in" (onClick)="goToLogin()"></p-button>
+    </ng-container>
+    <ng-container *ngIf="authService.isLoggedIn() && state !== 'success'">
       <p-button
         label="Cancel"
         severity="secondary"

--- a/frontend/src/app/module-blueprint/components/dialogs/feedback-dialog/feedback-dialog.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/feedback-dialog/feedback-dialog.component.spec.ts
@@ -1,0 +1,69 @@
+import { of, throwError } from "rxjs";
+
+import { FeedbackDialogComponent } from "./feedback-dialog.component";
+
+describe("FeedbackDialogComponent", () => {
+  let component: FeedbackDialogComponent;
+  let feedbackService: any;
+  let authService: any;
+  let router: any;
+
+  beforeEach(() => {
+    feedbackService = {
+      submit: vi.fn().mockReturnValue(of({ message: "ok" })),
+    };
+    authService = { isLoggedIn: vi.fn().mockReturnValue(true) };
+    router = { navigate: vi.fn() };
+    component = new FeedbackDialogComponent(
+      feedbackService,
+      authService,
+      router,
+    );
+  });
+
+  it("goToLogin closes the dialog and routes to /login", () => {
+    component.visible = true;
+    component.goToLogin();
+    expect(component.visible).toBe(false);
+    expect(router.navigate).toHaveBeenCalledWith(["/login"]);
+  });
+
+  describe("submit when logged out", () => {
+    beforeEach(() => authService.isLoggedIn.mockReturnValue(false));
+
+    it("does not call the feedback service and does not error", () => {
+      component.open();
+      component.message = "some feedback";
+      component.submit();
+      expect(feedbackService.submit).not.toHaveBeenCalled();
+      expect(component.state).toBe("idle");
+    });
+  });
+
+  describe("submit when logged in", () => {
+    it("submits and reaches the success state", () => {
+      component.open();
+      component.message = "great site";
+      component.submit();
+      expect(feedbackService.submit).toHaveBeenCalledWith("great site");
+      expect(component.state).toBe("success");
+    });
+
+    it("reaches the error state when the request fails", () => {
+      feedbackService.submit.mockReturnValue(
+        throwError(() => new Error("boom")),
+      );
+      component.open();
+      component.message = "great site";
+      component.submit();
+      expect(component.state).toBe("error");
+    });
+
+    it("ignores an empty message", () => {
+      component.open();
+      component.message = "   ";
+      component.submit();
+      expect(feedbackService.submit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/app/module-blueprint/components/dialogs/feedback-dialog/feedback-dialog.component.ts
+++ b/frontend/src/app/module-blueprint/components/dialogs/feedback-dialog/feedback-dialog.component.ts
@@ -1,5 +1,7 @@
 import { Component } from "@angular/core";
+import { Router } from "@angular/router";
 import { FeedbackService } from "../../../services/feedback.service";
+import { AuthenticationService } from "../../../services/authentification-service";
 
 type State = "idle" | "submitting" | "success" | "error";
 
@@ -13,7 +15,11 @@ export class FeedbackDialogComponent {
   message = "";
   state: State = "idle";
 
-  constructor(private feedbackService: FeedbackService) {}
+  constructor(
+    private feedbackService: FeedbackService,
+    public authService: AuthenticationService,
+    private router: Router,
+  ) {}
 
   public open() {
     this.visible = true;
@@ -21,7 +27,17 @@ export class FeedbackDialogComponent {
     this.state = "idle";
   }
 
+  // Sending feedback requires an account (the endpoint is JWT-guarded, which is
+  // our spam guard). Rather than let a logged-out visitor type a paragraph and
+  // then fail on submit, the template shows a sign-in prompt instead of the
+  // form — the gate is at open time, before any typing.
+  public goToLogin() {
+    this.visible = false;
+    this.router.navigate(["/login"]);
+  }
+
   public submit() {
+    if (!this.authService.isLoggedIn()) return;
     if (!this.message.trim() || this.state === "submitting") return;
     this.state = "submitting";
     this.feedbackService.submit(this.message).subscribe({


### PR DESCRIPTION
## Problem

A customer reported a red **"Something went wrong. Please try again."** error in the feedback modal and guessed it was because they weren't logged in. They were right.

The feedback API (`POST /api/feedback`) is JWT-guarded — that's our spam guard, and it's correct. But the **UI was not gated to match**:

- The "Send Feedback" menu item has no `visible` guard (`user-menu.component.ts`), and the `<app-user-menu>` itself renders for everyone (only the notification bell beside it is gated on `isLoggedIn()`).
- The dialog posted unconditionally and, on **any** error, showed one generic message — so a logged-out submit's 401 was indistinguishable from a real server error.

Net effect: a logged-out visitor could type a whole message, hit Send, and get a cryptic red error with no hint that they just needed to sign in.

## Fix

Gate the dialog **at open time, before any typing** (rather than failing on submit), so nobody invests effort in a message that will be rejected:

- **Logged out** → the dialog shows a short *"Please sign in to send feedback — it keeps out spam and only takes a moment."* line with a **Sign in** button that routes to `/login`, in place of the textarea.
- **Logged in** → the form, exactly as before.

This mirrors the existing **comment-section** pattern (form when `authService.isLoggedIn()`, sign-in prompt otherwise), so it's consistent with how the site already handles login-required actions.

### Design notes / decisions
- **Backend unchanged.** Requiring an account stays as the spam guard, per the product intent. This PR only fixes the UI/UX mismatch.
- **Button stays always-visible** (per request) — discoverability of the feedback affordance is preserved; the login requirement is surfaced on click, up front.
- **No return-URL round-trip.** Login navigates to `/` as it does everywhere; adding a returnUrl would touch every auth-completion path (password/magic-link/verify) for little gain here. Chose the simpler prompt-before-typing flow.
- **Not implemented (deferred):** preserving a typed draft across a logged-out → sign-in round-trip. Not needed with gate-at-open, but noted as a future enhancement if we ever want to capture impulse feedback from anonymous users.

## Verification
- New `feedback-dialog.component.spec.ts` (5 tests, all passing): logged-out submit is a no-op and stays `idle`; `goToLogin()` closes the dialog and routes to `/login`; logged-in submit reaches `success`; request failure reaches `error`; empty message ignored.
- `cd frontend && npm run lint` — clean.
- Committed via the standard pre-commit hooks (prettier + ng lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)