### PR TITLE
chore: contributor experience — guide, PR template, Slack PR alerts

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!--
+Thanks for contributing! Short PRs need only short answers — don't pad.
+If you (or your agent) used AI to write this change, please keep the
+disclosure note below; otherwise delete it.
+-->
+
+> [!NOTE]
+> **AI-assisted change.** Written with the help of AI (<model / tool>).
+> Please review it as you would any other change.
+
+## What shipped
+
+<!-- What does this PR do, and why? If it fixes a bug, describe how the bug
+is reached — reproduction beats speculation. -->
+
+## Design decisions
+
+<!-- Anything you decided that a reviewer might question: alternatives
+rejected, deviations from existing patterns, scope deliberately left out.
+Delete the section if there were none. -->
+
+## Verification
+
+<!--
+What was actually run and what happened. Be explicit about what was NOT
+verified — an honest gap is easy to check at review time; a hidden one isn't.
+
+- [ ] Backend: `npm run tsc` and `npm run test` (if backend/lib changed)
+- [ ] Frontend: `npm run lint` and `npm test` (if frontend changed)
+- [ ] New/changed behaviour covered by a test that fails without the change
+- [ ] Manually exercised (say where: local dev server, real game, browser…)
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,9 +24,9 @@ Delete the section if there were none. -->
 <!--
 What was actually run and what happened. Be explicit about what was NOT
 verified — an honest gap is easy to check at review time; a hidden one isn't.
+-->
 
 - [ ] Backend: `npm run tsc` and `npm run test` (if backend/lib changed)
-- [ ] Frontend: `npm run lint` and `npm test` (if frontend changed)
+- [ ] Frontend: `cd frontend && npm run lint` and `cd frontend && npm test` (if frontend changed)
 - [ ] New/changed behaviour covered by a test that fails without the change
 - [ ] Manually exercised (say where: local dev server, real game, browser…)
--->

