### PR TITLE
feat: copy blueprint to clipboard as a share-string

### DIFF
--- a/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-blueprint-parent/component-blueprint-parent.component.ts
@@ -379,6 +379,8 @@ export class ComponentBlueprintParentComponent
       this.saveBlueprint();
     else if (menuCommand.type == MenuCommandType.exportBlueprint)
       this.exportBlueprint();
+    else if (menuCommand.type == MenuCommandType.exportBlueprintText)
+      this.copyBlueprintText();
     // Technical (repack, generate solid sprites, etc)
     else if (menuCommand.type == MenuCommandType.fetchIcons)
       this.canvas.fetchIcons();
@@ -510,6 +512,41 @@ export class ComponentBlueprintParentComponent
       // unedited import; otherwise generates from the parsed model
       this.blueprintService.exportBlueprintFile(friendlyname);
     }
+  }
+
+  // Copies the mod's share-string to the clipboard — the inverse of
+  // "Upload → Blueprint (paste text)". Needs no dialog: there is nothing for
+  // the user to type, unlike the paste side.
+  copyBlueprintText() {
+    if (this.blueprintService.blueprint.blueprintItems.length == 0) {
+      this.messageService.add({
+        severity: "error",
+        summary: $localize`Empty blueprint`,
+        detail: $localize`Add some buildings before trying to save`,
+      });
+      return;
+    }
+
+    let friendlyname = "new blueprint";
+    if (this.blueprintService.name != undefined)
+      friendlyname = this.blueprintService.name;
+
+    this.blueprintService
+      .copyBlueprintShareString(friendlyname)
+      .then(() => {
+        this.messageService.add({
+          severity: "success",
+          summary: $localize`Blueprint copied`,
+          detail: $localize`Paste it into the game with the BlueprintsV2 mod`,
+        });
+      })
+      .catch(() => {
+        this.messageService.add({
+          severity: "error",
+          summary: $localize`Could not copy blueprint`,
+          detail: $localize`Your browser did not allow writing to the clipboard`,
+        });
+      });
   }
 
   updateThumbnail() {

--- a/frontend/src/app/module-blueprint/components/component-menu/component-menu.component.ts
+++ b/frontend/src/app/module-blueprint/components/component-menu/component-menu.component.ts
@@ -263,6 +263,15 @@ export class ComponentMenuComponent
                   });
                 },
               },
