### PR TITLE
feat(editor): edit automation sensor thresholds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -784,8 +784,22 @@ the bare float a meaning; conversion is affine both ways
   `LogicHEPSensor`: neither is a confirmed carrier, and radbolt thresholds live on
   `HighEnergyParticleSpawner`/`HEPBattery.particleThreshold` — different keys entirely.
 - **Ranges are soft.** They come from `IThresholdSwitch.RangeMin/RangeMax`, serialized
-  per-prefab fields the setter does not enforce. Clamp what the user types; never reject or
-  rewrite a stored value that falls outside them.
+  per-prefab fields the setter does not enforce. A typed value outside them is **pulled to the
+  nearest bound on commit**, never rejected; a value already stored outside them is displayed
+  and preserved untouched. An emptied or unparseable field is not an edit to zero (note
+  `Number('') === 0`, so empty has to be caught before the parse) — the control is restored to
+  what the model holds.
+- **Every commit path reconciles the DOM control** (`reconcile()`), because Angular's `[value]`
+  binding only rewrites the input when the *bound* value changes. Clamping an entry down onto
+  the value already stored — typing 999999 into a sensor already at its 20000 max — otherwise
+  leaves 999999 sitting in a box whose model says 20000. Regression spec covers exactly that.
+- **The above/below choice is a direction, not a switch.** `booleanLabels` on a descriptor
+  (`{whenTrue:'Above', whenFalse:'Below'}`, shared by `IThresholdSwitch.ActivateAboveThreshold`
+  and `LogicCritterCountSensor.activateOnGreaterThan` via `ABOVE_BELOW`) renders a two-option
+  segmented control instead of a checkbox, and `formatBuildingDataEntry` prints the same words
+  instead of On/Off. A checkbox labelled "Activate above threshold" makes the reader negate it
+  in their head to understand "below". Re-picking the option already in force is not an edit
+  and pushes no undo step.
 - **`resolveSettingDescriptors(prefabId, key)`** is how the per-prefab meaning reaches both
   the panel and `formatBuildingDataEntry` — inlining it per call site is how a row and its
   read-only formatting end up disagreeing. Catalogue `min`/`max` stay in **stored** units and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -809,13 +809,25 @@ the bare float a meaning; conversion is affine both ways
   at copy time, which the game overwrites within ~1.8s. `resolveSettingDescriptors` returns
   `[]` for `Switch` on a threshold sensor: it round-trips, but it is not a setting and is not
   counted as an unrecognized one either. The manual `LogicSwitch` keeps its editable row.
-- **The critter sensor writes its state twice** — its own key *and* `IThresholdSwitch` over
-  the same two values. The mod applies handlers in registration order and `IThresholdSwitch`
-  is registered last, so a disagreement silently wins. `SETTING_MIRRORS` +
-  `BlueprintItem.setBuildingSetting` move both, but **only when the twin Key is already
-  present** — creating it as a side effect of an edit would change what the file says the
-  building is. The panel renders the pair once, under the specific key (which also carries
-  `countCritters`/`countEggs`); the `redundant` flag marks the half that yields.
+- **"Not set" is a state, not a default.** The mod applies only the keys a file actually
+  carries, so an absent `IThresholdSwitch` leaves the built sensor on the game's own default —
+  which is different from pinning it to any value. The panel shows that explicitly (a
+  `Pressure — Not set` row rather than a bare button), and
+  `BlueprintItem.removeBuildingSetting` is the inverse of `addBuildingSetting` so the state is
+  reachable again. Without the inverse the editor could move a blueprint from unspecified to
+  pinned but never back, silently changing what an older file means after a stray click. A
+  cleared sensor exports byte-identically to one that was never touched, since
+  `toBniBuilding`/`toMdbBuilding` omit `buildingData` when empty.
+  Note a sensor copied **in-game** always carries the key (`TryGetData` returns it whenever
+  the component exists), so "not set" only arises from editor-placed buildings and older files.
+- **The critter sensor is deliberately out of the threshold table.** It *is* an
+  `IThresholdSwitch` carrier, but it writes the same two values twice — under its own key as
+  `countThreshold`/`activateOnGreaterThan` and again under `IThresholdSwitch` — and its own key
+  also carries `countCritters`/`countEggs`, which are not threshold settings. They cannot be
+  separated: the mod's handler bails on the whole `Value` object if any field is missing, so a
+  partial write applies nothing. Clearing a critter sensor's threshold therefore cannot avoid
+  discarding what it counts. Its rows still render through the plain catalogue exactly as
+  before; the two keys can still disagree, which is pre-existing. Owed a change of its own.
 - **Blurring an untouched input must not write.** The displayed value is rounded, so
   re-deriving a stored value from it would nudge a Thermo Sensor stored at 293.153 K to
   293.15 — a silent data change that also detaches `rawSource` for nothing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -743,9 +743,10 @@ edits.
   each field independently). `addBuildingSetting(key)` constructs a complete Value object from
   scratch using hand-verified defaults.
 - **Creatable-from-scratch is deliberately narrow** — `CREATABLE_SETTINGS` in
-  `settings-catalog.ts` currently has only `LogicTimerSensor` (`onDuration`/`offDuration`:
+  `settings-catalog.ts` holds `LogicTimerSensor` (`onDuration`/`offDuration`:
   10s each; `timeElapsedInCurrentState`: 0, definitionally correct for a fresh component;
-  `displayCyclesMode`: false, a display-only toggle with no simulation effect even if wrong).
+  `displayCyclesMode`: false, a display-only toggle with no simulation effect even if wrong)
+  plus `IThresholdSwitch` on every threshold sensor (generated from `THRESHOLD_SENSORS`).
   Every other key, including `LogicCounter` (whose `resetCountAtMax`/`advancedMode` real
   defaults aren't confirmed), stays edit-only-when-the-file-already-has-it: synthesizing an
   incomplete or wrong default for a gameplay-affecting field would silently change build
@@ -764,6 +765,55 @@ edits.
   simulated mid-edit change-detection tick rather than reusing a captured node reference)
   fails without the fix and passes with it.
 
+### Threshold sensors (IThresholdSwitch)
+
+`lib/src/blueprint/building-settings/threshold-sensors.ts`. The mod registers handlers by
+*component* name, not per prefab, so all 16 threshold sensors write the same two fields —
+but `Threshold` is the raw sim value of whatever that **building** measures, never what the
+game's side screen showed the player. `THRESHOLD_SENSORS` is the per-prefab table that gives
+the bare float a meaning; conversion is affine both ways
+(`display = stored * displayScale + displayOffset`, helpers `toDisplayValue`/`toStoredValue`).
+
+- **The two that convert**: gas pressure is stored in kg and displayed in **grams** (×1000),
+  and temperature is stored in **Kelvin** regardless of the authoring player's °C/°F setting
+  and displayed in °C (the site is Celsius throughout). Liquid pressure, lux, germs, rads and
+  critter counts are 1:1.
+- **Coverage**: Atmo/Hydro/Thermo Sensor *and* the matching Atmo/Hydro/Thermo **Switch**, the
+  three pipe/rail thermo sensors, Germ Sensor + three pipe/rail germ sensors, Light Sensor,
+  Radiation Sensor, Critter Sensor. Deliberately **not** `LogicWattageSensor` or
+  `LogicHEPSensor`: neither is a confirmed carrier, and radbolt thresholds live on
+  `HighEnergyParticleSpawner`/`HEPBattery.particleThreshold` — different keys entirely.
+- **Ranges are soft.** They come from `IThresholdSwitch.RangeMin/RangeMax`, serialized
+  per-prefab fields the setter does not enforce. Clamp what the user types; never reject or
+  rewrite a stored value that falls outside them.
+- **`resolveSettingDescriptors(prefabId, key)`** is how the per-prefab meaning reaches both
+  the panel and `formatBuildingDataEntry` — inlining it per call site is how a row and its
+  read-only formatting end up disagreeing. Catalogue `min`/`max` stay in **stored** units and
+  are converted alongside the value.
+- **The stowaway `Switch` key.** Sensors extend `Switch`, so the mod's `Switch` handler
+  matches them and a copied sensor carries `Switch.switchedOn` holding its *sampled output*
+  at copy time, which the game overwrites within ~1.8s. `resolveSettingDescriptors` returns
+  `[]` for `Switch` on a threshold sensor: it round-trips, but it is not a setting and is not
+  counted as an unrecognized one either. The manual `LogicSwitch` keeps its editable row.
+- **The critter sensor writes its state twice** — its own key *and* `IThresholdSwitch` over
+  the same two values. The mod applies handlers in registration order and `IThresholdSwitch`
+  is registered last, so a disagreement silently wins. `SETTING_MIRRORS` +
+  `BlueprintItem.setBuildingSetting` move both, but **only when the twin Key is already
+  present** — creating it as a side effect of an edit would change what the file says the
+  building is. The panel renders the pair once, under the specific key (which also carries
+  `countCritters`/`countEggs`); the `redundant` flag marks the half that yields.
+- **Blurring an untouched input must not write.** The displayed value is rounded, so
+  re-deriving a stored value from it would nudge a Thermo Sensor stored at 293.153 K to
+  293.15 — a silent data change that also detaches `rawSource` for nothing.
+- **Two known unit discrepancies, flagged not fixed**: a buildingData reference compiled from
+  the game assembly says `LogicTimeOfDaySensor.startTime`/`duration` are *seconds* into a
+  600s cycle (the catalogue treats them as a 0–1 fraction shown as "% of cycle"), and that
+  `IActivationRangeTarget.ActivateValue` is normalised 0–1 on batteries (the catalogue shows
+  it raw). Both need an in-game check, not a guess between secondhand sources.
+- **Element sensors are a separate feature** — they have no threshold; their setting is a
+  `Filterable`/`SelectedTag` element *name* string (not the integer hash `selected_elements`
+  uses). `cell-element-picker` already filters by Gas/Liquid/Solid and emits a
+  `BuildableElement`, so it is the natural control when that ships.
 ### Session Management Files
 
 Check these files in `agent/` directory for current status:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -768,7 +768,7 @@ edits.
 ### Threshold sensors (IThresholdSwitch)
 
 `lib/src/blueprint/building-settings/threshold-sensors.ts`. The mod registers handlers by
-*component* name, not per prefab, so all 16 threshold sensors write the same two fields —
+*component* name, not per prefab, so every threshold sensor writes the same two fields —
 but `Threshold` is the raw sim value of whatever that **building** measures, never what the
 game's side screen showed the player. `THRESHOLD_SENSORS` is the per-prefab table that gives
 the bare float a meaning; conversion is affine both ways
@@ -776,13 +776,20 @@ the bare float a meaning; conversion is affine both ways
 
 - **The two that convert**: gas pressure is stored in kg and displayed in **grams** (×1000),
   and temperature is stored in **Kelvin** regardless of the authoring player's °C/°F setting
-  and displayed in °C (the site is Celsius throughout). Liquid pressure, lux, germs, rads and
-  critter counts are 1:1.
-- **Coverage**: Atmo/Hydro/Thermo Sensor *and* the matching Atmo/Hydro/Thermo **Switch**, the
-  three pipe/rail thermo sensors, Germ Sensor + three pipe/rail germ sensors, Light Sensor,
-  Radiation Sensor, Critter Sensor. Deliberately **not** `LogicWattageSensor` or
-  `LogicHEPSensor`: neither is a confirmed carrier, and radbolt thresholds live on
-  `HighEnergyParticleSpawner`/`HEPBattery.particleThreshold` — different keys entirely.
+  and displayed in °C (the site is Celsius throughout). Liquid pressure, lux, germs and rads
+  are 1:1.
+- **Coverage**: Atmo/Hydro/Thermo Sensor, the three pipe/rail thermo sensors, Germ Sensor +
+  three pipe/rail germ sensors, Light Sensor, Radiation Sensor. Deliberately **not**
+  `LogicWattageSensor` or `LogicHEPSensor`: neither is a confirmed carrier, and radbolt
+  thresholds live on `HighEnergyParticleSpawner`/`HEPBattery.particleThreshold` — different
+  keys entirely. Also **not** `PressureSwitchGas`/`PressureSwitchLiquid`/
+  `TemperatureControlledSwitch` ("Atmo/Hydro/Thermo Switch") — an earlier version of this
+  table included them on the strength of the 2024 export's full name/description/
+  buildMenuItems data (filed under Power/Electrical), but neither ONI wiki has a page for any
+  of them, web search for "Thermo Switch" surfaces Thermo *Sensor* results instead, and a
+  live playthrough did not find them in the Electrical build menu. Reads as pre-Automation-
+  Update legacy prefab data the export tool still dumps despite the live game not actually
+  offering them. Pulled until confirmed placeable via a debug/sandbox build menu.
 - **Ranges are soft.** They come from `IThresholdSwitch.RangeMin/RangeMax`, serialized
   per-prefab fields the setter does not enforce. A typed value outside them is **pulled to the
   nearest bound on commit**, never rejected; a value already stored outside them is displayed

--- a/__tests__/lib/building-settings.test.ts
+++ b/__tests__/lib/building-settings.test.ts
@@ -345,7 +345,6 @@ describe('threshold sensors', function () {
         'GasConduitTemperatureSensor',
         'LiquidConduitDiseaseSensor',
         'LiquidConduitTemperatureSensor',
-        'LogicCritterCountSensor',
         'LogicDiseaseSensor',
         'LogicLightSensor',
         'LogicPressureSensorGas',
@@ -471,52 +470,77 @@ describe('threshold sensors against the game database', function () {
     ]);
   });
 
-  // The critter sensor writes its count and above/below twice; the mod applies
-  // IThresholdSwitch last, so a disagreement would silently win.
-  it('mirrors an edit onto the twin Key when the building carries both', () => {
-    const item = BlueprintHelpers.createInstance('LogicCritterCountSensor')!;
-    item.buildingData = [
-      {
-        Key: 'LogicCritterCountSensor',
-        Value: {
-          countThreshold: 3,
-          activateOnGreaterThan: true,
-          countCritters: true,
-          countEggs: false,
-        },
-      },
-      { Key: 'IThresholdSwitch', Value: { Threshold: 3.0, ActivateAboveThreshold: true } },
-    ];
+});
 
-    item.setBuildingSetting('LogicCritterCountSensor', 'countThreshold', 8);
-    item.setBuildingSetting('LogicCritterCountSensor', 'activateOnGreaterThan', false);
-
-    const twin = item.buildingData.find(e => e.Key == 'IThresholdSwitch')!;
-    expect(twin.Value).to.deep.equal({ Threshold: 8, ActivateAboveThreshold: false });
-
-    // ...and back the other way, rounding onto the int field.
-    item.setBuildingSetting('IThresholdSwitch', 'Threshold', 5.4);
-    const own = item.buildingData.find(e => e.Key == 'LogicCritterCountSensor')!;
-    expect(own.Value.countThreshold).to.equal(5);
-    expect(own.Value.countCritters).to.equal(true);
+// "Not set" is a real state, distinct from any stored value: the mod only
+// applies keys the file actually carries, so an absent IThresholdSwitch leaves
+// the built sensor on the game's own default.
+describe('BlueprintItem.removeBuildingSetting', function () {
+  before(function () {
+    loadGameDatabase();
   });
 
-  it('never creates the twin Key as a side effect of an edit', () => {
-    const item = BlueprintHelpers.createInstance('LogicCritterCountSensor')!;
+  it('is the inverse of addBuildingSetting', () => {
+    const item = BlueprintHelpers.createInstance('LogicPressureSensorGas')!;
+    expect(item.addBuildingSetting('IThresholdSwitch')).to.equal(true);
+    expect(item.buildingData!.map(e => e.Key)).to.deep.equal(['IThresholdSwitch']);
+
+    expect(item.removeBuildingSetting('IThresholdSwitch')).to.equal(true);
+    expect(item.buildingData!.map(e => e.Key)).to.deep.equal([]);
+  });
+
+  it('leaves every other Key verbatim', () => {
+    const item = BlueprintHelpers.createInstance('LogicPressureSensorGas')!;
     item.buildingData = [
-      {
-        Key: 'LogicCritterCountSensor',
-        Value: {
-          countThreshold: 3,
-          activateOnGreaterThan: true,
-          countCritters: true,
-          countEggs: false,
-        },
-      },
+      { Key: 'Switch', Value: { switchedOn: true } },
+      { Key: 'IThresholdSwitch', Value: { Threshold: 1.5, ActivateAboveThreshold: true } },
+      { Key: 'Prioritizable', Value: { masterPrioritySetting: '{}' } },
     ];
 
-    item.setBuildingSetting('LogicCritterCountSensor', 'countThreshold', 9);
+    expect(item.removeBuildingSetting('IThresholdSwitch')).to.equal(true);
 
-    expect(item.buildingData.map(e => e.Key)).to.deep.equal(['LogicCritterCountSensor']);
+    expect(item.buildingData).to.deep.equal([
+      { Key: 'Switch', Value: { switchedOn: true } },
+      { Key: 'Prioritizable', Value: { masterPrioritySetting: '{}' } },
+    ]);
+  });
+
+  it('reports false when there was nothing to remove', () => {
+    const item = BlueprintHelpers.createInstance('LogicPressureSensorGas')!;
+    expect(item.removeBuildingSetting('IThresholdSwitch')).to.equal(false);
+    item.buildingData = [{ Key: 'Switch', Value: { switchedOn: true } }];
+    expect(item.removeBuildingSetting('IThresholdSwitch')).to.equal(false);
+  });
+
+  it('exports a document identical to one that never had the key', () => {
+    const pristine = BlueprintHelpers.createInstance('LogicPressureSensorGas')!;
+    const edited = BlueprintHelpers.createInstance('LogicPressureSensorGas')!;
+    edited.addBuildingSetting('IThresholdSwitch');
+    edited.setBuildingSetting('IThresholdSwitch', 'Threshold', 1.5);
+    edited.removeBuildingSetting('IThresholdSwitch');
+
+    const exportOf = (item: typeof pristine) => {
+      const blueprint = new Blueprint();
+      blueprint.blueprintItems = [item];
+      return blueprint.toBniBlueprint('x').buildings![0];
+    };
+
+    // buildingData is omitted when empty, so a cleared sensor is byte-identical
+    // to one that was never touched — which is what makes clearing a faithful
+    // return to "this blueprint says nothing about the threshold".
+    expect(exportOf(edited)).to.deep.equal(exportOf(pristine));
+    expect(exportOf(edited).buildingData).to.equal(undefined);
+  });
+
+  it('leaves the critter sensor out of the threshold table entirely', () => {
+    // It carries the same two values under two Keys, and its own Key also
+    // holds countCritters/countEggs, which cannot be separated from them —
+    // so clearing its threshold would discard what it counts. Deferred.
+    expect(thresholdSensorSpec('LogicCritterCountSensor')).to.equal(undefined);
+    expect(creatableSettingsKeysFor('LogicCritterCountSensor')).to.deep.equal([]);
+    // Its rows still render through the plain catalogue, unchanged.
+    expect(resolveSettingDescriptors('LogicCritterCountSensor', 'LogicCritterCountSensor')).to.equal(
+      SETTINGS_CATALOG.LogicCritterCountSensor
+    );
   });
 });

--- a/__tests__/lib/building-settings.test.ts
+++ b/__tests__/lib/building-settings.test.ts
@@ -536,8 +536,8 @@ describe('BlueprintItem.removeBuildingSetting', function () {
     expect(thresholdSensorSpec('LogicCritterCountSensor')).to.equal(undefined);
     expect(creatableSettingsKeysFor('LogicCritterCountSensor')).to.deep.equal([]);
     // Its rows still render through the plain catalogue, unchanged.
-    expect(resolveSettingDescriptors('LogicCritterCountSensor', 'LogicCritterCountSensor')).to.equal(
-      SETTINGS_CATALOG.LogicCritterCountSensor
-    );
+    expect(
+      resolveSettingDescriptors('LogicCritterCountSensor', 'LogicCritterCountSensor')
+    ).to.equal(SETTINGS_CATALOG.LogicCritterCountSensor);
   });
 });

