### PR TITLE
fix(editor): anchor pinch zoom to the fingers, disambiguate touch intent

### DIFF
--- a/__tests__/lib/camera-service.test.ts
+++ b/__tests__/lib/camera-service.test.ts
@@ -1,0 +1,88 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { CameraService, Vector2 } from '../../lib/index';
+
+// Pure camera math — no PIXI needed: the constructor only stores the
+// container reference, and pinchZoom/updateZoom/changeZoom never touch it.
+const makeCamera = () => new CameraService(null);
+
+describe('CameraService.pinchZoom', function () {
+  it('scales currentZoom multiplicatively', function () {
+    const camera = makeCamera();
+    camera.setHardZoom(32);
+    camera.pinchZoom(1.5, new Vector2(100, 100));
+    expect(camera.currentZoom).to.be.closeTo(48, 1e-9);
+  });
+
+  it('keeps the tile under the gesture center fixed (the pinch anchor)', function () {
+    const camera = makeCamera();
+    camera.setHardZoom(32);
+    camera.cameraOffset.x = 3;
+    camera.cameraOffset.y = 7;
+
+    const center = new Vector2(250, 180);
+    const before = camera.getTileCoordsForZoom(center);
+    camera.pinchZoom(1.4, center);
+    const after = camera.getTileCoordsForZoom(center);
+
+    expect(after.x).to.be.closeTo(before.x, 1e-9);
+    expect(after.y).to.be.closeTo(before.y, 1e-9);
+  });
+
+  it('is not fought by the per-frame zoom animation (the pinch-drift regression)', function () {
+    // updateZoom() runs every render frame and eases currentZoom toward
+    // targetZoom around lastZoomCenter. Before the fix, a pinch moved only
+    // currentZoom, so every frame the camera zoomed back toward the stale
+    // target around a stale center — reading as a simultaneous zoom + pan
+    // away from the fingers.
+    const camera = makeCamera();
+    camera.setHardZoom(32);
+    camera.pinchZoom(1.7, new Vector2(300, 200));
+
+    const zoomAfterPinch = camera.currentZoom;
+    const offsetAfterPinch = new Vector2(camera.cameraOffset.x, camera.cameraOffset.y);
+
+    for (let frame = 0; frame < 60; frame++) camera.updateZoom();
+
+    expect(camera.currentZoom).to.equal(zoomAfterPinch);
+    expect(camera.cameraOffset.x).to.equal(offsetAfterPinch.x);
+    expect(camera.cameraOffset.y).to.equal(offsetAfterPinch.y);
+  });
+
+  it('clamps to the wheel zoom range', function () {
+    const minZoom = 16;
+    const maxZoom = 128;
+
+    const camera = makeCamera();
+    camera.setHardZoom(32);
+    camera.pinchZoom(0.01, new Vector2(0, 0));
+    expect(camera.currentZoom).to.equal(minZoom);
+
+    camera.setHardZoom(90);
+    camera.pinchZoom(100, new Vector2(0, 0));
+    expect(camera.currentZoom).to.equal(maxZoom);
+  });
+
+  it('ignores degenerate scales', function () {
+    const camera = makeCamera();
+    camera.setHardZoom(32);
+    for (const scale of [0, -1, NaN, Infinity]) {
+      camera.pinchZoom(scale, new Vector2(0, 0));
+      expect(camera.currentZoom).to.equal(32);
+    }
+  });
+
+  it('re-anchors the wheel/keyboard step index, so the next step is adjacent to the pinched zoom', function () {
+    const camera = makeCamera();
+    camera.setHardZoom(32);
+    // Pinch to 50 px/tile — between the 45 and 54 steps, nearest is 54.
+    camera.pinchZoom(50 / 32, new Vector2(0, 0));
+    expect(camera.currentZoom).to.be.closeTo(50, 1e-9);
+
+    // One wheel step up should ease to 64 (the level above 54), not to
+    // wherever the index sat before the pinch.
+    camera.zoom(1, new Vector2(0, 0));
+    for (let frame = 0; frame < 300; frame++) camera.updateZoom();
+    expect(camera.currentZoom).to.be.closeTo(64, 1e-6);
+  });
+});