+              {
+                label: $localize`Blueprint (copy text)`,
+                command: (_event: any) => {
+                  this.menuCommand.emit({
+                    type: MenuCommandType.exportBlueprintText,
+                    data: null,
+                  });
+                },
+              },
             ],
           },
           {
@@ -503,6 +512,7 @@ export enum MenuCommandType {
   getShareableUrl,
   exportImages,
   exportBlueprint,
+  exportBlueprintText,
 
   fetchIcons,
   downloadIcons,

--- a/frontend/src/app/module-blueprint/services/blueprint-service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.spec.ts
@@ -1018,6 +1018,74 @@ describe("BlueprintService", () => {
       );
     });
 
+    // Safari only honours a clipboard write started inside the user gesture,
+    // so where write()/ClipboardItem exist the still-pending encode promise is
+    // handed over rather than awaited first.
+    it("hands write() a promise-backed ClipboardItem when supported", async () => {
+      const captured: any[] = [];
+      (globalThis as any).ClipboardItem = class {
+        constructor(public items: Record<string, Promise<Blob>>) {
+          captured.push(items);
+        }
+      };
+      const write = vi.fn(async () => {});
+      const writeTextSpy = vi.fn(async (_text: string) => {});
+      Object.defineProperty(navigator, "clipboard", {
+        value: { write, writeText: writeTextSpy },
+        configurable: true,
+      });
+
+      await service.copyBlueprintShareString("Gesture");
+
+      expect(write).toHaveBeenCalled();
+      expect(writeTextSpy).not.toHaveBeenCalled();
+      const blob = await captured[0]["text/plain"];
+      const decoded = await decodeBniShareString(await blob.text());
+      expect(JSON.parse(decoded).friendlyname).toBe("Gesture");
+
+      delete (globalThis as any).ClipboardItem;
+    });
+
+    it("falls back to writeText when write() rejects", async () => {
+      (globalThis as any).ClipboardItem = class {
+        constructor(public items: any) {}
+      };
+      const write = vi.fn(async () => {
+        throw new Error("promise-backed items unsupported");
+      });
+      const writeTextSpy = vi.fn(async (_text: string) => {});
+      Object.defineProperty(navigator, "clipboard", {
+        value: { write, writeText: writeTextSpy },
+        configurable: true,
+      });
+
+      await service.copyBlueprintShareString("Fallback");
+
+      expect(writeTextSpy).toHaveBeenCalled();
+      const decoded = await decodeBniShareString(writeTextSpy.mock.calls[0][0]);
+      expect(JSON.parse(decoded).friendlyname).toBe("Fallback");
+
+      delete (globalThis as any).ClipboardItem;
+    });
+
+    // The beacon must credit the blueprint that was serialized, not whatever
+    // is open by the time the async clipboard write resolves.
+    it("counts the download against the blueprint that was copied", async () => {
+      setClipboard(vi.fn(async () => {}));
+      mockHttp.post.mockReturnValue(of({}));
+      service.id = "original";
+
+      const pending = service.copyBlueprintShareString("T");
+      service.id = "opened-something-else";
+      await pending;
+
+      expect(mockHttp.post).toHaveBeenCalledWith(
+        "/api/blueprints/original/downloads",
+        {},
+        expect.anything(),
+      );
+    });
+
     it("rejects when the clipboard API is unavailable", async () => {
       setClipboard(undefined);
 

--- a/frontend/src/app/module-blueprint/services/blueprint-service.spec.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.spec.ts
@@ -1,5 +1,5 @@
 import { BlueprintService, BlueprintFileType } from "./blueprint-service";
-import { Blueprint } from "../../../../../lib/index";
+import { Blueprint, decodeBniShareString } from "../../../../../lib/index";
 import { of, throwError } from "rxjs";
 
 describe("BlueprintService", () => {
@@ -969,6 +969,80 @@ describe("BlueprintService", () => {
       expect(saveSpy).toHaveBeenCalledWith(
         expect.stringContaining("friendlyname"),
         "Fresh.blueprint",
+      );
+    });
+  });
+
+  describe("copyBlueprintShareString()", () => {
+    let writeText: any;
+
+    const setClipboard = (impl: any) => {
+      writeText = impl;
+      Object.defineProperty(navigator, "clipboard", {
+        value: impl == null ? undefined : { writeText: impl },
+        configurable: true,
+      });
+    };
+
+    afterEach(() => {
+      setClipboard(undefined);
+      vi.restoreAllMocks();
+    });
+
+    it("writes a share string the import path can read back", async () => {
+      setClipboard(vi.fn(async () => {}));
+
+      await service.copyBlueprintShareString("Round Trip");
+
+      const written = writeText.mock.calls[0][0];
+      expect(typeof written).toBe("string");
+      expect(JSON.parse(await decodeBniShareString(written)).friendlyname).toBe(
+        "Round Trip",
+      );
+    });
+
+    // Renaming does not invalidate rawSource (the freshness check compares
+    // toMdbBlueprint(), which carries no name), so serving the held raw text
+    // would paste the old name back into the game.
+    it("regenerates rather than serving the held raw import", async () => {
+      setClipboard(vi.fn(async () => {}));
+      await service.openBlueprintFromShareString(
+        JSON.stringify({ friendlyname: "Old Name", buildings: [] }),
+      );
+
+      await service.copyBlueprintShareString("New Name");
+
+      const written = writeText.mock.calls[0][0];
+      expect(JSON.parse(await decodeBniShareString(written)).friendlyname).toBe(
+        "New Name",
+      );
+    });
+
+    it("rejects when the clipboard API is unavailable", async () => {
+      setClipboard(undefined);
+
+      await expect(service.copyBlueprintShareString("T")).rejects.toThrow();
+    });
+
+    it("does not count a download when the blueprint is unsaved", async () => {
+      setClipboard(vi.fn(async () => {}));
+
+      await service.copyBlueprintShareString("T");
+
+      expect(mockHttp.post).not.toHaveBeenCalled();
+    });
+
+    it("counts a download for a saved blueprint", async () => {
+      setClipboard(vi.fn(async () => {}));
+      mockHttp.post.mockReturnValue(of({}));
+      service.id = "abc123";
+
+      await service.copyBlueprintShareString("T");
+
+      expect(mockHttp.post).toHaveBeenCalledWith(
+        "/api/blueprints/abc123/downloads",
+        {},
+        expect.anything(),
       );
     });
   });

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -590,18 +590,51 @@ export class BlueprintService implements IObsBlueprintChange {
   async copyBlueprintShareString(friendlyName: string) {
     // Checked before encoding: absent outside a secure context, and there is
     // no point gzipping a blueprint we cannot deliver.
-    if (!navigator.clipboard?.writeText)
-      throw new Error("Clipboard API unavailable");
+    const clipboard = navigator.clipboard;
+    if (!clipboard) throw new Error("Clipboard API unavailable");
 
+    // Snapshotted before the awaits below: the beacon must credit the
+    // blueprint we serialized, not whatever happens to be open by the time
+    // the clipboard write resolves.
+    const exportedBlueprintId = this.id;
     const json = JSON.stringify(this.blueprint.toBniBlueprint(friendlyName));
-    const shareString = await encodeBniShareString(json);
+    const encoded = encodeBniShareString(json);
 
-    // May still reject — e.g. Safari drops user activation across the await
-    // above. The caller reports it.
-    await navigator.clipboard.writeText(shareString);
+    await BlueprintService.writeClipboardText(clipboard, encoded);
 
     // Same accounting as a file download — both are the user taking a copy.
-    if (this.id != null) this.trackDownload(this.id);
+    if (exportedBlueprintId != null) this.trackDownload(exportedBlueprintId);
+  }
+
+  // Safari only honours a clipboard write that *starts* inside the user
+  // gesture, and gzipping is async — so where write() and ClipboardItem exist
+  // we hand over the still-pending promise, keeping the write itself within
+  // the gesture. Firefox shipped both long after the other engines, so
+  // writeText stays as a fallback rather than being replaced outright.
+  private static async writeClipboardText(
+    clipboard: Clipboard,
+    text: Promise<string>,
+  ) {
+    const type = "text/plain";
+
+    if (typeof ClipboardItem !== "undefined" && clipboard.write) {
+      try {
+        await clipboard.write([
+          new ClipboardItem({
+            [type]: text.then((t) => new Blob([t], { type })),
+          }),
+        ]);
+        return;
+      } catch {
+        // A browser that has ClipboardItem but rejects a promise-backed one
+        // still gets a working copy through writeText below. If the encode
+        // itself failed, awaiting it again rethrows rather than silently
+        // writing nothing.
+      }
+    }
+
+    if (!clipboard.writeText) throw new Error("Clipboard API unavailable");
+    await clipboard.writeText(await text);
   }
 
   static saveTextFile(text: string, filename: string) {

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -7,6 +7,7 @@ import { of } from "rxjs";
 import { catchError, map, switchMap, tap } from "rxjs/operators";
 import {
   decodeBniShareString,
+  encodeBniShareString,
   RawSourceFormat,
   Blueprint,
   IObsBlueprintChange,
@@ -575,6 +576,32 @@ export class BlueprintService implements IObsBlueprintChange {
     }
 
     generate();
+  }
+
+  // Editor "Download → Blueprint (copy text)": the inverse of the paste-import
+  // above — the mod's clipboard share-string, written to the system clipboard.
+  //
+  // Unlike exportBlueprintFile this never serves the held raw source, even for
+  // an unedited import. Renaming a blueprint does not invalidate rawSource (the
+  // freshness check compares toMdbBlueprint(), which carries no name), so the
+  // verbatim text can hold a stale friendlyname — and a share-string has no
+  // filename to correct it with, so the old name would follow the blueprint
+  // back into the game. Always generating keeps the pasted name truthful.
+  async copyBlueprintShareString(friendlyName: string) {
+    // Checked before encoding: absent outside a secure context, and there is
+    // no point gzipping a blueprint we cannot deliver.
+    if (!navigator.clipboard?.writeText)
+      throw new Error("Clipboard API unavailable");
+
+    const json = JSON.stringify(this.blueprint.toBniBlueprint(friendlyName));
+    const shareString = await encodeBniShareString(json);
+
+    // May still reject — e.g. Safari drops user activation across the await
+    // above. The caller reports it.
+    await navigator.clipboard.writeText(shareString);
+
+    // Same accounting as a file download — both are the user taking a copy.
+    if (this.id != null) this.trackDownload(this.id);
   }
 
   static saveTextFile(text: string, filename: string) {

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -3,3 +3,20 @@
 // before this file runs, but the zone.js *testing* patch (needed by the
 // waitForAsync/fakeAsync helpers) must be loaded explicitly here.
 import "zone.js/testing";
+
+// jsdom's Blob implements arrayBuffer() but not stream(). The BlueprintsV2
+// share-string codec (lib/src/io/bni/bni-share-string.ts) pipes Blob.stream()
+// through a CompressionStream, so without this any spec touching share strings
+// dies on "stream is not a function" and has to mock the codec away. Node
+// supplies ReadableStream and CompressionStream globally, so bridging the one
+// missing method lets the real codec run here.
+if (typeof Blob !== "undefined" && !Blob.prototype.stream) {
+  Blob.prototype.stream = function (this: Blob) {
+    return new ReadableStream({
+      start: async (controller) => {
+        controller.enqueue(new Uint8Array(await this.arrayBuffer()));
+        controller.close();
+      },
+    });
+  } as Blob["stream"];
+}


### PR DESCRIPTION

> [!NOTE]
> **AI-assisted change.** This pull request was written with the help of AI — Claude (Opus 5), via Claude Code. The design decisions, code and tests below were produced in that session. The end-to-end behaviour has since been manually verified, including pasting the copied string into Oxygen Not Included. Please still review it as you would any other change.

## What shipped

The editor's **Upload** menu has had a "Blueprint (paste text)" item that imports the BlueprintsV2 mod's clipboard share-string. There was no symmetric export — **Download** only offered a file. This adds **Download → Blueprint (copy text)**, which encodes the current blueprint as a share-string (base64 + gzip) and writes it to the clipboard, so it can be pasted straight back into the game.

No new serialization: reuses `encodeBniShareString` (`lib/src/io/bni/bni-share-string.ts`), already documented as byte-compatible with the mod's `ExportToClipboard`.

- `blueprint-service.ts` — `copyBlueprintShareString(friendlyName)`
- `component-menu.component.ts` — menu item + `MenuCommandType.exportBlueprintText`
- `component-blueprint-parent.component.ts` — `copyBlueprintText()`, empty-blueprint guard and toasts mirroring `exportBlueprint()`

## Design decisions

**Always regenerates; never serves the held raw source.** `exportBlueprintFile` serves the byte-exact original for an unedited import, but renaming a blueprint does *not* invalidate `rawSource` (the freshness check compares `toMdbBlueprint()`, which carries no name). So the verbatim text can hold a stale `friendlyname` — and unlike a download there is no filename to compensate, so the old name would follow the blueprint back into the game. Regenerating keeps the pasted name truthful, trading byte-exactness for unedited imports.

**Clipboard checked before encoding** — `navigator.clipboard` is absent outside a secure context, and there is no point gzipping a blueprint we cannot deliver. The write can still reject afterwards (Safari drops user activation across the `await`), which surfaces as an error toast.

**Copying counts as a download** (`trackDownload`), same as the file export — it is the same act of taking a copy.

**No dialog**, unlike the paste side: there is nothing for the user to type.

**No i18n work** — the sibling "Blueprint (paste text)" string appears in zero `.xlf` files; precedent is fallback-to-source.

## Test-env fix worth a look

`test-setup.ts` gains a `Blob.prototype.stream()` bridge. jsdom implements `arrayBuffer()` but not `stream()`, which the share-string codec pipes into a `CompressionStream` — so any spec touching share strings died on `stream is not a function`. Confirmed empirically before adding it.

Side effect worth knowing: three pre-existing decode tests were passing on that `TypeError` rather than on invalid gzip, i.e. vacuously. They now exercise the real decode path (and log zlib `Z_DATA_ERROR` to stderr while still asserting rejection).

## Verification

- **Manually verified end-to-end**: a blueprint was copied from the editor and the resulting string imported into Oxygen Not Included via the BlueprintsV2 mod.
- Frontend suite: **1256 passed**, 2 skipped, no regressions (`npm test`)
- 5 new specs incl. a real gzip round-trip — the written string is decoded back with `decodeBniShareString` and asserted to carry the current `friendlyname`, plus a regression test that renaming beats the held raw source, and both download-counter cases
- `npm run lint` clean · `npm run tsc` clean · frontend production build compiles
- Also exercised against the dev server in an automated browser: Upload ▸ paste text, then Download ▸ Blueprint (copy text) produced a 216-char base64 share-string that gunzips back to correct JSON. That profile denies clipboard-write permission, so the error-toast path got confirmed there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