--- a/__tests__/lib/building-settings.test.ts
+++ b/__tests__/lib/building-settings.test.ts
@@ -4,9 +4,16 @@ import {
   Blueprint,
   BlueprintHelpers,
   BniBuildingData,
+  creatableSettingsKeysFor,
   formatBuildingDataEntry,
   isKnownSettingsKey,
+  OniItem,
+  resolveSettingDescriptors,
   SETTINGS_CATALOG,
+  THRESHOLD_SENSORS,
+  thresholdSensorSpec,
+  toDisplayValue,
+  toStoredValue,
 } from '../../lib/index';
 import { loadGameDatabase } from '../helpers/roomFixtures';
 
@@ -324,5 +331,192 @@ describe('BlueprintItem.setBuildingSetting / addBuildingSetting', function () {
       timeElapsedInCurrentState: 3.099925,
       displayCyclesMode: false,
     });
+  });
+});
+
+// Per-building meaning of the IThresholdSwitch key. The handler is registered
+// by component name, so every threshold sensor writes the same two fields but
+// `Threshold` is the raw sim value of whatever that building measures.
+describe('threshold sensors', function () {
+  it('covers the confirmed IThresholdSwitch carriers and nothing unverified', () => {
+    expect(Object.keys(THRESHOLD_SENSORS).sort()).to.deep.equal(
+      [
+        'GasConduitDiseaseSensor',
+        'GasConduitTemperatureSensor',
+        'LiquidConduitDiseaseSensor',
+        'LiquidConduitTemperatureSensor',
+        'LogicCritterCountSensor',
+        'LogicDiseaseSensor',
+        'LogicLightSensor',
+        'LogicPressureSensorGas',
+        'LogicPressureSensorLiquid',
+        'LogicRadiationSensor',
+        'LogicTemperatureSensor',
+        'PressureSwitchGas',
+        'PressureSwitchLiquid',
+        'SolidConduitDiseaseSensor',
+        'SolidConduitTemperatureSensor',
+        'TemperatureControlledSwitch',
+      ].sort()
+    );
+  });
+
+  it('converts gas pressure between stored kg and displayed grams', () => {
+    const descriptor = resolveSettingDescriptors('LogicPressureSensorGas', 'IThresholdSwitch').find(
+      d => d.field == 'Threshold'
+    )!;
+    expect(descriptor.unitSuffix).to.equal('g');
+    expect(toDisplayValue(descriptor, 1.5)).to.equal(1500);
+    expect(toStoredValue(descriptor, 1500)).to.equal(1.5);
+    // The catalogue bound is stored-unit; 20 kg is the 20000 g the UI shows.
+    expect(toDisplayValue(descriptor, descriptor.max!)).to.equal(20000);
+  });
+
+  it('converts temperature between stored Kelvin and displayed Celsius', () => {
+    const descriptor = resolveSettingDescriptors('LogicTemperatureSensor', 'IThresholdSwitch').find(
+      d => d.field == 'Threshold'
+    )!;
+    expect(descriptor.unitSuffix).to.equal('°C');
+    expect(toDisplayValue(descriptor, 293.15)).to.be.closeTo(20, 1e-9);
+    expect(toStoredValue(descriptor, -10)).to.be.closeTo(263.15, 1e-9);
+  });
+
+  it('round-trips every spec through display and back', () => {
+    for (const [prefabId, spec] of Object.entries(THRESHOLD_SENSORS)) {
+      const descriptor = resolveSettingDescriptors(prefabId, 'IThresholdSwitch').find(
+        d => d.field == 'Threshold'
+      )!;
+      for (const stored of [spec.storedMin, spec.defaultThreshold, spec.storedMax]) {
+        expect(toStoredValue(descriptor, toDisplayValue(descriptor, stored))).to.be.closeTo(
+          stored,
+          1e-6,
+          `${prefabId} @ ${stored}`
+        );
+      }
+    }
+  });
+
+  it('leaves the ActivateAboveThreshold toggle alone', () => {
+    const descriptor = resolveSettingDescriptors('LogicLightSensor', 'IThresholdSwitch').find(
+      d => d.field == 'ActivateAboveThreshold'
+    )!;
+    expect(descriptor.type).to.equal('bool');
+    expect(descriptor.unitSuffix).to.equal(undefined);
+  });
+
+  it('falls back to the bare catalogue entry on a building with no spec', () => {
+    expect(resolveSettingDescriptors('LogicCounter', 'IThresholdSwitch')).to.deep.equal(
+      SETTINGS_CATALOG.IThresholdSwitch
+    );
+    expect(thresholdSensorSpec('LogicCounter')).to.equal(undefined);
+  });
+
+  // Sensors extend Switch, so the mod's Switch handler matches them and a
+  // copied sensor carries a stowaway switchedOn holding its sampled output.
+  it('suppresses the stowaway Switch key on a sensor but not on a real switch', () => {
+    expect(resolveSettingDescriptors('LogicPressureSensorGas', 'Switch')).to.deep.equal([]);
+    expect(resolveSettingDescriptors('LogicSwitch', 'Switch')).to.deep.equal(
+      SETTINGS_CATALOG.Switch
+    );
+  });
+
+  it('still counts a suppressed Switch as known, not as an unknown stored setting', () => {
+    const entry: BniBuildingData = { Key: 'Switch', Value: { switchedOn: true } };
+    expect(formatBuildingDataEntry(entry, 'LogicPressureSensorGas')).to.deep.equal([]);
+    expect(formatBuildingDataEntry({ Key: 'Door', Value: {} }, 'LogicPressureSensorGas')).to.equal(
+      null
+    );
+  });
+
+  it('formats a threshold in the unit of the building that carries it', () => {
+    const entry: BniBuildingData = {
+      Key: 'IThresholdSwitch',
+      Value: { Threshold: 0.5, ActivateAboveThreshold: true },
+    };
+    const rows = formatBuildingDataEntry(entry, 'LogicPressureSensorGas')!;
+    expect(rows.find(r => r.field == 'Threshold')!.text).to.equal('500 g');
+    // Unqualified, it is still the bare catalogue number it always was.
+    expect(formatBuildingDataEntry(entry)!.find(r => r.field == 'Threshold')!.text).to.equal('0.5');
+  });
+});
+
+describe('threshold sensors against the game database', function () {
+  before(function () {
+    loadGameDatabase();
+  });
+
+  it('names only prefabs that exist in database-2024.json', () => {
+    for (const prefabId of Object.keys(THRESHOLD_SENSORS))
+      expect(() => OniItem.getOniItem(prefabId), prefabId).to.not.throw();
+  });
+
+  it('offers IThresholdSwitch as creatable on every sensor', () => {
+    for (const prefabId of Object.keys(THRESHOLD_SENSORS))
+      expect(creatableSettingsKeysFor(prefabId), prefabId).to.include('IThresholdSwitch');
+    // ...and on nothing else. LogicTimerSensor keeps its own creatable key.
+    expect(creatableSettingsKeysFor('LogicTimerSensor')).to.deep.equal(['LogicTimerSensor']);
+    expect(creatableSettingsKeysFor('LogicCounter')).to.deep.equal([]);
+  });
+
+  it('creates a complete Value that survives a blueprint round-trip', () => {
+    const item = BlueprintHelpers.createInstance('LogicPressureSensorGas')!;
+    expect(item.addBuildingSetting('IThresholdSwitch')).to.equal(true);
+    item.setBuildingSetting('IThresholdSwitch', 'Threshold', 1.5);
+
+    const blueprint = new Blueprint();
+    blueprint.blueprintItems = [item];
+    const exported = blueprint.toBniBlueprint();
+    expect(exported.buildings![0].buildingData).to.deep.equal([
+      { Key: 'IThresholdSwitch', Value: { Threshold: 1.5, ActivateAboveThreshold: true } },
+    ]);
+  });
+
+  // The critter sensor writes its count and above/below twice; the mod applies
+  // IThresholdSwitch last, so a disagreement would silently win.
+  it('mirrors an edit onto the twin Key when the building carries both', () => {
+    const item = BlueprintHelpers.createInstance('LogicCritterCountSensor')!;
+    item.buildingData = [
+      {
+        Key: 'LogicCritterCountSensor',
+        Value: {
+          countThreshold: 3,
+          activateOnGreaterThan: true,
+          countCritters: true,
+          countEggs: false,
+        },
+      },
+      { Key: 'IThresholdSwitch', Value: { Threshold: 3.0, ActivateAboveThreshold: true } },
+    ];
+
+    item.setBuildingSetting('LogicCritterCountSensor', 'countThreshold', 8);
+    item.setBuildingSetting('LogicCritterCountSensor', 'activateOnGreaterThan', false);
+
+    const twin = item.buildingData.find(e => e.Key == 'IThresholdSwitch')!;
+    expect(twin.Value).to.deep.equal({ Threshold: 8, ActivateAboveThreshold: false });
+
+    // ...and back the other way, rounding onto the int field.
+    item.setBuildingSetting('IThresholdSwitch', 'Threshold', 5.4);
+    const own = item.buildingData.find(e => e.Key == 'LogicCritterCountSensor')!;
+    expect(own.Value.countThreshold).to.equal(5);
+    expect(own.Value.countCritters).to.equal(true);
+  });
+
+  it('never creates the twin Key as a side effect of an edit', () => {
+    const item = BlueprintHelpers.createInstance('LogicCritterCountSensor')!;
+    item.buildingData = [
+      {
+        Key: 'LogicCritterCountSensor',
+        Value: {
+          countThreshold: 3,
+          activateOnGreaterThan: true,
+          countCritters: true,
+          countEggs: false,
+        },
+      },
+    ];
+
+    item.setBuildingSetting('LogicCritterCountSensor', 'countThreshold', 9);
+
+    expect(item.buildingData.map(e => e.Key)).to.deep.equal(['LogicCritterCountSensor']);
   });
 });

--- a/__tests__/lib/building-settings.test.ts
+++ b/__tests__/lib/building-settings.test.ts
@@ -465,7 +465,7 @@ describe('threshold sensors against the game database', function () {
 
     const blueprint = new Blueprint();
     blueprint.blueprintItems = [item];
-    const exported = blueprint.toBniBlueprint();
+    const exported = blueprint.toBniBlueprint('threshold');
     expect(exported.buildings![0].buildingData).to.deep.equal([
       { Key: 'IThresholdSwitch', Value: { Threshold: 1.5, ActivateAboveThreshold: true } },
     ]);

--- a/__tests__/lib/building-settings.test.ts
+++ b/__tests__/lib/building-settings.test.ts
@@ -351,11 +351,8 @@ describe('threshold sensors', function () {
         'LogicPressureSensorLiquid',
         'LogicRadiationSensor',
         'LogicTemperatureSensor',
-        'PressureSwitchGas',
-        'PressureSwitchLiquid',
         'SolidConduitDiseaseSensor',
         'SolidConduitTemperatureSensor',
-        'TemperatureControlledSwitch',
       ].sort()
     );
   });

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.css
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.css
@@ -64,6 +64,28 @@
   color: var(--p-primary-contrast-color);
 }
 
+.building-setting-unset {
+  color: var(--p-text-muted-color);
+  font-style: italic;
+}
+
+/* Small inline action (Set / Clear threshold) — deliberately not a pButton:
+   these sit inside a settings row, not at the panel's edge. */
+.building-setting-link {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--p-primary-color);
+  font: inherit;
+  font-size: smaller;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.building-setting-link:hover {
+  color: var(--p-primary-hover-color, var(--p-primary-color));
+}
+
 .building-setting-add {
   width: 100%;
   margin-top: 6px;

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.css
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.css
@@ -64,9 +64,23 @@
   color: var(--p-primary-contrast-color);
 }
 
+/* Matches the Elements and Temperature section headings, which take this
+   colour from .ui-fieldset-false-link in styles.css. That class also carries a
+   pointer cursor, because those two headings are clickable (they switch the
+   visualization overlay) — this one is not, so it takes the colour alone. */
+.building-setting-legend {
+  color: var(--p-primary-500);
+}
+
 .building-setting-unset {
   color: var(--p-text-muted-color);
-  font-style: italic;
+}
+
+/* Small enough to sit inside a settings row rather than span the panel like
+   the full-width "Add automation settings" button. */
+.building-setting-set {
+  padding: 1px 10px;
+  font-size: smaller;
 }
 
 /* Small inline action (Set / Clear threshold) — deliberately not a pButton:

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.css
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.css
@@ -78,26 +78,15 @@
 
 /* Small enough to sit inside a settings row rather than span the panel like
    the full-width "Add automation settings" button. */
