### PR TITLE
docs: keep the session-end PR in draft until manually tested

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -910,12 +910,16 @@ Commit message format:
 
 Stage only relevant files — never `git add -A` blindly. Do not skip hooks (`--no-verify`).
 
-**Session end — push and open a PR (autonomously, without asking):**
+**Session end — push and open a _draft_ PR (autonomously, without asking):**
 
 1. Update any committed docs that describe shipped state (e.g. `agent/TODO.md`) so they reflect what this branch ships
 2. `git push -u origin <branch>`
-3. `gh pr create` with a real description: what shipped, design decisions and spec deviations, how it was verified (test counts, migrations run), and anything deferred
-4. Report the PR URL as the session's final output
+3. `gh pr create --draft` with a real description: what shipped, design decisions and spec deviations, how it was verified (test counts, migrations run), and anything deferred — leading with what has **not** been verified yet
+4. Report the PR URL and the outstanding verification as the session's final output
+
+**The PR stays in draft until the feature is done, and done means manually tested by the
+user.** Passing tests are not done — they show the code does what its author intended, not
+that the feature works. Never take a PR out of draft; the user publishes it.
 
 ## Important Instructions
 


### PR DESCRIPTION
## What changed

`CLAUDE.md`'s session-end step now opens a **draft** PR rather than a ready one, and states
that it stays a draft until the feature is done — where done means manually tested by a
human, not "the tests pass".

Net +7 lines. Everything else in `## Work Session Lifecycle` is untouched: the opening
rationale, session start, and the committing rules.

```diff
-**Session end — push and open a PR (autonomously, without asking):**
+**Session end — push and open a _draft_ PR (autonomously, without asking):**
-3. `gh pr create` with a real description: …
+3. `gh pr create --draft` with a real description: … — leading with what has **not** been verified yet
-4. Report the PR URL as the session's final output
+4. Report the PR URL and the outstanding verification as the session's final output
+
+**The PR stays in draft until the feature is done, and done means manually tested by the
+user.** Passing tests are not done — they show the code does what its author intended, not
+that the feature works. Never take a PR out of draft; the user publishes it.
```

## Why

Claude opened #225 the moment `tsc`, 273 lib tests, 1291 frontend tests and lint went green, plus
a browser session It drove. The feature was not finished — it still needed a person to
read the code and exercise it by hand in the game these blueprints are for. #225 was
converted to draft, and the manual round trip later found the work sound, but only because
someone ran it.

The old instruction was not misread. It said to open a PR at session end and said nothing
about what "session end" requires, so passing checks became the finish line.

## Deliberately unchanged

Session end still pushes and opens a PR **autonomously** — the section exists because work
stranded on a local branch is invisible, and that reasoning still holds. The only change is
that the PR arrives as a draft, and publishing it is the user's signal that the feature is
done.

## Verification

Docs only — no code, no tests, no runtime behaviour. Opened as a normal PR at the user's
explicit request; under its own rule it would have gone up as a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