--- a/.github/workflows/pr-alert.yml
+++ b/.github/workflows/pr-alert.yml
@@ -1,0 +1,52 @@
+name: PR Alert
+
+# Posts to Slack when a pull request is opened, so external contributions get
+# noticed the day they arrive instead of whenever notifications get read.
+#
+# Setup (one-time): create a Slack incoming webhook (Slack app directory →
+# "Incoming WebHooks", pick the channel) and store its URL as the repo secret
+# SLACK_WEBHOOK_URL. Until the secret exists this workflow is a no-op.
+#
+# This uses pull_request_target, not pull_request, on purpose: a fork-opened
+# PR runs plain pull_request workflows WITHOUT secrets, so the webhook would
+# fire only for the maintainer's own branches — exactly backwards. The
+# _target variant runs the base branch's copy of this file with secrets
+# available. That is safe here because the job never checks out, builds or
+# executes anything from the PR — it only forwards event metadata to Slack.
+# Keep it that way: do not add a checkout step or run PR-controlled code in
+# this workflow.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions: {}
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    steps:
+      - name: Post to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          # PR title and author are attacker-controlled text. They are passed
+          # via env (never interpolated into the script with ${{ }}) and
+          # JSON-encoded by jq, so they can only ever be data.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_ACTION: ${{ github.event.action }}
+          PR_ADDITIONS: ${{ github.event.pull_request.additions }}
+          PR_DELETIONS: ${{ github.event.pull_request.deletions }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "::notice::SLACK_WEBHOOK_URL secret not set; skipping notification"
+            exit 0
+          fi
+          payload=$(jq -n \
+            --arg text ":mailbox_with_mail: PR #${PR_NUMBER} ${PR_ACTION} by ${PR_AUTHOR}: ${PR_TITLE} (+${PR_ADDITIONS}/−${PR_DELETIONS}) — ${PR_URL}" \
+            '{text: $text}')
+          curl -fsS -X POST -H 'Content-Type: application/json' \
+            -d "$payload" "$SLACK_WEBHOOK_URL"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,6 @@ A few constraints worth knowing before you design a change:
 - An automated reviewer (CodeRabbit) usually comments first. Engage with it
   as you see fit — its findings are suggestions, and reasoned pushback is
   fine.
-- The maintainer doesn't live in GitHub notifications; there's an alert set
-  up for new PRs, but a day of latency can still happen. It's not a lack of
-  interest.
+- The maintainer doesn't live in GitHub notifications; an alert for new PRs
+  is planned (inactive until its Slack webhook is configured), so a day or
+  two of latency can still happen. It's not a lack of interest.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing to Blueprintnotincluded
+
+Thank you for considering a contribution — external PRs are genuinely welcome
+here, and small ones are just as valued as big ones.
+
+## The maintainer's philosophy
+
+**Safe, positive contributions get merged.** You don't need to match the house
+style perfectly or anticipate every edge case — if your change works, is
+tested, and doesn't break anything, it will be accepted, and any cleanup the
+maintainer cares about happens afterwards in follow-up commits. Don't let
+polish anxiety stop you from opening a PR.
+
+AI-assisted contributions are welcome. Please say so in the PR description
+(the PR template has a place for it) — recent AI-assisted PRs here have been
+excellent precisely because they disclosed what was verified by a human and
+what wasn't.
+
+## Getting set up
+
+The full toolchain (Node, native build deps for `canvas`/`sharp`, MongoDB,
+Mailpit) lives in a dev container — the host needs only a container runtime:
+
+```bash
+cp .env.sample .env
+docker compose --env-file .env -f .devcontainer/docker-compose.yml up -d
+docker compose --env-file .env -f .devcontainer/docker-compose.yml exec app bash
+# then, inside the container, first run only:
+npm ci && (cd frontend && npm ci) && npm run build:lib && npm run migrate:up
+```
+
+Frontend: http://localhost:4200 · Backend: http://localhost:3000
+
+To work on the host instead, use Node **20.19.4** (see `.nvmrc`; Canvas 3.x
+requires Node 20 — do not use Node 22) and run `./dev-setup.sh` to start just
+the database and mail server.
+
+More detail on the development environment lives in [CLAUDE.md](CLAUDE.md) —
+it's written for AI agents but the commands are the same for humans.
+
+## Before opening a PR
+
+Run the checks that CI will run:
+
+| Area | Commands |
+| --- | --- |
+| Backend | `npm run tsc` · `npm run test` (needs the database up) |
+| Frontend | `cd frontend && npm run lint && npm test` |
+| Frontend types | `cd frontend && npx tsc -p tsconfig.app.json --noEmit && npx tsc -p tsconfig.spec.json --noEmit` |
+
+A few constraints worth knowing before you design a change:
+
+- **Backend tests are Mocha + Chai; frontend tests are Vitest.** Do not
+  introduce Jest.
+- **Rate limiting is handled by Cloudflare** — don't add `express-rate-limit`.
+- The frontend test runner wires globals through the Angular builder — run
+  specs via `npm test -- --include='**/your.spec.ts'`, not bare `vitest <file>`.
+- Commit messages follow conventional commits (`feat:`, `fix:`, `chore:`, …).
+
+## What to expect after you open a PR
+
+- **First-time contributors: CI waits for maintainer approval.** That's
+  GitHub's default protection for fork PRs, not distrust — once your first PR
+  is merged, later ones run automatically.
+- An automated reviewer (CodeRabbit) usually comments first. Engage with it
+  as you see fit — its findings are suggestions, and reasoned pushback is
+  fine.
+- The maintainer doesn't live in GitHub notifications; there's an alert set
+  up for new PRs, but a day of latency can still happen. It's not a lack of
+  interest.


### PR DESCRIPTION
Follow-up to the first external contributions (#222, #223): make the next contributor's path smoother, and make sure the maintainer hears about a new PR the day it arrives.

## What shipped

- **`CONTRIBUTING.md`** — states the actual maintenance policy (safe contributions are merged as-is; cleanup happens in follow-ups), the dev-container setup, the exact checks CI runs, the repo's hard constraints (Mocha not Jest, Node 20, Cloudflare rate limiting), and the two surprises an outside contributor hits: the first-time-contributor CI approval gate and notification latency. Explicitly welcomes disclosed AI-assisted PRs, since both of the ones received were excellent.
- **`.github/pull_request_template.md`** — mirrors the structure #222/#223 used voluntarily: what shipped, design decisions, verification with an honest "what was NOT verified". Since contributors may be working agentically, the template doubles as instructions their agents will follow.
- **`.github/workflows/pr-alert.yml`** *(pending — see below)* — posts to Slack when a PR is opened, reopened, or marked ready for review.

## Design decisions

- The Slack alert uses **`pull_request_target`**, deliberately: fork-opened PRs run plain `pull_request` workflows *without* secrets, so a webhook there would fire only for the maintainer's own branches — exactly backwards. `pull_request_target` is safe in this shape because the job has `permissions: {}`, never checks out or executes PR code, and passes the attacker-controlled title/author via env into `jq` (JSON-encoded, never shell-evaluated — verified against a title containing `$(…)`). The workflow file carries a comment warning future editors never to add a checkout step.
- The workflow is a **no-op until the `SLACK_WEBHOOK_URL` secret exists**, so it can merge before the Slack side is configured.
- CONTRIBUTING.md links to CLAUDE.md for deep setup detail rather than duplicating it.

## Not yet on this branch

The workflow commit exists locally but the CI token lacks the `workflow` scope, so the push was rejected for that file. Once the PAT gains `workflow` scope (or the commit is pushed from a machine with full credentials), `git push` on this branch adds it to this PR.

**Slack setup (one-time, maintainer):** Slack → Apps → "Incoming WebHooks" → pick the channel → copy the webhook URL → `gh secret set SLACK_WEBHOOK_URL`. Alternative considered: the official GitHub Slack app (`/github subscribe blueprintnotincluded/blueprintnotincluded pulls`) does this with zero code — the workflow was chosen because it keeps the alert format and scope in the repo, but the app is a fine substitute if preferred.

## Verification

- Workflow YAML parses; payload construction tested with a hostile title (`$(touch …)`, backticks, quotes) — expands as literal text, no execution.
- Docs-only change otherwise; backend/frontend CI will run on this PR and should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEeNpFedse54LB7ASaEhGY