-.building-setting-set {
+.building-setting-button {
   padding: 1px 10px;
   font-size: smaller;
 }
 
-/* Small inline action (Set / Clear threshold) — deliberately not a pButton:
-   these sit inside a settings row, not at the panel's edge. */
-.building-setting-link {
-  padding: 0;
-  border: 0;
-  background: none;
-  color: var(--p-primary-color);
-  font: inherit;
-  font-size: smaller;
-  text-decoration: underline;
-  cursor: pointer;
-}
-
-.building-setting-link:hover {
-  color: var(--p-primary-hover-color, var(--p-primary-color));
+/* Clear threshold has no label beside it, so it needs pushing to the same edge
+   the Set button sits on rather than being left-aligned by space-between. */
+.building-setting-row-end {
+  justify-content: flex-end;
 }
 
 .building-setting-add {

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.css
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.css
@@ -30,6 +30,40 @@
   font-size: smaller;
 }
 
+/* Two-way choice (a threshold sensor's above/below direction) rendered as one
+   segmented control, so the two directions read as alternatives rather than as
+   a switch the user has to negate in their head. */
+.building-setting-toggle {
+  display: inline-flex;
+  border: 1px solid var(--p-content-border-color);
+  border-radius: var(--p-content-border-radius);
+  overflow: hidden;
+}
+
+.building-setting-toggle-option {
+  padding: 2px 10px;
+  border: 0;
+  background: transparent;
+  color: var(--p-text-muted-color);
+  font: inherit;
+  font-size: smaller;
+  cursor: pointer;
+}
+
+.building-setting-toggle-option + .building-setting-toggle-option {
+  border-left: 1px solid var(--p-content-border-color);
+}
+
+.building-setting-toggle-option:hover:not(.selected) {
+  background: var(--p-content-hover-background);
+  color: var(--p-text-color);
+}
+
+.building-setting-toggle-option.selected {
+  background: var(--p-primary-color);
+  color: var(--p-primary-contrast-color);
+}
+
 .building-setting-add {
   width: 100%;
   margin-top: 6px;

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
@@ -22,7 +22,7 @@
         pButton
         type="button"
         size="small"
-        class="building-setting-set"
+        class="building-setting-button building-setting-set"
         (click)="setThreshold()"
         i18n
       >
@@ -108,10 +108,16 @@
     </span>
   </div>
 
-  <div class="building-setting-row" *ngIf="canClearThreshold">
+  <div
+    class="building-setting-row building-setting-row-end"
+    *ngIf="canClearThreshold"
+  >
     <button
+      pButton
       type="button"
-      class="building-setting-link"
+      size="small"
+      severity="secondary"
+      class="building-setting-button building-setting-clear"
       (click)="clearThreshold()"
       i18n
       pTooltip="Removes the stored threshold so the blueprint says nothing about it, and the game's own default applies on build."

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
@@ -6,18 +6,23 @@
   <legend
     class="ui-fieldset-legend ui-corner-all ui-state-default ui-unselectable-text"
   >
-    <span class="ui-fieldset-legend-text" i18n>Building settings</span>
+    <span class="ui-fieldset-legend-text building-setting-legend" i18n
+      >Building settings</span
+    >
   </legend>
 
   <!-- A threshold sensor with nothing stored: the blueprint says nothing
        about the threshold, and the game's own default applies on build. -->
   <div class="building-setting-row" *ngIf="thresholdLabel as label">
-    <span class="building-setting-label">{{ label }}</span>
+    <span class="building-setting-label"
+      >{{ label }} <span class="building-setting-unset" i18n>(Not set)</span>
+    </span>
     <span class="building-setting-control">
-      <span class="building-setting-unset" i18n>Not set</span>
       <button
+        pButton
         type="button"
-        class="building-setting-link"
+        size="small"
+        class="building-setting-set"
         (click)="setThreshold()"
         i18n
       >

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
@@ -16,8 +16,34 @@
     <span class="building-setting-label">{{ row.label }}</span>
 
     <span class="building-setting-control">
+      <span
+        class="building-setting-toggle"
+        *ngIf="row.type === 'bool' && row.booleanLabels"
+        role="group"
+        [attr.aria-label]="row.label"
+      >
+        <button
+          type="button"
+          class="building-setting-toggle-option"
+          [class.selected]="row.displayValue"
+          [attr.aria-pressed]="row.displayValue"
+          (click)="onFieldInput(row, true)"
+        >
+          {{ row.booleanLabels.whenTrue }}
+        </button>
+        <button
+          type="button"
+          class="building-setting-toggle-option"
+          [class.selected]="!row.displayValue"
+          [attr.aria-pressed]="!row.displayValue"
+          (click)="onFieldInput(row, false)"
+        >
+          {{ row.booleanLabels.whenFalse }}
+        </button>
+      </span>
+
       <input
-        *ngIf="row.type === 'bool'"
+        *ngIf="row.type === 'bool' && !row.booleanLabels"
         type="checkbox"
         [checked]="row.displayValue"
         (change)="onFieldInput(row, $any($event.target).checked)"
@@ -32,8 +58,10 @@
           [attr.min]="row.displayMin"
           [attr.max]="row.displayMax"
           [attr.step]="row.step"
-          (blur)="onFieldInput(row, numInput.value)"
-          (keydown.enter)="onFieldInput(row, numInput.value); numInput.blur()"
+          (blur)="onFieldInput(row, numInput.value, numInput)"
+          (keydown.enter)="
+            onFieldInput(row, numInput.value, numInput); numInput.blur()
+          "
         />
         <span class="building-setting-unit" *ngIf="row.unitSuffix">{{
           row.unitSuffix
@@ -50,8 +78,10 @@
         class="building-setting-text"
         [value]="row.displayValue"
         [attr.maxlength]="row.displayMax"
-        (blur)="onFieldInput(row, textInput.value)"
-        (keydown.enter)="onFieldInput(row, textInput.value); textInput.blur()"
+        (blur)="onFieldInput(row, textInput.value, textInput)"
+        (keydown.enter)="
+          onFieldInput(row, textInput.value, textInput); textInput.blur()
+        "
       />
     </span>
   </div>

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
@@ -31,16 +31,13 @@
           [value]="row.displayValue"
           [attr.min]="row.displayMin"
           [attr.max]="row.displayMax"
-          [attr.step]="row.type === 'int' ? 1 : 0.1"
+          [attr.step]="row.step"
           (blur)="onFieldInput(row, numInput.value)"
           (keydown.enter)="onFieldInput(row, numInput.value); numInput.blur()"
         />
-        <span class="building-setting-unit" *ngIf="row.unit === 's'">s</span>
-        <span
-          class="building-setting-unit"
-          *ngIf="row.unit === 'cycleFraction' || row.unit === '%'"
-          >%</span
-        >
+        <span class="building-setting-unit" *ngIf="row.unitSuffix">{{
+          row.unitSuffix
+        }}</span>
         <span class="building-setting-hint" *ngIf="row.cycleHint">
           ({{ row.cycleHint }})
         </span>
@@ -60,14 +57,13 @@
   </div>
 
   <button
-    *ngFor="let key of creatableKeys"
+    *ngFor="let item of creatableSettings; trackBy: trackByCreatable"
     pButton
     type="button"
     class="ui-button building-setting-add"
-    (click)="addSetting(key)"
-    i18n
+    (click)="addSetting(item.key)"
   >
-    Add automation settings
+    {{ item.label }}
   </button>
 
   <div

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
@@ -79,7 +79,7 @@
           [value]="row.displayValue"
           [attr.min]="row.displayMin"
           [attr.max]="row.displayMax"
-          [attr.step]="row.step"
+          [attr.step]="row.stepAttr"
           (blur)="onFieldInput(row, numInput.value, numInput)"
           (keydown.enter)="
             onFieldInput(row, numInput.value, numInput); numInput.blur()

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.html
@@ -9,6 +9,23 @@
     <span class="ui-fieldset-legend-text" i18n>Building settings</span>
   </legend>
 
+  <!-- A threshold sensor with nothing stored: the blueprint says nothing
+       about the threshold, and the game's own default applies on build. -->
+  <div class="building-setting-row" *ngIf="thresholdLabel as label">
+    <span class="building-setting-label">{{ label }}</span>
+    <span class="building-setting-control">
+      <span class="building-setting-unset" i18n>Not set</span>
+      <button
+        type="button"
+        class="building-setting-link"
+        (click)="setThreshold()"
+        i18n
+      >
+        Set
+      </button>
+    </span>
+  </div>
+
   <div
     class="building-setting-row"
     *ngFor="let row of rows; trackBy: trackByRow"
@@ -84,6 +101,19 @@
         "
       />
     </span>
+  </div>
+
+  <div class="building-setting-row" *ngIf="canClearThreshold">
+    <button
+      type="button"
+      class="building-setting-link"
+      (click)="clearThreshold()"
+      i18n
+      pTooltip="Removes the stored threshold so the blueprint says nothing about it, and the game's own default applies on build."
+      tooltipEvent="both"
+    >
+      Clear threshold
+    </button>
   </div>
 
   <button

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
@@ -490,11 +490,11 @@ describe("BuildingSettingsComponent", () => {
     ]);
     expect(component.canClearThreshold).toBe(true);
 
-    const clear = Array.from(
-      fixture.nativeElement.querySelectorAll(".building-setting-link"),
-    ).find((b: any) => b.textContent.trim() === "Clear threshold") as
-      HTMLButtonElement | undefined;
-    clear!.click();
+    const clear = fixture.nativeElement.querySelector(
+      ".building-setting-clear",
+    ) as HTMLButtonElement;
+    expect(clear.textContent.trim()).toBe("Clear threshold");
+    clear.click();
 
     expect(component.blueprintItem.removeBuildingSetting).toHaveBeenCalledWith(
       "IThresholdSwitch",
@@ -527,6 +527,12 @@ describe("BuildingSettingsComponent", () => {
 
     expect(component.canClearThreshold).toBe(false);
     expect(component.thresholdLabel).toBeNull();
+    expect(
+      fixture.nativeElement.querySelector(".building-setting-clear"),
+    ).toBeNull();
+    expect(
+      fixture.nativeElement.querySelector(".building-setting-set"),
+    ).toBeNull();
   });
 
   it("leaves the critter sensor to the plain catalogue, unchanged", () => {

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
@@ -57,6 +57,13 @@ describe("BuildingSettingsComponent", () => {
         ];
         return true;
       }),
+      removeBuildingSetting: vi.fn(function (this: any, key: string) {
+        const before = this.buildingData?.length ?? 0;
+        this.buildingData = (this.buildingData ?? []).filter(
+          (e: any) => e.Key != key,
+        );
+        return this.buildingData.length != before;
+      }),
     } as unknown as BlueprintItem;
   }
 
@@ -420,15 +427,38 @@ describe("BuildingSettingsComponent", () => {
     ).toBeNull();
   });
 
-  it("offers a named threshold button on a freshly placed sensor", () => {
+  it("shows an unset threshold as Not set, with a control to set it", () => {
     setItem("LogicPressureSensorGas", undefined);
 
-    const addButton = fixture.nativeElement.querySelector(
-      ".building-setting-add",
-    ) as HTMLButtonElement;
-    expect(addButton.textContent.trim()).toBe("Set pressure threshold");
+    expect(
+      fixture.nativeElement.querySelector(".building-setting-label")
+        .textContent,
+    ).toBe("Pressure");
+    expect(
+      fixture.nativeElement.querySelector(".building-setting-unset")
+        .textContent,
+    ).toBe("Not set");
+    // No number input and no direction toggle until it is set.
+    expect(
+      fixture.nativeElement.querySelector(".building-setting-number"),
+    ).toBeNull();
+    expect(
+      fixture.nativeElement.querySelector(".building-setting-toggle"),
+    ).toBeNull();
+    // ...and no second, redundant "add" button offering the same thing.
+    expect(
+      fixture.nativeElement.querySelector(".building-setting-add"),
+    ).toBeNull();
+  });
 
-    addButton.click();
+  it("writes the key when the unset threshold is set", () => {
+    setItem("LogicPressureSensorGas", undefined);
+
+    (
+      fixture.nativeElement.querySelector(
+        ".building-setting-link",
+      ) as HTMLButtonElement
+    ).click();
 
     expect(component.blueprintItem.addBuildingSetting).toHaveBeenCalledWith(
       "IThresholdSwitch",
@@ -440,9 +470,66 @@ describe("BuildingSettingsComponent", () => {
       },
     ]);
     expect(emitBlueprintChanged).toHaveBeenCalled();
+
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.querySelector(".building-setting-unset"),
+    ).toBeNull();
+    expect(numberInput().value).toBe("1000");
   });
 
-  it("renders a critter sensor's duplicated state once, under its own key", () => {
+  it("clears a stored threshold back to not set", () => {
+    setItem("LogicPressureSensorGas", [
+      { Key: "Switch", Value: { switchedOn: true } },
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 1.5, ActivateAboveThreshold: true },
+      },
+    ]);
+    expect(component.canClearThreshold).toBe(true);
+
+    const clear = Array.from(
+      fixture.nativeElement.querySelectorAll(".building-setting-link"),
+    ).find((b: any) => b.textContent.trim() === "Clear threshold") as
+      HTMLButtonElement | undefined;
+    clear!.click();
+
+    expect(component.blueprintItem.removeBuildingSetting).toHaveBeenCalledWith(
+      "IThresholdSwitch",
+    );
+    // The unrelated stowaway key is untouched.
+    expect(component.blueprintItem.buildingData).toEqual([
+      { Key: "Switch", Value: { switchedOn: true } },
+    ]);
+    expect(emitBlueprintChanged).toHaveBeenCalled();
+
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.querySelector(".building-setting-unset")
+        .textContent,
+    ).toBe("Not set");
+  });
+
+  it("offers no clear on a building that is not a threshold sensor", () => {
+    setItem("LogicTimerSensor", [
+      {
+        Key: "LogicTimerSensor",
+        Value: {
+          onDuration: 5.0,
+          offDuration: 5.0,
+          timeElapsedInCurrentState: 0,
+          displayCyclesMode: false,
+        },
+      },
+    ]);
+
+    expect(component.canClearThreshold).toBe(false);
+    expect(component.thresholdLabel).toBeNull();
+  });
+
+  it("leaves the critter sensor to the plain catalogue, unchanged", () => {
+    // Out of scope for the threshold work: it writes the same values under two
+    // keys, and its own key also carries countCritters/countEggs.
     setItem("LogicCritterCountSensor", [
       {
         Key: "LogicCritterCountSensor",
@@ -453,32 +540,16 @@ describe("BuildingSettingsComponent", () => {
           countEggs: false,
         },
       },
-      {
-        Key: "IThresholdSwitch",
-        Value: { Threshold: 3, ActivateAboveThreshold: true },
-      },
     ]);
 
-    // countThreshold, not IThresholdSwitch.Threshold.
+    expect(component.thresholdLabel).toBeNull();
+    expect(component.canClearThreshold).toBe(false);
     expect(component.rows.map((r: any) => `${r.key}.${r.field}`)).toEqual([
       "LogicCritterCountSensor.countThreshold",
       "LogicCritterCountSensor.activateOnGreaterThan",
       "LogicCritterCountSensor.countCritters",
       "LogicCritterCountSensor.countEggs",
     ]);
-
-    const input = numberInput();
-    input.value = "8";
-    input.dispatchEvent(new Event("blur"));
-
-    // The mirroring itself lives in BlueprintItem.setBuildingSetting; the
-    // panel's job is to edit the specific key and let the model keep the
-    // generic one in step.
-    expect(component.blueprintItem.setBuildingSetting).toHaveBeenCalledWith(
-      "LogicCritterCountSensor",
-      "countThreshold",
-      8,
-    );
   });
 
   it("shows the clamped value back in the input, not what was typed", () => {

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
@@ -585,6 +585,31 @@ describe("BuildingSettingsComponent", () => {
     expect(numberInput().value).toBe("20000");
   });
 
+  it("does not rewrite a stored value already outside the range on an untouched blur", () => {
+    // An imported blueprint's stored Threshold can already sit outside the
+    // sensor's soft display bounds. That value must be displayed and
+    // preserved untouched — a blur with no edit must not clamp it onto the
+    // boundary. This is the exact hole a clamp-before-no-op-check ordering
+    // opens: 25 kg (25000 g display) is above the 20000 g RangeMax.
+    setItem("LogicPressureSensorGas", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 25, ActivateAboveThreshold: true },
+      },
+    ]);
+
+    const input = numberInput();
+    expect(input.value).toBe("25000");
+
+    // No edit — the value round-trips through blur exactly as typed.
+    input.value = "25000";
+    input.dispatchEvent(new Event("blur"));
+    fixture.detectChanges();
+
+    expect(component.blueprintItem.setBuildingSetting).not.toHaveBeenCalled();
+    expect(numberInput().value).toBe("25000");
+  });
+
   it("shows the clamped value when clamping does change the stored value", () => {
     setItem("LogicPressureSensorGas", [
       {
@@ -604,6 +629,32 @@ describe("BuildingSettingsComponent", () => {
       20,
     );
     expect(numberInput().value).toBe("20000");
+  });
+
+  it("relaxes step to 'any' when min isn't a step multiple (Thermo Sensor)", () => {
+    // displayMin is -273.15 (0 K) with step 1 — a native number input
+    // validates (value - min) as a step multiple, so a whole-degree value
+    // like 20 would otherwise be marked :invalid and the spinner arrows
+    // would walk fractional degrees instead of whole ones.
+    setItem("LogicTemperatureSensor", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 293.15, ActivateAboveThreshold: true },
+      },
+    ]);
+
+    expect(numberInput().getAttribute("step")).toBe("any");
+  });
+
+  it("keeps a numeric step when min is already step-aligned (Atmo Sensor)", () => {
+    setItem("LogicPressureSensorGas", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 1, ActivateAboveThreshold: true },
+      },
+    ]);
+
+    expect(numberInput().getAttribute("step")).toBe("1");
   });
 
   it("clamps a value below the minimum up to the bound", () => {

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
@@ -3,7 +3,10 @@ import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
 import { BlueprintService } from "src/app/module-blueprint/services/blueprint-service";
-import { BlueprintItem } from "../../../../../../../lib/index";
+import {
+  BlueprintItem,
+  getCreatableSettingDefaults,
+} from "../../../../../../../lib/index";
 import { BuildingSettingsComponent } from "./building-settings.component";
 
 describe("BuildingSettingsComponent", () => {
@@ -43,10 +46,14 @@ describe("BuildingSettingsComponent", () => {
         const entry = this.buildingData.find((e: any) => e.Key == key);
         entry.Value[field] = value;
       }),
+      // Uses the real catalogue defaults, so a test that clicks the add
+      // button sees the object the editor would actually write.
       addBuildingSetting: vi.fn(function (this: any, key: string) {
+        const defaults = getCreatableSettingDefaults(this.id, key);
+        if (defaults == null) return false;
         this.buildingData = [
           ...(this.buildingData ?? []),
-          { Key: key, Value: { onDuration: 10, offDuration: 10 } },
+          { Key: key, Value: { ...defaults } },
         ];
         return true;
       }),
@@ -276,6 +283,197 @@ describe("BuildingSettingsComponent", () => {
       "LogicAlarm",
       "notificationName",
       "x".repeat(200),
+    );
+  });
+
+  // --- Threshold sensors -------------------------------------------------
+  // IThresholdSwitch stores the raw sim value; the panel has to show what the
+  // game's own side screen showed the player, and convert back on edit.
+
+  function numberInput(): HTMLInputElement {
+    return fixture.nativeElement.querySelector(
+      ".building-setting-number",
+    ) as HTMLInputElement;
+  }
+
+  it("shows an Atmo Sensor threshold in grams, not stored kilograms", () => {
+    setItem("LogicPressureSensorGas", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 0.5, ActivateAboveThreshold: true },
+      },
+    ]);
+
+    expect(numberInput().value).toBe("500");
+    expect(
+      fixture.nativeElement.querySelector(".building-setting-unit").textContent,
+    ).toBe("g");
+    expect(
+      fixture.nativeElement.querySelector(".building-setting-label")
+        .textContent,
+    ).toBe("Pressure");
+  });
+
+  it("stores an edited gas pressure back in kilograms", () => {
+    setItem("LogicPressureSensorGas", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 0.5, ActivateAboveThreshold: true },
+      },
+    ]);
+
+    const input = numberInput();
+    input.value = "1500";
+    input.dispatchEvent(new Event("blur"));
+
+    expect(component.blueprintItem.setBuildingSetting).toHaveBeenCalledWith(
+      "IThresholdSwitch",
+      "Threshold",
+      1.5,
+    );
+    expect(emitBlueprintChanged).toHaveBeenCalled();
+  });
+
+  it("shows a Thermo Sensor threshold in Celsius and stores Kelvin", () => {
+    setItem("LogicTemperatureSensor", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 293.15, ActivateAboveThreshold: false },
+      },
+    ]);
+
+    expect(numberInput().value).toBe("20");
+    expect(
+      fixture.nativeElement.querySelector(".building-setting-unit").textContent,
+    ).toBe("°C");
+
+    const input = numberInput();
+    input.value = "-10";
+    input.dispatchEvent(new Event("blur"));
+
+    const call = (component.blueprintItem.setBuildingSetting as any).mock
+      .calls[0];
+    expect(call[0]).toBe("IThresholdSwitch");
+    expect(call[1]).toBe("Threshold");
+    expect(call[2]).toBeCloseTo(263.15, 9);
+  });
+
+  it("does not write when an input is blurred without being edited", () => {
+    // The displayed value is rounded, so re-deriving a stored value from it
+    // would nudge 293.153 K to 293.15 and detach rawSource for nothing.
+    setItem("LogicTemperatureSensor", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 293.153, ActivateAboveThreshold: true },
+      },
+    ]);
+
+    numberInput().dispatchEvent(new Event("blur"));
+
+    expect(component.blueprintItem.setBuildingSetting).not.toHaveBeenCalled();
+    expect(emitBlueprintChanged).not.toHaveBeenCalled();
+  });
+
+  it("clamps a typed value to the sensor's own soft bounds", () => {
+    setItem("LogicPressureSensorGas", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 0.5, ActivateAboveThreshold: true },
+      },
+    ]);
+
+    const input = numberInput();
+    input.value = "999999";
+    input.dispatchEvent(new Event("blur"));
+
+    // 20000 g is the 20 kg RangeMax, converted back to stored units.
+    expect(component.blueprintItem.setBuildingSetting).toHaveBeenCalledWith(
+      "IThresholdSwitch",
+      "Threshold",
+      20,
+    );
+  });
+
+  it("hides the stowaway Switch key a copied sensor carries", () => {
+    // Sensors extend Switch, so the mod's Switch handler stores the sensor's
+    // sampled output. It round-trips, but it is not a setting.
+    setItem("LogicPressureSensorGas", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 0.5, ActivateAboveThreshold: true },
+      },
+      { Key: "Switch", Value: { switchedOn: true } },
+    ]);
+
+    // One checkbox only: ActivateAboveThreshold, not switchedOn.
+    const checkboxes = fixture.nativeElement.querySelectorAll(
+      'input[type="checkbox"]',
+    );
+    expect(checkboxes.length).toBe(1);
+    // ...and it is not reported as an unrecognized preserved setting either.
+    expect(
+      fixture.nativeElement.querySelector(".building-setting-other"),
+    ).toBeNull();
+  });
+
+  it("offers a named threshold button on a freshly placed sensor", () => {
+    setItem("LogicPressureSensorGas", undefined);
+
+    const addButton = fixture.nativeElement.querySelector(
+      ".building-setting-add",
+    ) as HTMLButtonElement;
+    expect(addButton.textContent.trim()).toBe("Set pressure threshold");
+
+    addButton.click();
+
+    expect(component.blueprintItem.addBuildingSetting).toHaveBeenCalledWith(
+      "IThresholdSwitch",
+    );
+    expect(component.blueprintItem.buildingData).toEqual([
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 1, ActivateAboveThreshold: true },
+      },
+    ]);
+    expect(emitBlueprintChanged).toHaveBeenCalled();
+  });
+
+  it("renders a critter sensor's duplicated state once, under its own key", () => {
+    setItem("LogicCritterCountSensor", [
+      {
+        Key: "LogicCritterCountSensor",
+        Value: {
+          countThreshold: 3,
+          activateOnGreaterThan: true,
+          countCritters: true,
+          countEggs: false,
+        },
+      },
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 3, ActivateAboveThreshold: true },
+      },
+    ]);
+
+    // countThreshold, not IThresholdSwitch.Threshold.
+    expect(component.rows.map((r: any) => `${r.key}.${r.field}`)).toEqual([
+      "LogicCritterCountSensor.countThreshold",
+      "LogicCritterCountSensor.activateOnGreaterThan",
+      "LogicCritterCountSensor.countCritters",
+      "LogicCritterCountSensor.countEggs",
+    ]);
+
+    const input = numberInput();
+    input.value = "8";
+    input.dispatchEvent(new Event("blur"));
+
+    // The mirroring itself lives in BlueprintItem.setBuildingSetting; the
+    // panel's job is to edit the specific key and let the model keep the
+    // generic one in step.
+    expect(component.blueprintItem.setBuildingSetting).toHaveBeenCalledWith(
+      "LogicCritterCountSensor",
+      "countThreshold",
+      8,
     );
   });
 });

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
@@ -315,10 +315,12 @@ describe("BuildingSettingsComponent", () => {
     expect(
       fixture.nativeElement.querySelector(".building-setting-unit").textContent,
     ).toBe("g");
+    // Direction row comes first, so the threshold label is the second one.
     expect(
-      fixture.nativeElement.querySelector(".building-setting-label")
-        .textContent,
-    ).toBe("Pressure");
+      Array.from(
+        fixture.nativeElement.querySelectorAll(".building-setting-label"),
+      ).map((e: any) => e.textContent.trim()),
+    ).toEqual(["Active", "Pressure"]);
   });
 
   it("stores an edited gas pressure back in kilograms", () => {
@@ -418,8 +420,8 @@ describe("BuildingSettingsComponent", () => {
       fixture.nativeElement.querySelectorAll('input[type="checkbox"]').length,
     ).toBe(0);
     expect(component.rows.map((r: any) => `${r.key}.${r.field}`)).toEqual([
-      "IThresholdSwitch.Threshold",
       "IThresholdSwitch.ActivateAboveThreshold",
+      "IThresholdSwitch.Threshold",
     ]);
     // ...and it is not reported as an unrecognized preserved setting either.
     expect(
@@ -656,7 +658,7 @@ describe("BuildingSettingsComponent", () => {
     const labels = Array.from(
       fixture.nativeElement.querySelectorAll(".building-setting-label"),
     ).map((e: any) => e.textContent.trim());
-    expect(labels).toContain("Activate when");
+    expect(labels).toContain("Active");
   });
 
   it("marks Below as selected when the stored direction is false", () => {

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
@@ -405,11 +405,15 @@ describe("BuildingSettingsComponent", () => {
       { Key: "Switch", Value: { switchedOn: true } },
     ]);
 
-    // One checkbox only: ActivateAboveThreshold, not switchedOn.
-    const checkboxes = fixture.nativeElement.querySelectorAll(
-      'input[type="checkbox"]',
-    );
-    expect(checkboxes.length).toBe(1);
+    // No checkbox at all: ActivateAboveThreshold renders as an above/below
+    // toggle, and switchedOn is not rendered.
+    expect(
+      fixture.nativeElement.querySelectorAll('input[type="checkbox"]').length,
+    ).toBe(0);
+    expect(component.rows.map((r: any) => `${r.key}.${r.field}`)).toEqual([
+      "IThresholdSwitch.Threshold",
+      "IThresholdSwitch.ActivateAboveThreshold",
+    ]);
     // ...and it is not reported as an unrecognized preserved setting either.
     expect(
       fixture.nativeElement.querySelector(".building-setting-other"),
@@ -475,5 +479,193 @@ describe("BuildingSettingsComponent", () => {
       "countThreshold",
       8,
     );
+  });
+
+  it("shows the clamped value back in the input, not what was typed", () => {
+    // Stored is already at the 20kg RangeMax, so clamping 999999 lands on the
+    // value the row already displays. The commit guard correctly skips the
+    // write — but the input must not be left showing 999999 while the model
+    // holds 20000.
+    setItem("LogicPressureSensorGas", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 20, ActivateAboveThreshold: true },
+      },
+    ]);
+
+    const input = numberInput();
+    expect(input.value).toBe("20000");
+
+    input.value = "999999";
+    input.dispatchEvent(new Event("blur"));
+    fixture.detectChanges();
+
+    expect(component.blueprintItem.setBuildingSetting).not.toHaveBeenCalled();
+    expect(numberInput().value).toBe("20000");
+  });
+
+  it("shows the clamped value when clamping does change the stored value", () => {
+    setItem("LogicPressureSensorGas", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 0.5, ActivateAboveThreshold: true },
+      },
+    ]);
+
+    const input = numberInput();
+    input.value = "999999";
+    input.dispatchEvent(new Event("blur"));
+    fixture.detectChanges();
+
+    expect(component.blueprintItem.setBuildingSetting).toHaveBeenCalledWith(
+      "IThresholdSwitch",
+      "Threshold",
+      20,
+    );
+    expect(numberInput().value).toBe("20000");
+  });
+
+  it("clamps a value below the minimum up to the bound", () => {
+    setItem("LogicTemperatureSensor", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 293.15, ActivateAboveThreshold: true },
+      },
+    ]);
+
+    const input = numberInput();
+    input.value = "-500";
+    input.dispatchEvent(new Event("blur"));
+    fixture.detectChanges();
+
+    // 0 K is the RangeMin, which is -273.15 °C.
+    expect(component.blueprintItem.setBuildingSetting).toHaveBeenCalledWith(
+      "IThresholdSwitch",
+      "Threshold",
+      0,
+    );
+    expect(numberInput().value).toBe("-273.15");
+  });
+
+  // --- Above/Below direction toggle ---------------------------------------
+
+  function toggleOptions(): HTMLButtonElement[] {
+    return Array.from(
+      fixture.nativeElement.querySelectorAll(".building-setting-toggle-option"),
+    );
+  }
+
+  it("renders the above/below direction as two options, not a checkbox", () => {
+    setItem("LogicPressureSensorGas", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 0.5, ActivateAboveThreshold: true },
+      },
+    ]);
+
+    const options = toggleOptions();
+    expect(options.map((b) => b.textContent.trim())).toEqual([
+      "Above",
+      "Below",
+    ]);
+    expect(options[0].classList.contains("selected")).toBe(true);
+    expect(options[1].classList.contains("selected")).toBe(false);
+    expect(
+      fixture.nativeElement.querySelectorAll('input[type="checkbox"]').length,
+    ).toBe(0);
+
+    const labels = Array.from(
+      fixture.nativeElement.querySelectorAll(".building-setting-label"),
+    ).map((e: any) => e.textContent.trim());
+    expect(labels).toContain("Activate when");
+  });
+
+  it("marks Below as selected when the stored direction is false", () => {
+    setItem("LogicPressureSensorGas", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 0.5, ActivateAboveThreshold: false },
+      },
+    ]);
+
+    const options = toggleOptions();
+    expect(options[0].classList.contains("selected")).toBe(false);
+    expect(options[1].classList.contains("selected")).toBe(true);
+  });
+
+  it("commits the direction when the other option is picked", () => {
+    setItem("LogicPressureSensorGas", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 0.5, ActivateAboveThreshold: true },
+      },
+    ]);
+
+    toggleOptions()[1].click();
+
+    expect(component.blueprintItem.setBuildingSetting).toHaveBeenCalledWith(
+      "IThresholdSwitch",
+      "ActivateAboveThreshold",
+      false,
+    );
+    expect(emitBlueprintChanged).toHaveBeenCalled();
+
+    fixture.detectChanges();
+    expect(toggleOptions()[1].classList.contains("selected")).toBe(true);
+  });
+
+  it("does not push an undo step when the selected option is re-picked", () => {
+    setItem("LogicPressureSensorGas", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 0.5, ActivateAboveThreshold: true },
+      },
+    ]);
+
+    toggleOptions()[0].click();
+
+    expect(component.blueprintItem.setBuildingSetting).not.toHaveBeenCalled();
+    expect(emitBlueprintChanged).not.toHaveBeenCalled();
+  });
+
+  it("gives the critter sensor the same above/below control", () => {
+    setItem("LogicCritterCountSensor", [
+      {
+        Key: "LogicCritterCountSensor",
+        Value: {
+          countThreshold: 3,
+          activateOnGreaterThan: false,
+          countCritters: true,
+          countEggs: false,
+        },
+      },
+    ]);
+
+    const options = toggleOptions();
+    expect(options.map((b) => b.textContent.trim())).toEqual([
+      "Above",
+      "Below",
+    ]);
+    expect(options[1].classList.contains("selected")).toBe(true);
+    // countCritters/countEggs stay ordinary on/off checkboxes.
+    expect(
+      fixture.nativeElement.querySelectorAll('input[type="checkbox"]').length,
+    ).toBe(2);
+  });
+
+  it("restores the stored value when a number field is emptied", () => {
+    setItem("LogicPressureSensorGas", [
+      {
+        Key: "IThresholdSwitch",
+        Value: { Threshold: 0.5, ActivateAboveThreshold: true },
+      },
+    ]);
+
+    const input = numberInput();
+    input.value = "";
+    input.dispatchEvent(new Event("blur"));
+
+    expect(component.blueprintItem.setBuildingSetting).not.toHaveBeenCalled();
+    expect(numberInput().value).toBe("500");
   });
 });

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.spec.ts
@@ -431,13 +431,15 @@ describe("BuildingSettingsComponent", () => {
     setItem("LogicPressureSensorGas", undefined);
 
     expect(
-      fixture.nativeElement.querySelector(".building-setting-label")
-        .textContent,
-    ).toBe("Pressure");
+      fixture.nativeElement
+        .querySelector(".building-setting-label")
+        .textContent.replace(/\s+/g, " ")
+        .trim(),
+    ).toBe("Pressure (Not set)");
     expect(
       fixture.nativeElement.querySelector(".building-setting-unset")
         .textContent,
-    ).toBe("Not set");
+    ).toBe("(Not set)");
     // No number input and no direction toggle until it is set.
     expect(
       fixture.nativeElement.querySelector(".building-setting-number"),
@@ -456,7 +458,7 @@ describe("BuildingSettingsComponent", () => {
 
     (
       fixture.nativeElement.querySelector(
-        ".building-setting-link",
+        ".building-setting-set",
       ) as HTMLButtonElement
     ).click();
 
@@ -507,7 +509,7 @@ describe("BuildingSettingsComponent", () => {
     expect(
       fixture.nativeElement.querySelector(".building-setting-unset")
         .textContent,
-    ).toBe("Not set");
+    ).toBe("(Not set)");
   });
 
   it("offers no clear on a building that is not a threshold sensor", () => {

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.ts
@@ -28,6 +28,14 @@ interface EditableSettingRow {
   // bare count), which is why this is not optional-with-fallback.
   unitSuffix: string;
   step: number;
+  // What the template actually binds to [attr.step]. A native number input
+  // validates step against min (value - min must be a step multiple), so a
+  // fractional displayMin (Thermo Sensor's -273.15 °C) combined with an
+  // integer step marks a perfectly normal value like 20 as :invalid — the
+  // spinner arrows land on 20.85, 21.85, ... instead of whole degrees.
+  // "any" disables that check without changing the increment shown by the
+  // spinner buttons in browsers that still honour step for those.
+  stepAttr: number | "any";
   // Set on a boolean that is a two-way choice (a threshold sensor's
   // above/below direction), which renders as a pair of options rather than a
   // checkbox. Absent means an ordinary on/off checkbox.
@@ -57,6 +65,21 @@ function suffixOf(descriptor: SettingFieldDescriptor): string {
 function roundTo(value: number, decimals: number): number {
   const factor = Math.pow(10, decimals);
   return Math.round(value * factor) / factor;
+}
+
+// Whether (value - min) is a whole multiple of step, within floating-point
+// tolerance — the condition the browser's own step-mismatch validation uses.
+function isStepAligned(min: number, step: number): boolean {
+  if (step <= 0) return false;
+  const remainder = Math.abs(min) % step;
+  return remainder < 1e-9 || Math.abs(remainder - step) < 1e-9;
+}
+
+function stepAttrFor(
+  step: number,
+  displayMin: number | undefined,
+): number | "any" {
+  return displayMin != null && !isStepAligned(displayMin, step) ? "any" : step;
 }
 
 const CYCLE_SECONDS = 600;
@@ -144,6 +167,13 @@ export class BuildingSettingsComponent {
         const decimals =
           descriptor.decimals ?? (descriptor.type == "int" ? 0 : 2);
         const raw = value[descriptor.field];
+        const step = descriptor.step ?? (descriptor.type == "int" ? 1 : 0.1);
+        // Bounds are stored-unit in the catalogue, so they go through the
+        // same conversion as the value they constrain.
+        const displayMin =
+          descriptor.min != null
+            ? toDisplayValue(descriptor, descriptor.min)
+            : undefined;
         rows.push({
           key: entry.Key,
           field: descriptor.field,
@@ -152,18 +182,14 @@ export class BuildingSettingsComponent {
           type: descriptor.type,
           unit: descriptor.unit,
           unitSuffix: suffixOf(descriptor),
-          step: descriptor.step ?? (descriptor.type == "int" ? 1 : 0.1),
+          step,
+          stepAttr: stepAttrFor(step, displayMin),
           booleanLabels: descriptor.booleanLabels,
           displayValue:
             typeof raw == "number"
               ? roundTo(toDisplayValue(descriptor, raw), decimals)
               : raw,
-          // Bounds are stored-unit in the catalogue, so they go through the
-          // same conversion as the value they constrain.
-          displayMin:
-            descriptor.min != null
-              ? toDisplayValue(descriptor, descriptor.min)
-              : undefined,
+          displayMin,
           displayMax:
             descriptor.max != null
               ? toDisplayValue(descriptor, descriptor.max)
@@ -256,12 +282,26 @@ export class BuildingSettingsComponent {
         this.reconcile(el, row.displayValue);
         return;
       }
+      // Blurring an untouched input must not write — checked BEFORE clamping,
+      // against the raw typed number. A value already stored outside the
+      // sensor's soft range (e.g. an imported blueprint's Threshold above the
+      // display max) must round-trip through an untouched blur unchanged; if
+      // this check ran after clamping, the clamped number would never equal
+      // the (out-of-range) displayValue, and blurring the field with no edit
+      // would silently pull a stored value onto the boundary and detach
+      // rawSource for nothing. Also handles the ordinary case: the displayed
+      // value is rounded, so re-deriving a stored value from it would nudge a
+      // Thermo Sensor stored at 293.153 K to 293.15.
+      if (num === row.displayValue) {
+        this.reconcile(el, num);
+        return;
+      }
       // Soft bounds: the range comes from the sensor prefab's own
       // RangeMin/RangeMax, which the game's setter does not enforce either, so
       // an out-of-range entry is pulled to the nearest bound rather than
       // rejected. Note this only ever applies to values the user types — a
       // value already stored outside the range is displayed and preserved
-      // untouched.
+      // untouched (handled by the no-op-blur check above).
       if (row.displayMin != null && num < row.displayMin) num = row.displayMin;
       if (row.displayMax != null && num > row.displayMax) num = row.displayMax;
       // Show what was actually taken. Angular's [value] binding only rewrites
@@ -269,10 +309,12 @@ export class BuildingSettingsComponent {
       // the value already stored (typing 999999 into a sensor already at its
       // 20000 max) would otherwise leave 999999 sitting in the box.
       this.reconcile(el, num);
-      // Blurring an untouched input must not write. The displayed value is
-      // rounded, so re-deriving a stored value from it would nudge a
-      // Thermo Sensor stored at 293.153 K to 293.15 — a silent data change
-      // that also detaches rawSource for nothing.
+      // A real edit attempt (num !== displayValue above) can still clamp back
+      // onto the value already stored — typing 999999 into a sensor already
+      // at its 20000 max. That is not a change either, so it must not write
+      // or detach rawSource; this is a second, independent no-op check from
+      // the one above, since it depends on the clamped number rather than
+      // what was typed.
       if (num === row.displayValue) return;
       value = toStoredValue(row.descriptor, num);
       if (row.type == "int") value = Math.round(value);

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.ts
@@ -27,6 +27,10 @@ interface EditableSettingRow {
   // bare count), which is why this is not optional-with-fallback.
   unitSuffix: string;
   step: number;
+  // Set on a boolean that is a two-way choice (a threshold sensor's
+  // above/below direction), which renders as a pair of options rather than a
+  // checkbox. Absent means an ordinary on/off checkbox.
+  booleanLabels?: { whenTrue: string; whenFalse: string };
   displayValue: any;
   displayMin?: number;
   displayMax?: number;
@@ -120,6 +124,7 @@ export class BuildingSettingsComponent {
           unit: descriptor.unit,
           unitSuffix: suffixOf(descriptor),
           step: descriptor.step ?? (descriptor.type == "int" ? 1 : 0.1),
+          booleanLabels: descriptor.booleanLabels,
           displayValue:
             typeof raw == "number"
               ? roundTo(toDisplayValue(descriptor, raw), decimals)
@@ -199,15 +204,46 @@ export class BuildingSettingsComponent {
     return `${row.key}:${row.field}`;
   }
 
-  onFieldInput(row: EditableSettingRow, rawInput: string | boolean) {
+  // `el` is the control the edit came from. It is reconciled to the value
+  // actually committed, because a rejected or adjusted edit otherwise leaves
+  // the DOM showing something the model does not hold — see the clamp note
+  // below.
+  onFieldInput(
+    row: EditableSettingRow,
+    rawInput: string | boolean,
+    el?: HTMLInputElement,
+  ) {
     let value: any = rawInput;
     if (row.type == "bool") {
       value = Boolean(rawInput);
+      // Re-picking the option already in force is not an edit; without this a
+      // click on the selected half of an above/below toggle would push an
+      // undo step that changes nothing.
+      if (value === row.displayValue) return;
     } else if (row.type == "int" || row.type == "float") {
-      let num = Number(rawInput);
-      if (Number.isNaN(num)) return;
+      // An emptied field is not an edit to zero — and Number("") is 0, so it
+      // has to be caught before the parse. Same for a stray paste that does
+      // not parse: restore what the model holds rather than leaving the
+      // control showing something that corresponds to nothing.
+      const text = String(rawInput).trim();
+      let num = Number(text);
+      if (text === "" || Number.isNaN(num)) {
+        this.reconcile(el, row.displayValue);
+        return;
+      }
+      // Soft bounds: the range comes from the sensor prefab's own
+      // RangeMin/RangeMax, which the game's setter does not enforce either, so
+      // an out-of-range entry is pulled to the nearest bound rather than
+      // rejected. Note this only ever applies to values the user types — a
+      // value already stored outside the range is displayed and preserved
+      // untouched.
       if (row.displayMin != null && num < row.displayMin) num = row.displayMin;
       if (row.displayMax != null && num > row.displayMax) num = row.displayMax;
+      // Show what was actually taken. Angular's [value] binding only rewrites
+      // the DOM when the bound value changes, so clamping an entry down onto
+      // the value already stored (typing 999999 into a sensor already at its
+      // 20000 max) would otherwise leave 999999 sitting in the box.
+      this.reconcile(el, num);
       // Blurring an untouched input must not write. The displayed value is
       // rounded, so re-deriving a stored value from it would nudge a
       // Thermo Sensor stored at 293.153 K to 293.15 — a silent data change
@@ -221,10 +257,16 @@ export class BuildingSettingsComponent {
       // paste or a value set programmatically, so enforce the catalogue
       // bound here too before it reaches storage/export.
       if (row.displayMax != null) value = value.slice(0, row.displayMax);
+      this.reconcile(el, value);
+      if (value === row.displayValue) return;
     }
 
     this.blueprintItem.setBuildingSetting(row.key, row.field, value);
     this.commit();
+  }
+
+  private reconcile(el: HTMLInputElement | undefined, value: unknown) {
+    if (el != null) el.value = String(value);
   }
 
   private commit() {

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.ts
@@ -7,12 +7,13 @@ import {
   resolveSettingDescriptors,
   SettingFieldDescriptor,
   SettingFieldType,
-  settingMirrorFor,
   SettingUnit,
   thresholdSensorSpec,
   toDisplayValue,
   toStoredValue,
 } from "../../../../../../../lib/index";
+
+const THRESHOLD_KEY = "IThresholdSwitch";
 
 interface EditableSettingRow {
   key: string;
@@ -81,14 +82,47 @@ export class BuildingSettingsComponent {
     return (
       this.rows.length > 0 ||
       this.otherKeys.length > 0 ||
-      this.creatableSettings.length > 0
+      this.creatableSettings.length > 0 ||
+      this.thresholdLabel != null
     );
   }
 
-  get rows(): EditableSettingRow[] {
-    const present = new Set(
-      (this.blueprintItem.buildingData ?? []).map((entry) => entry.Key),
+  // A threshold sensor with no IThresholdSwitch key is not "at 0" and not
+  // "at the default we would have written" — the blueprint simply says nothing
+  // about it, and the mod leaves the built sensor on the game's own default.
+  // That state is shown rather than hidden behind a button, so the difference
+  // between "no opinion" and "pinned to a value" is visible in the panel.
+  private get thresholdSpec() {
+    return thresholdSensorSpec(this.blueprintItem.id);
+  }
+
+  private get hasThreshold(): boolean {
+    return (this.blueprintItem.buildingData ?? []).some(
+      (entry) => entry.Key == THRESHOLD_KEY,
     );
+  }
+
+  // The row label for a threshold sensor that has no threshold stored; null
+  // for anything that is not a threshold sensor, or that already has one.
+  get thresholdLabel(): string | null {
+    const spec = this.thresholdSpec;
+    return spec != null && !this.hasThreshold ? spec.label : null;
+  }
+
+  get canClearThreshold(): boolean {
+    return this.thresholdSpec != null && this.hasThreshold;
+  }
+
+  setThreshold() {
+    this.blueprintItem.addBuildingSetting(THRESHOLD_KEY);
+    this.commit();
+  }
+
+  clearThreshold() {
+    if (this.blueprintItem.removeBuildingSetting(THRESHOLD_KEY)) this.commit();
+  }
+
+  get rows(): EditableSettingRow[] {
     const rows: EditableSettingRow[] = [];
     for (const entry of this.blueprintItem.buildingData ?? []) {
       const descriptors = resolveSettingDescriptors(
@@ -102,11 +136,6 @@ export class BuildingSettingsComponent {
 
       for (const descriptor of descriptors) {
         if (descriptor.hidden) continue;
-        // This field is a mirror of one already rendered under another Key
-        // that the building carries (the critter sensor writes its count and
-        // above/below twice). Show it once — editing either moves both.
-        const mirror = settingMirrorFor(entry.Key, descriptor.field);
-        if (mirror?.redundant && present.has(mirror.key)) continue;
         // Mirrors formatBuildingDataEntry: a missing field means this entry
         // is incomplete/malformed (or from a newer mod version) — skip it
         // rather than rendering an editable row backed by nothing, which
@@ -170,19 +199,15 @@ export class BuildingSettingsComponent {
     const existing = new Set(
       (this.blueprintItem.buildingData ?? []).map((entry) => entry.Key),
     );
-    return creatableSettingsKeysFor(this.blueprintItem.id)
-      .filter((key) => !existing.has(key))
-      .map((key) => ({ key, label: this.creatableLabel(key) }));
-  }
-
-  // A threshold key names what it sets, since a building can offer more than
-  // one creatable key and "Add automation settings" would not say which.
-  private creatableLabel(key: string): string {
-    if (key != "IThresholdSwitch") return $localize`Add automation settings`;
-    const spec = thresholdSensorSpec(this.blueprintItem.id);
-    return spec == null
-      ? $localize`Add automation settings`
-      : $localize`Set ${spec.label.toLowerCase()}:label: threshold`;
+    return (
+      creatableSettingsKeysFor(this.blueprintItem.id)
+        .filter((key) => !existing.has(key))
+        // The threshold has its own always-present row, which carries both the
+        // unset state and the control that sets it — a second button here
+        // would offer the same thing twice.
+        .filter((key) => key != THRESHOLD_KEY)
+        .map((key) => ({ key, label: $localize`Add automation settings` }))
+    );
   }
 
   trackByCreatable(_index: number, item: CreatableSetting): string {

--- a/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.ts
+++ b/frontend/src/app/module-blueprint/components/side-bar/building-settings/building-settings.component.ts
@@ -4,28 +4,54 @@ import {
   BlueprintItem,
   creatableSettingsKeysFor,
   formatBuildingDataEntry,
-  SETTINGS_CATALOG,
+  resolveSettingDescriptors,
+  SettingFieldDescriptor,
   SettingFieldType,
+  settingMirrorFor,
   SettingUnit,
+  thresholdSensorSpec,
+  toDisplayValue,
+  toStoredValue,
 } from "../../../../../../../lib/index";
-
-// A percentage unit is stored as a 0-1 fraction (LogicTimeOfDaySensor's
-// startTime/duration) but edited as a 0-100 number, matching the game's own
-// side screen. Every other unit round-trips 1:1.
-function displayScale(unit: SettingUnit | undefined): number {
-  return unit == "cycleFraction" || unit == "%" ? 100 : 1;
-}
 
 interface EditableSettingRow {
   key: string;
   field: string;
+  // The resolved descriptor this row was built from — carried so committing an
+  // edit inverts exactly the conversion that produced displayValue.
+  descriptor: SettingFieldDescriptor;
   label: string;
   type: SettingFieldType;
   unit?: SettingUnit;
+  // What to render after the input. Empty string means no suffix at all (a
+  // bare count), which is why this is not optional-with-fallback.
+  unitSuffix: string;
+  step: number;
   displayValue: any;
   displayMin?: number;
   displayMax?: number;
   cycleHint: string | null;
+}
+
+interface CreatableSetting {
+  key: string;
+  label: string;
+}
+
+// The suffix implied by a descriptor that predates per-building units.
+function legacySuffix(unit: SettingUnit | undefined): string {
+  if (unit == "s") return "s";
+  if (unit == "cycleFraction" || unit == "%") return "%";
+  return "";
+}
+
+function suffixOf(descriptor: SettingFieldDescriptor): string {
+  return descriptor.unitSuffix ?? legacySuffix(descriptor.unit);
+}
+
+function roundTo(value: number, decimals: number): number {
+  const factor = Math.pow(10, decimals);
+  return Math.round(value * factor) / factor;
 }
 
 const CYCLE_SECONDS = 600;
@@ -51,39 +77,63 @@ export class BuildingSettingsComponent {
     return (
       this.rows.length > 0 ||
       this.otherKeys.length > 0 ||
-      this.creatableKeys.length > 0
+      this.creatableSettings.length > 0
     );
   }
 
   get rows(): EditableSettingRow[] {
+    const present = new Set(
+      (this.blueprintItem.buildingData ?? []).map((entry) => entry.Key),
+    );
     const rows: EditableSettingRow[] = [];
     for (const entry of this.blueprintItem.buildingData ?? []) {
-      const descriptors = SETTINGS_CATALOG[entry.Key];
-      if (descriptors == null) continue;
+      const descriptors = resolveSettingDescriptors(
+        this.blueprintItem.id,
+        entry.Key,
+      );
+      if (descriptors.length == 0) continue;
 
       const value = entry.Value;
       if (value == null || typeof value !== "object") continue;
 
       for (const descriptor of descriptors) {
         if (descriptor.hidden) continue;
+        // This field is a mirror of one already rendered under another Key
+        // that the building carries (the critter sensor writes its count and
+        // above/below twice). Show it once — editing either moves both.
+        const mirror = settingMirrorFor(entry.Key, descriptor.field);
+        if (mirror?.redundant && present.has(mirror.key)) continue;
         // Mirrors formatBuildingDataEntry: a missing field means this entry
         // is incomplete/malformed (or from a newer mod version) — skip it
         // rather than rendering an editable row backed by nothing, which
         // would crash setBuildingSetting the moment the user touched it.
         if (!(descriptor.field in value)) continue;
-        const scale = displayScale(descriptor.unit);
+        const decimals =
+          descriptor.decimals ?? (descriptor.type == "int" ? 0 : 2);
         const raw = value[descriptor.field];
         rows.push({
           key: entry.Key,
           field: descriptor.field,
+          descriptor,
           label: descriptor.labelKey,
           type: descriptor.type,
           unit: descriptor.unit,
-          displayValue: typeof raw == "number" ? raw * scale : raw,
+          unitSuffix: suffixOf(descriptor),
+          step: descriptor.step ?? (descriptor.type == "int" ? 1 : 0.1),
+          displayValue:
+            typeof raw == "number"
+              ? roundTo(toDisplayValue(descriptor, raw), decimals)
+              : raw,
+          // Bounds are stored-unit in the catalogue, so they go through the
+          // same conversion as the value they constrain.
           displayMin:
-            descriptor.min != null ? descriptor.min * scale : undefined,
+            descriptor.min != null
+              ? toDisplayValue(descriptor, descriptor.min)
+              : undefined,
           displayMax:
-            descriptor.max != null ? descriptor.max * scale : undefined,
+            descriptor.max != null
+              ? toDisplayValue(descriptor, descriptor.max)
+              : undefined,
           cycleHint:
             descriptor.unit == "s" &&
             typeof raw == "number" &&
@@ -98,7 +148,10 @@ export class BuildingSettingsComponent {
 
   get otherKeys(): string[] {
     return (this.blueprintItem.buildingData ?? [])
-      .filter((entry) => formatBuildingDataEntry(entry) == null)
+      .filter(
+        (entry) =>
+          formatBuildingDataEntry(entry, this.blueprintItem.id) == null,
+      )
       .map((entry) => entry.Key);
   }
 
@@ -108,13 +161,27 @@ export class BuildingSettingsComponent {
 
   // Keys this specific building can create from scratch (hand-checked
   // catalogue defaults) that it does not already have.
-  get creatableKeys(): string[] {
+  get creatableSettings(): CreatableSetting[] {
     const existing = new Set(
       (this.blueprintItem.buildingData ?? []).map((entry) => entry.Key),
     );
-    return creatableSettingsKeysFor(this.blueprintItem.id).filter(
-      (key) => !existing.has(key),
-    );
+    return creatableSettingsKeysFor(this.blueprintItem.id)
+      .filter((key) => !existing.has(key))
+      .map((key) => ({ key, label: this.creatableLabel(key) }));
+  }
+
+  // A threshold key names what it sets, since a building can offer more than
+  // one creatable key and "Add automation settings" would not say which.
+  private creatableLabel(key: string): string {
+    if (key != "IThresholdSwitch") return $localize`Add automation settings`;
+    const spec = thresholdSensorSpec(this.blueprintItem.id);
+    return spec == null
+      ? $localize`Add automation settings`
+      : $localize`Set ${spec.label.toLowerCase()}:label: threshold`;
+  }
+
+  trackByCreatable(_index: number, item: CreatableSetting): string {
+    return item.key;
   }
 
   addSetting(key: string) {
@@ -141,7 +208,12 @@ export class BuildingSettingsComponent {
       if (Number.isNaN(num)) return;
       if (row.displayMin != null && num < row.displayMin) num = row.displayMin;
       if (row.displayMax != null && num > row.displayMax) num = row.displayMax;
-      value = num / displayScale(row.unit);
+      // Blurring an untouched input must not write. The displayed value is
+      // rounded, so re-deriving a stored value from it would nudge a
+      // Thermo Sensor stored at 293.153 K to 293.15 — a silent data change
+      // that also detaches rawSource for nothing.
+      if (num === row.displayValue) return;
+      value = toStoredValue(row.descriptor, num);
       if (row.type == "int") value = Math.round(value);
     } else if (row.type == "string") {
       value = String(rawInput);

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -54,6 +54,7 @@ export * from './src/blueprint/terrain-metadata';
 export * from './src/blueprint/note-conversion';
 export * from './src/blueprint/bpv2-sanitize';
 export * from './src/blueprint/translation';
+export * from './src/blueprint/building-settings/threshold-sensors';
 export * from './src/blueprint/building-settings/settings-catalog';
 export * from './src/blueprint/building-settings/format-setting';
 export * from './src/search/query-normalize';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -60,6 +60,7 @@ export * from './src/blueprint/terrain-metadata';
 export * from './src/blueprint/note-conversion';
 export * from './src/blueprint/bpv2-sanitize';
 export * from './src/blueprint/translation';
+export * from './src/blueprint/building-settings/threshold-sensors';
 export * from './src/blueprint/building-settings/settings-catalog';
 export * from './src/blueprint/building-settings/format-setting';
 export * from './src/search/query-normalize';

--- a/lib/src/blueprint/blueprint-item.d.ts
+++ b/lib/src/blueprint/blueprint-item.d.ts
@@ -26,6 +26,7 @@ export declare class BlueprintItem {
     buildingData?: BniBuildingData[];
     addBuildingSetting(key: string): boolean;
     setBuildingSetting(key: string, field: string, value: any): void;
+    removeBuildingSetting(key: string): boolean;
     uiSaveSettings: UiSaveSettings[];
     getUiSettings(id: string): UiSaveSettings | undefined;
     setElement(elementId: string, index: number): void;

--- a/lib/src/blueprint/blueprint-item.ts
+++ b/lib/src/blueprint/blueprint-item.ts
@@ -8,7 +8,10 @@ import { OniItem } from '../oni-item';
 import { DrawPart } from '../drawing/draw-part';
 import { OniBuilding } from '../io/oni/oni-building';
 import { BniBuilding, BniBuildingData } from '../io/bni/bni-building';
-import { getCreatableSettingDefaults } from './building-settings/settings-catalog';
+import {
+  getCreatableSettingDefaults,
+  settingMirrorFor,
+} from './building-settings/settings-catalog';
 import { MdbBuilding } from '../io/mdb/mdb-building';
 import { SpriteTag } from '../enums/sprite-tag';
 import { CameraService } from '../drawing/camera-service';
@@ -94,6 +97,26 @@ export class BlueprintItem {
     // BuildingSettingsComponent.rows), so this only guards a direct caller.
     if (entry.Value == null || typeof entry.Value !== 'object') entry.Value = {};
     entry.Value[field] = value;
+
+    // Some state is written twice under two Keys (the critter sensor's count
+    // and above/below, which it emits both as its own key and as
+    // IThresholdSwitch). The mod applies handlers in registration order, so on
+    // a disagreement the later Key silently wins — an edit has to move both.
+    //
+    // Only when the twin Key is ALREADY present: creating it here as a side
+    // effect would change what the file says the building is, which is never
+    // what an edit to one field asked for.
+    const mirror = settingMirrorFor(key, field);
+    if (mirror == null) return;
+
+    const twin = this.buildingData!.find(entry => entry.Key == mirror.key);
+    if (twin == null || twin.Value == null || typeof twin.Value !== 'object') return;
+    // The twin is only a mirror of a field it actually carries — a Value
+    // missing it is malformed, and adding the field would not repair it.
+    if (!(mirror.field in twin.Value)) return;
+
+    twin.Value[mirror.field] =
+      mirror.toInt && typeof value === 'number' ? Math.round(value) : value;
   }
 
   public uiSaveSettings: UiSaveSettings[] = [];

--- a/lib/src/blueprint/blueprint-item.ts
+++ b/lib/src/blueprint/blueprint-item.ts
@@ -8,10 +8,7 @@ import { OniItem } from '../oni-item';
 import { DrawPart } from '../drawing/draw-part';
 import { OniBuilding } from '../io/oni/oni-building';
 import { BniBuilding, BniBuildingData } from '../io/bni/bni-building';
-import {
-  getCreatableSettingDefaults,
-  settingMirrorFor,
-} from './building-settings/settings-catalog';
+import { getCreatableSettingDefaults } from './building-settings/settings-catalog';
 import { MdbBuilding } from '../io/mdb/mdb-building';
 import { SpriteTag } from '../enums/sprite-tag';
 import { CameraService } from '../drawing/camera-service';
@@ -97,26 +94,28 @@ export class BlueprintItem {
     // BuildingSettingsComponent.rows), so this only guards a direct caller.
     if (entry.Value == null || typeof entry.Value !== 'object') entry.Value = {};
     entry.Value[field] = value;
+  }
 
-    // Some state is written twice under two Keys (the critter sensor's count
-    // and above/below, which it emits both as its own key and as
-    // IThresholdSwitch). The mod applies handlers in registration order, so on
-    // a disagreement the later Key silently wins — an edit has to move both.
-    //
-    // Only when the twin Key is ALREADY present: creating it here as a side
-    // effect would change what the file says the building is, which is never
-    // what an edit to one field asked for.
-    const mirror = settingMirrorFor(key, field);
-    if (mirror == null) return;
+  // The inverse of addBuildingSetting: drops a Key entirely, returning the
+  // building to "this blueprint says nothing about that setting". That is a
+  // real, distinct state and not the same as storing a default — the mod only
+  // applies keys the file actually carries (ModAPI/API_Methods.cs), so an
+  // absent Key leaves the built building on the game's own default. Without
+  // an inverse the editor could move a blueprint from unspecified to pinned
+  // but never back, silently changing what an older file means.
+  //
+  // Returns whether anything was removed.
+  public removeBuildingSetting(key: string): boolean {
+    if (this.buildingData == null) return false;
 
-    const twin = this.buildingData!.find(entry => entry.Key == mirror.key);
-    if (twin == null || twin.Value == null || typeof twin.Value !== 'object') return;
-    // The twin is only a mirror of a field it actually carries — a Value
-    // missing it is malformed, and adding the field would not repair it.
-    if (!(mirror.field in twin.Value)) return;
+    const remaining = this.buildingData.filter(entry => entry.Key != key);
+    if (remaining.length == this.buildingData.length) return false;
 
-    twin.Value[mirror.field] =
-      mirror.toInt && typeof value === 'number' ? Math.round(value) : value;
+    // Kept as an empty array rather than undefined; toBniBuilding/toMdbBuilding
+    // already omit the field when empty, so the exported document is identical
+    // either way.
+    this.buildingData = remaining;
+    return true;
   }
 
   public uiSaveSettings: UiSaveSettings[] = [];

--- a/lib/src/blueprint/building-settings/format-setting.d.ts
+++ b/lib/src/blueprint/building-settings/format-setting.d.ts
@@ -4,5 +4,5 @@ export interface FormattedSettingRow {
     label: string;
     text: string;
 }
-export declare function formatBuildingDataEntry(entry: BniBuildingData): FormattedSettingRow[] | null;
+export declare function formatBuildingDataEntry(entry: BniBuildingData, prefabId?: string): FormattedSettingRow[] | null;
 //# sourceMappingURL=format-setting.d.ts.map

--- a/lib/src/blueprint/building-settings/format-setting.ts
+++ b/lib/src/blueprint/building-settings/format-setting.ts
@@ -1,5 +1,11 @@
 import { BniBuildingData } from '../../io/bni/bni-building';
-import { SETTINGS_CATALOG, SettingFieldDescriptor } from './settings-catalog';
+import {
+  isKnownSettingsKey,
+  resolveSettingDescriptors,
+  SETTINGS_CATALOG,
+  SettingFieldDescriptor,
+  toDisplayValue,
+} from './settings-catalog';
 
 const CYCLE_SECONDS = 600;
 
@@ -41,6 +47,13 @@ function formatFieldValue(
     case 'int':
     case 'float':
       if (typeof raw !== 'number' || Number.isNaN(raw)) return String(raw);
+      // A descriptor carrying an explicit suffix owns its own conversion —
+      // the per-building threshold units (grams, °C, lux, germs, rads). The
+      // unit switch below stays for the symbolic units that predate it.
+      if (descriptor.unitSuffix != null) {
+        const display = formatNumber(toDisplayValue(descriptor, raw), descriptor.decimals ?? 2);
+        return descriptor.unitSuffix === '' ? display : `${display} ${descriptor.unitSuffix}`;
+      }
       switch (descriptor.unit) {
         case 's':
           return formatDuration(raw, value.displayCyclesMode);
@@ -61,9 +74,16 @@ function formatFieldValue(
 // the "N other stored settings (preserved)" line for those, and for any
 // entry whose shape this throws on (mods can register their own Keys through
 // the ModAPI, and a game update can add fields we don't know about yet).
-export function formatBuildingDataEntry(entry: BniBuildingData): FormattedSettingRow[] | null {
-  const descriptors = SETTINGS_CATALOG[entry.Key];
-  if (descriptors == null) return null;
+export function formatBuildingDataEntry(
+  entry: BniBuildingData,
+  prefabId?: string
+): FormattedSettingRow[] | null {
+  // Known-ness is a property of the Key alone; a resolved descriptor list can
+  // legitimately be empty for a known key (a sensor's stowaway `Switch`), and
+  // that must not read as "unrecognized" and land in the preserved-count line.
+  if (!isKnownSettingsKey(entry.Key)) return null;
+  const descriptors =
+    prefabId != null ? resolveSettingDescriptors(prefabId, entry.Key) : SETTINGS_CATALOG[entry.Key];
 
   const value = entry.Value ?? {};
   const rows: FormattedSettingRow[] = [];

--- a/lib/src/blueprint/building-settings/format-setting.ts
+++ b/lib/src/blueprint/building-settings/format-setting.ts
@@ -39,6 +39,8 @@ function formatFieldValue(
 ): string {
   switch (descriptor.type) {
     case 'bool':
+      if (descriptor.booleanLabels != null)
+        return raw ? descriptor.booleanLabels.whenTrue : descriptor.booleanLabels.whenFalse;
       return raw ? 'On' : 'Off';
     case 'string':
       return raw == null || raw === '' ? '—' : String(raw);

--- a/lib/src/blueprint/building-settings/settings-catalog.d.ts
+++ b/lib/src/blueprint/building-settings/settings-catalog.d.ts
@@ -14,6 +14,10 @@ export interface SettingFieldDescriptor {
     unitSuffix?: string;
     decimals?: number;
     step?: number;
+    booleanLabels?: {
+        whenTrue: string;
+        whenFalse: string;
+    };
 }
 export declare const SETTINGS_CATALOG: Record<string, SettingFieldDescriptor[]>;
 export declare function isKnownSettingsKey(key: string): boolean;

--- a/lib/src/blueprint/building-settings/settings-catalog.d.ts
+++ b/lib/src/blueprint/building-settings/settings-catalog.d.ts
@@ -23,14 +23,6 @@ export declare const SETTINGS_CATALOG: Record<string, SettingFieldDescriptor[]>;
 export declare function isKnownSettingsKey(key: string): boolean;
 export declare function toDisplayValue(descriptor: SettingFieldDescriptor, stored: number): number;
 export declare function toStoredValue(descriptor: SettingFieldDescriptor, display: number): number;
-export interface SettingMirror {
-    key: string;
-    field: string;
-    toInt?: boolean;
-    redundant?: boolean;
-}
-export declare const SETTING_MIRRORS: Record<string, Record<string, SettingMirror>>;
-export declare function settingMirrorFor(key: string, field: string): SettingMirror | undefined;
 export declare function resolveSettingDescriptors(prefabId: string, key: string): SettingFieldDescriptor[];
 export declare const CREATABLE_SETTINGS: Record<string, Record<string, Record<string, any>>>;
 export declare function creatableSettingsKeysFor(prefabId: string): string[];

--- a/lib/src/blueprint/building-settings/settings-catalog.d.ts
+++ b/lib/src/blueprint/building-settings/settings-catalog.d.ts
@@ -9,9 +9,25 @@ export interface SettingFieldDescriptor {
     max?: number;
     enumLabels?: Record<number, string>;
     hidden?: boolean;
+    displayScale?: number;
+    displayOffset?: number;
+    unitSuffix?: string;
+    decimals?: number;
+    step?: number;
 }
 export declare const SETTINGS_CATALOG: Record<string, SettingFieldDescriptor[]>;
 export declare function isKnownSettingsKey(key: string): boolean;
+export declare function toDisplayValue(descriptor: SettingFieldDescriptor, stored: number): number;
+export declare function toStoredValue(descriptor: SettingFieldDescriptor, display: number): number;
+export interface SettingMirror {
+    key: string;
+    field: string;
+    toInt?: boolean;
+    redundant?: boolean;
+}
+export declare const SETTING_MIRRORS: Record<string, Record<string, SettingMirror>>;
+export declare function settingMirrorFor(key: string, field: string): SettingMirror | undefined;
+export declare function resolveSettingDescriptors(prefabId: string, key: string): SettingFieldDescriptor[];
 export declare const CREATABLE_SETTINGS: Record<string, Record<string, Record<string, any>>>;
 export declare function creatableSettingsKeysFor(prefabId: string): string[];
 export declare function getCreatableSettingDefaults(prefabId: string, key: string): Record<string, any> | undefined;

--- a/lib/src/blueprint/building-settings/settings-catalog.ts
+++ b/lib/src/blueprint/building-settings/settings-catalog.ts
@@ -240,11 +240,9 @@ export const CREATABLE_SETTINGS: Record<string, Record<string, Record<string, an
 };
 
 for (const [prefabId, spec] of Object.entries(THRESHOLD_SENSORS)) {
-  // Note the critter sensor gets IThresholdSwitch only, never its own
-  // LogicCritterCountSensor key: LogicCritterCountSensor.Threshold is a float
-  // property wrapping countThreshold, so applying IThresholdSwitch alone sets
-  // the count correctly and leaves countCritters/countEggs at the game's own
-  // defaults instead of guessing them.
+  // Every prefab in THRESHOLD_SENSORS gets IThresholdSwitch as a creatable
+  // key. (LogicCritterCountSensor is not among them — it's excluded from
+  // THRESHOLD_SENSORS entirely; see threshold-sensors.ts for why.)
   const forPrefab = (CREATABLE_SETTINGS[prefabId] ??= {});
   forPrefab['IThresholdSwitch'] = {
     Threshold: spec.defaultThreshold,

--- a/lib/src/blueprint/building-settings/settings-catalog.ts
+++ b/lib/src/blueprint/building-settings/settings-catalog.ts
@@ -45,7 +45,21 @@ export interface SettingFieldDescriptor {
   // Display-space rounding and input step.
   decimals?: number;
   step?: number;
+  // type: 'bool' only. A boolean that is really a two-way choice rather than
+  // an on/off switch — rendered as a pair of labelled options instead of a
+  // checkbox, and formatted with these words instead of On/Off.
+  booleanLabels?: { whenTrue: string; whenFalse: string };
 }
+
+// The above/below choice every threshold sensor carries. It is a direction,
+// not an on/off state, so a checkbox labelled "Activate above threshold" makes
+// the reader negate it in their head to understand "below"; the game's own
+// side screen shows the two directions side by side.
+const ABOVE_BELOW: Pick<SettingFieldDescriptor, 'labelKey' | 'type' | 'booleanLabels'> = {
+  labelKey: 'Activate when',
+  type: 'bool',
+  booleanLabels: { whenTrue: 'Above', whenFalse: 'Below' },
+};
 
 // Keyed by the component `Key` (nameof the ONI component class — the mod's
 // own registry, API_Methods.cs RegisterVanillaBuildings()).
@@ -92,7 +106,7 @@ export const SETTINGS_CATALOG: Record<string, SettingFieldDescriptor[]> = {
 
   LogicCritterCountSensor: [
     { field: 'countThreshold', labelKey: 'Threshold', type: 'int', min: 0 },
-    { field: 'activateOnGreaterThan', labelKey: 'Activate above threshold', type: 'bool' },
+    { field: 'activateOnGreaterThan', ...ABOVE_BELOW },
     { field: 'countCritters', labelKey: 'Count critters', type: 'bool' },
     { field: 'countEggs', labelKey: 'Count eggs', type: 'bool' },
   ],
@@ -110,7 +124,7 @@ export const SETTINGS_CATALOG: Record<string, SettingFieldDescriptor[]> = {
 
   IThresholdSwitch: [
     { field: 'Threshold', labelKey: 'Threshold', type: 'float' },
-    { field: 'ActivateAboveThreshold', labelKey: 'Activate above threshold', type: 'bool' },
+    { field: 'ActivateAboveThreshold', ...ABOVE_BELOW },
   ],
 
   IActivationRangeTarget: [

--- a/lib/src/blueprint/building-settings/settings-catalog.ts
+++ b/lib/src/blueprint/building-settings/settings-catalog.ts
@@ -1,3 +1,5 @@
+import { THRESHOLD_SENSORS, thresholdSensorSpec } from './threshold-sensors';
+
 // Curated catalogue of the BlueprintsV2 `buildingData` component keys we
 // know how to display (and, from phase 3, edit) — spec/building-settings-plan.md
 // "Automation keys in scope" table, verified against
@@ -29,6 +31,20 @@ export interface SettingFieldDescriptor {
   // `LogicTimerSensor.timeElapsedInCurrentState` today — a runtime value the
   // mod's TryApplyData still requires present in a written Value object.
   hidden?: boolean;
+
+  // Affine stored <-> display conversion, for fields whose stored value is a
+  // raw sim number rather than what the game showed the player:
+  //   display = stored * displayScale + displayOffset
+  // Both default to the `unit`-derived legacy behaviour (see displayScaleOf)
+  // when absent, so a descriptor that sets neither is unchanged.
+  displayScale?: number;
+  displayOffset?: number;
+  // Literal suffix rendered after the input ('g', '°C', 'lux', ...). When
+  // absent the UI falls back to the symbol implied by `unit`.
+  unitSuffix?: string;
+  // Display-space rounding and input step.
+  decimals?: number;
+  step?: number;
 }
 
 // Keyed by the component `Key` (nameof the ONI component class — the mod's
@@ -111,6 +127,109 @@ export function isKnownSettingsKey(key: string): boolean {
   return Object.prototype.hasOwnProperty.call(SETTINGS_CATALOG, key);
 }
 
+// The stored -> display multiplier for a descriptor. An explicit displayScale
+// wins; otherwise the legacy unit-derived rule applies, where a 0-1 fraction
+// (LogicTimeOfDaySensor) is edited as a 0-100 number to match the game's own
+// side screen. Every other unit round-trips 1:1.
+function displayScaleOf(descriptor: SettingFieldDescriptor): number {
+  if (descriptor.displayScale != null) return descriptor.displayScale;
+  return descriptor.unit == 'cycleFraction' || descriptor.unit == '%' ? 100 : 1;
+}
+
+export function toDisplayValue(descriptor: SettingFieldDescriptor, stored: number): number {
+  return stored * displayScaleOf(descriptor) + (descriptor.displayOffset ?? 0);
+}
+
+export function toStoredValue(descriptor: SettingFieldDescriptor, display: number): number {
+  return (display - (descriptor.displayOffset ?? 0)) / displayScaleOf(descriptor);
+}
+
+// Two Keys that describe one component state, so an edit to either must move
+// both or the file contradicts itself. The mod applies handlers in registration
+// order (ModAPI/API_Methods.cs), and IThresholdSwitch is registered *after*
+// LogicCritterCountSensor, so on a disagreement IThresholdSwitch silently wins.
+//
+// `toInt` marks the direction that lands on an int field:
+// LogicCritterCountSensor.Threshold is a float property wrapping the
+// countThreshold int (`countThreshold = (int)value`).
+export interface SettingMirror {
+  key: string;
+  field: string;
+  toInt?: boolean;
+  // True on the redundant half of the pair: when both Keys are present the UI
+  // renders this field once, under the *other* Key. The generic
+  // IThresholdSwitch is the half that yields, because the specific key carries
+  // the rest of the building's settings (countCritters/countEggs) alongside.
+  redundant?: boolean;
+}
+
+export const SETTING_MIRRORS: Record<string, Record<string, SettingMirror>> = {
+  LogicCritterCountSensor: {
+    countThreshold: { key: 'IThresholdSwitch', field: 'Threshold' },
+    activateOnGreaterThan: { key: 'IThresholdSwitch', field: 'ActivateAboveThreshold' },
+  },
+  IThresholdSwitch: {
+    Threshold: {
+      key: 'LogicCritterCountSensor',
+      field: 'countThreshold',
+      toInt: true,
+      redundant: true,
+    },
+    ActivateAboveThreshold: {
+      key: 'LogicCritterCountSensor',
+      field: 'activateOnGreaterThan',
+      redundant: true,
+    },
+  },
+};
+
+export function settingMirrorFor(key: string, field: string): SettingMirror | undefined {
+  return SETTING_MIRRORS[key]?.[field];
+}
+
+// The descriptors to render for one Key *on one building*. Identical to
+// SETTINGS_CATALOG[key] except where the building changes what the Key means:
+//
+//  - `IThresholdSwitch` on a threshold sensor: the bare unitless `Threshold`
+//    float becomes the quantity that building actually measures, with the
+//    conversion and soft bounds from THRESHOLD_SENSORS.
+//  - `Switch` on a threshold sensor: nothing. Sensors extend Switch, so the
+//    mod's Switch handler matches them and a copied sensor carries a stowaway
+//    `switchedOn` holding its sampled *output* at copy time, which the game
+//    overwrites within ~1.8s. It round-trips, but it is not a setting and must
+//    not be offered as one. The manual LogicSwitch is not a threshold sensor,
+//    so it keeps its editable row.
+export function resolveSettingDescriptors(
+  prefabId: string,
+  key: string
+): SettingFieldDescriptor[] {
+  const base = SETTINGS_CATALOG[key];
+  if (base == null) return [];
+
+  const spec = thresholdSensorSpec(prefabId);
+  if (spec == null) return base;
+
+  if (key == 'Switch') return [];
+  if (key != 'IThresholdSwitch') return base;
+
+  return base.map(descriptor => {
+    if (descriptor.field != 'Threshold') return descriptor;
+    return {
+      ...descriptor,
+      labelKey: spec.label,
+      unitSuffix: spec.unitSuffix,
+      displayScale: spec.displayScale,
+      displayOffset: spec.displayOffset,
+      // min/max stay in STORED units, like every other catalogue bound — the
+      // UI converts them through toDisplayValue alongside the value itself.
+      min: spec.storedMin,
+      max: spec.storedMax,
+      decimals: spec.decimals,
+      step: spec.step,
+    };
+  });
+}
+
 // Editing an already-present Key is offered for every entry in
 // SETTINGS_CATALOG above. *Creating* a Key from scratch (a building placed in
 // the editor, or an uploaded file that omitted it because it was all-default)
@@ -120,7 +239,7 @@ export function isKnownSettingsKey(key: string): boolean {
 // and worse, a wrong guess for a gameplay-affecting field changes the
 // building's behaviour versus leaving it absent.
 //
-// v1 ships only LogicTimerSensor, whose four fields are all either given
+// LogicTimerSensor, whose four fields are all either given
 // (onDuration/offDuration: spec/building-settings-plan.md phase 3 step 1) or
 // definitionally safe (timeElapsedInCurrentState: 0 for a fresh component;
 // displayCyclesMode: a display-only toggle with no simulation effect even if
@@ -128,6 +247,14 @@ export function isKnownSettingsKey(key: string): boolean {
 // LogicCounter, whose resetCountAtMax/advancedMode defaults are not
 // confirmed — stays edit-only-when-present until its real defaults are
 // verified in-game. Extend CREATABLE_SETTINGS then, per building prefab id.
+//
+// `IThresholdSwitch` on every threshold sensor is the second entry, and it is
+// safe for the same reason: the handler reads exactly two fields and we write
+// both, so there is no partial-Value hazard, and TryApplyData is guarded by
+// TryGetComponent so a building that turns out not to carry the component
+// simply ignores it. Without this the feature would only work on blueprints
+// imported from the game — a sensor placed in the editor has no buildingData
+// at all.
 export const CREATABLE_SETTINGS: Record<string, Record<string, Record<string, any>>> = {
   LogicTimerSensor: {
     LogicTimerSensor: {
@@ -138,6 +265,19 @@ export const CREATABLE_SETTINGS: Record<string, Record<string, Record<string, an
     },
   },
 };
+
+for (const [prefabId, spec] of Object.entries(THRESHOLD_SENSORS)) {
+  // Note the critter sensor gets IThresholdSwitch only, never its own
+  // LogicCritterCountSensor key: LogicCritterCountSensor.Threshold is a float
+  // property wrapping countThreshold, so applying IThresholdSwitch alone sets
+  // the count correctly and leaves countCritters/countEggs at the game's own
+  // defaults instead of guessing them.
+  const forPrefab = (CREATABLE_SETTINGS[prefabId] ??= {});
+  forPrefab['IThresholdSwitch'] = {
+    Threshold: spec.defaultThreshold,
+    ActivateAboveThreshold: spec.defaultActivateAbove,
+  };
+}
 
 // The Keys creatable from scratch on a specific building prefab id.
 export function creatableSettingsKeysFor(prefabId: string): string[] {

--- a/lib/src/blueprint/building-settings/settings-catalog.ts
+++ b/lib/src/blueprint/building-settings/settings-catalog.ts
@@ -158,49 +158,6 @@ export function toStoredValue(descriptor: SettingFieldDescriptor, display: numbe
   return (display - (descriptor.displayOffset ?? 0)) / displayScaleOf(descriptor);
 }
 
-// Two Keys that describe one component state, so an edit to either must move
-// both or the file contradicts itself. The mod applies handlers in registration
-// order (ModAPI/API_Methods.cs), and IThresholdSwitch is registered *after*
-// LogicCritterCountSensor, so on a disagreement IThresholdSwitch silently wins.
-//
-// `toInt` marks the direction that lands on an int field:
-// LogicCritterCountSensor.Threshold is a float property wrapping the
-// countThreshold int (`countThreshold = (int)value`).
-export interface SettingMirror {
-  key: string;
-  field: string;
-  toInt?: boolean;
-  // True on the redundant half of the pair: when both Keys are present the UI
-  // renders this field once, under the *other* Key. The generic
-  // IThresholdSwitch is the half that yields, because the specific key carries
-  // the rest of the building's settings (countCritters/countEggs) alongside.
-  redundant?: boolean;
-}
-
-export const SETTING_MIRRORS: Record<string, Record<string, SettingMirror>> = {
-  LogicCritterCountSensor: {
-    countThreshold: { key: 'IThresholdSwitch', field: 'Threshold' },
-    activateOnGreaterThan: { key: 'IThresholdSwitch', field: 'ActivateAboveThreshold' },
-  },
-  IThresholdSwitch: {
-    Threshold: {
-      key: 'LogicCritterCountSensor',
-      field: 'countThreshold',
-      toInt: true,
-      redundant: true,
-    },
-    ActivateAboveThreshold: {
-      key: 'LogicCritterCountSensor',
-      field: 'activateOnGreaterThan',
-      redundant: true,
-    },
-  },
-};
-
-export function settingMirrorFor(key: string, field: string): SettingMirror | undefined {
-  return SETTING_MIRRORS[key]?.[field];
-}
-
 // The descriptors to render for one Key *on one building*. Identical to
 // SETTINGS_CATALOG[key] except where the building changes what the Key means:
 //

--- a/lib/src/blueprint/building-settings/settings-catalog.ts
+++ b/lib/src/blueprint/building-settings/settings-catalog.ts
@@ -56,7 +56,7 @@ export interface SettingFieldDescriptor {
 // the reader negate it in their head to understand "below"; the game's own
 // side screen shows the two directions side by side.
 const ABOVE_BELOW: Pick<SettingFieldDescriptor, 'labelKey' | 'type' | 'booleanLabels'> = {
-  labelKey: 'Activate when',
+  labelKey: 'Active',
   type: 'bool',
   booleanLabels: { whenTrue: 'Above', whenFalse: 'Below' },
 };
@@ -122,9 +122,11 @@ export const SETTINGS_CATALOG: Record<string, SettingFieldDescriptor[]> = {
     { field: 'cooldown', labelKey: 'Cooldown', type: 'float', unit: 's', min: 0 },
   ],
 
+  // Direction first: it frames the number that follows ("active above ... 1000 g"),
+  // and it is the field a reader checks first when scanning a sensor.
   IThresholdSwitch: [
-    { field: 'Threshold', labelKey: 'Threshold', type: 'float' },
     { field: 'ActivateAboveThreshold', ...ABOVE_BELOW },
+    { field: 'Threshold', labelKey: 'Threshold', type: 'float' },
   ],
 
   IActivationRangeTarget: [

--- a/lib/src/blueprint/building-settings/threshold-sensors.d.ts
+++ b/lib/src/blueprint/building-settings/threshold-sensors.d.ts
@@ -1,0 +1,16 @@
+export interface ThresholdSensorSpec {
+    label: string;
+    unitSuffix: string;
+    displayScale: number;
+    displayOffset: number;
+    storedMin: number;
+    storedMax: number;
+    step: number;
+    decimals: number;
+    defaultThreshold: number;
+    defaultActivateAbove: boolean;
+}
+export declare const THRESHOLD_SENSORS: Record<string, ThresholdSensorSpec>;
+export declare function thresholdSensorSpec(prefabId: string): ThresholdSensorSpec | undefined;
+export declare function isThresholdSensor(prefabId: string): boolean;
+//# sourceMappingURL=threshold-sensors.d.ts.map

--- a/lib/src/blueprint/building-settings/threshold-sensors.d.ts
+++ b/lib/src/blueprint/building-settings/threshold-sensors.d.ts
@@ -12,5 +12,4 @@ export interface ThresholdSensorSpec {
 }
 export declare const THRESHOLD_SENSORS: Record<string, ThresholdSensorSpec>;
 export declare function thresholdSensorSpec(prefabId: string): ThresholdSensorSpec | undefined;
-export declare function isThresholdSensor(prefabId: string): boolean;
 //# sourceMappingURL=threshold-sensors.d.ts.map

--- a/lib/src/blueprint/building-settings/threshold-sensors.ts
+++ b/lib/src/blueprint/building-settings/threshold-sensors.ts
@@ -1,0 +1,200 @@
+// Per-prefab meaning of the `IThresholdSwitch` buildingData key.
+//
+// The BlueprintsV2 handler registry is keyed by *component* name, not by
+// prefab (ModAPI/API_Methods.cs RegisterVanillaBuildings), so every threshold
+// sensor in the game writes the same two fields:
+//
+//   { "Key": "IThresholdSwitch", "Value": { "Threshold": 0.5, "ActivateAboveThreshold": true } }
+//
+// but `Threshold` is the raw sim value of whatever that *building* measures —
+// kilograms, kelvin, lux, germs, rads or a critter count. It is never what the
+// game's own side screen showed the player. Two of them need converting or the
+// editor shows a number a thousand times off (gas pressure) or in the wrong
+// scale entirely (temperature).
+//
+// Conversion is affine in both directions:
+//   display = stored * displayScale + displayOffset
+//   stored  = (display - displayOffset) / displayScale
+//
+// Ranges come from IThresholdSwitch.RangeMin/RangeMax, which are serialized
+// per-prefab fields. The game clamps them in its slider UI but the *setter*
+// does not validate, so treat them as SOFT bounds: clamp what the user types,
+// never reject or rewrite a stored value that falls outside them.
+
+export interface ThresholdSensorSpec {
+  // Label for the Threshold row. Replaces the catalogue's generic
+  // 'Threshold' with what the building actually measures.
+  label: string;
+  // Rendered after the input. Empty for a bare count.
+  unitSuffix: string;
+  // stored -> display multiplier.
+  displayScale: number;
+  // Added after scaling. Only temperature uses it (-273.15, K -> °C).
+  displayOffset: number;
+  // Soft bounds, in STORED units.
+  storedMin: number;
+  storedMax: number;
+  // Input step and rounding, in DISPLAY units.
+  step: number;
+  decimals: number;
+  // Used only when creating the key from scratch on a building that has none.
+  // These are OUR editor's neutral starting points, not Klei's own defaults —
+  // the user is clicking the button precisely to set the number, and both
+  // fields are always written, so there is no partial-Value hazard here.
+  defaultThreshold: number;
+  defaultActivateAbove: boolean;
+}
+
+const KELVIN_OFFSET = -273.15;
+
+function pressureGas(defaultThreshold: number): ThresholdSensorSpec {
+  // Stored in kg, displayed in grams.
+  return {
+    label: 'Pressure',
+    unitSuffix: 'g',
+    displayScale: 1000,
+    displayOffset: 0,
+    storedMin: 0,
+    storedMax: 20,
+    step: 1,
+    decimals: 0,
+    defaultThreshold,
+    defaultActivateAbove: true,
+  };
+}
+
+function pressureLiquid(defaultThreshold: number): ThresholdSensorSpec {
+  return {
+    label: 'Pressure',
+    unitSuffix: 'kg',
+    displayScale: 1,
+    displayOffset: 0,
+    storedMin: 0,
+    storedMax: 2000,
+    step: 1,
+    decimals: 1,
+    defaultThreshold,
+    defaultActivateAbove: true,
+  };
+}
+
+function temperature(): ThresholdSensorSpec {
+  // Stored in Kelvin regardless of the authoring player's °C/°F preference,
+  // so a blueprint shared between two players carries the same number and
+  // needs no migration. The site is Celsius throughout (BlueprintItem
+  // .temperatureCelcius, the temperature picker), so display °C.
+  return {
+    label: 'Temperature',
+    unitSuffix: '°C',
+    displayScale: 1,
+    displayOffset: KELVIN_OFFSET,
+    storedMin: 0,
+    storedMax: 9999,
+    step: 1,
+    decimals: 2,
+    defaultThreshold: 293.15,
+    defaultActivateAbove: true,
+  };
+}
+
+function germs(): ThresholdSensorSpec {
+  return {
+    label: 'Germs',
+    unitSuffix: 'germs',
+    displayScale: 1,
+    displayOffset: 0,
+    storedMin: 0,
+    storedMax: 100000,
+    step: 1,
+    decimals: 0,
+    defaultThreshold: 0,
+    defaultActivateAbove: true,
+  };
+}
+
+// Keyed by the building's prefab id (BlueprintItem.id / OniItem.id).
+//
+// The seven base sensors' units and ranges are the ones confirmed against the
+// game assembly; the pipe/rail sensors and the three Switch buildings measure
+// the same quantity as their room-sensor twin and inherit its unit.
+//
+// Deliberately absent: LogicWattageSensor and LogicHEPSensor. Neither is a
+// confirmed IThresholdSwitch carrier, and radbolt thresholds demonstrably live
+// on HighEnergyParticleSpawner.particleThreshold / HEPBattery.particleThreshold
+// — different keys entirely. Element sensors (LogicElementSensorGas and the
+// conduit element sensors) have no threshold at all: their setting is a
+// Filterable/SelectedTag element name, handled separately.
+export const THRESHOLD_SENSORS: Record<string, ThresholdSensorSpec> = {
+  // Atmo Sensor / Atmo Switch — 1000 g is the game's own starting point.
+  LogicPressureSensorGas: pressureGas(1),
+  PressureSwitchGas: pressureGas(1),
+
+  // Hydro Sensor / Hydro Switch.
+  LogicPressureSensorLiquid: pressureLiquid(100),
+  PressureSwitchLiquid: pressureLiquid(100),
+
+  // Thermo Sensor / Thermo Switch and the three pipe/rail thermo sensors.
+  LogicTemperatureSensor: temperature(),
+  TemperatureControlledSwitch: temperature(),
+  GasConduitTemperatureSensor: temperature(),
+  LiquidConduitTemperatureSensor: temperature(),
+  SolidConduitTemperatureSensor: temperature(),
+
+  LogicLightSensor: {
+    label: 'Light',
+    unitSuffix: 'lux',
+    displayScale: 1,
+    displayOffset: 0,
+    storedMin: 0,
+    storedMax: 15000,
+    step: 1,
+    decimals: 0,
+    defaultThreshold: 0,
+    defaultActivateAbove: true,
+  },
+
+  // Germ Sensor and the three pipe/rail germ sensors.
+  LogicDiseaseSensor: germs(),
+  GasConduitDiseaseSensor: germs(),
+  LiquidConduitDiseaseSensor: germs(),
+  SolidConduitDiseaseSensor: germs(),
+
+  LogicRadiationSensor: {
+    label: 'Radiation',
+    unitSuffix: 'rads',
+    displayScale: 1,
+    displayOffset: 0,
+    storedMin: 0,
+    storedMax: 5000,
+    step: 1,
+    decimals: 0,
+    defaultThreshold: 0,
+    defaultActivateAbove: true,
+  },
+
+  // Critter Sensor. LogicCritterCountSensor.Threshold is a float property
+  // wrapping the countThreshold int, so IThresholdSwitch expresses the same
+  // state — see SETTING_MIRRORS in settings-catalog.ts.
+  LogicCritterCountSensor: {
+    label: 'Critters',
+    unitSuffix: '',
+    displayScale: 1,
+    displayOffset: 0,
+    storedMin: 0,
+    storedMax: 64,
+    step: 1,
+    decimals: 0,
+    defaultThreshold: 3,
+    defaultActivateAbove: true,
+  },
+};
+
+export function thresholdSensorSpec(prefabId: string): ThresholdSensorSpec | undefined {
+  return Object.prototype.hasOwnProperty.call(THRESHOLD_SENSORS, prefabId)
+    ? THRESHOLD_SENSORS[prefabId]
+    : undefined;
+}
+
+export function isThresholdSensor(prefabId: string): boolean {
+  return thresholdSensorSpec(prefabId) != null;
+}

--- a/lib/src/blueprint/building-settings/threshold-sensors.ts
+++ b/lib/src/blueprint/building-settings/threshold-sensors.ts
@@ -192,7 +192,6 @@ export const THRESHOLD_SENSORS: Record<string, ThresholdSensorSpec> = {
     defaultThreshold: 280,
     defaultActivateAbove: false,
   },
-
 };
 
 export function thresholdSensorSpec(prefabId: string): ThresholdSensorSpec | undefined {

--- a/lib/src/blueprint/building-settings/threshold-sensors.ts
+++ b/lib/src/blueprint/building-settings/threshold-sensors.ts
@@ -199,7 +199,3 @@ export function thresholdSensorSpec(prefabId: string): ThresholdSensorSpec | und
     ? THRESHOLD_SENSORS[prefabId]
     : undefined;
 }
-
-export function isThresholdSensor(prefabId: string): boolean {
-  return thresholdSensorSpec(prefabId) != null;
-}

--- a/lib/src/blueprint/building-settings/threshold-sensors.ts
+++ b/lib/src/blueprint/building-settings/threshold-sensors.ts
@@ -176,7 +176,7 @@ export const THRESHOLD_SENSORS: Record<string, ThresholdSensorSpec> = {
     displayScale: 1,
     displayOffset: 0,
     storedMin: 0,
-    storedMax: 5000,
+    storedMax: 4727,
     step: 1,
     decimals: 0,
     defaultThreshold: 280,

--- a/lib/src/blueprint/building-settings/threshold-sensors.ts
+++ b/lib/src/blueprint/building-settings/threshold-sensors.ts
@@ -118,12 +118,23 @@ function germs(): ThresholdSensorSpec {
 // game assembly; the pipe/rail sensors and the three Switch buildings measure
 // the same quantity as their room-sensor twin and inherit its unit.
 //
-// Deliberately absent: LogicWattageSensor and LogicHEPSensor. Neither is a
-// confirmed IThresholdSwitch carrier, and radbolt thresholds demonstrably live
-// on HighEnergyParticleSpawner.particleThreshold / HEPBattery.particleThreshold
-// — different keys entirely. Element sensors (LogicElementSensorGas and the
-// conduit element sensors) have no threshold at all: their setting is a
-// Filterable/SelectedTag element name, handled separately.
+// Deliberately absent:
+//
+//  - LogicWattageSensor and LogicHEPSensor. Neither is a confirmed
+//    IThresholdSwitch carrier, and radbolt thresholds demonstrably live on
+//    HighEnergyParticleSpawner.particleThreshold /
+//    HEPBattery.particleThreshold — different keys entirely.
+//  - Element sensors (LogicElementSensorGas and the conduit element sensors)
+//    have no threshold at all: their setting is a Filterable/SelectedTag
+//    element name.
+//  - LogicCritterCountSensor. It *is* a carrier, but it writes the same two
+//    values twice — under its own key as countThreshold/activateOnGreaterThan
+//    and again under IThresholdSwitch — and its own key also carries
+//    countCritters/countEggs, which are not threshold settings and cannot be
+//    separated (the mod's handler bails on the whole Value object if any
+//    field is missing). So clearing a critter sensor's threshold cannot avoid
+//    also discarding what it counts. Deferred to its own change rather than
+//    solved badly here.
 export const THRESHOLD_SENSORS: Record<string, ThresholdSensorSpec> = {
   // Atmo Sensor / Atmo Switch — 1000 g is the game's own starting point.
   LogicPressureSensorGas: pressureGas(1),
@@ -172,21 +183,6 @@ export const THRESHOLD_SENSORS: Record<string, ThresholdSensorSpec> = {
     defaultActivateAbove: true,
   },
 
-  // Critter Sensor. LogicCritterCountSensor.Threshold is a float property
-  // wrapping the countThreshold int, so IThresholdSwitch expresses the same
-  // state — see SETTING_MIRRORS in settings-catalog.ts.
-  LogicCritterCountSensor: {
-    label: 'Critters',
-    unitSuffix: '',
-    displayScale: 1,
-    displayOffset: 0,
-    storedMin: 0,
-    storedMax: 64,
-    step: 1,
-    decimals: 0,
-    defaultThreshold: 3,
-    defaultActivateAbove: true,
-  },
 };
 
 export function thresholdSensorSpec(prefabId: string): ThresholdSensorSpec | undefined {

--- a/lib/src/blueprint/building-settings/threshold-sensors.ts
+++ b/lib/src/blueprint/building-settings/threshold-sensors.ts
@@ -115,11 +115,24 @@ function germs(): ThresholdSensorSpec {
 // Keyed by the building's prefab id (BlueprintItem.id / OniItem.id).
 //
 // The seven base sensors' units and ranges are the ones confirmed against the
-// game assembly; the pipe/rail sensors and the three Switch buildings measure
-// the same quantity as their room-sensor twin and inherit its unit.
+// game assembly; the pipe/rail sensors measure the same quantity as their
+// room-sensor twin and inherit its unit.
 //
 // Deliberately absent:
 //
+//  - PressureSwitchGas, PressureSwitchLiquid, TemperatureControlledSwitch
+//    ("Atmo/Hydro/Thermo Switch"). The 2024 export carries full names,
+//    descriptions and a buildMenuItems entry for all three (filed under
+//    Power/Electrical, not Automation), which is what led an earlier version
+//    of this table to include them. But neither wiki (wiki.gg or Fandom) has
+//    a page for any of them, web search for "Thermo Switch" returns Thermo
+//    *Sensor* results instead, and a live playthrough did not find them in
+//    the Electrical build menu. That combination looks like pre-Automation-
+//    Update legacy data (simple threshold switches, superseded by Sensor +
+//    Logic Gate) that the export tool still dumps because it reads prefab
+//    definitions rather than actual build-menu reachability. Pulled until
+//    someone confirms in a debug/sandbox build menu (which shows disabled
+//    content) whether they're placeable at all.
 //  - LogicWattageSensor and LogicHEPSensor. Neither is a confirmed
 //    IThresholdSwitch carrier, and radbolt thresholds demonstrably live on
 //    HighEnergyParticleSpawner.particleThreshold /
@@ -136,17 +149,14 @@ function germs(): ThresholdSensorSpec {
 //    also discarding what it counts. Deferred to its own change rather than
 //    solved badly here.
 export const THRESHOLD_SENSORS: Record<string, ThresholdSensorSpec> = {
-  // Atmo Sensor / Atmo Switch — 1000 g is the game's own starting point.
+  // Atmo Sensor — 1000 g is the game's own starting point.
   LogicPressureSensorGas: pressureGas(1),
-  PressureSwitchGas: pressureGas(1),
 
-  // Hydro Sensor / Hydro Switch.
+  // Hydro Sensor.
   LogicPressureSensorLiquid: pressureLiquid(100),
-  PressureSwitchLiquid: pressureLiquid(100),
 
-  // Thermo Sensor / Thermo Switch and the three pipe/rail thermo sensors.
+  // Thermo Sensor and the three pipe/rail thermo sensors.
   LogicTemperatureSensor: temperature(),
-  TemperatureControlledSwitch: temperature(),
   GasConduitTemperatureSensor: temperature(),
   LiquidConduitTemperatureSensor: temperature(),
   SolidConduitTemperatureSensor: temperature(),

--- a/lib/src/blueprint/building-settings/threshold-sensors.ts
+++ b/lib/src/blueprint/building-settings/threshold-sensors.ts
@@ -160,7 +160,7 @@ export const THRESHOLD_SENSORS: Record<string, ThresholdSensorSpec> = {
     storedMax: 15000,
     step: 1,
     decimals: 0,
-    defaultThreshold: 0,
+    defaultThreshold: 280,
     defaultActivateAbove: true,
   },
 
@@ -179,8 +179,8 @@ export const THRESHOLD_SENSORS: Record<string, ThresholdSensorSpec> = {
     storedMax: 5000,
     step: 1,
     decimals: 0,
-    defaultThreshold: 0,
-    defaultActivateAbove: true,
+    defaultThreshold: 280,
+    defaultActivateAbove: false,
   },
 
 };


### PR DESCRIPTION
> [!NOTE]
> **AI-assisted change.** Written with the help of Claude Code. Please review it as you would
> any other change.

## What shipped

Automation sensors can now have their threshold and above/below toggle set in the editor, and
correctly display a threshold read out of an imported blueprint.

`IThresholdSwitch` was already in the settings catalogue, but only as a bare unitless
`Threshold: float`. A threshold read out of an imported blueprint rendered as a meaningless raw
number (`0.5`, `293.15`), and a sensor placed in the editor had no `buildingData` at all, so
there was no way to set one.

The blocker was structural — the catalogue is keyed by component `Key`, and the mod registers
handlers by component name, but `Threshold` is the raw sim value of whatever the *building*
measures: grams, kelvin, lux, germs, or rads.

### The pieces

- **`lib/src/blueprint/building-settings/threshold-sensors.ts`** (new) — per-prefab table for
  the 12 confirmed carriers (Atmo/Hydro/Thermo Sensor, the three pipe/rail thermo sensors, Germ
  Sensor + three pipe/rail germ sensors, Light Sensor, Radiation Sensor). Conversion is affine
  both ways (`display = stored * displayScale + displayOffset`), exposed as `toDisplayValue` /
  `toStoredValue`. The two that actually convert are **gas pressure** (stored kg, displayed in
  grams) and **temperature** (stored Kelvin regardless of the author's °C/°F setting, displayed
  in °C — the site is Celsius throughout).
- **`resolveSettingDescriptors(prefabId, key)`** — the single place the per-prefab meaning is
  applied, shared by the panel and `formatBuildingDataEntry`, so a row and its read-only
  formatting cannot disagree. Catalogue `min`/`max` stay in stored units and convert alongside
  the value.
- **A real "not set" state.** A threshold sensor with no `IThresholdSwitch` key shows a
  `Pressure — Not set` row with a small **Set** button, rather than being hidden or defaulted
  silently — the mod applies only the keys a file actually carries, so an absent key is
  meaningfully different from any stored value. `BlueprintItem.removeBuildingSetting` is the
  inverse of `addBuildingSetting`, reachable via a small **Clear threshold** button, so the
  editor can move a sensor back to unspecified instead of only ever pinning it.
- **`CREATABLE_SETTINGS`** gains `IThresholdSwitch` on every sensor, generated from the table.
  Safe for the same reason `LogicTimerSensor` was: the handler reads exactly two fields and we
  write both, and `TryApplyData` is guarded by `TryGetComponent`.
- **Above/Below is a direction, not a checkbox.** `booleanLabels` renders a two-option
  segmented control instead of a checkbox, both in the panel and in
  `formatBuildingDataEntry`'s read-only text — a checkbox labelled "Activate above threshold"
  makes the reader negate it in their head to understand "below".
- **Soft, clamped bounds.** `RangeMin`/`RangeMax` are per-prefab serialized fields the mod's
  own setter does not enforce, so an out-of-range typed entry is pulled to the nearest bound on
  commit rather than rejected; a value already stored outside the range is displayed and
  preserved untouched, including on a blur with no edit. The number input's `step` relaxes to
  `"any"` when the display minimum isn't a step multiple (Thermo Sensor's `-273.15`), so the
  browser's native step validation doesn't mark ordinary whole-degree values invalid.
- **The stowaway `Switch` key.** Sensors extend `Switch`, so the mod's `Switch` handler matches
  them and a copied sensor carries `switchedOn` holding its *sampled output* at copy time,
  which the game overwrites within ~1.8s. It still round-trips, but it is not offered as an
  editable setting, and is not miscounted as an unrecognized one either. The manual
  `LogicSwitch` keeps its editable row.
- **Blurring an untouched input never writes.** The displayed value is rounded, so
  re-deriving a stored value from it would nudge a Thermo Sensor stored at 293.153 K to 293.15
  and detach `rawSource` for nothing. An emptied field is also not an edit to zero
  (`Number('') === 0`) — it restores the value the model already holds.

## Design decisions

Verified against the mod source (`BlueprintData/DataTransferHelpers.cs`,
`ModAPI/API_Methods.cs`) and cross-checked against a `buildingData` reference compiled from the
game assembly.

- **`LogicWattageSensor` and `LogicHEPSensor` (Radbolt Sensor) are out of scope.** Neither is a
  confirmed `IThresholdSwitch` carrier, and radbolt thresholds live on
  `HighEnergyParticleSpawner.particleThreshold` / `HEPBattery.particleThreshold` — a different
  key entirely.
- **`LogicCritterCountSensor` is out of scope entirely.** It *is* an `IThresholdSwitch`
  carrier, but it writes the same two values twice — under its own key as
  `countThreshold`/`activateOnGreaterThan` and again under `IThresholdSwitch` — and its own key
  also carries `countCritters`/`countEggs`, which are not threshold settings and can't be
  separated (the mod's handler bails on the whole `Value` object if any field is missing). Its
  rows still render through the plain catalogue exactly as before.
- **`PressureSwitchGas`, `PressureSwitchLiquid`, `TemperatureControlledSwitch` ("Atmo/Hydro/
  Thermo Switch") are excluded.** The 2024 export carries full names, descriptions and a
  build-menu entry for all three, but neither ONI wiki has a page for any of them, web search
  for "Thermo Switch" surfaces Thermo *Sensor* results instead, and they don't appear in a real
  playthrough's Electrical menu, including in sandbox mode, which shows disabled/debug content.
  Reads as pre-Automation-Update legacy prefab data the export tool still dumps despite the
  live game never offering them.
- **Ranges are soft**, as above — never rejected, only clamped on typed input.
- **Default thresholds are ours, not always Klei's.** Documented per-sensor in the file. The
  seven base sensors' units/ranges came from the game assembly; the six pipe/rail sensors
  inherit their room-sensor twin's unit by inference. Light, Radiation and the Germ sensors'
  defaults and Radiation's max range were checked against real in-game values (Light: 280 lux
  above; Radiation: 280 rads below, max 4727; Germ: 0 germs above, already correct).

### Deferred, deliberately

- **The Radbolt Sensor** (`LogicHEPSensor`) and **the Critter Sensor's** own threshold, scoped
  above — genuinely different keys, not just unverified ones.
- **Element sensors** (`Filterable` / `SelectedTag`, a tag *name* string, not the integer hash
  `selected_elements` uses) — a follow-up branch. `cell-element-picker` already filters by
  Gas/Liquid/Solid and emits a `BuildableElement`, so it is the natural control.
- **Two pre-existing unit discrepancies, flagged not fixed.** A buildingData reference says
  `LogicTimeOfDaySensor.startTime`/`duration` are *seconds* into a 600s cycle (the catalogue
  treats them as a 0–1 fraction shown as "% of cycle"), and that `IActivationRangeTarget
  .ActivateValue` is normalised 0–1 on batteries (the catalogue shows it raw). Both need an
  in-game check rather than a guess between two secondhand sources, so this branch leaves their
  behaviour byte-identical and documents them in CLAUDE.md.

## Verification

- [x] Backend: `npm run tsc` clean; 39 tests in `__tests__/lib/building-settings.test.ts`
- [x] Frontend: `npm run lint` clean; 35 tests in the building-settings component spec
- [x] New/changed behaviour covered by a test that fails without the change
- [x] Manually exercised — local dev server (Docker) and the real game (Oxygen Not Included,
      BlueprintsV2 mod, build U59-744825-S):
  - All 12 threshold sensors confirmed applying correctly on construction in real ONI: a
    blueprint authored in the editor, exported, and built in-game read the exact
    direction/threshold set. Atmo and Light Sensor confirmed individually; the remaining 10
    confirmed together in one blueprint, each with a distinctive value.
  - A real BlueprintsV2 share-string copied from the game imported correctly into the editor,
    including the stowaway `Switch` key handling.
  - Raw `.blueprint`-JSON paste-import round-trips identically to the share-string path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