--- a/frontend/src/app/module-blueprint/components/component-canvas/component-canvas.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-canvas/component-canvas.component.ts
@@ -556,13 +556,13 @@ export class ComponentCanvasComponent
     this.cameraService.cameraOffset.y +=
       event.panY / this.cameraService.currentZoom;
 
-    if (event.zoomDelta) {
+    if (event.zoomScale && event.zoomScale != 1) {
       const rect = this.canvasRef.nativeElement.getBoundingClientRect();
       const centerPos = new Vector2(
         event.centerClientX - rect.left,
         event.centerClientY - rect.top,
       );
-      this.cameraService.changeZoom(event.zoomDelta, centerPos);
+      this.cameraService.pinchZoom(event.zoomScale, centerPos);
     }
   }
 

--- a/frontend/src/app/module-blueprint/directives/draganddrop.directive.spec.ts
+++ b/frontend/src/app/module-blueprint/directives/draganddrop.directive.spec.ts
@@ -333,8 +333,10 @@ describe("DragAndDropDirective", () => {
     it("never fires the tool at all when the second finger lands before the first committed", () => {
       const downHandler = vi.fn();
       const clickHandler = vi.fn();
+      const stopDragHandler = vi.fn();
       dir.myMouseDown.subscribe(downHandler);
       dir.myMouseClick.subscribe(clickHandler);
+      dir.myMouseStopDrag.subscribe(stopDragHandler);
 
       dir.onPointerDown(
         pointerEvent(0, 10, 10, { pointerId: 1, pointerType: "touch" }),
@@ -349,9 +351,11 @@ describe("DragAndDropDirective", () => {
         pointerEvent(0, 10, 10, { pointerId: 1, pointerType: "touch" }),
       );
 
-      // The first finger of an intended pinch must not place/select anything.
+      // The first finger of an intended pinch must not place/select anything,
+      // and there was no committed drag, so there is nothing to stop either.
       expect(downHandler).not.toHaveBeenCalled();
       expect(clickHandler).not.toHaveBeenCalled();
+      expect(stopDragHandler).not.toHaveBeenCalled();
     });
 
     it("emits myMultiTouchGesture with pan and zoom deltas as the two fingers move", () => {

--- a/frontend/src/app/module-blueprint/directives/draganddrop.directive.spec.ts
+++ b/frontend/src/app/module-blueprint/directives/draganddrop.directive.spec.ts
@@ -72,14 +72,15 @@ describe("DragAndDropDirective", () => {
       expect(dir.isMouseDown[2]).toBe(true);
     });
 
-    it("synthesizes a myMouseMove before myMouseDown for touch, to drive hover/preview state on tap", () => {
+    it("synthesizes a myMouseMove for touch to drive hover/preview, but defers myMouseDown until intent is known", () => {
       const calls: string[] = [];
       dir.myMouseMove.subscribe(() => calls.push("move"));
       dir.myMouseDown.subscribe(() => calls.push("down"));
 
       dir.onPointerDown(pointerEvent(0, 10, 20, { pointerType: "touch" }));
 
-      expect(calls).toEqual(["move", "down"]);
+      // No down yet: this touch could still become a pinch, a drag or a tap.
+      expect(calls).toEqual(["move"]);
     });
 
     it("does not synthesize myMouseMove for a real mouse press", () => {
@@ -136,9 +137,11 @@ describe("DragAndDropDirective", () => {
       expect(handler).toHaveBeenCalled();
     });
 
-    it("a tap (touch down+up at same tile) fires a click, matching the tap-to-place flow", () => {
-      const clickHandler = vi.fn();
-      dir.myMouseClick.subscribe(clickHandler);
+    it("a tap (touch down+up at same tile) fires down/click/up, matching the tap-to-place flow", () => {
+      const calls: string[] = [];
+      dir.myMouseDown.subscribe(() => calls.push("down"));
+      dir.myMouseClick.subscribe(() => calls.push("click"));
+      dir.myMouseUp.subscribe(() => calls.push("up"));
 
       const id = nextPointerId++;
       dir.onPointerDown(
@@ -148,7 +151,105 @@ describe("DragAndDropDirective", () => {
         pointerEvent(0, 30, 40, { pointerId: id, pointerType: "touch" }),
       );
 
+      expect(calls).toEqual(["down", "click", "up"]);
+    });
+
+    it("a touch tap still clicks when the finger jitters a few px, unlike the mouse's exact-position rule", () => {
+      const clickHandler = vi.fn();
+      dir.myMouseClick.subscribe(clickHandler);
+
+      const id = nextPointerId++;
+      dir.onPointerDown(
+        pointerEvent(0, 30, 40, { pointerId: id, pointerType: "touch" }),
+      );
+      dir.onPointerMove(
+        pointerEvent(0, 33, 42, { pointerId: id, pointerType: "touch" }),
+      );
+      dir.onPointerUp(
+        pointerEvent(0, 33, 42, { pointerId: id, pointerType: "touch" }),
+      );
+
       expect(clickHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it("a cancelled pending touch fires neither down nor click", () => {
+      const downHandler = vi.fn();
+      const clickHandler = vi.fn();
+      dir.myMouseDown.subscribe(downHandler);
+      dir.myMouseClick.subscribe(clickHandler);
+
+      const id = nextPointerId++;
+      dir.onPointerDown(
+        pointerEvent(0, 30, 40, { pointerId: id, pointerType: "touch" }),
+      );
+      dir.onPointerCancel(
+        pointerEvent(0, 30, 40, { pointerId: id, pointerType: "touch" }),
+      );
+
+      expect(downHandler).not.toHaveBeenCalled();
+      expect(clickHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("single-touch drag commitment", () => {
+    it("stays in hover mode within the slop radius", () => {
+      const moveHandler = vi.fn();
+      const dragHandler = vi.fn();
+      dir.myMouseMove.subscribe(moveHandler);
+      dir.myMouseDrag.subscribe(dragHandler);
+
+      const id = nextPointerId++;
+      dir.onPointerDown(
+        pointerEvent(0, 100, 100, { pointerId: id, pointerType: "touch" }),
+      );
+      dir.onPointerMove(
+        pointerEvent(0, 104, 103, { pointerId: id, pointerType: "touch" }),
+      );
+
+      expect(dragHandler).not.toHaveBeenCalled();
+      expect(moveHandler).toHaveBeenCalled();
+    });
+
+    it("commits to a drag past the slop, firing myMouseDown at the original touch point first", () => {
+      const downEvents: any[] = [];
+      const dragHandler = vi.fn();
+      dir.myMouseDown.subscribe((e: any) => downEvents.push(e));
+      dir.myMouseDrag.subscribe(dragHandler);
+
+      const id = nextPointerId++;
+      dir.onPointerDown(
+        pointerEvent(0, 100, 100, { pointerId: id, pointerType: "touch" }),
+      );
+      dir.onPointerMove(
+        pointerEvent(0, 130, 100, { pointerId: id, pointerType: "touch" }),
+      );
+
+      expect(downEvents.length).toBe(1);
+      expect(downEvents[0].clientX).toBe(100);
+      expect(downEvents[0].clientY).toBe(100);
+      expect(dragHandler).toHaveBeenCalled();
+      // The committing move itself is the drag's first step, measured from
+      // the original touch point.
+      const dragEvent = dragHandler.mock.calls.at(-1)![0];
+      expect(dragEvent.dragX).toBe(30);
+    });
+
+    it("does not fire a click when a committed drag ends", () => {
+      const clickHandler = vi.fn();
+      dir.myMouseClick.subscribe(clickHandler);
+
+      const id = nextPointerId++;
+      dir.onPointerDown(
+        pointerEvent(0, 100, 100, { pointerId: id, pointerType: "touch" }),
+      );
+      dir.onPointerMove(
+        pointerEvent(0, 150, 100, { pointerId: id, pointerType: "touch" }),
+      );
+      dir.onPointerUp(
+        pointerEvent(0, 150, 100, { pointerId: id, pointerType: "touch" }),
+      );
+
+      expect(clickHandler).not.toHaveBeenCalled();
     });
   });
 
@@ -216,6 +317,10 @@ describe("DragAndDropDirective", () => {
       dir.onPointerDown(
         pointerEvent(0, 10, 10, { pointerId: 1, pointerType: "touch" }),
       );
+      // First finger committed to a drag before the second finger lands.
+      dir.onPointerMove(
+        pointerEvent(0, 40, 10, { pointerId: 1, pointerType: "touch" }),
+      );
       dir.onPointerDown(
         pointerEvent(0, 50, 10, { pointerId: 2, pointerType: "touch" }),
       );
@@ -223,6 +328,30 @@ describe("DragAndDropDirective", () => {
       expect(stopDragHandler).toHaveBeenCalled();
       expect(clickHandler).not.toHaveBeenCalled();
       expect(dir.isMouseDown[0]).toBe(false);
+    });
+
+    it("never fires the tool at all when the second finger lands before the first committed", () => {
+      const downHandler = vi.fn();
+      const clickHandler = vi.fn();
+      dir.myMouseDown.subscribe(downHandler);
+      dir.myMouseClick.subscribe(clickHandler);
+
+      dir.onPointerDown(
+        pointerEvent(0, 10, 10, { pointerId: 1, pointerType: "touch" }),
+      );
+      dir.onPointerDown(
+        pointerEvent(0, 50, 10, { pointerId: 2, pointerType: "touch" }),
+      );
+      dir.onPointerUp(
+        pointerEvent(0, 50, 10, { pointerId: 2, pointerType: "touch" }),
+      );
+      dir.onPointerUp(
+        pointerEvent(0, 10, 10, { pointerId: 1, pointerType: "touch" }),
+      );
+
+      // The first finger of an intended pinch must not place/select anything.
+      expect(downHandler).not.toHaveBeenCalled();
+      expect(clickHandler).not.toHaveBeenCalled();
     });
 
     it("emits myMultiTouchGesture with pan and zoom deltas as the two fingers move", () => {
@@ -247,7 +376,28 @@ describe("DragAndDropDirective", () => {
       expect(gestureHandler).toHaveBeenCalled();
       const lastEvent = gestureHandler.mock.calls.at(-1)![0];
       expect(lastEvent.panX).toBeGreaterThan(0);
-      expect(lastEvent.zoomDelta).toBeGreaterThan(0);
+      expect(lastEvent.zoomScale).toBeGreaterThan(1);
+    });
+
+    it("emits the zoom as the ratio of finger separations, with the midpoint as center", () => {
+      const gestureHandler = vi.fn();
+      dir.myMultiTouchGesture.subscribe(gestureHandler);
+
+      dir.onPointerDown(
+        pointerEvent(0, 0, 0, { pointerId: 1, pointerType: "touch" }),
+      );
+      dir.onPointerDown(
+        pointerEvent(0, 100, 0, { pointerId: 2, pointerType: "touch" }),
+      );
+      // Finger 2 spreads from 100px separation to 150px.
+      dir.onPointerMove(
+        pointerEvent(0, 150, 0, { pointerId: 2, pointerType: "touch" }),
+      );
+
+      const lastEvent = gestureHandler.mock.calls.at(-1)![0];
+      expect(lastEvent.zoomScale).toBeCloseTo(1.5);
+      expect(lastEvent.centerClientX).toBe(75);
+      expect(lastEvent.centerClientY).toBe(0);
     });
 
     it("does not emit myMouseClick/myMouseUp for a finger lifted while gesturing", () => {
@@ -270,7 +420,7 @@ describe("DragAndDropDirective", () => {
       expect(upHandler).not.toHaveBeenCalled();
     });
 
-    it("lets the user keep dragging with the remaining finger after the pinch ends", () => {
+    it("keeps the remaining finger inert after the pinch ends — it was zooming, not aiming", () => {
       dir.onPointerDown(
         pointerEvent(0, 0, 0, { pointerId: 1, pointerType: "touch" }),
       );
@@ -281,14 +431,52 @@ describe("DragAndDropDirective", () => {
         pointerEvent(0, 100, 0, { pointerId: 2, pointerType: "touch" }),
       );
 
-      expect(dir.isMouseDown[0]).toBe(true);
+      expect(dir.isMouseDown[0]).toBe(false);
 
       const dragHandler = vi.fn();
+      const clickHandler = vi.fn();
+      const moveHandler = vi.fn();
       dir.myMouseDrag.subscribe(dragHandler);
+      dir.myMouseClick.subscribe(clickHandler);
+      dir.myMouseMove.subscribe(moveHandler);
+
       dir.onPointerMove(
         pointerEvent(0, 20, 0, { pointerId: 1, pointerType: "touch" }),
       );
-      expect(dragHandler).toHaveBeenCalled();
+      dir.onPointerUp(
+        pointerEvent(0, 20, 0, { pointerId: 1, pointerType: "touch" }),
+      );
+
+      expect(dragHandler).not.toHaveBeenCalled();
+      expect(clickHandler).not.toHaveBeenCalled();
+      // It still hovers, so the ghost/preview tracks it.
+      expect(moveHandler).toHaveBeenCalled();
+    });
+
+    it("a fresh touch after an inert finger lifts interacts normally again", () => {
+      dir.onPointerDown(
+        pointerEvent(0, 0, 0, { pointerId: 1, pointerType: "touch" }),
+      );
+      dir.onPointerDown(
+        pointerEvent(0, 100, 0, { pointerId: 2, pointerType: "touch" }),
+      );
+      dir.onPointerUp(
+        pointerEvent(0, 100, 0, { pointerId: 2, pointerType: "touch" }),
+      );
+      dir.onPointerUp(
+        pointerEvent(0, 0, 0, { pointerId: 1, pointerType: "touch" }),
+      );
+
+      const clickHandler = vi.fn();
+      dir.myMouseClick.subscribe(clickHandler);
+      dir.onPointerDown(
+        pointerEvent(0, 30, 40, { pointerId: 1, pointerType: "touch" }),
+      );
+      dir.onPointerUp(
+        pointerEvent(0, 30, 40, { pointerId: 1, pointerType: "touch" }),
+      );
+
+      expect(clickHandler).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/frontend/src/app/module-blueprint/directives/draganddrop.directive.ts
+++ b/frontend/src/app/module-blueprint/directives/draganddrop.directive.ts
@@ -82,8 +82,10 @@ export class DragAndDropDirective {
       // discarded (it was the start of this gesture, not a tap), any
       // committed drag stops here (without registering as a click), and we
       // switch to interpreting further movement as a pan/zoom gesture.
+      // stopDrag only fires if a drag actually committed - an uncommitted
+      // touch never reached the tool, so there is nothing to stop.
       this.pendingTouchDown = null;
-      this.stopDrag(event, 0);
+      if (this.isMouseDown[0]) this.stopDrag(event, 0);
       this.gestureActive = true;
       this.primeGestureBaseline();
       if (event.preventDefault) event.preventDefault();

--- a/frontend/src/app/module-blueprint/directives/draganddrop.directive.ts
+++ b/frontend/src/app/module-blueprint/directives/draganddrop.directive.ts
@@ -7,9 +7,10 @@ import {
 } from "@angular/core";
 import { Vector2 } from "../../../../../lib/index";
 
-// How much a two-finger pinch (in screen px of finger separation) changes
-// CameraService.currentZoom (in px/tile). Lower = less sensitive pinch.
-const PINCH_ZOOM_SENSITIVITY = 0.5;
+// How far (screen px) a single touch may wander and still count as a tap.
+// Fingers never hold a pixel-exact position, so tap detection needs slop;
+// past it, the touch commits to a drag and drives the active tool.
+const TOUCH_DRAG_SLOP_PX = 8;
 
 @Directive({
   selector: "[appDragAndDrop]",
@@ -39,6 +40,19 @@ export class DragAndDropDirective {
   private gestureLastDistance: number = 0;
   private gestureLastMidpoint: Vector2 | null = null;
 
+  // A touch-down is deferred until we know its intent: a second finger makes
+  // it a pan/zoom gesture (no tool action at all), movement past the slop
+  // makes it a drag (myMouseDown fires then, at the original touch point),
+  // and lifting within the slop makes it a tap (down+click+up fire together).
+  // Without this, the first finger of an intended pinch already fired the
+  // active tool — placing a building the user only meant to zoom past.
+  private pendingTouchDown: any = null;
+
+  // After a two-finger gesture ends, a finger still on the screen is inert:
+  // it can no longer drag or tap (it was zooming, not aiming), it only
+  // hovers. Interaction resumes on the next fresh touch.
+  private inertTouchIds: Set<number> = new Set();
+
   constructor(private el: ElementRef) {
     this.isMouseDown = [];
     this.lastDragPosition = [];
@@ -64,9 +78,11 @@ export class DragAndDropDirective {
     }
 
     if (this.activePointers.size == 2) {
-      // A second finger just touched down: whatever single-pointer drag was
-      // in progress stops here (without registering as a click), and we
+      // A second finger just touched down: a still-pending first touch is
+      // discarded (it was the start of this gesture, not a tap), any
+      // committed drag stops here (without registering as a click), and we
       // switch to interpreting further movement as a pan/zoom gesture.
+      this.pendingTouchDown = null;
       this.stopDrag(event, 0);
       this.gestureActive = true;
       this.primeGestureBaseline();
@@ -79,11 +95,16 @@ export class DragAndDropDirective {
       return;
     }
 
-    // Touch has no hover state distinct from touching, so synthesize one
-    // hover event at touch-down. This drives the build tool's placement
-    // preview/validity check before the matching touch-up fires the tap.
     if (event.pointerType === "touch") {
+      this.inertTouchIds.delete(event.pointerId);
+      // Touch has no hover state distinct from touching, so synthesize one
+      // hover event at touch-down. This drives the build tool's placement
+      // preview/validity check before anything commits.
       this.myMouseMove.emit(event);
+      // Intent unknown yet — hold the down event, fire nothing else.
+      this.pendingTouchDown = event;
+      if (event.preventDefault) event.preventDefault();
+      return;
     }
 
     const dragButton: number = event.button;
@@ -125,18 +146,29 @@ export class DragAndDropDirective {
       this.gestureActive = false;
       this.gestureLastMidpoint = null;
 
-      if (this.activePointers.size == 1) {
-        // One finger is still down after the pinch ends: let the user keep
-        // dragging with it, but re-baseline drag tracking to that finger's
-        // current position so it doesn't jump.
-        const remaining = this.activePointers.values().next().value as Vector2;
-        this.isMouseDown[0] = true;
-        this.startDragPosition[0] = new Vector2(remaining.x, remaining.y);
-        this.lastDragPosition[0] = new Vector2(remaining.x, remaining.y);
-      } else {
-        this.isMouseDown[0] = false;
-        this.startDragPosition[0] = null;
-        this.lastDragPosition[0] = null;
+      // A finger still down after the pinch ends is inert until lifted: it
+      // was zooming, not aiming, so letting it drag or tap the active tool
+      // would edit the blueprint by accident.
+      for (const id of this.activePointers.keys()) this.inertTouchIds.add(id);
+      this.isMouseDown[0] = false;
+      this.startDragPosition[0] = null;
+      this.lastDragPosition[0] = null;
+      return;
+    }
+
+    if (this.inertTouchIds.delete(event.pointerId)) return;
+
+    if (this.pendingTouchDown?.pointerId === event.pointerId) {
+      // The touch never left the slop radius: it's a tap. Fire the full
+      // down/click/up sequence a desktop click produces, with the down at
+      // the original touch point.
+      const down = this.pendingTouchDown;
+      this.pendingTouchDown = null;
+      if (allowClick) {
+        this.myMouseDown.emit(down);
+        this.myMouseClick.emit(event);
+        this.myMouseUp.emit(event);
+        this.stopDrag(event, 0);
       }
       return;
     }
@@ -178,6 +210,33 @@ export class DragAndDropDirective {
     if (this.gestureActive) {
       this.handleGestureMove(event);
       return;
+    }
+
+    if (this.inertTouchIds.has(event.pointerId)) {
+      this.myMouseMove.emit(event);
+      return;
+    }
+
+    if (this.pendingTouchDown?.pointerId === event.pointerId) {
+      const moved = Math.hypot(
+        event.clientX - this.pendingTouchDown.clientX,
+        event.clientY - this.pendingTouchDown.clientY,
+      );
+      if (moved <= TOUCH_DRAG_SLOP_PX) {
+        // Still ambiguous between tap and drag — keep hovering so the
+        // placement ghost tracks the finger.
+        this.myMouseMove.emit(event);
+        return;
+      }
+      // Left the slop radius: commit to a drag, anchored at the original
+      // touch point so the whole movement counts, then let this move flow
+      // into the ordinary drag path below.
+      const down = this.pendingTouchDown;
+      this.pendingTouchDown = null;
+      this.myMouseDown.emit(down);
+      this.isMouseDown[0] = true;
+      this.startDragPosition[0] = new Vector2(down.clientX, down.clientY);
+      this.lastDragPosition[0] = new Vector2(down.clientX, down.clientY);
     }
 
     let isDragging = false;
@@ -229,8 +288,12 @@ export class DragAndDropDirective {
 
     event.panX = midpoint.x - this.gestureLastMidpoint.x;
     event.panY = midpoint.y - this.gestureLastMidpoint.y;
-    event.zoomDelta =
-      (distance - this.gestureLastDistance) * PINCH_ZOOM_SENSITIVITY;
+    // Multiplicative: the camera scales by the same ratio the finger
+    // separation changed by, which is what keeps the content glued to the
+    // fingers (an additive px/tile delta felt wildly different at 16 vs 128
+    // px/tile, and never matched the finger motion at either).
+    event.zoomScale =
+      this.gestureLastDistance > 1 ? distance / this.gestureLastDistance : 1;
     event.centerClientX = midpoint.x;
     event.centerClientY = midpoint.y;
 

--- a/lib/src/drawing/camera-service.d.ts
+++ b/lib/src/drawing/camera-service.d.ts
@@ -46,6 +46,8 @@ export declare class CameraService {
     private currentZoomIndex;
     zoom(delta: number, zoomCenter: Vector2): void;
     setHardZoom(zoomLevel: number): void;
+    private syncZoomIndexToCurrent;
+    pinchZoom(scale: number, zoomCenter: Vector2): void;
     changeZoom(zoomDelta: number, zoomCenter: Vector2): void;
     getTileCoordsForZoom(screenCoords: Vector2): Vector2;
     getTileCoords(cursorPosition: Vector2): Vector2;

--- a/lib/src/drawing/camera-service.ts
+++ b/lib/src/drawing/camera-service.ts
@@ -193,15 +193,42 @@ export class CameraService {
 
   setHardZoom(zoomLevel: number) {
     this.targetZoom = this.currentZoom = zoomLevel;
+    this.syncZoomIndexToCurrent();
+  }
 
+  // Keeps the wheel/keyboard zoom-step index pointing at the level nearest
+  // currentZoom, so stepping after a continuous (pinch/hard) zoom moves to an
+  // adjacent level instead of jumping to wherever the index last was.
+  private syncZoomIndexToCurrent() {
     let zoomLevelDif = -1;
     for (let zoomLevelIndex = 0; zoomLevelIndex < this.zoomLevels.length; zoomLevelIndex++) {
-      let dif = Math.abs(zoomLevel - this.zoomLevels[zoomLevelIndex]);
+      let dif = Math.abs(this.currentZoom - this.zoomLevels[zoomLevelIndex]);
       if (zoomLevelDif == -1 || dif < zoomLevelDif) {
         this.currentZoomIndex = zoomLevelIndex;
         zoomLevelDif = dif;
       }
     }
+  }
+
+  // Direct-manipulation zoom for a touch pinch: multiplicative (a 2x finger
+  // spread doubles px/tile at any zoom level), clamped to the wheel zoom's
+  // range, and applied immediately with no easing. Syncing targetZoom is the
+  // load-bearing part: updateZoom() runs every frame and eases currentZoom
+  // toward targetZoom around lastZoomCenter, so a pinch that moved only
+  // currentZoom would be fought each frame by an animation anchored at a
+  // stale center — which reads as the view zooming AND panning away from
+  // the fingers.
+  pinchZoom(scale: number, zoomCenter: Vector2) {
+    if (!isFinite(scale) || scale <= 0) return;
+
+    const minZoom = this.zoomLevels[0];
+    const maxZoom = this.zoomLevels[this.zoomLevels.length - 1];
+    const newZoom = Math.min(maxZoom, Math.max(minZoom, this.currentZoom * scale));
+
+    this.changeZoom(newZoom - this.currentZoom, zoomCenter);
+    this.targetZoom = this.currentZoom;
+    this.lastZoomCenter = zoomCenter;
+    this.syncZoomIndexToCurrent();
   }
 
   changeZoom(zoomDelta: number, zoomCenter: Vector2) {


### PR DESCRIPTION
## What shipped

Fixes the mobile-editor gesture regressions from the touch-input foundation (af24de14), chiefly the pinch-to-zoom that felt like a simultaneous zoom **and** pan.

### The pinch drift, root-caused

`updateZoom()` runs every render frame and eases `currentZoom` toward `targetZoom`, anchored at `lastZoomCenter`. The pinch path called `changeZoom()` directly, which moved `currentZoom` but left `targetZoom` and `lastZoomCenter` stale (the last wheel-zoom position — or the origin if you never wheel-zoomed). So every frame of a pinch, the wheel-zoom animation zoomed the view *back* around a different anchor than the fingers. Two zooms with different centers fighting = the perceived zoom+pan.

New `CameraService.pinchZoom(scale, center)` treats pinch as direct manipulation:
- **Multiplicative** — camera scales by the finger-separation ratio, which is what keeps content glued to the fingers at every zoom level. The old additive `(Δdistance × 0.5) px/tile` could never match finger motion, and felt 8× more sensitive at min zoom than max.
- **Syncs `targetZoom` + `lastZoomCenter`** so the per-frame animation has nothing to ease (the actual drift fix).
- **Clamped to the wheel range (16–128 px/tile)** — the old path had no clamp and could drive zoom through zero into negative/NaN territory.
- **Re-anchors the wheel step index**, so a wheel/keyboard zoom after a pinch steps to an adjacent level instead of jumping to wherever the index sat pre-pinch.

### Related touch fixes (same event flow, found while in there)

- **A touch-down no longer fires the active tool immediately.** Intent is disambiguated first: past an 8px slop it commits as a drag (`myMouseDown` at the original touch point), lifted within the slop it's a tap (down/click/up together), and a second finger landing makes it a pure pan/zoom gesture that fires the tool **not at all**. Before, the first finger of an intended pinch already placed a building via the build tool's `mouseDown`.
- **Taps use the slop radius** instead of the mouse's exact-pixel-equality click rule, so real fingers (which always jitter) select/place reliably.
- **A finger still down when a pinch ends is now inert until lifted** — it was zooming, not aiming. Previously it kept driving the tool as a drag, which could paint buildings right after a zoom. This deliberately reverses a behavior the original commit chose; noted as a design decision.

Mouse and pen behavior is unchanged — the deferral applies only to `pointerType === "touch"`.

## Verification

- New `__tests__/lib/camera-service.test.ts` (6 tests): multiplicative scaling, anchor invariance (tile under the gesture center is fixed), **no drift across 60 `updateZoom()` frames after a pinch** (the regression mechanism itself), range clamping, degenerate-scale guards, step-index re-anchoring via the public API.
- Directive spec grown to 31 tests: tap-with-jitter clicks, slop hover vs drag commitment, pinch-fires-no-tool, inert trailing finger, cancel handling, zoom-scale ratio/center emission.
- Full suites green: backend 1089 passing, frontend 1258 passing; `npm run tsc` and frontend lint clean.
- **Not verified on a device** — this container has no browser or docker socket, so no Playwright pass like af24de14 had. Worth a quick phone check of pinch feel (especially the 8px slop and the inert-finger choice) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3F7aNrVLEuqHcuZGo5FEs